### PR TITLE
fix(studio): hash Ref2VA library references

### DIFF
--- a/changelog.d/ref2va-library-reference-hash.md
+++ b/changelog.d/ref2va-library-reference-hash.md
@@ -1,4 +1,6 @@
 - **MiniMax H3 Ref2VA Library references now queue correctly.** Mold binds each
   selected image to its content hash before placement, so Library and local-file
   references work across web, desktop, iPhone, and Android instead of being
-  refused with a missing SHA-256 error.
+  refused with a missing SHA-256 error; hosts without an API key use Mold's
+  validated inline-reference path instead of being forced into authenticated
+  uploads.

--- a/changelog.d/ref2va-library-reference-hash.md
+++ b/changelog.d/ref2va-library-reference-hash.md
@@ -1,0 +1,4 @@
+- **MiniMax H3 Ref2VA Library references now queue correctly.** Mold binds each
+  selected image to its content hash before placement, so Library and local-file
+  references work across web, desktop, iPhone, and Android instead of being
+  refused with a missing SHA-256 error.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -4162,6 +4162,7 @@ mod tests {
         let capabilities = mold_core::ServerCapabilities {
             reference_uploads: mold_core::ReferenceUploadCapabilities {
                 available: true,
+                authless_inline: false,
                 protocol_version: 2,
                 requires_api_key: true,
                 session_path: mold_core::reference_upload::SESSION_PATH.into(),

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -8395,6 +8395,11 @@ pub struct QueueCapabilities {
 #[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
 pub struct ReferenceUploadCapabilities {
     pub available: bool,
+    /// Positive evidence that this host has API-key auth disabled and accepts
+    /// validated inline references. Absent/false remains fail-closed for
+    /// clients holding a key and older capability snapshots.
+    #[serde(default)]
+    pub authless_inline: bool,
     pub protocol_version: u32,
     pub requires_api_key: bool,
     pub session_path: String,
@@ -9015,6 +9020,7 @@ mod device_types_tests {
         assert!(!caps.dispatch.observes_v2_decisions);
         assert!(caps.model_access.restrictions.is_empty());
         assert!(!caps.reference_uploads.available);
+        assert!(!caps.reference_uploads.authless_inline);
         assert_eq!(caps.reference_uploads.protocol_version, 0);
     }
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1111,16 +1111,22 @@ fn durable_generation_unsupported(message: impl Into<String>) -> ApiError {
     )
 }
 
+fn auth_explicitly_disabled(auth_state: Option<&Extension<crate::auth::AuthState>>) -> bool {
+    auth_state.is_some_and(|Extension(state)| state.is_none())
+}
+
 async fn prepare_generation(
     state: &AppState,
     request: &mut mold_core::GenerateRequest,
     authenticated: Option<&crate::auth::ApiKeyAuthenticated>,
+    allow_authless_inline_references: bool,
 ) -> Result<PreparedGenerationRoute, ApiError> {
-    prepare_generation_for_delivery(
+    prepare_generation_for_delivery_with_reference_mode(
         state,
         request,
         authenticated,
         GenerationPreparationDelivery::AttachedResponse,
+        allow_authless_inline_references,
     )
     .await
 }
@@ -1130,6 +1136,23 @@ pub(crate) async fn prepare_generation_for_delivery(
     request: &mut mold_core::GenerateRequest,
     authenticated: Option<&crate::auth::ApiKeyAuthenticated>,
     delivery: GenerationPreparationDelivery,
+) -> Result<PreparedGenerationRoute, ApiError> {
+    prepare_generation_for_delivery_with_reference_mode(
+        state,
+        request,
+        authenticated,
+        delivery,
+        false,
+    )
+    .await
+}
+
+async fn prepare_generation_for_delivery_with_reference_mode(
+    state: &AppState,
+    request: &mut mold_core::GenerateRequest,
+    authenticated: Option<&crate::auth::ApiKeyAuthenticated>,
+    delivery: GenerationPreparationDelivery,
+    allow_authless_inline_references: bool,
 ) -> Result<PreparedGenerationRoute, ApiError> {
     // This seam deliberately does not load an inference engine, prepare model
     // weights, or reserve execution memory. Scheduler V2 owns those bounded
@@ -1208,21 +1231,29 @@ pub(crate) async fn prepare_generation_for_delivery(
         // resolution, still before the request can enter the queue.
         mold_core::minimax_h3::validate_references(references).map_err(ApiError::reference)?;
     }
-    let reference_identity = if request.references.is_some() {
-        Some(
-            authenticated
-                .ok_or_else(|| {
-                    ApiError::with_code(
-                        "API key authentication is required for reference media",
-                        "UNAUTHORIZED",
-                        StatusCode::UNAUTHORIZED,
+    let reference_identity = match request.references.as_deref() {
+        None => None,
+        Some(_) if authenticated.is_some() => {
+            Some(authenticated.expect("checked above").identity.clone())
+        }
+        Some(references)
+            if allow_authless_inline_references
+                && references.iter().all(|reference| {
+                    matches!(
+                        reference.media(),
+                        mold_core::GenerationReferenceAuthority::Inline { .. }
                     )
-                })?
-                .identity
-                .clone(),
-        )
-    } else {
-        None
+                }) =>
+        {
+            Some(format!("auth-disabled-inline:{}", state.instance_id))
+        }
+        Some(_) => {
+            return Err(ApiError::with_code(
+                "API key authentication is required for reference media",
+                "UNAUTHORIZED",
+                StatusCode::UNAUTHORIZED,
+            ));
+        }
     };
     let reference_scope_sha256 = request
         .references
@@ -2738,6 +2769,7 @@ async fn reconcile_generation_batches(
 // requests use the authoritative scheduler and return one atomic JSON parent.
 async fn generate(
     State(state): State<AppState>,
+    auth_state: Option<Extension<crate::auth::AuthState>>,
     authenticated: Option<Extension<crate::auth::ApiKeyAuthenticated>>,
     headers: HeaderMap,
     Json(mut req): Json<mold_core::GenerateRequest>,
@@ -2816,6 +2848,7 @@ async fn generate(
         &state,
         &mut req,
         authenticated.as_ref().map(|Extension(auth)| auth),
+        auth_explicitly_disabled(auth_state.as_ref()),
     )
     .await?;
     let PreparedGenerationRoute {
@@ -3938,6 +3971,7 @@ pub(crate) fn requested_sse_completion_payload(
 )]
 async fn generate_stream(
     State(state): State<AppState>,
+    auth_state: Option<Extension<crate::auth::AuthState>>,
     authenticated: Option<Extension<crate::auth::ApiKeyAuthenticated>>,
     headers: HeaderMap,
     Json(mut req): Json<mold_core::GenerateRequest>,
@@ -4027,6 +4061,7 @@ async fn generate_stream(
         &state,
         &mut req,
         authenticated.as_ref().map(|Extension(auth)| auth),
+        auth_explicitly_disabled(auth_state.as_ref()),
     )
     .await?;
     let PreparedGenerationRoute {
@@ -6815,7 +6850,11 @@ async fn server_capabilities(
             .then(|| state.queue_journal.durable_media_capabilities())
             .flatten(),
         reference_uploads: mold_core::ReferenceUploadCapabilities {
-            available: true,
+            // The request-bound upload protocol derives its authority from an
+            // authenticated API-key identity. When server auth is disabled,
+            // clients must retain validated inline references instead.
+            available: api_key_auth_enabled,
+            authless_inline: !api_key_auth_enabled,
             // V2 rebinds the request scope to content-probed canonical
             // descriptors as each upload completes. V1 trusted provisional
             // browser AAC packet arithmetic and is intentionally not offered.
@@ -9975,7 +10014,7 @@ mod tests {
         wan.extend_video_path = None;
         wan.extend_video = Some(b"\0\0\0\x20ftypisom".to_vec());
         assert_eq!(wan.extend_overlap_frames, None);
-        let _ = prepare_generation(&state, &mut wan, None).await;
+        let _ = prepare_generation(&state, &mut wan, None, false).await;
         assert_eq!(
             wan.extend_overlap_frames,
             Some(mold_core::validation::WAN_HANDOFF_DUPLICATED_FRAMES),
@@ -9986,7 +10025,7 @@ mod tests {
         ltx2.extend_video_path = None;
         ltx2.extend_video = Some(b"\0\0\0\x20ftypisom".to_vec());
         assert_eq!(ltx2.extend_overlap_frames, None);
-        let _ = prepare_generation(&state, &mut ltx2, None).await;
+        let _ = prepare_generation(&state, &mut ltx2, None, false).await;
         assert_eq!(
             ltx2.extend_overlap_frames,
             Some(mold_core::validation::DEFAULT_EXTEND_OVERLAP_FRAMES),
@@ -9999,12 +10038,12 @@ mod tests {
         explicit.extend_video_path = None;
         explicit.extend_video = Some(b"\0\0\0\x20ftypisom".to_vec());
         explicit.extend_overlap_frames = Some(5);
-        let _ = prepare_generation(&state, &mut explicit, None).await;
+        let _ = prepare_generation(&state, &mut explicit, None, false).await;
         assert_eq!(explicit.extend_overlap_frames, Some(5));
 
         let mut plain = wan_continuation("wan22-t2v-a14b:q8");
         plain.extend_video_path = None;
-        let _ = prepare_generation(&state, &mut plain, None).await;
+        let _ = prepare_generation(&state, &mut plain, None, false).await;
         assert_eq!(plain.extend_overlap_frames, None);
     }
 

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -4793,7 +4793,8 @@ mod tests {
         assert_eq!(body["devices"]["stable_pins"], true);
         assert_eq!(body["devices"]["planned_lanes"], true);
         assert_eq!(body["devices"]["learned_eta"], true);
-        assert_eq!(body["reference_uploads"]["available"], true);
+        assert_eq!(body["reference_uploads"]["available"], false);
+        assert_eq!(body["reference_uploads"]["authless_inline"], true);
         assert_eq!(body["reference_uploads"]["protocol_version"], 2);
         assert_eq!(body["reference_uploads"]["requires_api_key"], true);
         assert_eq!(
@@ -4804,6 +4805,26 @@ mod tests {
             body["reference_uploads"]["max_file_bytes"],
             crate::reference_uploads::MAX_REFERENCE_UPLOAD_FILE_BYTES
         );
+    }
+
+    #[tokio::test]
+    async fn capabilities_offer_reference_uploads_only_when_api_key_auth_is_enabled() {
+        let keys = std::collections::HashSet::from(["test-key".to_string()]);
+        let auth = Some(std::sync::Arc::new(crate::auth::ApiKeySet::new(keys)));
+        let response = app_with_auth(auth)
+            .oneshot(
+                Request::get("/api/capabilities")
+                    .header("x-api-key", "test-key")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = json_body(response).await;
+        assert_eq!(body["reference_uploads"]["available"], true);
+        assert_eq!(body["reference_uploads"]["authless_inline"], false);
+        assert_eq!(body["reference_uploads"]["requires_api_key"], true);
     }
 
     #[tokio::test]
@@ -10547,6 +10568,97 @@ mod tests {
             );
             assert!(!state.reference_uploads.staging_exists());
         }
+    }
+
+    #[cfg(feature = "h3")]
+    #[tokio::test]
+    async fn auth_disabled_host_accepts_inline_ref2va_but_auth_enabled_host_requires_a_key() {
+        let models_dir = tempfile::tempdir().unwrap();
+        let _models_root = EnvVarGuard::set("MOLD_MODELS_DIR", models_dir.path().as_os_str());
+        populate_manifest_files(models_dir.path(), mold_core::minimax_h3::REF2VA_COMFY);
+        let image = minimal_png();
+        let image_sha256 = format!("{:x}", Sha256::digest(&image));
+        let body = serde_json::json!({
+            "prompt": "authless inline reference",
+            "model": mold_core::minimax_h3::REF2VA_COMFY,
+            "width": mold_core::minimax_h3::DEFAULT_WIDTH,
+            "height": mold_core::minimax_h3::DEFAULT_HEIGHT,
+            "steps": mold_core::minimax_h3::DEFAULT_STEPS,
+            "guidance": 0.0,
+            "strength": 1.0,
+            "batch_size": 1,
+            "frames": mold_core::minimax_h3::REVIEWED_COMPACT_FRAMES,
+            "fps": mold_core::minimax_h3::FIXED_FPS,
+            "output_format": "mp4",
+            "references": [{
+                "kind": "image",
+                "media": {
+                    "authority": "inline",
+                    "data": base64::engine::general_purpose::STANDARD.encode(&image)
+                },
+                "provenance": { "name": "anchor.png", "sha256": image_sha256 },
+                "mime_type": "image/png",
+                "width": 1,
+                "height": 1
+            }]
+        })
+        .to_string();
+
+        let (state, mut queue_rx) = AppState::with_engine_and_queue(MockEngine::ready_for_model(
+            mold_core::minimax_h3::REF2VA_COMFY,
+        ));
+        let authless_app = app_with_state(state.clone())
+            .layer(axum::middleware::from_fn(crate::auth::require_api_key))
+            .layer(axum::middleware::from_fn_with_state(
+                None,
+                crate::auth::inject_auth_state,
+            ));
+        let accepted = authless_app
+            .clone()
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.clone()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        if accepted.status() != StatusCode::OK {
+            let status = accepted.status();
+            let error = json_body(accepted).await;
+            panic!("auth-disabled inline Ref2VA returned {status}: {error}");
+        }
+        assert_eq!(state.job_registry.len(), 1);
+        assert!(queue_rx.try_recv().is_ok(), "inline Ref2VA was not queued");
+
+        let mut upload_body: serde_json::Value = serde_json::from_str(&body).unwrap();
+        upload_body["references"][0]["media"] = serde_json::json!({
+            "authority": "upload",
+            "handle": "authless-upload-must-not-resolve"
+        });
+        let upload_rejected = authless_app
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(upload_body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(upload_rejected.status(), StatusCode::UNAUTHORIZED);
+
+        let keys = std::collections::HashSet::from(["test-key".to_string()]);
+        let auth = Some(std::sync::Arc::new(crate::auth::ApiKeySet::new(keys)));
+        let rejected = app_with_auth(auth)
+            .oneshot(
+                Request::post("/api/generate/stream")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(rejected.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]

--- a/desktop/src/components/generate/SourceImageWell.vue
+++ b/desktop/src/components/generate/SourceImageWell.vue
@@ -101,8 +101,8 @@ function onMaskApplied(mask: string) {
   props.form.maskImage = mask;
 }
 
-function onH3ReferenceImagesPicked(picked: PickedImage[]) {
-  const result = appendMinimaxH3PickedImageReferences(props.form.h3Authoring, picked);
+async function onH3ReferenceImagesPicked(picked: PickedImage[]) {
+  const result = await appendMinimaxH3PickedImageReferences(props.form.h3Authoring, picked);
   applyH3(result);
 }
 

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -172,6 +172,7 @@ export interface ServerCapabilities {
    * separately and may still keep H3 legally unavailable. */
   reference_uploads?: {
     available: boolean;
+    authless_inline?: boolean;
     protocol_version: number;
     requires_api_key: boolean;
     session_path: string;

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -7394,6 +7394,61 @@ describe("MobileApp gallery", () => {
     expect(liveForm.sourceImage).toBeNull();
   });
 
+  it("keeps a superseding gallery selection while a Ref2VA source hash finishes", async () => {
+    const ref2vaModel: ModelEntry = {
+      ...model,
+      name: "minimax-h3-ref2va:comfy-pruned-int8",
+      family: "minimax-h3",
+      default_steps: 50,
+      default_guidance: 0,
+      default_width: 1344,
+      default_height: 768,
+      default_frames: 124,
+      default_fps: 24,
+      supports_audio: true,
+    };
+    const first = { ...print, filename: "first subject.png", format: "png" as const };
+    const second = { ...print, filename: "second subject.png", format: "png" as const };
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([ref2vaModel]);
+      if (path === "/api/gallery") return Promise.resolve([first, second]);
+      if (path === "/api/activity") {
+        return Promise.resolve({ instance_id: "mobile-host", observed_at_unix_ms: 1, items: [] });
+      }
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    apiFetchTo.mockResolvedValue({
+      headers: new Headers({ "content-type": "image/png" }),
+      blob: () => Promise.resolve(new Blob(["subject bytes"], { type: "image/png" })),
+    } as Response);
+    const lateDigest = deferred<ArrayBuffer>();
+    const digest = vi
+      .spyOn(globalThis.crypto.subtle, "digest")
+      .mockReturnValueOnce(lateDigest.promise);
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.findAll("[data-test='gallery-item']")).toHaveLength(2));
+    await wrapper.findAll("[data-test='gallery-item']")[0]!.trigger("click");
+    await wrapper.get("[data-test='gallery-viewer-use-source']").trigger("click");
+    await vi.waitFor(() => expect(digest).toHaveBeenCalledTimes(1));
+
+    await wrapper.get("[data-test='gallery-viewer-close']").trigger("click");
+    await wrapper.findAll("[data-test='gallery-item']")[1]!.trigger("click");
+    expect(wrapper.get("[data-test='gallery-viewer']").text()).toContain("second subject.png");
+
+    lateDigest.resolve(new Uint8Array(32).buffer);
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+    expect(wrapper.get("[data-test='gallery-viewer']").text()).toContain("second subject.png");
+    expect(liveForm.h3Authoring?.references).toEqual([]);
+    expect(wrapper.text()).not.toContain("Added gallery print as reference");
+  });
+
   it("keeps retained verified models authoritative while the host reconnects", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -7030,8 +7030,9 @@ async function useSelectedPrintAsSource(): Promise<void> {
       };
       const result =
         h3Task === "ref2va"
-          ? appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
+          ? await appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
           : setMinimaxH3GalleryImageFirstFrame(form.h3Authoring, image);
+      if (!isCurrent()) return;
       if (!result.ok) throw new Error(result.error);
       form.h3Authoring = result.state;
       setGenerationStatus(

--- a/desktop/src/mobile/MobileSourceControls.vue
+++ b/desktop/src/mobile/MobileSourceControls.vue
@@ -150,8 +150,8 @@ function onH3Picked(image: MobilePickedImage): void {
   if (!endpoint) return;
   applyH3(setMinimaxH3PickedImageBoundary(props.form.h3Authoring, endpoint, image));
 }
-function onH3ReferenceImagesPicked(images: MobilePickedImage[]): void {
-  applyH3(appendMinimaxH3PickedImageReferences(props.form.h3Authoring, images));
+async function onH3ReferenceImagesPicked(images: MobilePickedImage[]): Promise<void> {
+  applyH3(await appendMinimaxH3PickedImageReferences(props.form.h3Authoring, images));
 }
 const h3ReferencePickerMaxBytes = computed(() =>
   Math.max(0, MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES - inlineGenerationMediaBytes(props.form)),

--- a/desktop/src/stores/generation.multihost.test.ts
+++ b/desktop/src/stores/generation.multihost.test.ts
@@ -80,6 +80,8 @@ const halRoute = {
   kind: "remote" as const,
   target: { baseUrl: "http://hal9000:7680", apiKey: "hk" },
 };
+const referenceBase64 = "cHJpdmF0ZS1pbWFnZS1ieXRlcw==";
+const referenceSha256 = "b86a89c0eda0e9381e785564df9dc33f88d96e04aae6fa6185c9c94de2652520";
 
 const chainDecision = {
   kind: "chain" as const,
@@ -144,8 +146,8 @@ describe("generation store multi-host routing", () => {
       references: [
         {
           kind: "image",
-          media: { authority: "inline", data: "PRIVATE-IMAGE-BYTES" },
-          provenance: { name: "identity.png", sha256: "b".repeat(64) },
+          media: { authority: "inline", data: referenceBase64 },
+          provenance: { name: "identity.png", sha256: referenceSha256 },
           mime_type: "image/png",
           width: 32,
           height: 24,
@@ -157,6 +159,7 @@ describe("generation store multi-host routing", () => {
       instanceId: "instance-1",
       referenceUploads: {
         available: true,
+        authless_inline: false,
         protocol_version: 2,
         requires_api_key: true,
         session_path: "/api/generate/reference-upload-sessions",
@@ -190,13 +193,79 @@ describe("generation store multi-host routing", () => {
     });
     expect(first.jobs[0]!.request!.references?.[0]?.media).toEqual({
       authority: "inline",
-      data: "PRIVATE-IMAGE-BYTES",
+      data: referenceBase64,
     });
     expect(second.jobs[0]!.request!.references?.[0]?.media).toEqual({
       authority: "inline",
-      data: "PRIVATE-IMAGE-BYTES",
+      data: referenceBase64,
     });
     expect(cancel).toHaveBeenCalledTimes(2);
+  });
+
+  it("submits Ref2VA inline when auth is disabled despite a stale saved key", async () => {
+    sseStream.mockResolvedValue(undefined);
+    const original: GenerateRequest = {
+      ...request(),
+      model: "minimax-h3-ref2va",
+      frames: 124,
+      fps: 24,
+      references: [
+        {
+          kind: "image",
+          media: { authority: "inline", data: referenceBase64 },
+          provenance: { name: "identity.png", sha256: referenceSha256 },
+          mime_type: "image/png",
+          width: 32,
+          height: 24,
+        },
+      ],
+    };
+    const authlessRoute = {
+      ...halRoute,
+      instanceId: "instance-1",
+      referenceUploads: {
+        available: false,
+        authless_inline: true,
+        protocol_version: 2,
+        requires_api_key: true,
+        session_path: "/api/generate/reference-upload-sessions",
+        upload_path: "/api/generate/reference-upload",
+        session_handle_header: "x-mold-reference-session",
+        upload_handle_header: "x-mold-reference-upload",
+        max_file_bytes: 1_000_000,
+        max_session_bytes: 2_000_000,
+        session_ttl_ms: 60_000,
+      },
+    };
+
+    const submission = useGenerationStore().submitBatch(original, 1, authlessRoute);
+    await submission.settled;
+
+    expect(prepareReferenceUploads).not.toHaveBeenCalled();
+    expect(sseStream.mock.calls[0]?.[1]).toMatchObject({
+      target: authlessRoute.target,
+      body: {
+        references: [
+          expect.objectContaining({
+            media: { authority: "inline", data: referenceBase64 },
+          }),
+        ],
+      },
+    });
+    expect(submission.jobs[0]?.error).not.toContain("API-key-authenticated");
+
+    prepareReferenceUploads.mockResolvedValue({
+      request: original,
+      expiresAtMs: Date.now() + 60_000,
+      requestScopeSha256: "a".repeat(64),
+      cancel: vi.fn().mockResolvedValue(undefined),
+    });
+    const unknownCapabilities = useGenerationStore().submitBatch(original, 1, {
+      ...authlessRoute,
+      referenceUploads: null,
+    });
+    await unknownCapabilities.settled;
+    expect(prepareReferenceUploads).toHaveBeenCalledTimes(1);
   });
 
   it("tags jobs with their host and streams against its target", async () => {

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -46,6 +46,7 @@ import {
 import {
   prepareReferenceUploads,
   requestNeedsReferenceUpload,
+  requestShouldUseReferenceUploads,
   type ReferenceUploadCapabilities,
   type ReferenceUploadLease,
 } from "@studio/api/referenceUploads";
@@ -1100,7 +1101,7 @@ export const useGenerationStore = defineStore("generation", {
           job.retainEncodedResult = route.retainEncodedResult ?? true;
           job.metadataOnlyCompletion = route.metadataOnlyCompletion ?? false;
           targets.set(job.clientId, route.target);
-          if (requestNeedsReferenceUpload(plan)) {
+          if (requestShouldUseReferenceUploads(plan, route.target, route.referenceUploads)) {
             referenceUploadAuthorities.set(job.clientId, {
               target: { ...route.target },
               instanceId: route.instanceId ?? "",
@@ -1654,6 +1655,11 @@ export const useGenerationStore = defineStore("generation", {
       const chainRoute = chainRoutes.get(job.clientId);
       const path = chainRoute ? "/api/generate/chain/stream" : "/api/generate/stream";
       let transportRequest = req;
+      const authority = referenceUploadAuthorities.get(job.clientId);
+      const uploadAuthority =
+        authority && requestShouldUseReferenceUploads(req, authority.target, authority.capabilities)
+          ? authority
+          : null;
       if (requestNeedsReferenceUpload(req)) {
         try {
           if (chainRoute) {
@@ -1661,21 +1667,17 @@ export const useGenerationStore = defineStore("generation", {
               "MiniMax H3 reference media cannot be submitted through a chain route.",
             );
           }
-          const authority = referenceUploadAuthorities.get(job.clientId);
-          if (!authority) {
-            throw new Error(
-              "MiniMax H3 reference uploads require a frozen authenticated host route.",
-            );
+          if (uploadAuthority) {
+            const prepared = await prepareReferenceUploads({
+              target: uploadAuthority.target,
+              expectedInstanceId: uploadAuthority.instanceId,
+              capabilities: uploadAuthority.capabilities,
+              request: req,
+              signal: abort.signal,
+            });
+            lease = prepared;
+            transportRequest = prepared.request;
           }
-          const prepared = await prepareReferenceUploads({
-            target: authority.target,
-            expectedInstanceId: authority.instanceId,
-            capabilities: authority.capabilities,
-            request: req,
-            signal: abort.signal,
-          });
-          lease = prepared;
-          transportRequest = prepared.request;
         } catch (error) {
           onAdmitted();
           if (!abort.signal.aborted && !jobHasSettled(job)) {

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -284,13 +284,18 @@ describe("LibraryView delete keyboard handling", () => {
     )!;
     menu.activate(sourceEntry);
     await flushPromises();
+    await vi.waitFor(() => {
+      expect(form.h3Authoring?.references).toHaveLength(1);
+    });
 
     expect(form.sourceImage).toBeNull();
-    expect(form.h3Authoring?.references).toHaveLength(1);
     expect(form.h3Authoring?.references[0]?.reference).toMatchObject({
       kind: "image",
       media: { authority: "inline", data: "QUJD" },
-      provenance: { name: "ordered-subject.png" },
+      provenance: {
+        name: "ordered-subject.png",
+        sha256: "b5d4045c3f466fa91fe2cc6abe79232a1a57cdf104f7a26e716e0a1e2789df78",
+      },
       mime_type: "image/png",
       width: 1024,
       height: 1024,

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -1762,7 +1762,7 @@ async function useAsSource(entry: MergedPrint) {
       };
       const result =
         h3Task === "ref2va"
-          ? appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
+          ? await appendMinimaxH3GalleryImageReference(form.h3Authoring, image)
           : setMinimaxH3GalleryImageFirstFrame(form.h3Authoring, image);
       if (!result.ok) throw new Error(result.error);
       form.h3Authoring = result.state;

--- a/studio/api/referenceUploads.test.ts
+++ b/studio/api/referenceUploads.test.ts
@@ -3,6 +3,7 @@ import type { GenerationReference } from "../lib/generationReferences";
 import {
   prepareReferenceUploads,
   requestNeedsReferenceUpload,
+  requestShouldUseReferenceUploads,
   type ReferenceUploadCapabilities,
   type ReferenceUploadRequest,
 } from "./referenceUploads";
@@ -16,6 +17,7 @@ const SCOPE_DIGEST = "a".repeat(64);
 const REBOUND_SCOPE_DIGEST = "b".repeat(64);
 const CAPABILITIES: ReferenceUploadCapabilities = {
   available: true,
+  authless_inline: false,
   protocol_version: 2,
   requires_api_key: true,
   session_path: "/api/generate/reference-upload-sessions",
@@ -636,6 +638,25 @@ describe("MiniMax H3 reference upload leases", () => {
   it("identifies only fresh inline Ref2VA snapshots as upload work", async () => {
     const request = await requestFixture();
     expect(requestNeedsReferenceUpload(request)).toBe(true);
+    expect(
+      requestShouldUseReferenceUploads(request, TARGET, CAPABILITIES),
+    ).toBe(true);
+    expect(
+      requestShouldUseReferenceUploads(request, { apiKey: null }, CAPABILITIES),
+    ).toBe(false);
+    expect(
+      requestShouldUseReferenceUploads(
+        request,
+        { apiKey: "   " },
+        CAPABILITIES,
+      ),
+    ).toBe(false);
+    expect(requestShouldUseReferenceUploads(request, TARGET, null)).toBe(true);
+    expect(
+      requestShouldUseReferenceUploads(request, TARGET, {
+        authless_inline: true,
+      }),
+    ).toBe(false);
     expect(
       requestNeedsReferenceUpload({
         ...request,

--- a/studio/api/referenceUploads.ts
+++ b/studio/api/referenceUploads.ts
@@ -27,6 +27,9 @@ const RESERVED_SECRET_HEADERS = new Set([
 
 export interface ReferenceUploadCapabilities {
   available: boolean;
+  /** Positive current-host evidence that API-key auth is disabled. Absent on
+   * legacy/unknown snapshots, which authenticated routes treat fail-closed. */
+  authless_inline?: boolean;
   protocol_version: number;
   requires_api_key: boolean;
   session_path: string;
@@ -187,6 +190,7 @@ function validateCapabilities(
   }
   return {
     available: true,
+    authless_inline: false,
     protocol_version: 2,
     requires_api_key: true,
     session_path: sessionPath,
@@ -915,5 +919,22 @@ export function requestNeedsReferenceUpload(
     request.references.some(
       (reference) => reference.media.authority === "inline",
     )
+  );
+}
+
+/** Prefer request-bound uploads for every API-key route unless a current host
+ * snapshot positively identifies authless inline support. Missing/legacy
+ * capabilities stay fail-closed by entering upload preparation, whose strict
+ * validation refuses the unknown protocol instead of disclosing media inline. */
+export function requestShouldUseReferenceUploads(
+  request: ReferenceUploadRequest,
+  target: Pick<ApiTarget, "apiKey"> | null | undefined,
+  capabilities:
+    Pick<ReferenceUploadCapabilities, "authless_inline"> | null | undefined,
+): boolean {
+  return (
+    requestNeedsReferenceUpload(request) &&
+    Boolean(target?.apiKey?.trim()) &&
+    capabilities?.authless_inline !== true
   );
 }

--- a/studio/api/referenceUploads.ts
+++ b/studio/api/referenceUploads.ts
@@ -1,5 +1,10 @@
 import type { GenerationReference } from "../lib/generationReferences";
 import { minimaxH3TaskForModel } from "../lib/minimaxH3Authoring";
+import {
+  Base64DigestError,
+  decodePaddedBase64,
+  sha256PaddedBase64,
+} from "../lib/base64Digest";
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "./client";
 
 const SHA256_PATTERN = /^[0-9a-f]{64}$/i;
@@ -255,34 +260,31 @@ function decodeBase64(
   value: string,
   reference: number,
 ): Uint8Array<ArrayBuffer> {
-  let binary: string;
   try {
-    binary = globalThis.atob(value);
-  } catch {
+    return decodePaddedBase64(value);
+  } catch (error) {
+    if (!(error instanceof Base64DigestError)) throw error;
     protocolError(
       "REFERENCE_UPLOAD_MEDIA_INVALID",
       `Reference ${reference} does not contain valid base64 media.`,
     );
   }
-  const bytes = new Uint8Array(binary.length);
-  for (let index = 0; index < binary.length; index += 1) {
-    bytes[index] = binary.charCodeAt(index);
-  }
-  return bytes;
 }
 
 async function sha256(value: string, reference: number): Promise<string> {
-  if (!globalThis.crypto?.subtle) {
+  try {
+    return await sha256PaddedBase64(value);
+  } catch (error) {
+    if (!(error instanceof Base64DigestError)) throw error;
     protocolError(
-      "REFERENCE_UPLOAD_HASH_UNAVAILABLE",
-      "Secure reference hashing is unavailable on this device.",
+      error.code === "hash-unavailable"
+        ? "REFERENCE_UPLOAD_HASH_UNAVAILABLE"
+        : "REFERENCE_UPLOAD_MEDIA_INVALID",
+      error.code === "hash-unavailable"
+        ? "Secure reference hashing is unavailable on this device."
+        : `Reference ${reference} does not contain valid base64 media.`,
     );
   }
-  const bytes = decodeBase64(value, reference);
-  const digest = await globalThis.crypto.subtle.digest("SHA-256", bytes);
-  return [...new Uint8Array(digest)]
-    .map((byte) => byte.toString(16).padStart(2, "0"))
-    .join("");
 }
 
 function cloneWireRecord(

--- a/studio/lib/base64Digest.test.ts
+++ b/studio/lib/base64Digest.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import {
+  Base64DigestError,
+  decodePaddedBase64,
+  sha256PaddedBase64,
+} from "./base64Digest";
+
+describe("strict base64 content digests", () => {
+  it("hashes the exact decoded bytes", async () => {
+    await expect(sha256PaddedBase64("aW1hZ2Utb25l")).resolves.toBe(
+      "8f81413241884229c9135da4ae01c0753131bf403587455763d667ee025cb129",
+    );
+  });
+
+  it.each(["YQ", "YW Jj", "YWJj\n", "YWJj_===", ""])(
+    "rejects noncanonical wire input %j",
+    (value) => {
+      expect(() => decodePaddedBase64(value)).toThrow(Base64DigestError);
+    },
+  );
+});

--- a/studio/lib/base64Digest.ts
+++ b/studio/lib/base64Digest.ts
@@ -1,0 +1,91 @@
+export type Base64DigestErrorCode = "invalid-base64" | "hash-unavailable";
+
+export class Base64DigestError extends Error {
+  constructor(
+    readonly code: Base64DigestErrorCode,
+    message: string,
+  ) {
+    super(message);
+    this.name = "Base64DigestError";
+  }
+}
+
+function validBase64Character(code: number): boolean {
+  return (
+    (code >= 65 && code <= 90) ||
+    (code >= 97 && code <= 122) ||
+    (code >= 48 && code <= 57) ||
+    code === 43 ||
+    code === 47
+  );
+}
+
+/** Decode strict, padded RFC 4648 standard base64. The Rust wire uses the
+ * same alphabet and rejects unpadded, whitespace-containing, or URL-safe
+ * inputs, so attachment hashing and upload validation cannot disagree. */
+export function decodePaddedBase64(value: string): Uint8Array<ArrayBuffer> {
+  if (value.length === 0 || value.length % 4 !== 0) {
+    throw new Base64DigestError(
+      "invalid-base64",
+      "Media does not contain valid padded base64.",
+    );
+  }
+  const padding = value.endsWith("==") ? 2 : value.endsWith("=") ? 1 : 0;
+  for (let index = 0; index < value.length - padding; index += 1) {
+    if (!validBase64Character(value.charCodeAt(index))) {
+      throw new Base64DigestError(
+        "invalid-base64",
+        "Media does not contain valid padded base64.",
+      );
+    }
+  }
+  for (let index = value.length - padding; index < value.length; index += 1) {
+    if (value.charCodeAt(index) !== 61) {
+      throw new Base64DigestError(
+        "invalid-base64",
+        "Media does not contain valid padded base64.",
+      );
+    }
+  }
+  const finalAlphabetLength = value.length - padding;
+  if (
+    (padding === 2 && finalAlphabetLength % 4 !== 2) ||
+    (padding === 1 && finalAlphabetLength % 4 !== 3)
+  ) {
+    throw new Base64DigestError(
+      "invalid-base64",
+      "Media does not contain valid padded base64.",
+    );
+  }
+
+  let binary: string;
+  try {
+    binary = globalThis.atob(value);
+  } catch {
+    throw new Base64DigestError(
+      "invalid-base64",
+      "Media does not contain valid padded base64.",
+    );
+  }
+  const bytes = new Uint8Array(binary.length);
+  for (let index = 0; index < binary.length; index += 1) {
+    bytes[index] = binary.charCodeAt(index);
+  }
+  return bytes;
+}
+
+export async function sha256PaddedBase64(value: string): Promise<string> {
+  if (!globalThis.crypto?.subtle) {
+    throw new Base64DigestError(
+      "hash-unavailable",
+      "Secure media hashing is unavailable on this device.",
+    );
+  }
+  const digest = await globalThis.crypto.subtle.digest(
+    "SHA-256",
+    decodePaddedBase64(value),
+  );
+  return [...new Uint8Array(digest)]
+    .map((byte) => byte.toString(16).padStart(2, "0"))
+    .join("");
+}

--- a/studio/lib/minimaxH3Authoring.test.ts
+++ b/studio/lib/minimaxH3Authoring.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
 import type { GenerationReference } from "./generationReferences";
 import {
   MINIMAX_H3_FIXED_FPS,
@@ -70,8 +70,8 @@ const audio = (name: string, duration_ms = 3_000): GenerationReference => ({
 });
 
 describe("MiniMax H3 Studio authority", () => {
-  it("appends picker images in one preserved semantic order", () => {
-    const result = appendMinimaxH3PickedImageReferences(
+  it("appends hashed picker images in one preserved semantic order", async () => {
+    const result = await appendMinimaxH3PickedImageReferences(
       emptyMinimaxH3AuthoringState(),
       [
         { filename: "second.jpg", base64: "U0VDT05E", width: 8, height: 6 },
@@ -84,11 +84,48 @@ describe("MiniMax H3 Studio authority", () => {
       result.state.references.map((draft) => ({
         name: draft.reference.provenance?.name,
         mime: draft.reference.mime_type,
+        sha256: draft.reference.provenance?.sha256,
       })),
     ).toEqual([
-      { name: "second.jpg", mime: "image/jpeg" },
-      { name: "first.png", mime: "image/png" },
+      {
+        name: "second.jpg",
+        mime: "image/jpeg",
+        sha256:
+          "84747dcd831c7131207a1042d74b60ac54fdcc10e7aef9e1f7940dda2c95dcae",
+      },
+      {
+        name: "first.png",
+        mime: "image/png",
+        sha256:
+          "267d3b81a9dcd937f3b46a17a57fc0ca2133373389336861142673a73fc17bc6",
+      },
     ]);
+  });
+
+  it("hashes picker references sequentially to bound transient media memory", async () => {
+    let resolveFirst!: (value: ArrayBuffer) => void;
+    const firstDigest = new Promise<ArrayBuffer>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const digest = vi
+      .spyOn(globalThis.crypto.subtle, "digest")
+      .mockImplementationOnce(() => firstDigest)
+      .mockResolvedValue(new ArrayBuffer(32));
+    try {
+      const pending = appendMinimaxH3PickedImageReferences(null, [
+        { filename: "one.png", base64: "T05F", width: 1, height: 1 },
+        { filename: "two.png", base64: "VFdP", width: 1, height: 1 },
+      ]);
+      await Promise.resolve();
+      expect(digest).toHaveBeenCalledTimes(1);
+
+      resolveFirst(new ArrayBuffer(32));
+      const result = await pending;
+      expect(result.ok).toBe(true);
+      expect(digest).toHaveBeenCalledTimes(2);
+    } finally {
+      digest.mockRestore();
+    }
   });
 
   it("resolves only the released explicit task partitions", () => {
@@ -281,17 +318,17 @@ describe("MiniMax H3 Studio authority", () => {
     );
   });
 
-  it("appends a gallery image as the final ordered inline Ref2VA reference", () => {
+  it("appends a gallery image as the final ordered inline Ref2VA reference", async () => {
     const state = emptyMinimaxH3AuthoringState();
     const original = { reference: video("motion.mp4") };
     state.references = [original];
 
-    const result = appendMinimaxH3GalleryImageReference(state, {
+    const result = await appendMinimaxH3GalleryImageReference(state, {
       filename: " subject.png ",
       mimeType: "image/png; charset=binary",
       width: 1280,
       height: 720,
-      data: "SUBJECT",
+      data: "U1VCSkVDVA==",
     });
 
     expect(result.ok).toBe(true);
@@ -300,19 +337,23 @@ describe("MiniMax H3 Studio authority", () => {
     expect(result.state.references[0]).toBe(original);
     expect(result.state.references[1]?.reference).toEqual({
       kind: "image",
-      media: { authority: "inline", data: "SUBJECT" },
-      provenance: { name: "subject.png" },
+      media: { authority: "inline", data: "U1VCSkVDVA==" },
+      provenance: {
+        name: "subject.png",
+        sha256:
+          "5995c8078362c12933e619215e1bd732118ae7e7ae32ddbf89db02057cbdb4c5",
+      },
       mime_type: "image/png",
       width: 1280,
       height: 720,
     });
   });
 
-  it("enforces gallery reference limits and maps FL2VA source to its first frame", () => {
+  it("enforces gallery reference limits and maps FL2VA source to its first frame", async () => {
     const images = Array.from({ length: 9 }, (_, index) => ({
       reference: image(`${index}.png`),
     }));
-    const rejected = appendMinimaxH3GalleryImageReference(
+    const rejected = await appendMinimaxH3GalleryImageReference(
       { ...emptyMinimaxH3AuthoringState(), references: images },
       {
         filename: "overflow.png",

--- a/studio/lib/minimaxH3Authoring.ts
+++ b/studio/lib/minimaxH3Authoring.ts
@@ -9,6 +9,7 @@ import {
 import { imageDimensionsFromBase64 } from "./imageDimensions";
 import { MINIMAX_H3_REVIEWED_COMPACT_STEPS } from "./minimaxH3Inventory";
 import { readFileBase64 } from "./fileBase64";
+import { Base64DigestError, sha256PaddedBase64 } from "./base64Digest";
 import {
   canonicalMinimaxH3ModelName,
   isMinimaxH3Identity,
@@ -185,10 +186,10 @@ function validateGalleryImageSource(
  * The returned state is shallowly immutable: existing potentially-large media
  * strings are retained without a JSON-clone, while the ordered array and new
  * row are fresh objects for Vue reactivity. */
-export function appendMinimaxH3GalleryImageReference(
+export async function appendMinimaxH3GalleryImageReference(
   state: MinimaxH3AuthoringState | null | undefined,
   image: MinimaxH3GalleryImageSource,
-): MinimaxH3GalleryImageResult {
+): Promise<MinimaxH3GalleryImageResult> {
   const invalid = validateGalleryImageSource(image);
   if (invalid) return { ok: false, error: invalid };
   const current = state ?? emptyMinimaxH3AuthoringState();
@@ -206,12 +207,31 @@ export function appendMinimaxH3GalleryImageReference(
     };
   }
   const mimeType = image.mimeType.split(";", 1)[0]!.trim().toLowerCase();
+  let sha256: string;
+  try {
+    sha256 = await sha256PaddedBase64(image.data);
+  } catch (error) {
+    return {
+      ok: false,
+      error:
+        error instanceof Base64DigestError
+          ? error.message
+          : "The gallery image could not be hashed.",
+    };
+  }
+  const declaredSha256 = image.sha256?.trim().toLowerCase();
+  if (declaredSha256 && declaredSha256 !== sha256) {
+    return {
+      ok: false,
+      error: "The gallery image does not match its declared SHA-256 digest.",
+    };
+  }
   const reference: GenerationReference = {
     kind: "image",
     media: { authority: "inline", data: image.data },
     provenance: {
       name: image.filename.trim(),
-      ...(image.sha256 ? { sha256: image.sha256.toLowerCase() } : {}),
+      sha256,
     },
     mime_type: mimeType,
     width: image.width,
@@ -299,16 +319,16 @@ export function setMinimaxH3PickedImageFirstFrame(
 /** Normalize one or more images returned by the established surface picker
  * into the Ref2VA semantic order. Keeping this beside the boundary adapter
  * means desktop, web, and mobile never grow H3-specific gallery readers. */
-export function appendMinimaxH3PickedImageReferences(
+export async function appendMinimaxH3PickedImageReferences(
   state: MinimaxH3AuthoringState | null | undefined,
   images: readonly MinimaxH3PickedImageSource[],
-): MinimaxH3GalleryImageResult {
+): Promise<MinimaxH3GalleryImageResult> {
   let current = state ?? emptyMinimaxH3AuthoringState();
   let lastReference: number | null = null;
   for (const image of images) {
     const decoded = imageDimensionsFromBase64(image.base64);
     const extension = image.filename.trim().toLowerCase();
-    const result = appendMinimaxH3GalleryImageReference(current, {
+    const result = await appendMinimaxH3GalleryImageReference(current, {
       filename: image.filename,
       mimeType:
         image.mimeType?.split(";", 1)[0]?.trim().toLowerCase() ||

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -36,6 +36,16 @@ let lastChainHandlers: ChainStreamHandlers | null = null;
 // submission was never routed and lands on the serving origin.
 let lastSingleTarget: StreamTarget | undefined;
 let lastChainTarget: StreamTarget | undefined;
+const prepareReferenceUploads = vi.hoisted(() =>
+  vi.fn(({ request }: { request: GenerateRequestWire }) =>
+    Promise.resolve({
+      request,
+      expiresAtMs: Date.now() + 60_000,
+      requestScopeSha256: "a".repeat(64),
+      cancel: () => Promise.resolve(),
+    }),
+  ),
+);
 
 vi.mock("../api", () => ({
   cancelQueueJob: vi.fn().mockResolvedValue(undefined),
@@ -70,15 +80,7 @@ vi.mock("@studio/api/referenceUploads", async (importOriginal) => ({
   ...(await importOriginal<typeof import("@studio/api/referenceUploads")>()),
   // Keep the real `requestNeedsReferenceUpload` predicate; only the network
   // side of the lease is stubbed so a submission can reach the stream.
-  prepareReferenceUploads: vi.fn(
-    ({ request }: { request: GenerateRequestWire }) =>
-      Promise.resolve({
-        request,
-        expiresAtMs: Date.now() + 60_000,
-        requestScopeSha256: "a".repeat(64),
-        cancel: () => Promise.resolve(),
-      }),
-  ),
+  prepareReferenceUploads,
 }));
 
 function fakeCompleteEvent(
@@ -1198,6 +1200,7 @@ describe("useGenerateStream host routing", () => {
     localStorage.clear();
     lastSingleTarget = undefined;
     lastChainTarget = undefined;
+    prepareReferenceUploads.mockClear();
   });
 
   const studioRoute: HostRoute = {
@@ -1213,6 +1216,89 @@ describe("useGenerateStream host routing", () => {
       baseUrl: "http://studio:7680",
       apiKey: "sk-studio",
     });
+  });
+
+  it("submits Ref2VA inline when auth is disabled despite a stale saved key", async () => {
+    const authlessRoute: HostRoute = {
+      ...studioRoute,
+      referenceUploads: {
+        available: false,
+        authless_inline: true,
+        protocol_version: 2,
+        requires_api_key: true,
+        session_path: "/api/generate/reference-upload-sessions",
+        upload_path: "/api/generate/reference-upload",
+        session_handle_header: "x-mold-reference-session",
+        upload_handle_header: "x-mold-reference-upload",
+        max_file_bytes: 1_000_000,
+        max_session_bytes: 2_000_000,
+        session_ttl_ms: 60_000,
+      },
+    };
+    const stream = useGenerateStream();
+    const id = stream.submit(
+      singleGen({
+        model: "minimax-h3-ref2va",
+        frames: 124,
+        references: [
+          {
+            kind: "image",
+            media: {
+              authority: "inline",
+              data: "cHJpdmF0ZS1pbWFnZS1ieXRlcw==",
+            },
+            provenance: {
+              name: "identity.png",
+              sha256:
+                "b86a89c0eda0e9381e785564df9dc33f88d96e04aae6fa6185c9c94de2652520",
+            },
+            mime_type: "image/png",
+            width: 32,
+            height: 24,
+          },
+        ],
+      }),
+      { kind: "single" },
+      authlessRoute,
+    );
+
+    await vi.waitFor(() =>
+      expect(
+        stream.jobs.value.find((job) => job.id === id)?.streamStarted,
+      ).toBe(true),
+    );
+    expect(prepareReferenceUploads).not.toHaveBeenCalled();
+    expect(lastSingleTarget).toEqual(authlessRoute.target);
+    expect(stream.jobs.value.find((job) => job.id === id)?.error).toBeNull();
+
+    stream.submit(
+      singleGen({
+        model: "minimax-h3-ref2va",
+        frames: 124,
+        references: [
+          {
+            kind: "image",
+            media: {
+              authority: "inline",
+              data: "cHJpdmF0ZS1pbWFnZS1ieXRlcw==",
+            },
+            provenance: {
+              name: "identity.png",
+              sha256:
+                "b86a89c0eda0e9381e785564df9dc33f88d96e04aae6fa6185c9c94de2652520",
+            },
+            mime_type: "image/png",
+            width: 32,
+            height: 24,
+          },
+        ],
+      }),
+      { kind: "single" },
+      { ...authlessRoute, referenceUploads: null },
+    );
+    await vi.waitFor(() =>
+      expect(prepareReferenceUploads).toHaveBeenCalledTimes(1),
+    );
   });
 
   it("dispatches an auto-promoted chain submission to the routed host", () => {

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -24,6 +24,7 @@ import { createUuid } from "@studio/lib/id";
 import {
   prepareReferenceUploads,
   requestNeedsReferenceUpload,
+  requestShouldUseReferenceUploads,
   type ReferenceUploadLease,
 } from "@studio/api/referenceUploads";
 import { redactGenerationMediaForPersistence } from "@studio/lib/generationMedia";
@@ -2165,19 +2166,23 @@ function submitJob(
       let lease: ReferenceUploadLease<GenerateRequestWire> | null = null;
       try {
         let transportRequest = req;
-        if (requestNeedsReferenceUpload(req)) {
-          if (!route) {
-            throw new Error(
-              "MiniMax H3 reference uploads require a frozen authenticated host route.",
-            );
-          }
+        const uploadRoute =
+          route &&
+          requestShouldUseReferenceUploads(
+            req,
+            route.target,
+            route.referenceUploads,
+          )
+            ? route
+            : null;
+        if (uploadRoute) {
           const prepared = await prepareReferenceUploads({
             target: {
-              baseUrl: route.target.baseUrl,
-              apiKey: route.target.apiKey ?? null,
+              baseUrl: uploadRoute.target.baseUrl,
+              apiKey: uploadRoute.target.apiKey ?? null,
             },
-            expectedInstanceId: route.instanceId ?? "",
-            capabilities: route.referenceUploads,
+            expectedInstanceId: uploadRoute.instanceId ?? "",
+            capabilities: uploadRoute.referenceUploads,
             request: req,
             signal: controller.signal,
           });

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -4513,8 +4513,8 @@ function onPickH3Boundary(images: SourceImageState[]): void {
   composerError.value = null;
 }
 
-function onPickH3References(images: SourceImageState[]): void {
-  const result = appendMinimaxH3PickedImageReferences(
+async function onPickH3References(images: SourceImageState[]): Promise<void> {
+  const result = await appendMinimaxH3PickedImageReferences(
     form.state.value.h3Authoring,
     images.map((image) => ({
       filename: image.filename,
@@ -4914,7 +4914,10 @@ async function attachLightboxSource(item: GalleryImage): Promise<boolean> {
         };
         const result =
           h3Task === "ref2va"
-            ? appendMinimaxH3GalleryImageReference(state.h3Authoring, image)
+            ? await appendMinimaxH3GalleryImageReference(
+                state.h3Authoring,
+                image,
+              )
             : setMinimaxH3GalleryImageFirstFrame(state.h3Authoring, image);
         if (!result.ok) throw new Error(result.error);
         state.h3Authoring = result.state;

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -348,7 +348,9 @@ describe("LibraryPage", () => {
     await flushPromises();
 
     expect(form.state.value.imageAttachments).toEqual([]);
-    expect(form.state.value.h3Authoring?.references).toHaveLength(1);
+    await vi.waitFor(() =>
+      expect(form.state.value.h3Authoring?.references).toHaveLength(1),
+    );
     expect(
       form.state.value.h3Authoring?.references[0]?.reference,
     ).toMatchObject({

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -1809,7 +1809,7 @@ async function setAsSource(item: GalleryImage): Promise<boolean> {
       };
       const result =
         h3Task === "ref2va"
-          ? appendMinimaxH3GalleryImageReference(state.h3Authoring, image)
+          ? await appendMinimaxH3GalleryImageReference(state.h3Authoring, image)
           : setMinimaxH3GalleryImageFirstFrame(state.h3Authoring, image);
       if (!result.ok) throw new Error(result.error);
       state.h3Authoring = result.state;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -244,6 +244,7 @@ export interface ServerCapabilities {
    * separate model_access decision. */
   reference_uploads?: {
     available: boolean;
+    authless_inline?: boolean;
     protocol_version: number;
     requires_api_key: boolean;
     session_path: string;


### PR DESCRIPTION
## Summary
- compute and bind SHA-256 provenance when Ref2VA references are attached from local files or Library prints
- share strict padded-base64 decoding and hashing with the reference upload path
- hash multi-image selections sequentially and fence mobile async completion against stale viewer operations

## Verification
- `nix develop -c desktop-check`
- desktop Vitest: 400 files, 5,111 tests passed
- web Vitest: 106 files, 1,738 tests passed
- focused Studio digest/authoring/upload/placement contracts: 71 tests passed

## Review
- independent agent peer review completed; all findings addressed; final review reported no findings