### PR TITLE
fix(server): close SSE streams during shutdown

### DIFF
--- a/changelog.d/shutdown-sse-drain.md
+++ b/changelog.d/shutdown-sse-drain.md
@@ -1,0 +1,1 @@
+- **Fast idle server restarts.** Close connected SSE subscriptions during graceful shutdown so an idle `mold serve` no longer waits for the abort deadline ([#1415](https://github.com/utensils/mold/issues/1415)).

--- a/crates/mold-server/src/events.rs
+++ b/crates/mold-server/src/events.rs
@@ -21,6 +21,7 @@ const BROADCAST_BUFFER: usize = 64;
 
 pub struct EventBroadcaster {
     tx: broadcast::Sender<ServerEvent>,
+    shutdown: tokio_util::sync::CancellationToken,
 }
 
 /// What the host-wide SSE stream must do with one broadcast delivery.
@@ -48,7 +49,10 @@ pub(crate) fn classify_delivery(
 impl EventBroadcaster {
     pub fn new() -> Arc<Self> {
         let (tx, _rx) = broadcast::channel(BROADCAST_BUFFER);
-        Arc::new(Self { tx })
+        Arc::new(Self {
+            tx,
+            shutdown: tokio_util::sync::CancellationToken::new(),
+        })
     }
 
     /// Publish an event. Synchronous — safe to call from `spawn_blocking`
@@ -60,6 +64,16 @@ impl EventBroadcaster {
 
     pub fn subscribe(&self) -> broadcast::Receiver<ServerEvent> {
         self.tx.subscribe()
+    }
+
+    /// End every open-ended SSE subscription before Axum starts its HTTP
+    /// drain. Finite request streams keep their normal completion semantics.
+    pub fn shutdown(&self) {
+        self.shutdown.cancel();
+    }
+
+    pub fn shutdown_token(&self) -> tokio_util::sync::CancellationToken {
+        self.shutdown.clone()
     }
 }
 
@@ -119,5 +133,17 @@ mod tests {
             }
             other => panic!("normal event was changed by delivery classification: {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn shutdown_wakes_all_event_stream_waiters() {
+        let events = EventBroadcaster::new();
+        let first = events.shutdown_token();
+        let second = events.shutdown_token();
+
+        events.shutdown();
+
+        first.cancelled().await;
+        second.cancelled().await;
     }
 }

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -1109,6 +1109,7 @@ pub async fn run_server(
     let shutdown_chain_jobs = state.chain_jobs.clone();
     let shutdown_journal = state.queue_journal.clone();
     let shutdown_generation_cancel = state.generation_cancel.clone();
+    let shutdown_event_streams = state.events.clone();
     let shutdown_fatal_cuda = fatal_cuda_error.clone();
     tokio::spawn(async move {
         let _ = shutdown_request_rx.await;
@@ -1121,6 +1122,7 @@ pub async fn run_server(
             &shutdown_scheduler,
             &shutdown_journal,
             &shutdown_generation_cancel,
+            &shutdown_event_streams,
         );
         let _ = http_shutdown_tx.send(());
     });
@@ -1564,6 +1566,7 @@ fn begin_runtime_shutdown(
     scheduler_shutdown: &tokio_util::sync::CancellationToken,
     queue_journal: &queue_journal::QueueJournal,
     generation_cancel: &generation_cancel::CancelRegistry,
+    event_streams: &events::EventBroadcaster,
 ) {
     queue_journal.retain_all();
     let aborted = generation_cancel.request_all();
@@ -1577,6 +1580,7 @@ fn begin_runtime_shutdown(
         let active_chains = chain_jobs.request_shutdown();
         tracing::info!(active_chains, "cancelled chain work before HTTP drain");
     }
+    event_streams.shutdown();
     scheduler_shutdown.cancel();
 }
 
@@ -1695,12 +1699,20 @@ mod tests {
         let journal = Arc::new(crate::queue_journal::QueueJournal::disabled());
 
         let singletons = Arc::new(crate::generation_cancel::CancelRegistry::new());
-        begin_runtime_shutdown(Some(&chains), &scheduler, &journal, &singletons);
+        let event_streams = crate::events::EventBroadcaster::new();
+        begin_runtime_shutdown(
+            Some(&chains),
+            &scheduler,
+            &journal,
+            &singletons,
+            &event_streams,
+        );
 
         assert!(chains.is_cancelling("chain-in-flight"));
         chains.register_cancel_for_tests("chain-claimed-during-shutdown");
         assert!(chains.is_cancelling("chain-claimed-during-shutdown"));
         assert!(scheduler.is_cancelled());
+        assert!(event_streams.shutdown_token().is_cancelled());
     }
 
     /// The whole correctness argument for retention: the fence has to be up
@@ -1728,6 +1740,7 @@ mod tests {
             &scheduler,
             &journal,
             &crate::generation_cancel::CancelRegistry::new(),
+            &crate::events::EventBroadcaster::new(),
         );
         watcher.await.unwrap();
 
@@ -1839,7 +1852,13 @@ mod tests {
         let running = singletons.token("job-1");
         assert!(!running.is_cancelled());
 
-        begin_runtime_shutdown(None, &scheduler, &journal, &singletons);
+        begin_runtime_shutdown(
+            None,
+            &scheduler,
+            &journal,
+            &singletons,
+            &crate::events::EventBroadcaster::new(),
+        );
 
         assert!(running.is_cancelled());
     }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -9583,15 +9583,25 @@ pub async fn stream_downloads(
     // freshly-mounted SPA paints current state without waiting for the
     // next delta.
     let rx = state.downloads.subscribe();
+    let shutdown = state.events.shutdown_token();
     let initial = state.downloads.listing().await;
     let snapshot_event = mold_core::types::DownloadEvent::Snapshot { listing: initial };
 
     let stream = async_stream::stream! {
+        if shutdown.is_cancelled() {
+            return;
+        }
         let data = serde_json::to_string(&snapshot_event).unwrap_or_else(|_| "{}".to_string());
         yield Ok::<_, std::convert::Infallible>(Event::default().event("download").data(data));
 
         let mut bs = BroadcastStream::new(rx);
-        while let Some(item) = bs.next().await {
+        loop {
+            let item = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                item = bs.next() => item,
+            };
+            let Some(item) = item else { break };
             match item {
                 Ok(event) => {
                     let data = serde_json::to_string(&event)
@@ -9636,16 +9646,26 @@ async fn get_resources_stream(
     use tokio_stream::wrappers::BroadcastStream;
 
     let rx = state.resources.subscribe();
+    let shutdown = state.events.shutdown_token();
     // Attach the cached `latest` snapshot as the first frame so clients
     // don't wait up to one full tick for their initial value.
     let initial = state.resources.latest();
 
     let stream = async_stream::stream! {
+        if shutdown.is_cancelled() {
+            return;
+        }
         if let Some(snap) = initial {
             yield Ok::<_, Infallible>(snapshot_to_sse(&snap));
         }
         let mut bs = BroadcastStream::new(rx);
-        while let Some(item) = bs.next().await {
+        loop {
+            let item = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                item = bs.next() => item,
+            };
+            let Some(item) = item else { break };
             match item {
                 Ok(snap) => yield Ok(snapshot_to_sse(&snap)),
                 // Lag is normal for slow clients — skip dropped frames
@@ -9696,11 +9716,21 @@ async fn stream_events(
     use tokio_stream::wrappers::BroadcastStream;
 
     let rx = state.events.subscribe();
+    let shutdown = state.events.shutdown_token();
     let instance_id = state.instance_id.clone();
     let stream = async_stream::stream! {
+        if shutdown.is_cancelled() {
+            return;
+        }
         yield Ok::<_, Infallible>(event_authority_to_sse(instance_id.as_str()));
         let mut bs = BroadcastStream::new(rx);
-        while let Some(item) = bs.next().await {
+        loop {
+            let item = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                item = bs.next() => item,
+            };
+            let Some(item) = item else { break };
             match crate::events::classify_delivery(item) {
                 crate::events::BroadcastDelivery::Event(event) => {
                     yield Ok::<_, Infallible>(server_event_to_sse(&event));

--- a/crates/mold-server/src/routes_chain.rs
+++ b/crates/mold-server/src/routes_chain.rs
@@ -21,7 +21,6 @@ use mold_core::chain_job::{settled, ChainJobEvent, ChainJobState};
 use mold_core::{OutputFormat, OutputMetadata, VideoData};
 use mold_db::MetadataDb;
 use std::convert::Infallible;
-use tokio_stream::StreamExt as _;
 
 use crate::chain_job_runner::{ChainJobRunnerHandle, EphemeralClaimGuard};
 use crate::model_manager::ExistingModelAuthority;
@@ -1307,6 +1306,7 @@ pub async fn generate_chain_stream(
     let state_clone = state.clone();
     let db_holder = state.metadata_db.clone();
     let tx_for_task = tx.clone();
+    let task_shutdown = state.events.shutdown_token();
     let handle = state
         .chain_jobs
         .as_ref()
@@ -1371,7 +1371,12 @@ pub async fn generate_chain_stream(
         };
         let mut terminal: Option<(ChainJobState, Option<String>)> = None;
         while terminal.is_none() {
-            match live.recv().await {
+            let delivery = tokio::select! {
+                biased;
+                _ = task_shutdown.cancelled() => return,
+                delivery = live.recv() => delivery,
+            };
+            match delivery {
                 Ok(event) => {
                     if let Some(progress) = map_job_event_to_legacy(&event, &job_id) {
                         let _ = tx_for_task.send(ChainSseMessage::Progress(progress));
@@ -1474,8 +1479,19 @@ pub async fn generate_chain_stream(
     });
     drop(tx); // ensure only the task holds the sender
 
-    let stream = tokio_stream::wrappers::UnboundedReceiverStream::new(rx)
-        .map(|msg| Ok::<_, Infallible>(chain_sse_event(msg)));
+    let stream_shutdown = state.events.shutdown_token();
+    let stream = async_stream::stream! {
+        let mut rx = rx;
+        loop {
+            let message = tokio::select! {
+                biased;
+                _ = stream_shutdown.cancelled() => break,
+                message = rx.recv() => message,
+            };
+            let Some(message) = message else { break };
+            yield Ok::<_, Infallible>(chain_sse_event(message));
+        }
+    };
 
     // The filing advisory rides the response headers, which are sent before
     // the first SSE frame — the same `x-mold-request-warning` the one-shot
@@ -2662,6 +2678,45 @@ mod tests {
             .as_str()
             .is_some_and(|value| value.ends_with(".mp4")));
         assert!(complete["metadata"].is_object());
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_an_idle_legacy_chain_stream() {
+        use futures::StreamExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let home = dir.path().join("mold-home");
+        let _home_guard = MoldHomeGuard::set(&home);
+        let db = MetadataDb::open_in_memory().unwrap();
+        let output_dir = dir.path().join("gallery");
+        let handle = Arc::new(crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests());
+        let state = state_with_db_and_handle(db, handle.clone(), &output_dir);
+
+        let sse = generate_chain_stream(
+            State(state.clone()),
+            HeaderMap::new(),
+            Json(req(OutputFormat::Mp4)),
+        )
+        .await
+        .unwrap();
+        let response = sse.into_response();
+        let mut body = response.into_body().into_data_stream();
+        let initial = tokio::time::timeout(std::time::Duration::from_secs(1), body.next())
+            .await
+            .expect("legacy chain stream should emit its snapshot")
+            .expect("legacy chain stream should remain open")
+            .expect("legacy chain snapshot should be readable");
+        assert!(String::from_utf8_lossy(&initial).contains("event: progress"));
+
+        let row = wait_for_single_chain_job(state.metadata_db.as_ref().as_ref().unwrap()).await;
+        wait_for_bus_subscription(&handle, &row.id).await;
+
+        state.events.shutdown();
+
+        let end = tokio::time::timeout(std::time::Duration::from_secs(1), body.next())
+            .await
+            .expect("idle legacy chain stream should close during shutdown");
+        assert!(end.is_none());
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -332,10 +332,19 @@ pub async fn chain_job_events(
     detail.summary.cancelling =
         detail.summary.state == ChainJobState::Running && handle.is_cancelling(&id);
     let snapshot = ChainJobEvent::Snapshot { job: detail };
+    let shutdown = state.events.shutdown_token();
     let stream = async_stream::stream! {
+        if shutdown.is_cancelled() {
+            return;
+        }
         yield Ok(sse_event(snapshot));
         loop {
-            match live.recv().await {
+            let delivery = tokio::select! {
+                biased;
+                _ = shutdown.cancelled() => break,
+                delivery = live.recv() => delivery,
+            };
+            match delivery {
                 Ok(event) => yield Ok(sse_event(event)),
                 Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => break,
                 Err(tokio::sync::broadcast::error::RecvError::Closed) => break,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -12134,6 +12134,41 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn shutdown_closes_idle_chain_job_event_stream() {
+        use futures::StreamExt as _;
+
+        let home = tempfile::tempdir().unwrap();
+        let _home = MoldHomeGuard::set(home.path());
+        let db = mold_db::MetadataDb::open_in_memory().unwrap();
+        seed_chain_job(&db, home.path(), "shutdown-events", ChainJobState::Queued);
+        let mut state = AppState::for_tests();
+        state.metadata_db = Arc::new(Some(db));
+        state.chain_jobs = Some(Arc::new(
+            crate::chain_job_runner::ChainJobRunnerHandle::inert_for_tests(),
+        ));
+        let response = app_with_state(state.clone())
+            .oneshot(
+                Request::get("/api/chain-jobs/shutdown-events/events")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let mut body = response.into_body().into_data_stream();
+        let first = tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .expect("snapshot should arrive before shutdown");
+        assert!(first.is_some());
+
+        state.events.shutdown();
+
+        let end = tokio::time::timeout(Duration::from_secs(1), body.next())
+            .await
+            .expect("chain event stream did not close after shutdown");
+        assert!(end.is_none());
+    }
+
     #[cfg(not(feature = "mp4"))]
     #[tokio::test]
     async fn create_chain_job_rejects_audio_when_mp4_feature_is_disabled() {
@@ -14224,6 +14259,52 @@ mod tests {
             frame,
             "event: event\ndata: {\"type\":\"job_queued\",\"id\":\"j1\",\"model\":\"flux-dev:q4\"}\n\n"
         );
+    }
+
+    #[tokio::test]
+    async fn shutdown_closes_idle_server_subscription_streams() {
+        use futures::StreamExt as _;
+
+        for path in [
+            "/api/events",
+            "/api/downloads/stream",
+            "/api/resources/stream",
+        ] {
+            let state = AppState::empty(
+                mold_core::Config::default(),
+                crate::state::QueueHandle::new(tokio::sync::mpsc::channel(1).0),
+                AppState::empty_gpu_pool_for_test(),
+                200,
+            );
+            let response = app_with_state(state.clone())
+                .oneshot(Request::get(path).body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+            assert_eq!(response.status(), StatusCode::OK, "path: {path}");
+            let mut body = response.into_body().into_data_stream();
+
+            if path != "/api/resources/stream" {
+                let initial = tokio::time::timeout(Duration::from_secs(1), body.next())
+                    .await
+                    .unwrap_or_else(|_| panic!("{path} did not emit its initial frame"));
+                assert!(initial.is_some(), "{path} closed before becoming idle");
+            }
+
+            let (waiting_tx, waiting_rx) = tokio::sync::oneshot::channel();
+            let waiter = tokio::spawn(async move {
+                let _ = waiting_tx.send(());
+                body.next().await
+            });
+            waiting_rx.await.unwrap();
+            tokio::task::yield_now().await;
+            state.events.shutdown();
+
+            let end = tokio::time::timeout(Duration::from_secs(1), waiter)
+                .await
+                .unwrap_or_else(|_| panic!("{path} did not close after shutdown"))
+                .expect("subscription waiter should not panic");
+            assert!(end.is_none(), "{path} yielded another frame after shutdown");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- add a shared shutdown signal for open-ended server subscriptions
- close server events, downloads, resources, durable chain-job events, and the legacy chain stream before Axum starts draining HTTP
- cover already-established idle streams with shutdown regression tests

## Verification

- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `nix develop -c cargo test -p mold-ai-server shutdown_closes -- --test-threads=1`
- independent agent peer review: no actionable findings after follow-up

The full `mold-ai-server` suite was also attempted locally; under full parallel load, existing timing/shared-process-state tests produced 43 cascading failures (timeouts and poisoned locks). The affected shutdown tests pass serially, and CI remains the authoritative full-suite gate.

Closes #1415