### PR TITLE
fix(queue): report active sequence work accurately

### DIFF
--- a/changelog.d/mobile-sequence-queue-status.md
+++ b/changelog.d/mobile-sequence-queue-status.md
@@ -1,0 +1,3 @@
+- **Machine queue status now matches active video work.** Auto-chained one-shot
+  generations appear once in Create, and iPhone/Android machine details show
+  their active scheduler stages instead of incorrectly saying the queue is empty.

--- a/crates/mold-server/src/routes_activity.rs
+++ b/crates/mold-server/src/routes_activity.rs
@@ -150,7 +150,7 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
                 row.state,
                 mold_core::chain_job::ChainJobState::Queued
                     | mold_core::chain_job::ChainJobState::Running
-            )
+            ) && !crate::routes_chain_jobs::chain_job_is_ephemeral(row)
         }) {
             represented.insert(row.id.clone());
             let cancelling = row.state == mold_core::chain_job::ChainJobState::Running

--- a/crates/mold-server/src/routes_chain_jobs.rs
+++ b/crates/mold-server/src/routes_chain_jobs.rs
@@ -1137,6 +1137,10 @@ fn read_manifest_optional(row: &ChainJobRow, _root: &FsPath) -> Option<ChainJobM
     ChainJobManifest::read_from_dir(&row.job_dir).ok()
 }
 
+pub(crate) fn chain_job_is_ephemeral(row: &ChainJobRow) -> bool {
+    ChainJobManifest::read_from_dir(&row.job_dir).is_ok_and(|manifest| manifest.ephemeral)
+}
+
 /// Re-check every persisted source of model identity before an old durable
 /// job becomes schedulable again. Jobs can outlive both the server process and
 /// the policy that admitted them, so the row, request, frozen snapshot,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3387,6 +3387,11 @@ mod tests {
         let home = tempfile::tempdir().unwrap();
         let db = mold_db::MetadataDb::open_in_memory().unwrap();
         seed_chain_job(&db, home.path(), "sequence-c", ChainJobState::Running);
+        let ephemeral_dir =
+            seed_chain_job(&db, home.path(), "one-shot-chain", ChainJobState::Running);
+        let mut ephemeral = ChainJobManifest::read_from_dir(&ephemeral_dir).unwrap();
+        ephemeral.ephemeral = true;
+        ephemeral.write_atomic(&ephemeral_dir).unwrap();
         state.metadata_db = Arc::new(Some(db));
         let (download_id, _, _) = state
             .downloads
@@ -3451,6 +3456,10 @@ mod tests {
         assert_eq!(item("expand-parent")["phase"], "running");
         assert_eq!(item("sequence-c")["kind"], "sequence");
         assert_eq!(item("sequence-c")["phase"], "running");
+        assert!(
+            items.iter().all(|item| item["id"] != "one-shot-chain"),
+            "an auto-chained one-shot is represented by its generation row, not a second sequence"
+        );
         assert_eq!(item(&download_id)["kind"], "download");
         assert_eq!(item(&download_id)["phase"], "queued");
         assert_eq!(body["instance_id"], instance_id);

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -256,6 +256,51 @@ afterEach(() => {
 });
 
 describe("MobileHostDetail remote host data", () => {
+  it("shows active sequence stages instead of calling the machine queue empty", async () => {
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((target, path) => {
+      if (path === "/api/status") return Promise.resolve(serverStatus({ queue_depth: 0 }));
+      if (path === "/api/queue?limit=8") {
+        return Promise.resolve({
+          entries: [],
+          plan: {
+            plan_version: 1,
+            state_version: 1,
+            optimizer_state: "optimized",
+            dirty_since_unix_ms: null,
+            next_replan_at_unix_ms: null,
+            work_items: [
+              {
+                work_id: "chain:sequence-1:attempt:0:stage:0",
+                parent_id: "sequence-1",
+                work_kind: "chain_stage",
+                chain_stage: 0,
+                priority_class: "user",
+                queue_rank: 4,
+                bypass_count: 0,
+                gpu: 2,
+                planned_device_id: "cuda:gpu-2",
+                planned_lane_kind: "device",
+                lane_order: 0,
+                estimate_confidence: "low",
+                activity_phase: "active",
+              },
+            ],
+          },
+        });
+      }
+      return originalApi(target, path);
+    });
+
+    const view = await mountDetail();
+
+    expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("1 total");
+    expect(view.get("[data-test='host-detail-planned-work']").text()).toContain(
+      "activeChain stage · stage 1sequence-1GPU 2",
+    );
+    expect(view.text()).not.toContain("Queue is empty.");
+  });
+
   it("shows a CPU utility lane when the host reports no GPUs", async () => {
     const originalApi = apiJsonTo.getMockImplementation()!;
     apiJsonTo.mockImplementation((target, path) => {

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -12,6 +12,7 @@ import {
 } from "@studio/api/queuePlan";
 import { watchSelectedQueuePreview, type QueueJobProgress } from "@studio/api/generationSelection";
 import DevicePanel from "@studio/components/DevicePanel.vue";
+import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import QueueEntryDetail from "@studio/components/QueueEntryDetail.vue";
 import SwipeActionRow from "@studio/components/SwipeActionRow.vue";
 import MobileLibrarySheet from "./MobileLibrarySheet.vue";
@@ -20,6 +21,7 @@ import type { SwipeRowAction } from "@studio/lib/swipeAction";
 import MinimaxH3InventoryPanel from "@studio/components/MinimaxH3InventoryPanel.vue";
 import { canMutateDevice } from "@studio/lib/deviceLifecycle";
 import { queueWaitCode, resolveQueueWait } from "@studio/lib/queuePosition";
+import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 import { hostMemoryLevel } from "@studio/lib/hostMemory";
 import { apiJsonTo } from "../lib/api/client";
 import { describeTransportError } from "../lib/api/errors";
@@ -139,9 +141,13 @@ const runtimeWindow = computed(() => {
     ? capacity
     : null;
 });
-const queueSummary = computed(() =>
-  durableBacklog.value === null ? `${queue.value.length} loaded` : `${durableBacklog.value} total`,
-);
+const queueEntryIds = computed(() => queue.value.map((entry) => entry.id));
+const planOnlyWork = computed(() => queuePlanOnlyWork(queuePlan.value, queueEntryIds.value));
+const queueSummary = computed(() => {
+  const visibleWork = queue.value.length + planOnlyWork.value.length;
+  if (durableBacklog.value !== null) return `${Math.max(durableBacklog.value, visibleWork)} total`;
+  return `${visibleWork} loaded`;
+});
 const modelLabel = (name: string) => modelDisplayNameForId(name, installed.value);
 
 function downloadStatus(job: DownloadJob): string {
@@ -1110,7 +1116,12 @@ onBeforeUnmount(() => {
         >
           {{ queueRowError }}
         </p>
-        <p v-else class="mobile-empty-note">
+        <QueuePlanWorkList
+          :plan="queuePlan"
+          :exclude-ids="queueEntryIds"
+          data-test="host-detail-planned-work"
+        />
+        <p v-if="queue.length === 0 && planOnlyWork.length === 0" class="mobile-empty-note">
           {{ durableBacklog === 0 ? "Queue is empty." : "No queue rows are loaded." }}
         </p>
         <button


### PR DESCRIPTION
## Summary

- hide ephemeral auto-chain implementation jobs from `/api/activity` so one-shot generations appear once
- render scheduler-only chain stages in the iPhone machine queue instead of reporting an empty queue
- preserve the larger authoritative queue count while accounting for visible plan-only work

## Root cause

Plato was generating normally. Auto-chained one-shot requests were exposed twice: once as the client generation and again as an internal sequence activity. Separately, the iPhone machine screen rendered only `/api/queue.entries`, while active chain stages live in `plan.work_items`. That produced duplicate queued/running rows and an empty machine queue despite active GPU work.

## Verification

- `cargo test -p mold-ai-server activity_snapshot_exposes_only_server_owned_nonterminal_work`
- `cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `bunx vitest run --config vitest.config.ts src/mobile/MobileHostDetail.test.ts` (44 passed)
- `bun run test` (5,310 passed)
- `bunx vue-tsc -b`
- Rustfmt, Prettier, and `git diff --check`
- independent agent review: no findings