### PR TITLE
fix(mobile): unify source wells and touch interactions

### DIFF
--- a/changelog.d/mobile-source-library-touch.md
+++ b/changelog.d/mobile-source-library-touch.md
@@ -1,0 +1,1 @@
+- **Mobile source and Library touch controls now stay consistent.** iPhone and Android use the same replaceable source-image wells everywhere, Library tags stay above thumbnails, natural full-width scrolling and pull-to-refresh work, and queued work exposes Pause or Resume beside Cancel ([#1420](https://github.com/utensils/mold/pull/1420)).

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -102,6 +102,8 @@ export interface ServerStatus {
   gpus?: GpuWorkerStatus[] | null;
   queue_depth?: number | null;
   queue_capacity?: number | null;
+  /** Whether this host is currently holding queued work from dispatch. */
+  queue_paused?: boolean | null;
   /** Stable server-installation UUID; absent on older servers. */
   instance_id?: string | null;
   /** Disk stats for the filesystem holding the models dir; absent on older servers. */

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1086,6 +1086,56 @@ describe("MobileApp sequence generation", () => {
     expect(localStorage.getItem("mold.mobile.live-activity.v1")).not.toContain(target.apiKey);
   });
 
+  it("swipes a queued item from another client to exact-host pause and resume", async () => {
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status")
+        return Promise.resolve({ ...status, queue_paused: false, queue_capacity: 2 });
+      if (path === "/api/capabilities")
+        return Promise.resolve({
+          queue: { can_pause: true, heterogeneous_batch_max_outputs: 8 },
+        });
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/queue?limit=2") return Promise.resolve({ entries: [] });
+      if (path === "/api/activity")
+        return Promise.resolve({
+          instance_id: status.instance_id,
+          observed_at_unix_ms: 10,
+          items: [
+            {
+              id: "foreign-queued",
+              kind: "generation",
+              phase: "queued",
+              model: model.name,
+              created_at_unix_ms: 1,
+              updated_at_unix_ms: 9,
+              can_cancel: true,
+            },
+          ],
+        });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const row = wrapper.get(".live-activity-row");
+    const touch = (type: string, x: number, ended = false) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      const point = { clientX: x, clientY: 100 };
+      Object.defineProperty(event, "touches", { value: ended ? [] : [point] });
+      Object.defineProperty(event, "changedTouches", { value: [point] });
+      return event;
+    };
+    row.element.dispatchEvent(touch("touchstart", 260));
+    row.element.dispatchEvent(touch("touchmove", 160));
+    row.element.dispatchEvent(touch("touchend", 160, true));
+    await flushPromises();
+
+    expect(row.classes()).toContain("live-activity-row--actions-open");
+    await row.get("[data-test='mobile-fleet-queue-control']").trigger("click");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/queue/pause", { method: "POST" });
+  });
+
   it("loads a tapped server-owned generation into Create like desktop", async () => {
     const pagedStatus = { ...status, queue_capacity: 3 };
     const metadata = {
@@ -4014,7 +4064,7 @@ describe("MobileApp generation queue", () => {
 
     wrapper = mountMobileApp();
     await flushPromises();
-    await wrapper.get("[data-test='mobile-source-add']").trigger("click");
+    await wrapper.get("[data-test='mobile-source-gallery']").trigger("click");
     wrapper
       .getComponent(MobileImagePickerSheet)
       .vm.$emit("pick", { filename: "source.png", base64: btoa("source") });
@@ -5573,6 +5623,48 @@ describe("MobileApp generation queue", () => {
     expect(untouched?.text()).not.toContain("Cancelling");
   });
 
+  it("reveals exact-host pause, resume, and cancel actions with a natural queue swipe", async () => {
+    apiJsonTo.mockImplementation((_target: unknown, path: string) => {
+      if (path === "/api/status")
+        return Promise.resolve({ ...status, queue_paused: false, queue_capacity: 2 });
+      if (path === "/api/capabilities")
+        return Promise.resolve({
+          queue: { can_pause: true, heterogeneous_batch_max_outputs: 8 },
+        });
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/activity")
+        return Promise.resolve({ instance_id: "studio-id", observed_at_unix_ms: 1, items: [] });
+      if (path === "/api/queue?limit=2") return Promise.resolve({ entries: [] });
+      return Promise.reject(new Error(`Unexpected API path: ${path}`));
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    await submitPrompt("pause this queued print");
+    openStreams[0]?.options.onEvent(
+      "progress",
+      JSON.stringify({ type: "queued", position: 0, id: "job-pause" }),
+    );
+    await flushPromises();
+
+    const row = wrapper.get("[data-test='mobile-generation-job']");
+    const control = row.get("[data-test='swipe-action-queue-pause']");
+    expect(control.text()).toBe("Pause");
+    expect(row.get("[data-test='swipe-action-cancel']").text()).toBe("Cancel");
+
+    await control.trigger("click");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/queue/pause", { method: "POST" });
+    const resume = row.get("[data-test='swipe-action-queue-resume']");
+    expect(resume.text()).toBe("Resume");
+
+    await resume.trigger("click");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/queue/resume", { method: "POST" });
+    expect(row.get("[data-test='swipe-action-queue-pause']").text()).toBe("Pause");
+  });
+
   it("counts a queued print's live place in line rather than its submit slot", async () => {
     // A print carries no held stream, so its place in line comes from the
     // machine's own queue listing keyed on the durable child's job id.
@@ -6743,8 +6835,8 @@ describe("MobileApp wan source conditioning", () => {
     wrapper = mountMobileApp();
     await flushPromises();
 
-    expect(wrapper.find("[data-test='mobile-source-add']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='mobile-end-frame-add']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-source-well']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='mobile-end-frame-well']").exists()).toBe(false);
     await fieldControl("Prompt").setValue("a lantern drifting downriver");
     expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).not.toHaveProperty(
       "disabled",
@@ -6757,8 +6849,8 @@ describe("MobileApp wan source conditioning", () => {
     await flushPromises();
 
     expect(wrapper.find("[data-test='mobile-source-controls']").exists()).toBe(false);
-    expect(wrapper.find("[data-test='mobile-source-add']").exists()).toBe(false);
-    expect(wrapper.find("[data-test='mobile-end-frame-add']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-source-well']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-end-frame-well']").exists()).toBe(false);
     await fieldControl("Prompt").setValue("a lantern drifting downriver");
     expect(wrapper.get("[data-test='mobile-develop-button']").attributes()).not.toHaveProperty(
       "disabled",
@@ -10945,6 +11037,55 @@ describe("MobileApp Library organization", () => {
       [unknown, string, RequestInit | undefined]
     >;
   }
+
+  function libraryTouch(type: string, clientY?: number): Event {
+    const event = new Event(type, { bubbles: true, cancelable: true });
+    Object.defineProperty(event, "touches", {
+      configurable: true,
+      value: clientY === undefined ? [] : [{ identifier: 7, clientX: 120, clientY }],
+    });
+    return event;
+  }
+
+  it("refreshes the Library after a natural pull from the top", async () => {
+    installLibraryApi();
+    await openLibrary();
+    const content = wrapper!.get(".mobile-content").element;
+    const before = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/gallery").length;
+
+    content.dispatchEvent(libraryTouch("touchstart", 100));
+    const move = libraryTouch("touchmove", 230);
+    content.dispatchEvent(move);
+    await flushPromises();
+    expect(move.defaultPrevented).toBe(true);
+    expect(wrapper!.get("[data-test='mobile-library-pull']").text()).toContain(
+      "Release to refresh",
+    );
+    content.dispatchEvent(libraryTouch("touchend"));
+
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => path === "/api/gallery").length,
+      ).toBeGreaterThan(before),
+    );
+  });
+
+  it("resets a cancelled Library pull without refreshing", async () => {
+    installLibraryApi();
+    await openLibrary();
+    const content = wrapper!.get(".mobile-content").element;
+    const before = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/gallery").length;
+
+    content.dispatchEvent(libraryTouch("touchstart", 100));
+    content.dispatchEvent(libraryTouch("touchmove", 230));
+    content.dispatchEvent(libraryTouch("touchcancel"));
+    await flushPromises();
+
+    expect(wrapper!.get("[data-test='mobile-library-pull']").text()).not.toContain(
+      "Release to refresh",
+    );
+    expect(apiJsonTo.mock.calls.filter(([, path]) => path === "/api/gallery")).toHaveLength(before);
+  });
 
   it("hides every organization affordance when no host advertises it", async () => {
     await openLibrary();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -727,7 +727,11 @@ const chainLimits = ref<ChainLimits | null>(null);
  * proxy and every `sequenceRoute.value !== route` check would fire against a
  * live watch, silently dropping its own events.
  */
-const sequenceRoute = shallowRef<{ hostId: string; target: ApiTarget } | null>(null);
+const sequenceRoute = shallowRef<{
+  hostId: string;
+  target: ApiTarget;
+  instanceId: string;
+} | null>(null);
 let sequenceWatch: SequenceWatchHandle | null = null;
 const expandCapabilities = reactive<Record<string, ExpandCapabilities | null | undefined>>({});
 const serverCapabilities = reactive<Record<string, ServerCapabilities | null | undefined>>({});
@@ -965,6 +969,13 @@ const gallery = ref<GalleryPrint[]>([]);
 const galleryByThumbnailKey = new Map<string, GalleryPrint>();
 const galleryLoading = ref(false);
 const galleryError = ref("");
+const galleryPullDistance = ref(0);
+const galleryPullRefreshing = ref(false);
+const GALLERY_PULL_THRESHOLD = 72;
+const GALLERY_PULL_MAX = 112;
+let galleryPullTouchId: number | null = null;
+let galleryPullStartX = 0;
+let galleryPullStartY = 0;
 const gallerySelectMode = ref(false);
 let nativeGalleryContextKey: string | null = null;
 const gallerySelection = ref<Set<string>>(new Set());
@@ -1154,6 +1165,8 @@ interface HostTelemetry {
    * `null` means a legacy status response; an absent telemetry row means the
    * host has not answered status yet and queue polling must wait. */
   queueCapacity: number | null;
+  /** Whether this host has paused dispatching its queued work. */
+  queuePaused: boolean | null;
   /** `gpu_info.backend` as this machine reported it; null on servers ≤ 0.16,
    *  where the routing ladder falls back to inferring it from the GPU name. */
   gpuBackend: string | null;
@@ -1184,6 +1197,7 @@ function captureHostTelemetry(hostId: string, status: ServerStatus): void {
     vramTotalMb: memory?.totalMb ?? null,
     queueDepth: status.queue_depth ?? null,
     queueCapacity: status.queue_capacity ?? null,
+    queuePaused: status.queue_paused ?? null,
     gpuBackend: status.gpu_info?.backend ?? null,
     gpuName: status.gpu_info?.name ?? null,
   };
@@ -2288,6 +2302,118 @@ const activityRows = computed<ActivityRow[]>(() =>
       : [];
   }),
 );
+
+const queueControlHostIds = ref(new Set<string>());
+
+function activityRowHostId(row: ActivityRow): string {
+  return row.print?.hostId ?? row.sequence?.hostId ?? selectedHostId.value;
+}
+
+function activityRowIsQueued(row: ActivityRow): boolean {
+  return row.print ? row.print.status === "queued" : row.sequence?.state === "queued";
+}
+
+function canPauseActivityRow(row: ActivityRow): boolean {
+  const hostId = activityRowHostId(row);
+  return (
+    activityRowIsQueued(row) &&
+    serverCapabilities[hostId]?.queue?.can_pause === true &&
+    activityRowQueueAuthority(row) !== null
+  );
+}
+
+function activityRowQueuePaused(row: ActivityRow): boolean {
+  return hostTelemetry[activityRowHostId(row)]?.queuePaused === true;
+}
+
+interface MobileQueueControlAuthority {
+  host: MobileHost;
+  target: ApiTarget;
+  expectedInstanceId: string;
+}
+
+function activityRowQueueAuthority(row: ActivityRow): MobileQueueControlAuthority | null {
+  const hostId = activityRowHostId(row);
+  const host = connectedHosts.value.find((candidate) => candidate.id === hostId);
+  if (!host) return null;
+  if (row.sequence && sequenceRoute.value?.hostId === hostId) {
+    const expectedInstanceId = sequenceRoute.value.instanceId;
+    if (!expectedInstanceId) return null;
+    return { host, target: sequenceRoute.value.target, expectedInstanceId };
+  }
+  if (row.print) {
+    const durable = durableRecoveryForJob(row.print);
+    if (durable) {
+      return {
+        host,
+        target: mobileHostTarget(host),
+        expectedInstanceId: durable.recovery.tracker.expectedInstanceId,
+      };
+    }
+  }
+  const snapshot = liveActivityHosts.value[hostId];
+  const expectedInstanceId = snapshot?.instanceId?.trim() ?? "";
+  if (!snapshot || !expectedInstanceId || snapshot.routeUrl !== host.baseUrl) return null;
+  return { host, target: mobileHostTarget(host), expectedInstanceId };
+}
+
+function fleetQueueAuthority(row: FleetActiveWork): MobileQueueControlAuthority | null {
+  const host = connectedHosts.value.find((candidate) => candidate.id === row.hostId);
+  if (!host || row.stale || !row.instanceId || row.routeUrl !== host.baseUrl) return null;
+  return { host, target: mobileHostTarget(host), expectedInstanceId: row.instanceId };
+}
+
+function canPauseFleetActivity(row: FleetActiveWork): boolean {
+  return (
+    row.phase === "queued" &&
+    serverCapabilities[row.hostId]?.queue?.can_pause === true &&
+    fleetQueueAuthority(row) !== null
+  );
+}
+
+async function setQueuePaused(
+  authority: MobileQueueControlAuthority,
+  paused: boolean,
+): Promise<void> {
+  const { host, target, expectedInstanceId } = authority;
+  const hostId = host.id;
+  if (queueControlHostIds.value.has(hostId)) return;
+  queueControlHostIds.value = new Set(queueControlHostIds.value).add(hostId);
+  try {
+    const status = await apiJsonTo<ServerStatus>(target, "/api/status");
+    if (status.instance_id !== expectedInstanceId) {
+      throw new Error(`${host.name} now reaches a different Mold server instance.`);
+    }
+    captureHostTelemetry(hostId, status);
+    await apiFetchTo(target, paused ? "/api/queue/pause" : "/api/queue/resume", {
+      method: "POST",
+    });
+    if (hostTelemetry[hostId]) hostTelemetry[hostId]!.queuePaused = paused;
+    setGenerationStatus(
+      paused
+        ? `Paused ${host.name}'s queue. Running work continues.`
+        : `Resumed ${host.name}'s queue.`,
+    );
+  } catch (caught) {
+    setGenerationStatus(describeTransportError(caught, host.name), true);
+  } finally {
+    const next = new Set(queueControlHostIds.value);
+    next.delete(hostId);
+    queueControlHostIds.value = next;
+  }
+}
+
+async function setActivityHostQueuePaused(row: ActivityRow, paused: boolean): Promise<void> {
+  const authority = activityRowQueueAuthority(row);
+  if (!authority || !canPauseActivityRow(row)) return;
+  await setQueuePaused(authority, paused);
+}
+
+async function setFleetHostQueuePaused(row: FleetActiveWork, paused: boolean): Promise<void> {
+  const authority = fleetQueueAuthority(row);
+  if (!authority || !canPauseFleetActivity(row)) return;
+  await setQueuePaused(authority, paused);
+}
 
 /**
  * Status code for one queue row, in this list's compact uppercase idiom. A
@@ -4126,9 +4252,14 @@ function watchSequenceJob(
   target: ApiTarget,
   jobId: string,
   seed?: { model: string; stageCount: number },
+  expectedInstanceId?: string | null,
 ): void {
   stopSequenceTransport();
-  const route = { hostId, target: { ...target } };
+  const instanceId =
+    expectedInstanceId?.trim() ||
+    connectedHosts.value.find((candidate) => candidate.id === hostId)?.instanceId?.trim() ||
+    "";
+  const route = { hostId, target: { ...target }, instanceId };
   sequenceRoute.value = route;
   sequenceProgress.value = null;
   sequenceJob.value = pendingSequenceJob(jobId, seed?.model ?? "", seed?.stageCount ?? 0);
@@ -4701,10 +4832,16 @@ async function submitMobileSequence(): Promise<void> {
       return;
     }
     persistSequenceRecovery(host, response.job_id);
-    watchSequenceJob(host.id, target, response.job_id, {
-      model: requestForm.model,
-      stageCount: clips.length,
-    });
+    watchSequenceJob(
+      host.id,
+      target,
+      response.job_id,
+      {
+        model: requestForm.model,
+        stageCount: clips.length,
+      },
+      frozenRoute.instanceId,
+    );
   } catch (error) {
     if (!isCurrent()) return;
     sequenceError.value = describeTransportError(error, host.name);
@@ -4763,10 +4900,16 @@ async function resumeMobileSequence(): Promise<void> {
     });
     const host = hosts.value.find((candidate) => candidate.id === route.hostId);
     if (host) persistSequenceRecovery(host, job.id);
-    watchSequenceJob(route.hostId, route.target, job.id, {
-      model: job.model,
-      stageCount: job.stage_count,
-    });
+    watchSequenceJob(
+      route.hostId,
+      route.target,
+      job.id,
+      {
+        model: job.model,
+        stageCount: job.stage_count,
+      },
+      route.instanceId,
+    );
   } catch (error) {
     sequenceError.value = describeTransportError(error, sequenceHostName(route.hostId));
   }
@@ -4814,7 +4957,7 @@ function recoverMobileSequence(): void {
     sequenceError.value = "The exact machine for this saved sequence is no longer available.";
     return;
   }
-  watchSequenceJob(host.id, mobileHostTarget(host), saved.jobId);
+  watchSequenceJob(host.id, mobileHostTarget(host), saved.jobId, undefined, saved.instanceId);
 }
 
 /**
@@ -9778,6 +9921,60 @@ function handleForegroundResume(): void {
   }
 }
 
+function beginLibraryPull(event: TouchEvent): void {
+  const scroller = mobileContent.value;
+  if (
+    tab.value !== "gallery" ||
+    galleryPullRefreshing.value ||
+    !scroller ||
+    scroller.scrollTop > 0 ||
+    event.touches.length !== 1
+  ) {
+    galleryPullTouchId = null;
+    return;
+  }
+  const touch = event.touches[0];
+  if (!touch) return;
+  galleryPullTouchId = touch.identifier;
+  galleryPullStartX = touch.clientX;
+  galleryPullStartY = touch.clientY;
+}
+
+function moveLibraryPull(event: TouchEvent): void {
+  if (galleryPullTouchId === null || event.touches.length !== 1) return;
+  const touch = [...event.touches].find((candidate) => candidate.identifier === galleryPullTouchId);
+  if (!touch) return;
+  const deltaX = touch.clientX - galleryPullStartX;
+  const deltaY = touch.clientY - galleryPullStartY;
+  if (deltaY <= 0 || Math.abs(deltaX) >= deltaY) {
+    galleryPullDistance.value = 0;
+    return;
+  }
+  // Resist the drag like a native refresh control while keeping the threshold
+  // reachable with one ordinary thumb pull.
+  galleryPullDistance.value = Math.min(GALLERY_PULL_MAX, deltaY * 0.62);
+  event.preventDefault();
+}
+
+function finishLibraryPull(): void {
+  if (galleryPullTouchId === null) return;
+  galleryPullTouchId = null;
+  const shouldRefresh = galleryPullDistance.value >= GALLERY_PULL_THRESHOLD;
+  galleryPullDistance.value = 0;
+  if (!shouldRefresh || galleryPullRefreshing.value) return;
+  galleryPullRefreshing.value = true;
+  galleryPullDistance.value = 48;
+  void refreshGallery().finally(() => {
+    galleryPullRefreshing.value = false;
+    galleryPullDistance.value = 0;
+  });
+}
+
+function cancelLibraryPull(): void {
+  galleryPullTouchId = null;
+  galleryPullDistance.value = 0;
+}
+
 function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement {
   if (!(target instanceof HTMLElement)) return false;
   if (target.matches("textarea, select, [contenteditable='true']")) return true;
@@ -10030,6 +10227,12 @@ type MobileActivityRow = (typeof activityRows.value)[number];
  */
 function mobileQueueRowActions(row: MobileActivityRow): SwipeRowAction[] {
   const actions: SwipeRowAction[] = [];
+  if (canPauseActivityRow(row)) {
+    actions.push({
+      id: activityRowQueuePaused(row) ? "queue-resume" : "queue-pause",
+      label: activityRowQueuePaused(row) ? "Resume" : "Pause",
+    });
+  }
   if (row.print) {
     if (durableHold(row.print)?.retryable && !durableHeldIsRetrying(row.print)) {
       actions.push({ id: "retry", label: "Retry" });
@@ -10053,6 +10256,10 @@ function mobileQueueRowActions(row: MobileActivityRow): SwipeRowAction[] {
 }
 
 function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
+  if (action === "queue-pause" || action === "queue-resume") {
+    void setActivityHostQueuePaused(row, action === "queue-pause");
+    return;
+  }
   if (row.print) {
     if (action === "retry") void retryHeldGeneration(row.print);
     if (action === "cancel") void cancelGeneration(row.print);
@@ -10152,6 +10359,10 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       ref="mobileContent"
       class="mobile-content"
       :class="{ 'is-library': !settingsOpen && tab === 'gallery' }"
+      @touchstart="beginLibraryPull"
+      @touchmove="moveLibraryPull"
+      @touchend="finishLibraryPull"
+      @touchcancel="cancelLibraryPull"
     >
       <MobileSettingsView
         v-if="settingsOpen"
@@ -10871,7 +11082,10 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
                 <SwipeActionRow
                   :actions="mobileQueueRowActions(row)"
                   :label="row.print ? row.print.prompt : modelLabel(row.sequence?.model ?? '')"
-                  :disabled="row.print?.cancelling === true"
+                  :disabled="
+                    row.print?.cancelling === true ||
+                    queueControlHostIds.has(activityRowHostId(row))
+                  "
                   :data-test="row.print ? 'mobile-generation-job' : 'mobile-sequence-job'"
                   @act="onMobileQueueRowAction(row, $event)"
                 >
@@ -10952,8 +11166,24 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
             <LiveActivityList
               :rows="sharedMobileActivity"
               interactive
+              swipe-actions
+              :can-swipe="canPauseFleetActivity"
               @select="openMobileLiveWork"
-            />
+            >
+              <template #actions="{ row }">
+                <button
+                  type="button"
+                  data-test="mobile-fleet-queue-control"
+                  :disabled="queueControlHostIds.has(row.hostId)"
+                  :aria-label="`${hostTelemetry[row.hostId]?.queuePaused ? 'Resume' : 'Pause'} ${row.hostLabel} queue`"
+                  @click.stop="
+                    setFleetHostQueuePaused(row, !(hostTelemetry[row.hostId]?.queuePaused === true))
+                  "
+                >
+                  {{ hostTelemetry[row.hostId]?.queuePaused ? "Resume" : "Pause" }}
+                </button>
+              </template>
+            </LiveActivityList>
           </section>
           <p
             v-if="sequenceError && sequenceRoute && !isSequence"
@@ -10967,6 +11197,18 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       </template>
 
       <template v-else-if="tab === 'gallery'">
+        <div
+          class="mobile-library-pull"
+          :class="{ 'is-refreshing': galleryPullRefreshing }"
+          :style="{ height: `${galleryPullDistance}px` }"
+          role="status"
+          aria-live="polite"
+          data-test="mobile-library-pull"
+        >
+          <span v-if="galleryPullRefreshing">Refreshing…</span>
+          <span v-else-if="galleryPullDistance >= GALLERY_PULL_THRESHOLD">Release to refresh</span>
+          <span v-else-if="galleryPullDistance > 0">Pull to refresh</span>
+        </div>
         <div class="mobile-library-heading">
           <div>
             <h1 class="section-title">Library</h1>

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -536,9 +536,9 @@ describe("MobileSequenceComposer guardrails", () => {
   it("attaches a local-or-gallery image only to the opening clip", async () => {
     const draft = useSequenceDraftStore();
     mountComposer();
-    expect(wrapper!.findAll("[data-test='mobile-sequence-source-pick']")).toHaveLength(1);
+    expect(wrapper!.findAll("[data-test='mobile-sequence-source-well']")).toHaveLength(1);
 
-    await wrapper!.get("[data-test='mobile-sequence-source-pick']").trigger("click");
+    await wrapper!.get("[data-test='mobile-sequence-source-well']").trigger("click");
     const picker = wrapper!.getComponent({ name: "MobileImagePickerSheet" });
     expect(picker.props("open")).toBe(true);
     picker.vm.$emit("pick", { filename: "opening.jpg", base64: "wire-bytes" });
@@ -645,7 +645,7 @@ describe("MobileSequenceComposer opening image placement", () => {
     expect(disclosure.element.closest(".mobile-advanced-sheet")).toBeNull();
     expect(
       wrapper!
-        .get("[data-test='mobile-sequence-source-pick']")
+        .get("[data-test='mobile-sequence-source-well']")
         .element.closest(".mobile-advanced-sheet"),
     ).toBeNull();
     expect(wrapper!.find("[data-test='mobile-sequence-advanced-opening']").exists()).toBe(false);
@@ -674,7 +674,7 @@ describe("MobileSequenceComposer opening image placement", () => {
   it("hides the opening image for a checkpoint that reads no source image", () => {
     mountComposer({ selectedModel: { ...ltx2, source_image: "unsupported" } });
     expect(wrapper!.find("[data-test='mobile-sequence-source-disclosure']").exists()).toBe(false);
-    expect(wrapper!.find("[data-test='mobile-sequence-source-pick']").exists()).toBe(false);
+    expect(wrapper!.find("[data-test='mobile-sequence-source-well']").exists()).toBe(false);
   });
 
   it("keeps the opening image for an older server that advertises no contract", () => {

--- a/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
@@ -52,7 +52,7 @@ describe("MobileSequenceOpeningImage", () => {
     mountOpeningImage();
     expect(wrapper!.find("[data-test='mobile-sequence-source-strength']").exists()).toBe(false);
 
-    await wrapper!.get("[data-test='mobile-sequence-source-pick']").trigger("click");
+    await wrapper!.get("[data-test='mobile-sequence-source-well']").trigger("click");
     const picker = wrapper!.getComponent({ name: "MobileImagePickerSheet" });
     expect(picker.props("open")).toBe(true);
     picker.vm.$emit("pick", { filename: "opening.jpg", base64: "wire-bytes" });
@@ -63,7 +63,7 @@ describe("MobileSequenceOpeningImage", () => {
       "data:image/jpeg;base64,wire-bytes",
     );
 
-    await wrapper!.get("[data-test='mobile-sequence-source-clear']").trigger("click");
+    await wrapper!.get("[data-test='mobile-sequence-source-remove']").trigger("click");
     expect(draft.openingImage).toBeNull();
   });
 
@@ -81,7 +81,7 @@ describe("MobileSequenceOpeningImage", () => {
       },
     ];
     mountOpeningImage({ gallerySources });
-    await wrapper!.get("[data-test='mobile-sequence-source-pick']").trigger("click");
+    await wrapper!.get("[data-test='mobile-sequence-source-well']").trigger("click");
     expect(
       wrapper!.getComponent({ name: "MobileImagePickerSheet" }).props("gallerySources"),
     ).toEqual(gallerySources);
@@ -110,8 +110,8 @@ describe("MobileSequenceOpeningImage", () => {
     await wrapper!.vm.$nextTick();
 
     for (const id of [
-      "mobile-sequence-source-pick",
-      "mobile-sequence-source-clear",
+      "mobile-sequence-source-replace",
+      "mobile-sequence-source-remove",
       "mobile-sequence-source-strength",
       "mobile-sequence-source-fit",
     ]) {
@@ -126,8 +126,9 @@ describe("MobileSequenceOpeningImage", () => {
     draft.openingImage = { filename: "opening.png", base64: "QUJD" };
     mountOpeningImage();
 
-    for (const id of ["mobile-sequence-source-pick", "mobile-sequence-source-clear"]) {
-      expect(wrapper!.get(`[data-test='${id}']`).classes(), id).toContain("secondary-button");
+    expect(wrapper!.get(".image-well").classes()).toContain("image-well--touch");
+    for (const id of ["mobile-sequence-source-replace", "mobile-sequence-source-remove"]) {
+      expect(wrapper!.get(`[data-test='${id}']`).classes(), id).toContain("image-well__action");
     }
     expect(wrapper!.get("[data-test='mobile-sequence-source-fit']").classes()).toContain("control");
     expect(

--- a/desktop/src/mobile/MobileSequenceOpeningImage.vue
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.vue
@@ -26,7 +26,7 @@ import {
 import type { ApiTarget } from "../lib/api/client";
 import type { ModelEntry } from "../lib/api/types";
 import type { GenerateForm } from "../lib/generateForm";
-import { base64ToDataUrl } from "../lib/image";
+import ImageDropWell from "@studio/components/ImageDropWell.vue";
 import MobileImagePickerSheet, {
   type MobileGallerySource,
   type MobilePickedImage,
@@ -76,41 +76,21 @@ function sourceImageMime(filename: string): string {
 
 <template>
   <div class="mobile-sequence-opening">
-    <figure v-if="draft.openingImage?.base64" class="mobile-source-preview-wrap">
-      <img
-        class="mobile-source-preview"
-        :src="
-          base64ToDataUrl(
-            draft.openingImage.base64 ?? '',
-            sourceImageMime(draft.openingImage.filename),
-          )
-        "
-        :alt="draft.openingImage.filename"
-        data-test="mobile-sequence-source-preview"
-      />
-      <figcaption>{{ draft.openingImage.filename }}</figcaption>
-    </figure>
-    <div class="mobile-media-actions">
-      <button
-        type="button"
-        class="secondary-button"
-        data-test="mobile-sequence-source-pick"
-        :disabled="locked || !target"
-        @click="imagePickerOpen = true"
-      >
-        {{ draft.openingImage ? "Replace opening image" : "Attach opening image" }}
-      </button>
-      <button
-        v-if="draft.openingImage"
-        type="button"
-        class="secondary-button"
-        data-test="mobile-sequence-source-clear"
-        :disabled="locked"
-        @click="draft.openingImage = null"
-      >
-        Remove
-      </button>
-    </div>
+    <ImageDropWell
+      :image="draft.openingImage?.base64 ?? null"
+      :mime-type="draft.openingImage ? sourceImageMime(draft.openingImage.filename) : null"
+      :filename="draft.openingImage?.filename ?? null"
+      placeholder="Attach opening image"
+      alt="Sequence opening image"
+      test-id="mobile-sequence-source"
+      touch-friendly
+      :touch-target-size="48"
+      native-picker
+      :disabled="locked"
+      :pick-disabled="!target"
+      @pick="imagePickerOpen = true"
+      @clear="draft.openingImage = null"
+    />
     <template v-if="draft.openingImage">
       <label class="mobile-range-field">
         <span>

--- a/desktop/src/mobile/MobileSourceControls.test.ts
+++ b/desktop/src/mobile/MobileSourceControls.test.ts
@@ -77,8 +77,8 @@ describe("MobileSourceControls", () => {
     const wrapper = mount(MobileSourceControls, { props: { form } });
 
     expect(wrapper.find("[data-test='mobile-source-controls']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='mobile-source-add']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='mobile-source-required']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='mobile-source-well']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='source-required-badge']").exists()).toBe(false);
     // An older server rejects wan keyframes outright, so an absent contract
     // must never surface the End frame well.
     expect(wrapper.find("[data-test='mobile-end-frame-controls']").exists()).toBe(false);
@@ -102,9 +102,11 @@ describe("MobileSourceControls", () => {
       global: { stubs: { MobileImagePickerSheet: true } },
     });
 
-    expect(wrapper.get("[data-test='mobile-source-required']").text()).toContain("Required");
-    expect(wrapper.get("[data-test='mobile-source-add']").attributes("aria-required")).toBe("true");
-    expect(wrapper.get("[data-test='mobile-source-conditioning-error']").text()).toContain(
+    expect(wrapper.get("[data-test='source-required-badge']").text()).toContain("Required");
+    expect(wrapper.get("[data-test='mobile-source-well']").attributes("aria-required")).toBe(
+      "true",
+    );
+    expect(wrapper.get("[data-test='source-conditioning-error']").text()).toContain(
       "image-to-video only",
     );
     expect(wrapper.emitted("validity-change")?.at(-1)).toEqual([false]);
@@ -142,7 +144,7 @@ describe("MobileSourceControls", () => {
     // opt-out of the contract.
     form.extendVideo = null;
     await flushPromises();
-    expect(wrapper.get("[data-test='mobile-source-conditioning-error']").text()).toContain(
+    expect(wrapper.get("[data-test='source-conditioning-error']").text()).toContain(
       "image-to-video only",
     );
     expect(wrapper.emitted("validity-change")?.at(-1)).toEqual([false]);
@@ -154,11 +156,11 @@ describe("MobileSourceControls", () => {
     const target = { baseUrl: "http://halcyon:7680", apiKey: "remote-key" };
     const wrapper = mount(MobileSourceControls, { props: { form, target } });
 
-    expect(wrapper.find("[data-test='mobile-source-required']").exists()).toBe(false);
-    const endWell = wrapper.get("[data-test='mobile-end-frame-controls']");
+    expect(wrapper.find("[data-test='source-required-badge']").exists()).toBe(false);
+    const endWell = wrapper.get("[data-test='source-media-wells']");
     expect(endWell.text()).toContain("Optional");
 
-    await wrapper.get("[data-test='mobile-end-frame-add']").trigger("click");
+    await wrapper.get("[data-test='mobile-end-frame-gallery']").trigger("click");
     const endPicker = wrapper
       .findAllComponents(MobileImagePickerSheet)
       .find((sheet) => sheet.props("title") === "End frame");
@@ -179,14 +181,14 @@ describe("MobileSourceControls", () => {
 
     // A closing still with nothing to open the clip is refused, not silently
     // dropped or shipped as a lone keyframe.
-    expect(wrapper.get("[data-test='mobile-source-conditioning-error']").text()).toContain(
+    expect(wrapper.get("[data-test='source-conditioning-error']").text()).toContain(
       "needs a first frame",
     );
     expect(wrapper.emitted("validity-change")?.at(-1)).toEqual([false]);
 
     form.sourceImage = "T1BFTklORw==";
     await flushPromises();
-    expect(wrapper.find("[data-test='mobile-source-conditioning-error']").exists()).toBe(false);
+    expect(wrapper.find("[data-test='source-conditioning-error']").exists()).toBe(false);
     expect(wrapper.emitted("validity-change")?.at(-1)).toEqual([true]);
 
     await wrapper.get("[data-test='mobile-end-frame-remove']").trigger("click");
@@ -241,7 +243,7 @@ describe("MobileSourceControls", () => {
     ]);
     expect(wrapper.get("[data-test='mobile-source-error']").text()).toContain("Only PNG or JPEG");
 
-    await wrapper.get("[data-test='mobile-source-add']").trigger("click");
+    await wrapper.get("[data-test='mobile-source-gallery']").trigger("click");
     const picker = wrapper.getComponent(MobileImagePickerSheet);
     expect(picker.props()).toMatchObject({
       open: true,

--- a/desktop/src/mobile/MobileSourceControls.vue
+++ b/desktop/src/mobile/MobileSourceControls.vue
@@ -393,6 +393,41 @@ function clearEditTarget(): void {
   props.form.imageAttachments = props.form.imageAttachments.slice(1);
 }
 
+async function onSingleSourceFile(slot: SourceMediaSlot, file: File): Promise<void> {
+  if (!isAcceptedImage(file)) {
+    error.value = "Only PNG or JPEG photos can be used here.";
+    return;
+  }
+  const maxBytes = slot === "source" ? sourcePickerMaxBytes.value : endFramePickerMaxBytes.value;
+  if (file.size > maxBytes) {
+    error.value = MOBILE_MEDIA_BUDGET_ERROR;
+    return;
+  }
+  try {
+    const base64 = await fileToBase64(file);
+    error.value = "";
+    if (slot === "source") {
+      props.form.sourceImage = base64;
+      props.form.sourceImageName = file.name;
+      props.form.sourceFit = { mode: "lanczos-resize" };
+    } else {
+      props.form.endFrame = { filename: file.name, base64 };
+    }
+  } catch {
+    error.value = "Couldn’t read that photo. Try choosing it again.";
+  }
+}
+
+function openSingleSourcePicker(slot: SourceMediaSlot): void {
+  if (slot === "source") sourcePickerOpen.value = true;
+  else endFramePickerOpen.value = true;
+}
+
+function clearSingleSource(slot: SourceMediaSlot): void {
+  if (slot === "source") removeSource();
+  else removeEndFrame();
+}
+
 /** The closing still of a wan first/last-frame render (#779). It keeps its own
  * name because that name — with the digest — is all saved metadata will ever
  * hold of it. */
@@ -703,51 +738,22 @@ function applyMask(mask: string): void {
     </fieldset>
 
     <fieldset v-else class="mobile-source-controls" data-test="mobile-source-controls">
-      <legend class="mobile-source-legend">
-        Source<span v-if="caps.requiresSourceImage" data-test="mobile-source-required">
-          · Required</span
-        >
-      </legend>
-
-      <button
-        v-if="!form.sourceImage"
-        type="button"
-        class="secondary-button mobile-source-pick"
-        :aria-required="caps.requiresSourceImage ? 'true' : undefined"
-        data-test="mobile-source-add"
-        @click="sourcePickerOpen = true"
-      >
-        Choose source image
-      </button>
-      <template v-else>
-        <figure class="mobile-source-preview-wrap">
-          <img
-            class="mobile-source-preview"
-            data-test="mobile-source-preview"
-            :src="base64ToDataUrl(form.sourceImage)"
-            :alt="form.sourceImageName || 'Source photo'"
-          />
-          <figcaption v-if="form.sourceImageName">{{ form.sourceImageName }}</figcaption>
-        </figure>
-        <div class="mobile-media-actions">
-          <button
-            type="button"
-            class="secondary-button"
-            data-test="mobile-source-replace"
-            @click="sourcePickerOpen = true"
-          >
-            Replace photo
-          </button>
-          <button
-            type="button"
-            class="secondary-button"
-            data-test="mobile-source-remove"
-            @click="removeSource"
-          >
-            Remove
-          </button>
-        </div>
-
+      <SourceMediaWells
+        :plan="plan"
+        touch-friendly
+        test-id-prefix="mobile-"
+        :source="
+          form.sourceImage ? { data: form.sourceImage, filename: form.sourceImageName } : null
+        "
+        :end-frame="
+          form.endFrame ? { data: form.endFrame.base64, filename: form.endFrame.filename } : null
+        "
+        :error="conditioningError"
+        @file="onSingleSourceFile"
+        @gallery="openSingleSourcePicker"
+        @clear="clearSingleSource"
+      />
+      <template v-if="form.sourceImage">
         <!-- Wan pins the first frame exactly and never reads strength. -->
         <label v-if="caps.supportsStrength" class="mobile-range-field">
           <span
@@ -788,70 +794,6 @@ function applyMask(mask: string): void {
           }}
         </p>
       </template>
-
-      <!-- One message at a time, in the order admission checks them. The same
-           text is repeated beside Develop so a disabled button is never a dead
-           end while this sheet is closed. -->
-      <p
-        v-if="conditioningError"
-        class="mobile-source-error"
-        role="alert"
-        data-test="mobile-source-conditioning-error"
-      >
-        {{ conditioningError }}
-      </p>
-
-      <!-- End frame (wan first/last-frame conditioning). Offered only when the
-           server advertised a source-image contract for this checkpoint — an
-           older server rejects wan keyframes outright. -->
-      <fieldset
-        v-if="caps.supportsEndFrame"
-        class="mobile-source-subsection"
-        data-test="mobile-end-frame-controls"
-      >
-        <legend>End frame</legend>
-        <p class="mobile-source-note">
-          Optional. The source opens the clip and this photo closes it.
-        </p>
-        <button
-          v-if="!form.endFrame"
-          type="button"
-          class="secondary-button mobile-source-pick"
-          data-test="mobile-end-frame-add"
-          @click="endFramePickerOpen = true"
-        >
-          Choose end frame
-        </button>
-        <template v-else>
-          <figure class="mobile-source-preview-wrap">
-            <img
-              class="mobile-source-preview"
-              data-test="mobile-end-frame-preview"
-              :src="base64ToDataUrl(form.endFrame.base64)"
-              :alt="form.endFrame.filename || 'End frame photo'"
-            />
-            <figcaption v-if="form.endFrame.filename">{{ form.endFrame.filename }}</figcaption>
-          </figure>
-          <div class="mobile-media-actions">
-            <button
-              type="button"
-              class="secondary-button"
-              data-test="mobile-end-frame-replace"
-              @click="endFramePickerOpen = true"
-            >
-              Replace photo
-            </button>
-            <button
-              type="button"
-              class="secondary-button"
-              data-test="mobile-end-frame-remove"
-              @click="removeEndFrame"
-            >
-              Remove
-            </button>
-          </div>
-        </template>
-      </fieldset>
 
       <fieldset v-if="caps.supportsMask && form.sourceImage" class="mobile-source-subsection">
         <legend>Mask</legend>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -303,13 +303,31 @@ html.mobile-surface:has(.mobile-shell.is-pair-scanning) #app,
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
-  touch-action: manipulation;
+  /* This element owns vertical scrolling. Android WebView needs the pan axis
+     stated explicitly when descendants also listen for pointer gestures. */
+  touch-action: pan-y;
   padding: 16px max(16px, env(safe-area-inset-right)) 16px max(16px, env(safe-area-inset-left));
 }
 
 .mobile-content.is-library {
   display: flex;
   flex-direction: column;
+}
+
+.mobile-library-pull {
+  display: grid;
+  flex: none;
+  place-items: center;
+  min-height: 0;
+  overflow: hidden;
+  color: var(--halide);
+  font-family: var(--font-utility);
+  font-size: var(--text-data);
+  transition: height 140ms ease-out;
+}
+
+.mobile-library-pull:not(.is-refreshing) {
+  transition: none;
 }
 
 /*
@@ -2684,6 +2702,7 @@ button:disabled {
 
 .gallery-grid-window {
   position: relative;
+  z-index: 0;
   width: 100%;
 }
 
@@ -2748,7 +2767,9 @@ button:disabled {
       transparent 38%
     );
   border-radius: 9px;
-  touch-action: manipulation;
+  /* Every pixel of a tile must remain a native vertical-scroll handle. The
+     scoped pinch surface claims two fingers only after both have landed. */
+  touch-action: pan-y;
   -webkit-touch-callout: default;
 }
 
@@ -4797,12 +4818,16 @@ button:disabled {
 
 /* Horizontally scrolling filter chips (♥ Favorites, tags, hosts). */
 .mobile-library-chips {
+  position: relative;
+  z-index: 2;
   display: flex;
   margin-top: 10px;
   gap: 7px;
   overflow-x: auto;
   overscroll-behavior-x: contain;
-  touch-action: manipulation;
+  /* Preserve horizontal chip browsing without sacrificing a vertical Library
+     swipe that begins over a tag. */
+  touch-action: pan-x pan-y;
   scrollbar-width: none;
   padding-bottom: 2px;
 }

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -26,7 +26,7 @@ describe("mobile viewport scaling", () => {
     const root = css.match(/html,\s*body,\s*#app\s*\{([^}]*)\}/s);
     const content = css.match(/\.mobile-content\s*\{([^}]*)\}/s);
     expect(root?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
-    expect(content?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
+    expect(content?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
   });
 });
 
@@ -62,8 +62,10 @@ describe("mobile Library thumbnail sizing", () => {
 
   it("reserves the two-finger pinch while one-finger scrolling still works", () => {
     const base = css.match(/\.mobile-gallery-pinch-surface\s*\{([^}]*)\}/s);
+    const tile = css.match(/\.gallery-item\s*\{([^}]*)\}/s);
 
     expect(base?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
+    expect(tile?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
     expect(base?.[1]).toMatch(/flex:\s*1 0 auto\s*;/);
     expect(base?.[1]).toMatch(/min-height:\s*42vh\s*;/);
   });
@@ -103,6 +105,14 @@ describe("mobile scrolling", () => {
     expect(content?.[1]).toMatch(/overflow-y:\s*auto\s*;/);
     expect(content?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
     expect(content?.[1]).not.toMatch(/-webkit-overflow-scrolling/);
+  });
+
+  it("keeps the pull-to-refresh control in normal flow above the Library", () => {
+    const pull = css.match(/\.mobile-library-pull\s*\{([^}]*)\}/s);
+
+    expect(pull?.[1]).toMatch(/display:\s*grid\s*;/);
+    expect(pull?.[1]).toMatch(/flex:\s*none\s*;/);
+    expect(pull?.[1]).toMatch(/overflow:\s*hidden\s*;/);
   });
 
   it("turns wide mobile surfaces into a full-width responsive workspace", () => {
@@ -563,8 +573,17 @@ describe("mobile Library organization", () => {
     const scope = css.match(/\.mobile-library-scope\s*\{([^}]*)\}/s);
     const chips = css.match(/\.mobile-library-chips\s*\{([^}]*)\}/s);
     expect(scope?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
-    expect(chips?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
+    expect(chips?.[1]).toMatch(/touch-action:\s*pan-x pan-y\s*;/);
     expect(chips?.[1]).toMatch(/overflow-x:\s*auto\s*;/);
+  });
+
+  it("keeps tag controls painted above the virtualized print layer", () => {
+    const chips = css.match(/\.mobile-library-chips\s*\{([^}]*)\}/s);
+    const window = css.match(/\.gallery-grid-window\s*\{([^}]*)\}/s);
+
+    expect(chips?.[1]).toMatch(/position:\s*relative\s*;/);
+    expect(chips?.[1]).toMatch(/z-index:\s*2\s*;/);
+    expect(window?.[1]).toMatch(/z-index:\s*0\s*;/);
   });
 
   it("keeps Select-mode scrolling native and selection labels inside their buttons", () => {

--- a/studio/components/ImageDropWell.test.ts
+++ b/studio/components/ImageDropWell.test.ts
@@ -46,19 +46,24 @@ describe("ImageDropWell", () => {
     expect(wrapper.emitted("file")).toEqual([[file]]);
   });
 
-  it("renders a preview with a working remove control once attached", async () => {
+  it("renders one shared preview with replace, filename, and remove actions", async () => {
     const wrapper = mount(ImageDropWell, {
       props: {
         testId: "t",
         image: "QUJD",
         mimeType: "image/jpeg",
+        filename: "first-frame.jpg",
         alt: "First frame",
+        gallery: true,
       },
     });
     expect(wrapper.find("[data-test='t-well']").exists()).toBe(false);
     expect(wrapper.get("img").attributes("src")).toBe(
       "data:image/jpeg;base64,QUJD",
     );
+    expect(wrapper.get("figcaption").text()).toBe("first-frame.jpg");
+    await wrapper.get("[data-test='t-replace']").trigger("click");
+    expect(wrapper.emitted("gallery")).toHaveLength(1);
     await wrapper.get("[data-test='t-remove']").trigger("click");
     expect(wrapper.emitted("clear")).toHaveLength(1);
   });
@@ -119,5 +124,6 @@ describe("ImageDropWell", () => {
     expect(
       wrapper.get("[data-test='t-remove']").attributes("aria-label"),
     ).toContain("Remove");
+    expect(wrapper.get("[data-test='t-replace']").text()).toBe("Replace photo");
   });
 });

--- a/studio/components/ImageDropWell.vue
+++ b/studio/components/ImageDropWell.vue
@@ -78,6 +78,12 @@ function pick(): void {
   if (props.nativePicker) emit("pick");
   else input.value?.click();
 }
+function replace(): void {
+  if (inert.value) return;
+  if (props.nativePicker) emit("pick");
+  else if (props.gallery) emit("gallery");
+  else input.value?.click();
+}
 function onChange(event: Event): void {
   const el = event.target as HTMLInputElement;
   const file = el.files?.[0];
@@ -115,19 +121,10 @@ function onDrop(event: DragEvent): void {
       @change="onChange"
     />
 
-    <div v-if="previewUrl" class="image-well__preview">
-      <img :src="previewUrl" :alt="alt" />
-      <button
-        type="button"
-        class="image-well__clear"
-        :disabled="disabled"
-        :aria-label="`Remove ${alt.toLowerCase()}`"
-        :data-test="`${testId}-remove`"
-        @click="emit('clear')"
-      >
-        ✕
-      </button>
-    </div>
+    <figure v-if="previewUrl" class="image-well__preview">
+      <img :src="previewUrl" :alt="alt" :data-test="`${testId}-preview`" />
+      <figcaption v-if="filename">{{ filename }}</figcaption>
+    </figure>
 
     <div
       v-else
@@ -156,11 +153,30 @@ function onDrop(event: DragEvent): void {
       <template v-else>{{ placeholder }}</template>
     </div>
 
-    <div v-if="gallery || needsReattach" class="image-well__actions">
+    <div
+      v-if="previewUrl || gallery || needsReattach"
+      class="image-well__actions"
+    >
+      <span
+        v-if="previewUrl"
+        class="image-well__action-alias"
+        :data-test="gallery ? `${testId}-gallery` : undefined"
+        @click="replace"
+      >
+        <button
+          type="button"
+          class="image-well__action"
+          :disabled="inert"
+          :data-test="`${testId}-replace`"
+          @click.stop="replace"
+        >
+          Replace photo
+        </button>
+      </span>
       <button
-        v-if="gallery"
+        v-else-if="gallery"
         type="button"
-        class="image-well__gallery"
+        class="image-well__action image-well__action--quiet"
         :disabled="inert"
         :data-test="`${testId}-gallery`"
         @click="emit('gallery')"
@@ -168,9 +184,9 @@ function onDrop(event: DragEvent): void {
         {{ galleryLabel }}
       </button>
       <button
-        v-if="needsReattach"
+        v-if="previewUrl || needsReattach"
         type="button"
-        class="image-well__gallery"
+        class="image-well__action"
         :disabled="disabled"
         :aria-label="`Remove ${alt.toLowerCase()}`"
         :data-test="`${testId}-remove`"
@@ -190,6 +206,9 @@ function onDrop(event: DragEvent): void {
 }
 .image-well__input {
   display: none;
+}
+.image-well__action-alias {
+  display: contents;
 }
 .image-well__zone {
   display: grid;
@@ -228,8 +247,9 @@ function onDrop(event: DragEvent): void {
   color: var(--ink, currentColor);
 }
 .image-well__preview {
-  position: relative;
-  display: inline-block;
+  display: grid;
+  gap: 5px;
+  margin: 0;
   max-width: 100%;
   justify-self: start;
 }
@@ -240,52 +260,61 @@ function onDrop(event: DragEvent): void {
   border: 1px solid var(--edge, #bbb);
   border-radius: 10px;
 }
-.image-well__clear {
-  position: absolute;
-  top: 4px;
-  right: 4px;
-  display: grid;
-  place-items: center;
-  width: 22px;
-  height: 22px;
-  border: 1px solid var(--edge, #bbb);
-  border-radius: 6px;
-  background: var(--bench, rgba(255, 255, 255, 0.85));
-  color: var(--ink-2, inherit);
-  font-size: 11px;
-  cursor: pointer;
-}
-.image-well__clear:hover {
-  color: var(--stop, #b42318);
+.image-well__preview figcaption {
+  overflow: hidden;
+  color: var(--ink-3, #737373);
+  font-size: 12px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 .image-well__actions {
   display: flex;
-  gap: 12px;
+  gap: 10px;
 }
-.image-well__gallery {
+.image-well__action {
+  min-height: 30px;
+  padding: 5px 10px;
+  border: 1px solid var(--edge, #bbb);
+  border-radius: 8px;
+  background: var(--bench, transparent);
+  color: var(--ink-3, #737373);
+  font-size: 12px;
+  cursor: pointer;
+}
+.image-well__action--quiet {
   padding: 0;
   border: 0;
   background: none;
-  color: var(--ink-3, #737373);
-  font-size: 12px;
   text-decoration: underline;
   text-underline-offset: 2px;
-  cursor: pointer;
 }
-.image-well__gallery:hover {
+.image-well__action:hover {
   color: var(--ink, currentColor);
 }
-.image-well__gallery:disabled,
-.image-well__clear:disabled {
+.image-well__action:disabled {
   opacity: 0.5;
   cursor: default;
 }
-.image-well--touch .image-well__gallery {
-  min-height: var(--image-well-touch-target, 44px);
+.image-well--touch .image-well__preview {
+  width: 100%;
+  justify-self: stretch;
 }
-.image-well--touch .image-well__clear {
-  width: var(--image-well-touch-target, 44px);
-  height: var(--image-well-touch-target, 44px);
+.image-well--touch .image-well__preview img {
+  width: 100%;
+  max-height: min(55vh, 440px);
+  object-fit: contain;
+  background: var(--color-print-surface, #111);
+}
+.image-well--touch .image-well__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+.image-well--touch .image-well__action {
+  min-height: var(--image-well-touch-target, 44px);
+  color: var(--ink, currentColor);
+  font-family: var(--font-utility, inherit);
   font-size: 14px;
+  font-weight: 700;
+  text-decoration: none;
 }
 </style>

--- a/studio/components/SourceMediaWells.test.ts
+++ b/studio/components/SourceMediaWells.test.ts
@@ -77,11 +77,29 @@ describe("SourceMediaWells", () => {
     );
     await wrapper.get("[data-test='source-remove']").trigger("click");
     expect(wrapper.emitted("clear")).toEqual([["source"]]);
+    await wrapper.get("[data-test='source-replace']").trigger("click");
+    expect(wrapper.emitted("gallery")).toEqual([["source"]]);
     const file = new File(["png"], "closing.png", { type: "image/png" });
     await wrapper
       .get("[data-test='end-frame-well']")
       .trigger("drop", { dataTransfer: { files: [file] } });
     expect(wrapper.emitted("file")).toEqual([["end", file]]);
+  });
+
+  it("prefixes surface hooks without duplicating the well implementation", () => {
+    const wrapper = factory(
+      { kind: "single", required: false, endFrame: false, video: false },
+      { source: { data: "QUJD" }, testIdPrefix: "mobile-" },
+    );
+    expect(wrapper.find("[data-test='mobile-source-preview']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-test='mobile-source-replace']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.find("[data-test='mobile-source-remove']").exists()).toBe(
+      true,
+    );
   });
 
   it("renders H3 boundaries with frame wording and hides the empty last frame when only first is reviewed", () => {
@@ -107,8 +125,8 @@ describe("SourceMediaWells", () => {
     );
     expect(wrapper.text()).toContain("Incompatible");
     expect(wrapper.text()).toContain("first frame only");
-    const gallery = wrapper.get("[data-test='end-frame-gallery']");
-    expect(gallery.attributes("disabled")).toBeDefined();
+    const replace = wrapper.get("[data-test='end-frame-replace']");
+    expect(replace.attributes("disabled")).toBeDefined();
     await wrapper.get("[data-test='end-frame-remove']").trigger("click");
     expect(wrapper.emitted("clear")).toEqual([["end"]]);
   });

--- a/studio/components/SourceMediaWells.vue
+++ b/studio/components/SourceMediaWells.vue
@@ -31,6 +31,8 @@ const props = withDefaults(
     error?: string | null;
     /** The engine takes only PNG/JPEG as source/keyframe conditioning. */
     accept?: string;
+    /** Prefix for surface-specific test hooks while keeping one component. */
+    testIdPrefix?: string;
   }>(),
   {
     source: null,
@@ -39,6 +41,7 @@ const props = withDefaults(
     touchFriendly: false,
     error: null,
     accept: "image/png,image/jpeg",
+    testIdPrefix: "",
   },
 );
 
@@ -81,6 +84,11 @@ const sourcePlaceholder = computed(() =>
       ? "Drop the opening frame or click to pick"
       : "Drop an image or click to pick",
 );
+const sourceAlt = computed(
+  () =>
+    props.source?.filename ||
+    (h3.value ? "First frame" : target.value ? "Edit target" : "Source image"),
+);
 /** H3's reviewed first-frame-only runtime refuses a closing frame; a restored
  * one stays visible so it can be removed, but never re-acquired. */
 const endIncompatible = computed(
@@ -93,6 +101,7 @@ const showEndWell = computed(() => {
   return false;
 });
 const endLabel = computed(() => (h3.value ? "Last frame" : "End frame"));
+const endAlt = computed(() => props.endFrame?.filename || endLabel.value);
 const endHint = computed(() =>
   endIncompatible.value
     ? "This runtime accepts a first frame only — remove the closing frame."
@@ -127,8 +136,8 @@ const endHint = computed(() =>
       :required="required"
       gallery
       :touch-friendly="touchFriendly"
-      :alt="h3 ? 'First frame' : target ? 'Edit target' : 'Source image'"
-      test-id="source"
+      :alt="sourceAlt"
+      :test-id="`${testIdPrefix}source`"
       @file="emit('file', 'source', $event)"
       @gallery="emit('gallery', 'source')"
       @clear="emit('clear', 'source')"
@@ -161,8 +170,8 @@ const endHint = computed(() =>
         :pick-disabled="endIncompatible"
         gallery
         :touch-friendly="touchFriendly"
-        :alt="h3 ? 'Last frame' : 'End frame'"
-        test-id="end-frame"
+        :alt="endAlt"
+        :test-id="`${testIdPrefix}end-frame`"
         @file="emit('file', 'end', $event)"
         @gallery="emit('gallery', 'end')"
         @clear="emit('clear', 'end')"

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -1,15 +1,22 @@
 <script setup lang="ts">
+import { ref } from "vue";
 import type { FleetActiveWork } from "@studio/api/activity";
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     rows: FleetActiveWork[];
     compact?: boolean;
     interactive?: boolean;
+    swipeActions?: boolean;
+    actionWidth?: number;
+    canSwipe?: (row: FleetActiveWork) => boolean;
   }>(),
   {
     compact: false,
     interactive: false,
+    swipeActions: false,
+    actionWidth: 72,
+    canSwipe: () => true,
   },
 );
 
@@ -17,6 +24,56 @@ const emit = defineEmits<{
   select: [row: FleetActiveWork];
   contextmenu: [row: FleetActiveWork, event: MouseEvent];
 }>();
+
+const openActionKey = ref<string | null>(null);
+let swipe: { key: string; x: number; y: number; horizontal: boolean } | null =
+  null;
+
+function beginSwipe(row: FleetActiveWork, event: TouchEvent): void {
+  if (!props.swipeActions || !props.canSwipe(row) || event.touches.length !== 1)
+    return;
+  const touch = event.touches[0];
+  if (touch)
+    swipe = {
+      key: row.key,
+      x: touch.clientX,
+      y: touch.clientY,
+      horizontal: false,
+    };
+}
+
+function moveSwipe(event: TouchEvent): void {
+  const touch = event.touches[0];
+  if (!swipe || !touch) return;
+  const dx = touch.clientX - swipe.x;
+  const dy = touch.clientY - swipe.y;
+  if (!swipe.horizontal && Math.abs(dx) > 10 && Math.abs(dx) > Math.abs(dy)) {
+    swipe.horizontal = true;
+  }
+  if (swipe.horizontal) event.preventDefault();
+}
+
+function finishSwipe(event: TouchEvent): void {
+  const gesture = swipe;
+  swipe = null;
+  const touch = event.changedTouches[0];
+  if (!gesture || !gesture.horizontal || !touch) return;
+  const dx = touch.clientX - gesture.x;
+  if (dx <= -36) openActionKey.value = gesture.key;
+  else if (dx >= 36) openActionKey.value = null;
+}
+
+function cancelSwipe(): void {
+  swipe = null;
+}
+
+function select(row: FleetActiveWork): void {
+  if (openActionKey.value === row.key) {
+    openActionKey.value = null;
+    return;
+  }
+  if (props.interactive) emit("select", row);
+}
 
 function title(row: FleetActiveWork): string {
   if (row.kind === "download")
@@ -47,14 +104,27 @@ function progress(row: FleetActiveWork): number | null {
       v-for="row in rows"
       :key="row.key"
       class="live-activity-row"
+      :class="{
+        'live-activity-row--has-actions': swipeActions && canSwipe(row),
+        'live-activity-row--actions-open': openActionKey === row.key,
+      }"
+      :style="
+        swipeActions && canSwipe(row)
+          ? { '--live-activity-action-width': `${actionWidth}px` }
+          : undefined
+      "
       :data-stale="row.stale"
+      @touchstart="beginSwipe(row, $event)"
+      @touchmove="moveSwipe"
+      @touchend="finishSwipe"
+      @touchcancel="cancelSwipe"
     >
       <component
         :is="interactive ? 'button' : 'div'"
         :type="interactive ? 'button' : undefined"
         class="live-activity-surface"
         :data-test="interactive ? `live-activity-select-${row.key}` : undefined"
-        @click="interactive && emit('select', row)"
+        @click="select(row)"
         @contextmenu="interactive && emit('contextmenu', row, $event)"
       >
         <span
@@ -76,6 +146,13 @@ function progress(row: FleetActiveWork): number | null {
           </span>
         </span>
       </component>
+      <div
+        v-if="swipeActions && canSwipe(row)"
+        class="live-activity-actions"
+        @click.stop
+      >
+        <slot name="actions" :row="row" />
+      </div>
     </li>
   </ol>
 </template>
@@ -89,9 +166,16 @@ function progress(row: FleetActiveWork): number | null {
   list-style: none;
 }
 .live-activity-row {
+  position: relative;
   min-width: 0;
 }
+.live-activity-row--has-actions {
+  overflow: hidden;
+  touch-action: pan-y;
+}
 .live-activity-surface {
+  position: relative;
+  z-index: 1;
   display: flex;
   width: 100%;
   align-items: center;
@@ -102,6 +186,28 @@ function progress(row: FleetActiveWork): number | null {
   border: 1px solid var(--edge);
   border-radius: 9px;
   background: var(--surface);
+  color: inherit;
+  font: inherit;
+  transition: transform 180ms ease;
+}
+.live-activity-row--actions-open .live-activity-surface {
+  transform: translateX(calc(var(--live-activity-action-width) * -1));
+}
+.live-activity-actions {
+  position: absolute;
+  z-index: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: var(--live-activity-action-width);
+}
+.live-activity-actions :deep(button) {
+  width: 100%;
+  height: 100%;
+  min-height: 44px;
+  border: 1px solid var(--edge);
+  border-radius: 9px;
+  background: color-mix(in srgb, var(--safelight) 18%, var(--surface));
   color: inherit;
   font: inherit;
 }


### PR DESCRIPTION
## Summary
- use the shared populated source-image well everywhere on mobile, including H3, Qwen, one-shot/end-frame, and sequence opening images, with Replace photo and Remove actions
- restore natural full-width Library scrolling and pull-to-refresh while keeping tag controls above thumbnails on iOS, Android, and responsive web
- add swipe Pause/Resume alongside Cancel for queued work, with exact-host instance verification for local and reconciled rows

## Verification
- desktop full suite: 400 files, 5,124 tests passed
- web full suite: 106 files, 1,740 tests passed
- final focused suite: 6 files, 398 tests passed
- independent peer review: no blockers; 7 files, 447 tests passed
- mobile production build passed
- iOS simulator build passed
- Android universal debug APK build passed
- Android UAT: Library scrolls from quarter-screen touch input and pull-down shows Release to refresh
- responsive web Library rendered and organization/layout tests passed
