### PR TITLE
fix(mobile): persist library tag filters

### DIFF
--- a/changelog.d/mobile-library-tag-persistence.md
+++ b/changelog.d/mobile-library-tag-persistence.md
@@ -1,0 +1,3 @@
+- **Mobile Library tags stay visible with saved prints.** iPhone and Android now retain each
+  machine's tag filters while its cached Library is shown offline, without carrying tags across
+  server replacements.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -8228,6 +8228,117 @@ describe("MobileApp gallery", () => {
     expect(wrapper.text()).toContain("Showing saved Library");
   });
 
+  it("keeps saved Library tag filters visible when its host is offline", async () => {
+    Object.defineProperty(globalThis, "indexedDB", {
+      configurable: true,
+      value: new IDBFactory(),
+    });
+    localStorage.setItem(
+      "mold.mobile.hosts.v1",
+      JSON.stringify([
+        {
+          id: "url-derived-id",
+          instanceId: "studio-instance",
+          name: "Studio",
+          baseUrl: target.baseUrl,
+          online: false,
+        },
+      ]),
+    );
+    localStorage.setItem(
+      "mold.mobile.gallery-capabilities.v1",
+      JSON.stringify({
+        "url-derived-id": {
+          instanceId: "studio-instance",
+          gallery: { organize: true, trash: { enabled: true, retention_days: 30 } },
+        },
+      }),
+    );
+    localStorage.setItem(
+      "mold.mobile.gallery-tags.v1",
+      JSON.stringify({
+        "url-derived-id": {
+          instanceId: "studio-instance",
+          tags: [
+            { name: "Barbie", count: 6 },
+            { name: "moon", count: 6 },
+          ],
+        },
+      }),
+    );
+    // Older saved rows may not carry organization fields. Their known tag
+    // inventory must still survive the loading -> saved-Library transition.
+    await storeCachedGallery("studio-instance", [print]);
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+    apiFetchTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.text()).toContain("Showing saved Library"));
+
+    expect(wrapper.find("[data-test='mobile-library-chip-favorites']").exists()).toBe(true);
+    expect(
+      wrapper.findAll("[data-test='mobile-library-chip-tag']").map((chip) => chip.text()),
+    ).toEqual(["Barbie6", "moon6"]);
+  });
+
+  it("does not restore saved tags across a host instance boundary", async () => {
+    localStorage.setItem(
+      "mold.mobile.gallery-capabilities.v1",
+      JSON.stringify({
+        "studio-id": {
+          instanceId: "mobile-host",
+          gallery: { organize: true },
+        },
+      }),
+    );
+    localStorage.setItem(
+      "mold.mobile.gallery-tags.v1",
+      JSON.stringify({
+        "studio-id": {
+          instanceId: "replaced-instance",
+          tags: [{ name: "Wrong server", count: 9 }],
+        },
+      }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    expect(wrapper.find("[data-test='mobile-library-chip-tag']").exists()).toBe(false);
+  });
+
+  it("ignores malformed saved tag inventories", async () => {
+    localStorage.setItem(
+      "mold.mobile.gallery-capabilities.v1",
+      JSON.stringify({
+        "studio-id": {
+          instanceId: "mobile-host",
+          gallery: { organize: true },
+        },
+      }),
+    );
+    localStorage.setItem(
+      "mold.mobile.gallery-tags.v1",
+      JSON.stringify({
+        "studio-id": {
+          instanceId: "mobile-host",
+          tags: [{ name: null, count: 2 }],
+        },
+      }),
+    );
+    apiJsonTo.mockRejectedValue(new Error("offline"));
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+
+    expect(wrapper.find("[data-test='mobile-library-chip-tag']").exists()).toBe(false);
+  });
+
   it("does not restore an old instance cache from a gallery response that resolves after replacement", async () => {
     Object.defineProperty(globalThis, "indexedDB", {
       configurable: true,

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -633,6 +633,7 @@ const LIBRARY_VISITED_KEY = "mold.mobile.library-visited.v1";
 const SEQUENCE_RECOVERY_KEY = "mold.mobile.sequence-job.v1";
 const LIVE_ACTIVITY_KEY = "mold.mobile.live-activity.v1";
 const GALLERY_CAPABILITIES_KEY = "mold.mobile.gallery-capabilities.v1";
+const GALLERY_TAGS_KEY = "mold.mobile.gallery-tags.v1";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
 const GALLERY_HOST_TIMEOUT_MS = 9_000;
 /** A broken WebView connection must not hold a thumbnail page forever. Five
@@ -750,6 +751,53 @@ function loadSavedGalleryCapabilities(): Record<string, SavedGalleryCapability> 
   }
 }
 const savedGalleryCapabilities = reactive(loadSavedGalleryCapabilities());
+interface SavedGalleryTags {
+  instanceId: string | null;
+  tags: TagCount[];
+}
+function loadSavedGalleryTags(): Record<string, SavedGalleryTags> {
+  try {
+    const saved = JSON.parse(localStorage.getItem(GALLERY_TAGS_KEY) ?? "{}") as Record<
+      string,
+      SavedGalleryTags
+    >;
+    return Object.fromEntries(
+      Object.entries(saved).filter(
+        ([, entry]) =>
+          entry &&
+          (entry.instanceId === null || typeof entry.instanceId === "string") &&
+          Array.isArray(entry.tags) &&
+          entry.tags.every(
+            (tag) =>
+              tag &&
+              typeof tag.name === "string" &&
+              tag.name.trim().length > 0 &&
+              Number.isFinite(tag.count) &&
+              tag.count >= 0,
+          ),
+      ),
+    );
+  } catch {
+    return {};
+  }
+}
+const savedGalleryTags = reactive(loadSavedGalleryTags());
+function savedTagsForHost(host: MobileHost): readonly TagCount[] | undefined {
+  const saved = savedGalleryTags[host.id];
+  const instanceId = host.instanceId?.trim() || null;
+  if (!saved || host.instanceMismatch || !saved.instanceId || !instanceId) return undefined;
+  if (saved.instanceId !== instanceId) return undefined;
+  return saved.tags;
+}
+function rememberHostTags(host: MobileHost, tags: TagCount[]): void {
+  const instanceId = host.instanceId?.trim() || null;
+  if (!instanceId || host.instanceMismatch) return;
+  savedGalleryTags[host.id] = {
+    instanceId,
+    tags,
+  };
+  localStorage.setItem(GALLERY_TAGS_KEY, JSON.stringify(savedGalleryTags));
+}
 const effectiveGalleryCapabilities = computed<
   Record<string, ServerCapabilities | null | undefined>
 >(() => {
@@ -3762,6 +3810,7 @@ function updateHostStatus(payload: {
     const priorCacheKey = host.instanceId?.trim() || host.id;
     if (recordMobileHostStatus(host, payload.status) === "instance_mismatch") {
       retireMobileHostAuthority(host.id);
+      pruneHostOrganization(host.id);
       void clearCachedGalleryHosts([priorCacheKey]);
       return false;
     }
@@ -7924,7 +7973,9 @@ const hiddenCollectionSlugs = computed(
 // retained bucket leaves no ghost chips (its bucket is also pruned below).
 const mergedTags = computed(() =>
   mergeHostTags(
-    hostTags,
+    Object.fromEntries(
+      connectedHosts.value.map((host) => [host.id, hostTags[host.id] ?? savedTagsForHost(host)]),
+    ),
     connectedHosts.value.map((host) => host.id),
   ),
 );
@@ -8246,7 +8297,11 @@ async function refreshHostOrganization(hostIds: readonly string[]): Promise<void
         listHostTags(target),
       ]);
       if (collections.status === "fulfilled") hostCollections[hostId] = collections.value;
-      if (tags.status === "fulfilled") hostTags[hostId] = tags.value;
+      if (tags.status === "fulfilled") {
+        hostTags[hostId] = tags.value;
+        const host = connectedHosts.value.find((candidate) => candidate.id === hostId);
+        if (host) rememberHostTags(host, tags.value);
+      }
     }),
   );
 }


### PR DESCRIPTION
## Summary
- persist each mobile Library tag inventory for saved/offline galleries
- bind saved tags to the exact server instance and reject malformed snapshots
- prune stale organization state when a replacement server is detected

## UAT
- iPhone-width rendered Library showed Favorites, Barbie, and moon above the hydrated grid
- offline cached-gallery regression covers the loading-to-saved-Library transition

## Validation
- `nix develop -c bun run test -- --run src/mobile/MobileApp.test.ts` (314 passed)
- `nix develop -c bun run build:mobile`
- `nix develop -c bun run fmt:check`
- independent sub-agent peer review: no remaining findings