### PR TITLE
fix(studio): preserve square source resolution

### DIFF
--- a/changelog.d/source-aspect-resolution.md
+++ b/changelog.d/source-aspect-resolution.md
@@ -1,0 +1,3 @@
+- **Source-shaped canvases preserve their aspect ratio.** When a checkpoint such as Wan only
+  advertises landscape and portrait presets, a square source now stays on a model-safe square
+  canvas instead of being mislabeled as Source while rendering at a widescreen resolution.

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -241,6 +241,38 @@ describe("MobileResolutionPicker", () => {
     expect(remounted.get("[data-shape='source']").attributes("aria-checked")).toBe("true");
   });
 
+  it("applies a square Source canvas for Wan instead of its landscape default", async () => {
+    const wan = {
+      name: "wan22-ti2v-5b:fp16",
+      family: "wan",
+      default_width: 832,
+      default_height: 480,
+      recommended_dimensions: [
+        { width: 832, height: 480 },
+        { width: 480, height: 832 },
+        { width: 1280, height: 720 },
+        { width: 720, height: 1280 },
+      ],
+      max_pixels: 1_800_000,
+      dimension_alignment: 16,
+    } as ModelEntry;
+    const { wrapper, state } = mountPicker(
+      832,
+      480,
+      "wan",
+      { width: 1024, height: 1024 },
+      wan,
+      "model-default",
+    );
+
+    await wrapper.get("[data-shape='source']").trigger("click");
+
+    expect(state).toMatchObject({ width: 1024, height: 1024 });
+    expect(wrapper.getComponent(MobileResolutionPicker).emitted("canvas-intent")?.at(-1)).toEqual([
+      "source",
+    ]);
+  });
+
   it("advises on custom sizes above the 1.8 MP guideline without blocking", async () => {
     // The server is the authority: an oversized custom size submits anyway
     // and its refusal (if any) comes back as the job's own error.

--- a/studio/lib/outputShape.test.ts
+++ b/studio/lib/outputShape.test.ts
@@ -178,6 +178,44 @@ describe("resolveOutputShape", () => {
     expect(result.sizes.at(-1)!.mark).toBe("Source");
   });
 
+  it("keeps Source square for a Wan model whose authored presets are not square", () => {
+    const wan = {
+      family: "wan",
+      default_width: 832,
+      default_height: 480,
+      recommended_dimensions: [
+        { width: 832, height: 480 },
+        { width: 480, height: 832 },
+        { width: 1280, height: 720 },
+        { width: 720, height: 1280 },
+      ],
+      max_pixels: 1_800_000,
+      dimension_alignment: 16,
+    };
+    const source = { width: 1024, height: 1024 };
+
+    expect(
+      sizeForFamily(SOURCE_FAMILY_ID, {
+        model: wan,
+        width: 832,
+        height: 480,
+        source,
+        intent: "source",
+      }),
+    ).toEqual(source);
+
+    const result = resolveOutputShape({
+      model: wan,
+      width: 1024,
+      height: 1024,
+      source,
+      intent: "source",
+    });
+    expect(result.selectedFamilyId).toBe(SOURCE_FAMILY_ID);
+    expect(result.status).toBe("1024×1024 · Matches source");
+    expect(result.sizes.map((size) => size.label)).toEqual(["1024×1024"]);
+  });
+
   it("reports an exact source canvas as Matches source", () => {
     const { result } = shape({
       source: { width: 1024, height: 1024 },

--- a/studio/lib/sourceResolution.test.ts
+++ b/studio/lib/sourceResolution.test.ts
@@ -132,6 +132,41 @@ describe("source resolution", () => {
     ).toEqual({ width: 1024, height: 1024 });
   });
 
+  it("preserves a square source when Wan advertises only landscape and portrait presets", () => {
+    const wan = {
+      family: "wan",
+      default_width: 832,
+      default_height: 480,
+      recommended_dimensions: [
+        { width: 832, height: 480 },
+        { width: 480, height: 832 },
+        { width: 1280, height: 720 },
+        { width: 720, height: 1280 },
+      ],
+      max_pixels: 1_800_000,
+      dimension_alignment: 16,
+    };
+
+    expect(
+      resolveDefaultSourceResolution({ width: 1024, height: 1024 }, wan),
+    ).toEqual({ width: 1024, height: 1024 });
+  });
+
+  it("keeps the closest authored preset for a non-square source", () => {
+    const qwen = {
+      family: "qwen-image-edit",
+      default_width: 1664,
+      default_height: 928,
+      recommended_dimensions: [{ width: 1664, height: 928 }],
+      max_pixels: 1_048_576,
+      dimension_alignment: 16,
+    };
+
+    expect(
+      resolveDefaultSourceResolution({ width: 2048, height: 1024 }, qwen),
+    ).toEqual({ width: 1664, height: 928 });
+  });
+
   it("falls back to the model-safe source canvas when no preset is advertised", () => {
     const model = {
       family: "custom",

--- a/studio/lib/sourceResolution.ts
+++ b/studio/lib/sourceResolution.ts
@@ -41,6 +41,11 @@ export interface SourceCanvasTransition {
   preserveReplacement?: boolean;
 }
 
+/** A preset outside this log-ratio distance is a different shape, not a
+ * source-following canvas. This matches the canonical family tolerance used
+ * by the shared output-shape resolver without importing it circularly. */
+export const SOURCE_PRESET_ASPECT_LOG_TOLERANCE = 0.06;
+
 /**
  * Preserve authored/restored canvases while keeping source-driven defaults
  * live across model changes. All Create controllers use this transition so a
@@ -120,6 +125,19 @@ export function resolveDefaultSourceResolution(
       : Math.abs(leftArea - defaultArea) - Math.abs(rightArea - defaultArea);
   });
   const selected = ranked[0];
+  const sourceIsSquare =
+    Math.abs(Math.log(sourceRatio)) <= SOURCE_PRESET_ASPECT_LOG_TOLERANCE;
+  if (
+    sourceIsSquare &&
+    selected &&
+    Math.abs(Math.log(selected.width / selected.height / sourceRatio)) >
+      SOURCE_PRESET_ASPECT_LOG_TOLERANCE
+  ) {
+    // Wan checkpoints commonly advertise only landscape and portrait tiers.
+    // A square source is not either shape: keep its aspect on the model's
+    // aligned custom-canvas contract instead of silently cropping it to 16:9.
+    return resolveSourceResolution(source, model, pipeline).output;
+  }
   return selected
     ? { width: selected.width, height: selected.height }
     : resolveSourceResolution(source, model, pipeline).output;


### PR DESCRIPTION
## Summary
- preserve a square source canvas when a model such as Wan advertises only landscape and portrait presets
- keep non-square sources on their closest authored preset
- cover shared resolver, output-shape presentation, and rendered mobile picker behavior

## Verification
- `nix develop -c bun run test -- --run ../studio/lib/sourceResolution.test.ts ../studio/lib/outputShape.test.ts src/mobile/MobileResolutionPicker.test.ts`
- `nix develop -c bun --cwd web test --run src/components/create/ControlsAside.test.ts src/pages/CreatePage.test.ts`
- `nix develop -c bun run build:mobile`
- `nix develop -c bun run fmt:check`
- Browser UAT at 390x844: square 1024x1024 gallery source on Wan renders `1024x1024 · Matches source`

## Review
- Independent sub-agent peer review completed; blocker found, fixed, and exact diff re-reviewed with no remaining findings.