### PR TITLE
fix(mobile): keep Library filters visible offline

### DIFF
--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-08-28T04:26:11.649Z",
-  "gitCommitHash": "0ac04008eb0296736f9b033c37f8616a04fb9d45",
+  "lastAnalyzedAt": "2026-08-28T12:03:12.000Z",
+  "gitCommitHash": "3a400633b658883a05508bc8eb24e194ef5cb03d",
   "version": "1.0.0",
   "analyzedFiles": 2290
 }

--- a/changelog.d/mobile-library-error-layout.md
+++ b/changelog.d/mobile-library-error-layout.md
@@ -1,0 +1,2 @@
+- **Library filters stay visible when hosts are offline.** Mobile keeps the unavailable-host
+  message, but now places it below the Favorites and tag controls so thumbnails cannot cover them.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -8281,6 +8281,11 @@ describe("MobileApp gallery", () => {
     expect(
       wrapper.findAll("[data-test='mobile-library-chip-tag']").map((chip) => chip.text()),
     ).toEqual(["Barbie6", "moon6"]);
+    const filters = wrapper.get("[data-test='mobile-library-chips']").element;
+    const error = wrapper.get("[data-test='mobile-library-gallery-error']").element;
+    const grid = wrapper.get("[data-test='mobile-gallery-pinch-surface']").element;
+    expect(filters.compareDocumentPosition(error) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    expect(error.compareDocumentPosition(grid) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
   });
 
   it("does not restore saved tags across a host instance boundary", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -11338,15 +11338,6 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
             <span class="mobile-library-scope-count">{{ libraryScopeCounts[scope] }}</span>
           </button>
         </div>
-        <p v-if="galleryError" class="status-line error-text">{{ galleryError }}</p>
-        <p
-          v-if="organizationError"
-          class="status-line error-text"
-          role="alert"
-          data-test="mobile-library-organization-error"
-        >
-          {{ organizationError }}
-        </p>
         <div
           v-if="libraryChipRowVisible"
           class="mobile-library-chips"
@@ -11399,6 +11390,21 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
             {{ host.name }}<span class="mobile-library-chip-count">{{ host.count }}</span>
           </button>
         </div>
+        <p
+          v-if="galleryError"
+          class="status-line error-text"
+          data-test="mobile-library-gallery-error"
+        >
+          {{ galleryError }}
+        </p>
+        <p
+          v-if="organizationError"
+          class="status-line error-text"
+          role="alert"
+          data-test="mobile-library-organization-error"
+        >
+          {{ organizationError }}
+        </p>
 
         <template v-if="libraryScope === 'collections' && !activeCollection">
           <ul

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4821,6 +4821,7 @@ button:disabled {
   position: relative;
   z-index: 2;
   display: flex;
+  flex: none;
   margin-top: 10px;
   gap: 7px;
   overflow-x: auto;

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -581,6 +581,7 @@ describe("mobile Library organization", () => {
     const chips = css.match(/\.mobile-library-chips\s*\{([^}]*)\}/s);
     const window = css.match(/\.gallery-grid-window\s*\{([^}]*)\}/s);
 
+    expect(chips?.[1]).toMatch(/flex:\s*none\s*;/);
     expect(chips?.[1]).toMatch(/position:\s*relative\s*;/);
     expect(chips?.[1]).toMatch(/z-index:\s*2\s*;/);
     expect(window?.[1]).toMatch(/z-index:\s*0\s*;/);


### PR DESCRIPTION
## Summary
- keep Favorites/tag filters above retained unavailable-host messages
- prevent the horizontal filter rail from collapsing inside the mobile Library flex scroller
- add DOM-order and CSS flex regression coverage

## UAT
- rendered the shared mobile Vue surface at 390×844
- loaded 18 prints with Favorites, Barbie, and moon filters
- took the host offline and refreshed the Library
- verified the 46 px filter rail remains visible above the retained message and the grid starts below both

## Validation
- `bun run test -- --run src/mobile/MobileApp.test.ts src/mobile/mobile.css.test.ts` (363 passed)
- `bun run build:mobile`
- `bun run fmt:check`
- `git diff --check`
- independent peer review: no findings