### PR TITLE
fix: preserve chronological queue order

### DIFF
--- a/changelog.d/chronological-queue-order.md
+++ b/changelog.d/chronological-queue-order.md
@@ -1,0 +1,2 @@
+- **Keep active work in submission order.** Web, desktop, and mobile activity
+  timelines no longer move a newer developing print above older queued work.

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -35,6 +35,43 @@ function baseJob(): Job {
 }
 
 describe("ActivityStrip", () => {
+  it("keeps queued and recovered running work in chronological order", () => {
+    useGenerationStore().jobs = [
+      {
+        ...baseJob(),
+        prompt: "older queued print",
+        submittedAtUnixMs: 1_000,
+      },
+    ];
+    useLiveActivityStore().hosts = {
+      render: {
+        hostId: "render",
+        hostLabel: "Render box",
+        target: { baseUrl: "http://render", apiKey: null },
+        routeUrl: "http://render",
+        instanceId: "render-instance",
+        observedAtUnixMs: 3_000,
+        stale: false,
+        error: null,
+        items: [
+          {
+            id: "newer-running",
+            kind: "generation",
+            phase: "running",
+            model: "newer developing print",
+            created_at_unix_ms: 2_000,
+            updated_at_unix_ms: 3_000,
+            can_cancel: false,
+          },
+        ],
+        unavailableKinds: [],
+      },
+    };
+
+    const text = mount(ActivityStrip).get("[data-test='activity-list-scroll']").text();
+    expect(text.indexOf("older queued print")).toBeLessThan(text.indexOf("newer developing print"));
+  });
+
   it("keeps recovered shared work visible and actionable", async () => {
     useLiveActivityStore().hosts = {
       render: {

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -4,6 +4,7 @@ import { useRouter } from "vue-router";
 import ProgressBar from "@ui/components/ProgressBar.vue";
 import LiveActivityList from "@ui/components/LiveActivityList.vue";
 import SequenceJobRow from "@ui/components/SequenceJobRow.vue";
+import type { FleetActiveWork } from "@studio/api/activity";
 import {
   activityDigestLabel,
   mergeActivity,
@@ -118,7 +119,6 @@ const hiddenQueuedCount = computed(() =>
 const runningPct = computed(() =>
   running.value ? Math.round(jobProgress(running.value) * 100) : 0,
 );
-const runningFinalizing = computed(() => running.value?.status === "finishing");
 const runningHost = computed(() =>
   running.value?.hostId
     ? (hosts.all.find((host) => host.id === running.value?.hostId) ?? null)
@@ -261,6 +261,51 @@ const sequenceRows = computed(() =>
     (vm): vm is ActivityJobVM & { kind: "sequence" } => vm.kind === "sequence",
   ),
 );
+
+type DesktopActivityRow =
+  | { key: string; createdAtMs: number; kind: "shared"; shared: FleetActiveWork }
+  | { key: string; createdAtMs: number; kind: "print"; print: Job }
+  | {
+      key: string;
+      createdAtMs: number;
+      kind: "sequence";
+      sequence: ActivityJobVM & { kind: "sequence" };
+    };
+
+/** One visual queue across local prints, sequences, and recovered fleet work.
+ * A phase transition changes only the row contents, never its position. */
+const activeRows = computed<DesktopActivityRow[]>(() =>
+  [
+    ...sharedRows.value.map((shared): DesktopActivityRow => ({
+      key: `shared:${shared.key}`,
+      createdAtMs: shared.created_at_unix_ms,
+      kind: "shared",
+      shared,
+    })),
+    ...(running.value
+      ? [
+          {
+            key: `print:${running.value.clientId}`,
+            createdAtMs: running.value.submittedAtUnixMs,
+            kind: "print" as const,
+            print: running.value,
+          },
+        ]
+      : []),
+    ...visibleQueued.value.map((print): DesktopActivityRow => ({
+      key: `print:${print.clientId}`,
+      createdAtMs: print.submittedAtUnixMs,
+      kind: "print",
+      print,
+    })),
+    ...sequenceRows.value.map((sequence): DesktopActivityRow => ({
+      key: sequence.key,
+      createdAtMs: sequence.createdAtMs,
+      kind: "sequence",
+      sequence,
+    })),
+  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+);
 const attentionSequences = computed(() =>
   partition.value.attention.filter(
     (vm): vm is ActivityJobVM & { kind: "sequence" } => vm.kind === "sequence",
@@ -332,88 +377,7 @@ function deleteConfirmed() {
   <div v-if="show" data-test="activity-strip" class="ms-activity">
     <div class="ms-activity__row">
       <span class="ms-activity__kicker">Activity</span>
-      <template v-if="running">
-        <span class="ms-activity__thumb ms-shimmer" aria-hidden="true" />
-        <button
-          type="button"
-          class="ms-activity__running text-left"
-          data-test="activity-running-select"
-          @click="selectPrint(running)"
-        >
-          <div class="ms-activity__line">
-            <span class="ms-activity__prompt">{{ running.prompt }}</span>
-            <PodCostMeter
-              v-if="runningPod"
-              data-test="activity-pod-cost"
-              class="ms-activity__cost"
-              :cost-per-hr="runningPod.costPerHr"
-              :uptime-seconds="runningPod.uptimeSeconds"
-            />
-            <span class="ms-activity__pct data-mono">
-              {{ runningFinalizing ? "Finalizing" : `${runningPct}%` }}
-            </span>
-          </div>
-          <ProgressBar
-            :value="runningPct"
-            :height="4"
-            :label="runningFinalizing ? 'Finalizing print' : 'Print progress'"
-          />
-        </button>
-        <button
-          type="button"
-          class="ms-activity__cancel"
-          data-test="activity-running-cancel"
-          :disabled="running.cancelling"
-          :aria-label="
-            running.cancelling ? `Cancelling ${running.prompt}` : `Cancel ${running.prompt}`
-          "
-          @click="cancel(running)"
-        >
-          {{ running.cancelling ? "…" : "✕" }}
-        </button>
-      </template>
-      <div v-else class="ms-activity__idle-spacer" />
-      <div
-        v-for="job in visibleQueued"
-        :key="job.clientId"
-        class="ms-activity__pill"
-        data-test="activity-queued"
-        role="button"
-        tabindex="0"
-        :title="`${queuedLabel(job)} · ${job.prompt}`"
-        @click="selectPrint(job)"
-        @keydown.enter.prevent="selectPrint(job)"
-        @keydown.space.prevent="selectPrint(job)"
-      >
-        <span class="ms-activity__pill-text">
-          <span class="ms-activity__pill-queue" data-test="activity-queued-position">{{
-            queuedLabel(job)
-          }}</span>
-          · {{ job.prompt }}
-          <span v-if="job.holdError" class="ms-activity__seq-error"> · {{ job.holdError }}</span>
-        </span>
-        <button
-          v-if="job.retryable"
-          type="button"
-          class="ms-activity__seq-action"
-          data-test="activity-held-retry"
-          :disabled="job.retrying"
-          @click.stop="retry(job)"
-        >
-          {{ job.retrying ? "Retrying…" : "Retry" }}
-        </button>
-        <button
-          type="button"
-          class="ms-activity__cancel"
-          :aria-label="
-            job.cancelling ? `Cancelling ${job.prompt}` : `Cancel queued print: ${job.prompt}`
-          "
-          :disabled="job.cancelling"
-          @click.stop="cancel(job)"
-        >
-          {{ job.cancelling ? "…" : "✕" }}
-        </button>
-      </div>
+      <div class="ms-activity__idle-spacer" />
       <span
         v-if="hiddenQueuedCount > 0"
         class="ms-activity__overflow data-mono"
@@ -421,7 +385,6 @@ function deleteConfirmed() {
       >
         +{{ hiddenQueuedCount }} queued
       </span>
-      <!-- Everything settled the strip is not listing, in one mono count. -->
       <button
         v-if="digest"
         type="button"
@@ -435,19 +398,113 @@ function deleteConfirmed() {
     </div>
 
     <div data-test="activity-list-scroll" class="ms-activity__list">
-      <LiveActivityList :rows="sharedRows" interactive @select="openLiveWork" />
+      <template v-for="row in activeRows" :key="row.key">
+        <LiveActivityList
+          v-if="row.kind === 'shared'"
+          :rows="[row.shared]"
+          interactive
+          @select="openLiveWork"
+        />
 
-      <!-- In-flight sequence rows (merged jobs surface) -->
-      <SequenceJobRow
-        v-for="vm in sequenceRows"
-        :key="vm.key"
-        data-test="activity-sequence"
-        :vm="vm"
-        :model-label="modelLabel(vm.model)"
-        :show-error="false"
-        @action="runAction"
-        @select="selectSequence"
-      />
+        <div
+          v-else-if="row.kind === 'print' && row.print.status !== 'queued'"
+          class="ms-activity__row"
+        >
+          <span class="ms-activity__thumb ms-shimmer" aria-hidden="true" />
+          <button
+            type="button"
+            class="ms-activity__running text-left"
+            data-test="activity-running-select"
+            @click="selectPrint(row.print)"
+          >
+            <div class="ms-activity__line">
+              <span class="ms-activity__prompt">{{ row.print.prompt }}</span>
+              <PodCostMeter
+                v-if="runningPod"
+                data-test="activity-pod-cost"
+                class="ms-activity__cost"
+                :cost-per-hr="runningPod.costPerHr"
+                :uptime-seconds="runningPod.uptimeSeconds"
+              />
+              <span class="ms-activity__pct data-mono">
+                {{ row.print.status === "finishing" ? "Finalizing" : `${runningPct}%` }}
+              </span>
+            </div>
+            <ProgressBar
+              :value="runningPct"
+              :height="4"
+              :label="row.print.status === 'finishing' ? 'Finalizing print' : 'Print progress'"
+            />
+          </button>
+          <button
+            type="button"
+            class="ms-activity__cancel"
+            data-test="activity-running-cancel"
+            :disabled="row.print.cancelling"
+            :aria-label="
+              row.print.cancelling ? `Cancelling ${row.print.prompt}` : `Cancel ${row.print.prompt}`
+            "
+            @click="cancel(row.print)"
+          >
+            {{ row.print.cancelling ? "…" : "✕" }}
+          </button>
+        </div>
+
+        <div
+          v-else-if="row.kind === 'print'"
+          class="ms-activity__pill"
+          data-test="activity-queued"
+          role="button"
+          tabindex="0"
+          :title="`${queuedLabel(row.print)} · ${row.print.prompt}`"
+          @click="selectPrint(row.print)"
+          @keydown.enter.prevent="selectPrint(row.print)"
+          @keydown.space.prevent="selectPrint(row.print)"
+        >
+          <span class="ms-activity__pill-text">
+            <span class="ms-activity__pill-queue" data-test="activity-queued-position">{{
+              queuedLabel(row.print)
+            }}</span>
+            · {{ row.print.prompt }}
+            <span v-if="row.print.holdError" class="ms-activity__seq-error">
+              · {{ row.print.holdError }}
+            </span>
+          </span>
+          <button
+            v-if="row.print.retryable"
+            type="button"
+            class="ms-activity__seq-action"
+            data-test="activity-held-retry"
+            :disabled="row.print.retrying"
+            @click.stop="retry(row.print)"
+          >
+            {{ row.print.retrying ? "Retrying…" : "Retry" }}
+          </button>
+          <button
+            type="button"
+            class="ms-activity__cancel"
+            :aria-label="
+              row.print.cancelling
+                ? `Cancelling ${row.print.prompt}`
+                : `Cancel queued print: ${row.print.prompt}`
+            "
+            :disabled="row.print.cancelling"
+            @click.stop="cancel(row.print)"
+          >
+            {{ row.print.cancelling ? "…" : "✕" }}
+          </button>
+        </div>
+
+        <SequenceJobRow
+          v-else
+          data-test="activity-sequence"
+          :vm="row.sequence"
+          :model-label="modelLabel(row.sequence.model)"
+          :show-error="false"
+          @action="runAction"
+          @select="selectSequence"
+        />
+      </template>
 
       <!-- Settled but still wanting a decision: capped, expiring, dismissible. -->
       <SequenceJobRow

--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -121,6 +121,48 @@ describe("NavRail developing jobs", () => {
     };
   }
 
+  it("keeps recovered and local work in chronological order across phase changes", async () => {
+    const wrapper = await mountAt("/create");
+    useGenerationStore().jobs = [
+      {
+        clientId: 1,
+        id: "older-local",
+        model: "flux-dev:q8",
+        prompt: "older queued print",
+        status: "queued",
+        submittedAtUnixMs: 1_000,
+      } as never,
+    ];
+    useLiveActivityStore().hosts = {
+      render: {
+        hostId: "render",
+        hostLabel: "Render box",
+        target: { baseUrl: "http://render:7680", apiKey: null },
+        routeUrl: "http://render:7680",
+        instanceId: "render-instance",
+        observedAtUnixMs: 3_000,
+        stale: false,
+        error: null,
+        unavailableKinds: [],
+        items: [
+          {
+            id: "newer-running",
+            kind: "generation",
+            phase: "running",
+            model: "flux-schnell",
+            created_at_unix_ms: 2_000,
+            updated_at_unix_ms: 3_000,
+            can_cancel: false,
+          },
+        ],
+      },
+    };
+    await flushPromises();
+
+    const text = wrapper.get("[data-test='developing-jobs']").text();
+    expect(text.indexOf("flux-dev")).toBeLessThan(text.indexOf("flux-schnell"));
+  });
+
   it("shows cancellation progress, then offers to remove the cancelled row", async () => {
     const wrapper = await mountAt("/create");
     const generation = useGenerationStore();

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -180,30 +180,24 @@ type RailRow =
  * developing work above older queued work. */
 const railRows = computed<RailRow[]>(() =>
   [
-    ...sharedRows.value.map(
-      (shared): RailRow => ({
-        key: `shared:${shared.key}`,
-        createdAtMs: shared.created_at_unix_ms,
-        kind: "shared",
-        shared,
-      }),
-    ),
-    ...railSequences.value.map(
-      (sequence): RailRow => ({
-        key: sequence.key,
-        createdAtMs: sequence.createdAtMs,
-        kind: "sequence",
-        sequence,
-      }),
-    ),
-    ...railJobs.value.map(
-      (print): RailRow => ({
-        key: `print:${print.clientId}`,
-        createdAtMs: print.submittedAtUnixMs,
-        kind: "print",
-        print,
-      }),
-    ),
+    ...sharedRows.value.map((shared): RailRow => ({
+      key: `shared:${shared.key}`,
+      createdAtMs: shared.created_at_unix_ms,
+      kind: "shared",
+      shared,
+    })),
+    ...railSequences.value.map((sequence): RailRow => ({
+      key: sequence.key,
+      createdAtMs: sequence.createdAtMs,
+      kind: "sequence",
+      sequence,
+    })),
+    ...railJobs.value.map((print): RailRow => ({
+      key: `print:${print.clientId}`,
+      createdAtMs: print.submittedAtUnixMs,
+      kind: "print",
+      print,
+    })),
   ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
 );
 

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -165,6 +165,48 @@ const sharedRows = computed(() => {
   return liveActivity.rows.filter((row) => !local.has(row.key));
 });
 
+type RailRow =
+  | { key: string; createdAtMs: number; kind: "shared"; shared: FleetActiveWork }
+  | {
+      key: string;
+      createdAtMs: number;
+      kind: "sequence";
+      sequence: ActivityJobVM & { kind: "sequence" };
+    }
+  | { key: string; createdAtMs: number; kind: "print"; print: Job };
+
+/** One visual timeline across recovered work, sequences, prints, and retained
+ * print history. Status transitions update rows in place instead of promoting
+ * developing work above older queued work. */
+const railRows = computed<RailRow[]>(() =>
+  [
+    ...sharedRows.value.map(
+      (shared): RailRow => ({
+        key: `shared:${shared.key}`,
+        createdAtMs: shared.created_at_unix_ms,
+        kind: "shared",
+        shared,
+      }),
+    ),
+    ...railSequences.value.map(
+      (sequence): RailRow => ({
+        key: sequence.key,
+        createdAtMs: sequence.createdAtMs,
+        kind: "sequence",
+        sequence,
+      }),
+    ),
+    ...railJobs.value.map(
+      (print): RailRow => ({
+        key: `print:${print.clientId}`,
+        createdAtMs: print.submittedAtUnixMs,
+        kind: "print",
+        print,
+      }),
+    ),
+  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+);
+
 const developingCount = computed(
   () => generation.pending.length + railSequences.value.length + sharedRows.value.length,
 );
@@ -377,94 +419,97 @@ function selectSequence(vm: ActivityJobVM & { kind: "sequence" }) {
         </span>
       </div>
       <div
-        v-if="railJobs.length > 0 || railSequences.length > 0 || sharedRows.length > 0"
+        v-if="railRows.length > 0"
         data-test="developing-jobs"
         class="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto px-2"
       >
-        <LiveActivityList
-          :rows="sharedRows"
-          compact
-          interactive
-          @select="openLiveWork"
-          @contextmenu="(row, event) => contextMenu.open(event, sharedJobMenu(row))"
-        />
-        <a
-          v-for="vm in railSequences"
-          :key="vm.key"
-          href="#"
-          data-test="developing-sequence"
-          class="flex items-center gap-2.5 rounded-[8px] px-1 py-1 hover:bg-[color-mix(in_srgb,var(--rebate)_6%,transparent)]"
-          @click.prevent="selectSequence(vm)"
-        >
-          <span
-            class="h-[30px] w-[30px] shrink-0 overflow-hidden rounded-[6px] border border-[color-mix(in_srgb,var(--rebate)_12%,transparent)] bg-print-surface"
+        <template v-for="row in railRows" :key="row.key">
+          <LiveActivityList
+            v-if="row.kind === 'shared'"
+            :rows="[row.shared]"
+            compact
+            interactive
+            @select="openLiveWork"
+            @contextmenu="(item, event) => contextMenu.open(event, sharedJobMenu(item))"
+          />
+          <a
+            v-else-if="row.kind === 'sequence'"
+            href="#"
+            data-test="developing-sequence"
+            class="flex items-center gap-2.5 rounded-[8px] px-1 py-1 hover:bg-[color-mix(in_srgb,var(--rebate)_6%,transparent)]"
+            @click.prevent="selectSequence(row.sequence)"
           >
             <span
-              v-if="vm.phase === 'running' || vm.phase === 'finalizing'"
-              class="ms-shimmer block h-full w-full"
-              aria-hidden="true"
-            />
-            <span v-else class="block h-full w-full bg-print-surface" aria-hidden="true" />
-          </span>
-          <span class="min-w-0 flex-1">
-            <span class="block truncate text-[11.5px] text-ink-2" :title="vm.model">
-              {{ modelLabel(vm.model) }} · {{ vm.hostLabel }}
-            </span>
-            <span class="block font-utility text-[9.5px] text-safelight">
-              {{ sequenceLine(vm) }}
-            </span>
-          </span>
-        </a>
-        <a
-          v-for="job in railJobs"
-          :key="job.clientId"
-          href="#"
-          data-test="developing-print"
-          class="flex items-center gap-2.5 rounded-[8px] px-1 py-1 hover:bg-[color-mix(in_srgb,var(--rebate)_6%,transparent)]"
-          @click.prevent="selectPrint(job)"
-          @contextmenu.prevent="contextMenu.open($event, jobMenu(job))"
-        >
-          <span
-            class="h-[30px] w-[30px] shrink-0 overflow-hidden rounded-[6px] border border-[color-mix(in_srgb,var(--rebate)_12%,transparent)] bg-print-surface"
-          >
-            <AuthedMedia
-              v-if="job.status === 'complete' && job.result?.filename"
-              :path="thumbnailPath(job.result.filename)"
-              :target="generation.targetForJob(job.clientId)"
-              :cache-key="job.hostId ?? hosts.primaryHost?.id ?? 'primary'"
-              :alt="job.prompt"
-            />
-            <img
-              v-else-if="job.resultUrl && !job.result?.video_frames"
-              :src="job.resultUrl"
-              alt=""
-              class="h-full w-full object-cover"
-            />
-            <img
-              v-else-if="job.previewUrl"
-              :src="job.previewUrl"
-              alt=""
-              class="h-full w-full object-cover"
-              style="filter: blur(1px)"
-            />
-            <span v-else-if="jobRunning(job)" class="ms-shimmer block h-full w-full" />
-            <span v-else class="block h-full w-full bg-print-surface" />
-          </span>
-          <span class="min-w-0 flex-1">
-            <span class="block truncate text-[11.5px] text-ink-2" :title="job.prompt">
-              {{ modelLabel(job.model)
-              }}<template v-if="job.hostLabel"> · {{ job.hostLabel }}</template>
-            </span>
-            <span
-              class="block font-utility text-[9.5px]"
-              :class="
-                job.status === 'error' && !job.outcomeUnknown ? 'text-stop' : 'text-safelight'
-              "
+              class="h-[30px] w-[30px] shrink-0 overflow-hidden rounded-[6px] border border-[color-mix(in_srgb,var(--rebate)_12%,transparent)] bg-print-surface"
             >
-              {{ developingLabel(job) }}
+              <span
+                v-if="row.sequence.phase === 'running' || row.sequence.phase === 'finalizing'"
+                class="ms-shimmer block h-full w-full"
+                aria-hidden="true"
+              />
+              <span v-else class="block h-full w-full bg-print-surface" aria-hidden="true" />
             </span>
-          </span>
-        </a>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate text-[11.5px] text-ink-2" :title="row.sequence.model">
+                {{ modelLabel(row.sequence.model) }} · {{ row.sequence.hostLabel }}
+              </span>
+              <span class="block font-utility text-[9.5px] text-safelight">
+                {{ sequenceLine(row.sequence) }}
+              </span>
+            </span>
+          </a>
+          <a
+            v-else
+            href="#"
+            data-test="developing-print"
+            class="flex items-center gap-2.5 rounded-[8px] px-1 py-1 hover:bg-[color-mix(in_srgb,var(--rebate)_6%,transparent)]"
+            @click.prevent="selectPrint(row.print)"
+            @contextmenu.prevent="contextMenu.open($event, jobMenu(row.print))"
+          >
+            <span
+              class="h-[30px] w-[30px] shrink-0 overflow-hidden rounded-[6px] border border-[color-mix(in_srgb,var(--rebate)_12%,transparent)] bg-print-surface"
+            >
+              <AuthedMedia
+                v-if="row.print.status === 'complete' && row.print.result?.filename"
+                :path="thumbnailPath(row.print.result.filename)"
+                :target="generation.targetForJob(row.print.clientId)"
+                :cache-key="row.print.hostId ?? hosts.primaryHost?.id ?? 'primary'"
+                :alt="row.print.prompt"
+              />
+              <img
+                v-else-if="row.print.resultUrl && !row.print.result?.video_frames"
+                :src="row.print.resultUrl"
+                alt=""
+                class="h-full w-full object-cover"
+              />
+              <img
+                v-else-if="row.print.previewUrl"
+                :src="row.print.previewUrl"
+                alt=""
+                class="h-full w-full object-cover"
+                style="filter: blur(1px)"
+              />
+              <span v-else-if="jobRunning(row.print)" class="ms-shimmer block h-full w-full" />
+              <span v-else class="block h-full w-full bg-print-surface" />
+            </span>
+            <span class="min-w-0 flex-1">
+              <span class="block truncate text-[11.5px] text-ink-2" :title="row.print.prompt">
+                {{ modelLabel(row.print.model)
+                }}<template v-if="row.print.hostLabel"> · {{ row.print.hostLabel }}</template>
+              </span>
+              <span
+                class="block font-utility text-[9.5px]"
+                :class="
+                  row.print.status === 'error' && !row.print.outcomeUnknown
+                    ? 'text-stop'
+                    : 'text-safelight'
+                "
+              >
+                {{ developingLabel(row.print) }}
+              </span>
+            </span>
+          </a>
+        </template>
       </div>
       <p v-else class="px-3 text-caption text-ink-3">nothing developing</p>
     </div>

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1086,6 +1086,51 @@ describe("MobileApp sequence generation", () => {
     expect(localStorage.getItem("mold.mobile.live-activity.v1")).not.toContain(target.apiKey);
   });
 
+  it("interleaves local and recovered work by submission time", async () => {
+    apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/capabilities") return Promise.resolve(durableQueueCapabilities);
+      if (path === "/api/generation-batches" && init?.method === "POST") {
+        return Promise.resolve(durableBatchResponse(init));
+      }
+      if (path === "/api/generation-batches/status") {
+        return Promise.resolve({
+          instance_id: status.instance_id,
+          batches: [],
+          missing: { client_batch_ids: [], batch_ids: [] },
+        });
+      }
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: status.instance_id,
+          observed_at_unix_ms: Date.now(),
+          items: [
+            {
+              id: "newer-running",
+              kind: "generation",
+              phase: "running",
+              model: "newer developing print",
+              created_at_unix_ms: Date.now() + 60_000,
+              updated_at_unix_ms: Date.now() + 60_000,
+              can_cancel: false,
+            },
+          ],
+        });
+      }
+      return durableApiFallback(path, init, callTarget);
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("older queued print");
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await flushPromises();
+
+    const text = wrapper.get(".mobile-generation-queue-list").text();
+    expect(text.indexOf("older queued print")).toBeLessThan(text.indexOf("newer developing print"));
+  });
+
   it("swipes a queued item from another client to exact-host pause and resume", async () => {
     apiJsonTo.mockImplementation((_target: unknown, path: string) => {
       if (path === "/api/status")

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -2294,11 +2294,7 @@ const queueStatusIndex = computed(() =>
 );
 const printActivity = computed<ActivityJobVM[]>(() => {
   const ordered = queuedJobs.value;
-  // `mergeActivity` sorts active work by RECENCY, but a print queue is FIFO.
-  // Re-express each rail position as a descending timestamp so the merge can
-  // interleave sequences without ever reversing the queue the user submitted.
-  const newest = ordered.reduce((max, job) => Math.max(max, job.clientId), 0);
-  return ordered.map((job, index) => {
+  return ordered.map((job) => {
     const vm: PrintActivityVM = {
       kind: "print" as const,
       key: `print:${job.clientId}`,
@@ -2310,7 +2306,7 @@ const printActivity = computed<ActivityJobVM[]>(() => {
       progress: null,
       chain: null,
       actions: ["cancel" as const],
-      createdAtMs: newest - index,
+      createdAtMs: job.submittedAtUnixMs,
       // The iPhone queue renders `generation.pending` only, so nothing settled
       // ever reaches this list — the strip's attention/expiry rules are a
       // desktop and web concern for now.
@@ -2494,6 +2490,29 @@ const sharedMobileActivity = computed(() => {
     (row) => !local.has(row.key),
   );
 });
+
+type MobileActivityDisplayRow =
+  | { key: string; createdAtMs: number; kind: "local"; local: ActivityRow }
+  | { key: string; createdAtMs: number; kind: "shared"; shared: FleetActiveWork };
+
+/** One chronological queue across this session and server-owned/recovered
+ * work. Ownership and phase change row contents, never visual position. */
+const mobileActivityRows = computed<MobileActivityDisplayRow[]>(() =>
+  [
+    ...activityRows.value.map((local): MobileActivityDisplayRow => ({
+      key: `local:${local.key}`,
+      createdAtMs: local.print?.submittedAtUnixMs ?? local.sequence?.createdAtMs ?? 0,
+      kind: "local",
+      local,
+    })),
+    ...sharedMobileActivity.value.map((shared): MobileActivityDisplayRow => ({
+      key: `shared:${shared.key}`,
+      createdAtMs: shared.created_at_unix_ms,
+      kind: "shared",
+      shared,
+    })),
+  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+);
 const expandedQueueFailures = ref(new Set<string>());
 
 function toggleQueueFailure(key: string): void {
@@ -11123,7 +11142,7 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
           <!-- ONE queue for both outputs: single prints and durable sequences
                land in the same list (mockup 1c). -->
           <section
-            v-if="activityRows.length || sharedMobileActivity.length"
+            v-if="mobileActivityRows.length"
             class="mobile-generation-queue"
             aria-label="Generation queue"
             data-test="mobile-generation-queue"
@@ -11132,113 +11151,138 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
               <h2>Queue</h2>
               <span data-test="mobile-queue-count">{{ activityCountLabel(activityCounts) }}</span>
             </div>
-            <ol>
-              <li v-for="row in activityRows" :key="row.key" class="mobile-generation-row">
-                <SwipeActionRow
-                  :actions="mobileQueueRowActions(row)"
-                  :label="row.print ? row.print.prompt : modelLabel(row.sequence?.model ?? '')"
-                  :disabled="
-                    row.print?.cancelling === true ||
-                    queueControlHostIds.has(activityRowHostId(row))
-                  "
-                  :data-test="row.print ? 'mobile-generation-job' : 'mobile-sequence-job'"
-                  @act="onMobileQueueRowAction(row, $event)"
-                >
-                  <div
-                    class="mobile-generation-job"
-                    role="button"
-                    tabindex="0"
-                    @click="
-                      row.print ? selectMobilePrint(row.print) : selectCurrentMobileSequence()
+            <div class="mobile-generation-queue-list">
+              <template v-for="entry in mobileActivityRows" :key="entry.key">
+                <div v-if="entry.kind === 'local'" class="mobile-generation-row">
+                  <SwipeActionRow
+                    :actions="mobileQueueRowActions(entry.local)"
+                    :label="
+                      entry.local.print
+                        ? entry.local.print.prompt
+                        : modelLabel(entry.local.sequence?.model ?? '')
                     "
-                    @keydown.enter.prevent="
-                      row.print ? selectMobilePrint(row.print) : selectCurrentMobileSequence()
+                    :disabled="
+                      entry.local.print?.cancelling === true ||
+                      queueControlHostIds.has(activityRowHostId(entry.local))
                     "
+                    :data-test="entry.local.print ? 'mobile-generation-job' : 'mobile-sequence-job'"
+                    @act="onMobileQueueRowAction(entry.local, $event)"
                   >
-                    <template v-if="row.print">
-                      <div class="mobile-generation-job-copy">
-                        <p>{{ row.print.prompt }}</p>
-                        <span>{{ modelLabel(row.print.model) }} · {{ row.print.hostLabel }}</span>
-                        <p
-                          v-if="durableHold(row.print)?.error"
-                          class="mobile-generation-held-error"
-                          data-test="mobile-generation-held-error"
-                        >
-                          {{ durableHold(row.print)?.error }}
-                        </p>
-                      </div>
-                      <div class="mobile-generation-job-action">
-                        <span data-test="mobile-generation-status">{{
-                          activityRowStatus(row)
-                        }}</span>
-                        <span v-if="row.print.cancelling" data-test="mobile-generation-cancelling">
-                          Cancelling…
-                        </span>
-                      </div>
-                    </template>
-                    <template v-else-if="row.sequence">
-                      <div class="mobile-generation-job-copy">
-                        <p>
-                          {{ modelLabel(row.sequence.model) || "Sequence" }} ·
-                          {{ row.sequence.stageCount }} clips
-                        </p>
-                        <span>
-                          {{ row.sequence.phase ?? row.sequence.state }} · clip
-                          {{ Math.min(row.sequence.currentStage + 1, row.sequence.stageCount) }}/{{
-                            row.sequence.stageCount
-                          }}
-                          <template v-if="sequenceRowProgress !== null">
-                            · {{ sequenceRowProgress }}%
-                          </template>
-                        </span>
-                        <button
-                          v-if="row.sequence.error"
-                          type="button"
-                          class="mobile-sequence-row-error"
-                          :class="{
-                            'mobile-sequence-row-error--expanded': expandedQueueFailures.has(
-                              row.key,
-                            ),
-                          }"
-                          data-test="mobile-sequence-error-disclosure"
-                          :aria-expanded="expandedQueueFailures.has(row.key)"
-                          @click.stop="toggleQueueFailure(row.key)"
-                        >
-                          <span>{{ row.sequence.error }}</span>
-                          <span aria-hidden="true">
-                            {{ expandedQueueFailures.has(row.key) ? "Less" : "Details" }}
+                    <div
+                      class="mobile-generation-job"
+                      role="button"
+                      tabindex="0"
+                      @click="
+                        entry.local.print
+                          ? selectMobilePrint(entry.local.print)
+                          : selectCurrentMobileSequence()
+                      "
+                      @keydown.enter.prevent="
+                        entry.local.print
+                          ? selectMobilePrint(entry.local.print)
+                          : selectCurrentMobileSequence()
+                      "
+                    >
+                      <template v-if="entry.local.print">
+                        <div class="mobile-generation-job-copy">
+                          <p>{{ entry.local.print.prompt }}</p>
+                          <span>
+                            {{ modelLabel(entry.local.print.model) }} ·
+                            {{ entry.local.print.hostLabel }}
                           </span>
-                        </button>
-                      </div>
-                      <div class="mobile-generation-job-action">
-                        <span data-test="mobile-sequence-status">{{ row.sequence.hostLabel }}</span>
-                      </div>
-                    </template>
-                  </div>
-                </SwipeActionRow>
-              </li>
-            </ol>
-            <LiveActivityList
-              :rows="sharedMobileActivity"
-              interactive
-              swipe-actions
-              :can-swipe="canPauseFleetActivity"
-              @select="openMobileLiveWork"
-            >
-              <template #actions="{ row }">
-                <button
-                  type="button"
-                  data-test="mobile-fleet-queue-control"
-                  :disabled="queueControlHostIds.has(row.hostId)"
-                  :aria-label="`${hostTelemetry[row.hostId]?.queuePaused ? 'Resume' : 'Pause'} ${row.hostLabel} queue`"
-                  @click.stop="
-                    setFleetHostQueuePaused(row, !(hostTelemetry[row.hostId]?.queuePaused === true))
-                  "
+                          <p
+                            v-if="durableHold(entry.local.print)?.error"
+                            class="mobile-generation-held-error"
+                            data-test="mobile-generation-held-error"
+                          >
+                            {{ durableHold(entry.local.print)?.error }}
+                          </p>
+                        </div>
+                        <div class="mobile-generation-job-action">
+                          <span data-test="mobile-generation-status">{{
+                            activityRowStatus(entry.local)
+                          }}</span>
+                          <span
+                            v-if="entry.local.print.cancelling"
+                            data-test="mobile-generation-cancelling"
+                          >
+                            Cancelling…
+                          </span>
+                        </div>
+                      </template>
+                      <template v-else-if="entry.local.sequence">
+                        <div class="mobile-generation-job-copy">
+                          <p>
+                            {{ modelLabel(entry.local.sequence.model) || "Sequence" }} ·
+                            {{ entry.local.sequence.stageCount }} clips
+                          </p>
+                          <span>
+                            {{ entry.local.sequence.phase ?? entry.local.sequence.state }} · clip
+                            {{
+                              Math.min(
+                                entry.local.sequence.currentStage + 1,
+                                entry.local.sequence.stageCount,
+                              )
+                            }}/{{ entry.local.sequence.stageCount }}
+                            <template v-if="sequenceRowProgress !== null">
+                              · {{ sequenceRowProgress }}%
+                            </template>
+                          </span>
+                          <button
+                            v-if="entry.local.sequence.error"
+                            type="button"
+                            class="mobile-sequence-row-error"
+                            :class="{
+                              'mobile-sequence-row-error--expanded': expandedQueueFailures.has(
+                                entry.local.key,
+                              ),
+                            }"
+                            data-test="mobile-sequence-error-disclosure"
+                            :aria-expanded="expandedQueueFailures.has(entry.local.key)"
+                            @click.stop="toggleQueueFailure(entry.local.key)"
+                          >
+                            <span>{{ entry.local.sequence.error }}</span>
+                            <span aria-hidden="true">
+                              {{ expandedQueueFailures.has(entry.local.key) ? "Less" : "Details" }}
+                            </span>
+                          </button>
+                        </div>
+                        <div class="mobile-generation-job-action">
+                          <span data-test="mobile-sequence-status">
+                            {{ entry.local.sequence.hostLabel }}
+                          </span>
+                        </div>
+                      </template>
+                    </div>
+                  </SwipeActionRow>
+                </div>
+                <LiveActivityList
+                  v-else
+                  :rows="[entry.shared]"
+                  interactive
+                  swipe-actions
+                  :can-swipe="canPauseFleetActivity"
+                  @select="openMobileLiveWork"
                 >
-                  {{ hostTelemetry[row.hostId]?.queuePaused ? "Resume" : "Pause" }}
-                </button>
+                  <template #actions="{ row }">
+                    <button
+                      type="button"
+                      data-test="mobile-fleet-queue-control"
+                      :disabled="queueControlHostIds.has(row.hostId)"
+                      :aria-label="`${hostTelemetry[row.hostId]?.queuePaused ? 'Resume' : 'Pause'} ${row.hostLabel} queue`"
+                      @click.stop="
+                        setFleetHostQueuePaused(
+                          row,
+                          !(hostTelemetry[row.hostId]?.queuePaused === true),
+                        )
+                      "
+                    >
+                      {{ hostTelemetry[row.hostId]?.queuePaused ? "Resume" : "Pause" }}
+                    </button>
+                  </template>
+                </LiveActivityList>
               </template>
-            </LiveActivityList>
+            </div>
           </section>
           <p
             v-if="sequenceError && sequenceRoute && !isSequence"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2539,7 +2539,8 @@ button:disabled {
   font: inherit;
 }
 
-.mobile-generation-queue ol {
+.mobile-generation-queue-list,
+.mobile-generation-queue-list ol {
   margin: 0;
   padding: 0;
   list-style: none;

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -227,30 +227,34 @@ describe("job reactivity wiring", () => {
 });
 
 describe("railOrder", () => {
-  const job = (clientId: number, status: JobStatus, queuePosition: number | null): Job => ({
+  const job = (
+    clientId: number,
+    status: JobStatus,
+    queuePosition: number | null,
+    submittedAtUnixMs = clientId,
+  ): Job => ({
     ...newJob(req),
     clientId,
     status,
     queuePosition,
+    submittedAtUnixMs,
   });
 
-  it("shows developing first, then the server's queue order — not submission order", async () => {
+  it("keeps submission order when a newer job starts developing", async () => {
     const { railOrder } = await import("./generation");
-    // Concurrent batch submissions raced: job 1 landed at position #3,
-    // job 3 at #1. The rail must show the engine's actual run order.
     const jobs = [
       job(1, "queued", 3),
       job(2, "queued", 2),
       job(3, "queued", 1),
       job(4, "denoising", null),
     ];
-    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([4, 3, 2, 1]);
+    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([1, 2, 3, 4]);
   });
 
-  it("positionless queued jobs sink below positioned ones, stable by clientId", async () => {
+  it("uses client identity only to break equal submission timestamps", async () => {
     const { railOrder } = await import("./generation");
-    const jobs = [job(5, "queued", null), job(6, "queued", 1), job(7, "loading", null)];
-    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([7, 6, 5]);
+    const jobs = [job(7, "loading", null, 10), job(5, "queued", null, 10), job(6, "queued", 1, 10)];
+    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([5, 6, 7]);
   });
 });
 

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -243,22 +243,14 @@ export function planBatchRequests(
 }
 
 /**
- * Display order for the jobs rail: actively developing first, then the
- * server's real queue order. Concurrent batch submissions race to the
- * server, so submission order and queue position can disagree — the rail
- * must show the order the engine will actually run.
+ * Stable chronological display order for the jobs rail. A transition from
+ * queued to loading/developing must update a row in place, never move it to
+ * the top of the visual queue.
  */
 export function railOrder(jobs: Job[]): Job[] {
-  const rank = (j: Job): number =>
-    j.status === "denoising" || j.status === "finishing" ? 0 : j.status === "loading" ? 1 : 2;
-  return [...jobs].sort((a, b) => {
-    const r = rank(a) - rank(b);
-    if (r !== 0) return r;
-    const pa = a.queuePosition ?? Number.MAX_SAFE_INTEGER;
-    const pb = b.queuePosition ?? Number.MAX_SAFE_INTEGER;
-    if (pa !== pb) return pa - pb;
-    return a.clientId - b.clientId;
-  });
+  return [...jobs].sort(
+    (a, b) => a.submittedAtUnixMs - b.submittedAtUnixMs || a.clientId - b.clientId,
+  );
 }
 
 /**

--- a/studio/api/activity.test.ts
+++ b/studio/api/activity.test.ts
@@ -248,4 +248,34 @@ describe("active work reconciliation", () => {
       "host-b:generation:same",
     ]);
   });
+
+  it("keeps fleet work chronological instead of promoting running phases", () => {
+    const snapshot = reconcileActivityHost(route, undefined, {
+      instance_id: "instance-a",
+      observed_at_unix_ms: 10,
+      items: [
+        {
+          id: "older-queued",
+          kind: "generation",
+          phase: "queued",
+          created_at_unix_ms: 1,
+          updated_at_unix_ms: 9,
+          can_cancel: true,
+        },
+        {
+          id: "newer-running",
+          kind: "generation",
+          phase: "running",
+          created_at_unix_ms: 2,
+          updated_at_unix_ms: 9,
+          can_cancel: true,
+        },
+      ],
+    });
+
+    expect(mergeFleetActivity([snapshot]).map((row) => row.id)).toEqual([
+      "older-queued",
+      "newer-running",
+    ]);
+  });
 });

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -172,16 +172,12 @@ export function mergeFleetActivity(
       });
     }
   }
-  const phaseRank = (phase: string) =>
-    phase === "running" || phase === "downloading"
-      ? 0
-      : phase === "loading"
-        ? 1
-        : 2;
+  // A phase transition must never move a row. Across a fleet an older job can
+  // still be queued on one machine while a newer job is already running on
+  // another, so grouping by phase makes "developing" work jump to the top.
+  // Submission time is the only ordering shared by every work kind and host.
   return rows.sort(
     (a, b) =>
-      phaseRank(a.phase) - phaseRank(b.phase) ||
-      a.created_at_unix_ms - b.created_at_unix_ms ||
-      a.key.localeCompare(b.key),
+      a.created_at_unix_ms - b.created_at_unix_ms || a.key.localeCompare(b.key),
   );
 }

--- a/studio/lib/activity.test.ts
+++ b/studio/lib/activity.test.ts
@@ -108,14 +108,14 @@ describe("sequenceToVM", () => {
     expect(waiting.phase).toBe("queued");
     expect(leased.phase).toBe("running");
     expect(mergeActivity([], [waiting, leased]).map((vm) => vm.key)).toEqual([
-      leased.key,
       waiting.key,
+      leased.key,
     ]);
   });
 });
 
 describe("mergeActivity", () => {
-  it("orders active work first, then by recency", () => {
+  it("keeps active work chronological regardless of phase, then settled by recency", () => {
     const settledPrint = print({
       key: "print:1",
       phase: "done",
@@ -140,8 +140,8 @@ describe("mergeActivity", () => {
       [queuedSeq, settledSeq],
     );
     expect(merged.map((vm) => vm.key)).toEqual([
-      "print:2", // running first
-      "seq:plato:c1", // queued second
+      "print:2", // older running work stays where it was submitted
+      "seq:plato:c1", // newer queued work follows it
       "seq:plato:c2", // then settled, newest first
       "print:1",
     ]);

--- a/studio/lib/activity.ts
+++ b/studio/lib/activity.ts
@@ -233,14 +233,9 @@ export function needsAttention(vm: ActivityJobVM): boolean {
     : vm.state === "failed" || vm.state === "interrupted";
 }
 
-function isRunning(vm: ActivityJobVM): boolean {
-  return vm.kind === "print"
-    ? vm.phase === "running"
-    : vm.phase === "running" || vm.phase === "finalizing";
-}
-
-/** Merge prints and sequences into one list: active work first (running
- * before queued), then everything by recency. */
+/** Merge prints and sequences into one list. Active work stays in chronological
+ * submission order, regardless of whether a row is queued or running; settled
+ * work follows by recency and is partitioned into attention/history below. */
 export function mergeActivity(
   prints: readonly ActivityJobVM[],
   sequences: readonly ActivityJobVM[],
@@ -248,8 +243,7 @@ export function mergeActivity(
   return [...prints, ...sequences].sort((a, b) => {
     const activeDelta = Number(isActive(b)) - Number(isActive(a));
     if (activeDelta !== 0) return activeDelta;
-    const runningDelta = Number(isRunning(b)) - Number(isRunning(a));
-    if (runningDelta !== 0) return runningDelta;
+    if (isActive(a)) return a.createdAtMs - b.createdAtMs;
     return b.createdAtMs - a.createdAtMs;
   });
 }

--- a/web/src/components/create/ActivityStrip.test.ts
+++ b/web/src/components/create/ActivityStrip.test.ts
@@ -66,6 +66,45 @@ function makeSequenceVM(
 }
 
 describe("ActivityStrip", () => {
+  it("keeps an older queued print above newer running fleet work", () => {
+    const olderQueued = makeJob({
+      id: "older-queued",
+      startedAt: 1_000,
+      workStarted: false,
+      progress: {
+        stage: "Queued",
+        step: null,
+        totalSteps: null,
+        queuePosition: 0,
+        gpu: null,
+        elapsedMs: null,
+      },
+    });
+    const newerShared = {
+      key: "render:generation:newer-running",
+      id: "newer-running",
+      kind: "generation",
+      phase: "running",
+      model: "newer developing print",
+      hostId: "render",
+      hostLabel: "Render box",
+      routeUrl: "http://render:7680",
+      instanceId: "render-instance",
+      stale: false,
+      hostError: null,
+      created_at_unix_ms: 2_000,
+      updated_at_unix_ms: 3_000,
+      can_cancel: false,
+    };
+
+    const text = mount(ActivityStrip, {
+      props: { jobs: [olderQueued], shared: [newerShared] },
+    }).text();
+    expect(text.indexOf("a cat")).toBeLessThan(
+      text.indexOf("newer developing print"),
+    );
+  });
+
   it("keeps recovered shared work visible and actionable", async () => {
     const shared = {
       key: "render:download:pull-1",
@@ -222,6 +261,30 @@ describe("ActivityStrip", () => {
     expect(
       wrapper.get("[data-test='activity-queued-summary']").text(),
     ).toContain("9999 other queued prints");
+  });
+
+  it("does not promote a newer held print above an older queued print", () => {
+    const wrapper = mount(ActivityStrip, {
+      props: {
+        jobs: [
+          makeJob({ id: "older-queued", startedAt: 1, workStarted: false }),
+          makeJob({
+            id: "newer-held",
+            startedAt: 2,
+            workStarted: false,
+            holdError: "Waiting for memory",
+          }),
+        ],
+      },
+    });
+
+    expect(
+      wrapper.find("[data-test='activity-queued-older-queued']").exists(),
+    ).toBe(true);
+    expect(
+      wrapper.find("[data-test='activity-queued-newer-held']").exists(),
+    ).toBe(false);
+    expect(wrapper.text()).toContain("1 other queued print");
   });
 
   it("reveals the next actionable queued print while an earlier cancel is pending", () => {

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -115,9 +115,14 @@ const partition = computed(() =>
   }),
 );
 
-const orderedSequences = computed(() =>
-  [...partition.value.active, ...partition.value.attention].filter(
-    (vm) => vm.kind === "sequence",
+const activeSequences = computed(() =>
+  partition.value.active.filter(
+    (vm): vm is ActivityJobVM & { kind: "sequence" } => vm.kind === "sequence",
+  ),
+);
+const attentionSequences = computed(() =>
+  partition.value.attention.filter(
+    (vm): vm is ActivityJobVM & { kind: "sequence" } => vm.kind === "sequence",
   ),
 );
 
@@ -206,41 +211,69 @@ const running = computed(() =>
 const queued = computed(() =>
   props.jobs.filter((j) => j.state === "running" && !j.workStarted),
 );
-/** Render exactly the host-authoritative next queued print, then summarize the
- * rest. Cancellation reveals the following row, so every job remains
- * reachable without producing one interactive DOM subtree per backlog item. */
+/** Render exactly the oldest submitted queued print, then summarize the rest.
+ * Cancellation reveals the following row, so every job remains reachable
+ * without producing one interactive DOM subtree per backlog item. */
 const nextQueued = computed(() => {
-  // A held print has no queue position and needs a human: it is always the
-  // row that is shown, so its reason and Retry are never folded into
-  // "N more queued".
-  const held = queued.value.find((job) => job.holdError && !job.cancelling);
-  if (held) return held;
-  let best: Job | null = null;
-  let bestPosition: number | null = null;
   const actionable = queued.value.filter((job) => !job.cancelling);
-  for (const job of actionable.length > 0 ? actionable : queued.value) {
-    const position = queueStatusFor(
-      props.queueStatus,
-      job.hostId ?? ORIGIN_HOST_ID,
-      job.serverId,
-    )?.position;
-    if (
-      best === null ||
-      (position !== null &&
-        position !== undefined &&
-        (bestPosition === null || position < bestPosition)) ||
-      ((position === null || position === undefined) &&
-        bestPosition === null &&
-        job.startedAt < best.startedAt)
-    ) {
-      best = job;
-      bestPosition = position ?? null;
-    }
-  }
-  return best;
+  return (
+    [...(actionable.length > 0 ? actionable : queued.value)].sort(
+      (a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id),
+    )[0] ?? null
+  );
 });
 const summarizedQueuedCount = computed(() =>
   Math.max(0, queued.value.length - (nextQueued.value ? 1 : 0)),
+);
+
+type WebActivityRow =
+  | {
+      key: string;
+      createdAtMs: number;
+      kind: "shared";
+      shared: FleetActiveWork;
+    }
+  | { key: string; createdAtMs: number; kind: "print"; print: Job }
+  | {
+      key: string;
+      createdAtMs: number;
+      kind: "sequence";
+      sequence: ActivityJobVM & { kind: "sequence" };
+    };
+
+/** One visual queue across local prints, sequences, and recovered fleet work.
+ * A phase transition changes only the row contents, never its position. */
+const activeRows = computed<WebActivityRow[]>(() =>
+  [
+    ...props.shared.map((shared): WebActivityRow => ({
+      key: `shared:${shared.key}`,
+      createdAtMs: shared.created_at_unix_ms,
+      kind: "shared",
+      shared,
+    })),
+    ...running.value.map((print): WebActivityRow => ({
+      key: `print:${print.id}`,
+      createdAtMs: print.startedAt,
+      kind: "print",
+      print,
+    })),
+    ...(nextQueued.value
+      ? [
+          {
+            key: `print:${nextQueued.value.id}`,
+            createdAtMs: nextQueued.value.startedAt,
+            kind: "print" as const,
+            print: nextQueued.value,
+          },
+        ]
+      : []),
+    ...activeSequences.value.map((sequence): WebActivityRow => ({
+      key: sequence.key,
+      createdAtMs: sequence.createdAtMs,
+      kind: "sequence",
+      sequence,
+    })),
+  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
 );
 const active = computed(
   () =>
@@ -269,75 +302,198 @@ const active = computed(
       </button>
     </div>
 
-    <LiveActivityList
-      :rows="shared"
-      interactive
-      @select="emit('shared-open', $event)"
-    />
+    <template v-for="row in activeRows" :key="row.key">
+      <LiveActivityList
+        v-if="row.kind === 'shared'"
+        :rows="[row.shared]"
+        interactive
+        @select="emit('shared-open', $event)"
+      />
 
-    <div v-for="job in running" :key="job.id" class="activity__running">
-      <button
-        type="button"
-        class="activity__open"
-        :data-test="`activity-running-${job.id}`"
-        @click="emit('open', job)"
+      <div
+        v-else-if="row.kind === 'print' && row.print.workStarted"
+        class="activity__running"
       >
-        <span class="activity__thumb ms-shimmer" aria-hidden="true" />
-        <span class="activity__body">
+        <button
+          type="button"
+          class="activity__open"
+          :data-test="`activity-running-${row.print.id}`"
+          @click="emit('open', row.print)"
+        >
+          <span class="activity__thumb ms-shimmer" aria-hidden="true" />
+          <span class="activity__body">
+            <span class="activity__prompt">
+              <span
+                v-if="hostBadge(row.print)"
+                class="activity__host"
+                :data-test="`activity-host-${row.print.id}`"
+                >{{ hostBadge(row.print) }}</span
+              >
+              {{ promptFor(row.print) }}
+            </span>
+            <ProgressBar
+              :value="percentFor(row.print) ?? 0"
+              tone="accent"
+              :height="3"
+              :label="
+                isFinalizing(row.print)
+                  ? `${promptFor(row.print)} finalizing`
+                  : `${promptFor(row.print)} progress`
+              "
+            />
+          </span>
+          <span
+            v-if="isFinalizing(row.print)"
+            class="activity__pct activity__pct--stage"
+            >Finalizing</span
+          >
+          <span v-else-if="percentFor(row.print) !== null" class="activity__pct"
+            >{{ percentFor(row.print) }}%</span
+          >
+          <span v-else class="activity__pct activity__pct--stage">{{
+            row.print.progress.stage
+          }}</span>
+        </button>
+        <button
+          type="button"
+          class="activity__cancel activity__cancel--running"
+          :aria-label="
+            row.print.cancelling
+              ? `Cancelling ${promptFor(row.print)}`
+              : `Cancel ${promptFor(row.print)}`
+          "
+          :data-test="`activity-cancel-${row.print.id}`"
+          :disabled="row.print.cancelling"
+          @click="emit('cancel', row.print.id)"
+        >
+          <span v-if="row.print.cancelling" class="data-mono">…</span>
+          <Icon v-else name="close" :size="14" />
+        </button>
+      </div>
+
+      <div
+        v-else-if="row.kind === 'sequence'"
+        class="activity__sequence"
+        :data-test="`activity-sequence-${row.sequence.jobId}`"
+        role="button"
+        tabindex="0"
+        @click="emit('sequence-action', 'watch', row.sequence)"
+        @keydown.enter.prevent="emit('sequence-action', 'watch', row.sequence)"
+        @keydown.space.prevent="emit('sequence-action', 'watch', row.sequence)"
+      >
+        <span class="activity__seq-icon" aria-hidden="true">
+          <Icon name="video" :size="14" />
+        </span>
+        <span class="activity__seq-body">
           <span class="activity__prompt">
             <span
-              v-if="hostBadge(job)"
+              v-if="sequenceHostBadge(row.sequence)"
               class="activity__host"
-              :data-test="`activity-host-${job.id}`"
-              >{{ hostBadge(job) }}</span
+              :data-test="`activity-sequence-host-${row.sequence.jobId}`"
+              >{{ sequenceHostBadge(row.sequence) }}</span
             >
-            {{ promptFor(job) }}
+            {{ row.sequence.model }}
+            <span class="activity__seq-meta">
+              · {{ row.sequence.stageCount }} clips ·
+              {{ row.sequence.phase ?? row.sequence.state }}
+              <template v-if="sequenceStageLabel(row.sequence)">
+                · {{ sequenceStageLabel(row.sequence) }}</template
+              >
+            </span>
           </span>
           <ProgressBar
-            :value="percentFor(job) ?? 0"
+            v-if="sequencePercent(row.sequence) !== null"
+            :value="sequencePercent(row.sequence) ?? 0"
             tone="accent"
             :height="3"
-            :label="
-              isFinalizing(job)
-                ? `${promptFor(job)} finalizing`
-                : `${promptFor(job)} progress`
-            "
+            :label="`${row.sequence.model} sequence progress`"
           />
         </span>
         <span
-          v-if="isFinalizing(job)"
-          class="activity__pct activity__pct--stage"
-          >Finalizing</span
+          v-if="sequencePercent(row.sequence) !== null"
+          class="activity__pct"
+          >{{ sequencePercent(row.sequence) }}%</span
         >
-        <span v-else-if="percentFor(job) !== null" class="activity__pct"
-          >{{ percentFor(job) }}%</span
+        <span class="activity__seq-actions">
+          <button
+            v-for="action in row.sequence.actions"
+            :key="action"
+            type="button"
+            class="activity__seq-action"
+            :data-action="action"
+            @click.stop="emit('sequence-action', action, row.sequence)"
+          >
+            {{ ACTION_LABELS[action] }}
+          </button>
+        </span>
+      </div>
+
+      <div v-else class="activity__queued">
+        <span
+          class="activity__pill"
+          :data-test="`activity-queued-${row.print.id}`"
+          role="button"
+          tabindex="0"
+          @click="emit('open', row.print)"
+          @keydown.enter.prevent="emit('open', row.print)"
+          @keydown.space.prevent="emit('open', row.print)"
         >
-        <span v-else class="activity__pct activity__pct--stage">{{
-          job.progress.stage
-        }}</span>
-      </button>
-      <button
-        type="button"
-        class="activity__cancel activity__cancel--running"
-        :aria-label="
-          job.cancelling
-            ? `Cancelling ${promptFor(job)}`
-            : `Cancel ${promptFor(job)}`
-        "
-        :data-test="`activity-cancel-${job.id}`"
-        :disabled="job.cancelling"
-        @click="emit('cancel', job.id)"
-      >
-        <span v-if="job.cancelling" class="data-mono">…</span>
-        <Icon v-else name="close" :size="14" />
-      </button>
-    </div>
+          <span class="activity__pill-text">
+            <span
+              v-if="hostBadge(row.print)"
+              class="activity__host"
+              :data-test="`activity-host-${row.print.id}`"
+              >{{ hostBadge(row.print) }}</span
+            >
+            <span
+              class="activity__queue-position"
+              :data-test="`activity-queue-position-${row.print.id}`"
+              >{{ queueLabel(row.print) }}</span
+            >
+            {{ promptFor(row.print) }}
+            <span v-if="row.print.holdError" class="activity__hold-error">
+              · {{ row.print.holdError }}
+            </span>
+          </span>
+          <button
+            v-if="row.print.retryable"
+            type="button"
+            class="activity__seq-action"
+            :disabled="row.print.retrying"
+            :data-test="`activity-retry-${row.print.id}`"
+            @click.stop="emit('retry', row.print.id)"
+          >
+            {{ row.print.retrying ? "Retrying…" : "Retry" }}
+          </button>
+          <button
+            type="button"
+            class="activity__cancel"
+            :aria-label="`Cancel ${promptFor(row.print)}`"
+            :data-test="`activity-cancel-${row.print.id}`"
+            :disabled="row.print.cancelling"
+            @click.stop="emit('cancel', row.print.id)"
+          >
+            <span v-if="row.print.cancelling" class="data-mono">…</span>
+            <Icon v-else name="close" :size="12" />
+          </button>
+        </span>
+      </div>
+    </template>
+
+    <span
+      v-if="summarizedQueuedCount"
+      class="activity__queue-summary"
+      data-test="activity-queued-summary"
+    >
+      {{ summarizedQueuedCount }} other queued
+      {{ summarizedQueuedCount === 1 ? "print" : "prints" }}
+    </span>
 
     <div
-      v-for="vm in orderedSequences"
+      v-for="vm in attentionSequences"
       :key="vm.key"
       class="activity__sequence"
-      :data-test="`activity-sequence-${vm.kind === 'sequence' ? vm.jobId : ''}`"
+      :data-test="`activity-sequence-${vm.jobId}`"
       role="button"
       tabindex="0"
       @click="emit('sequence-action', 'watch', vm)"
@@ -348,32 +504,8 @@ const active = computed(
         <Icon name="video" :size="14" />
       </span>
       <span class="activity__seq-body">
-        <span class="activity__prompt">
-          <span
-            v-if="sequenceHostBadge(vm)"
-            class="activity__host"
-            :data-test="`activity-sequence-host-${vm.kind === 'sequence' ? vm.jobId : ''}`"
-            >{{ sequenceHostBadge(vm) }}</span
-          >
-          {{ vm.model }}
-          <span v-if="vm.kind === 'sequence'" class="activity__seq-meta">
-            · {{ vm.stageCount }} clips · {{ vm.phase ?? vm.state }}
-            <template v-if="sequenceStageLabel(vm)">
-              · {{ sequenceStageLabel(vm) }}</template
-            >
-          </span>
-        </span>
-        <ProgressBar
-          v-if="sequencePercent(vm) !== null"
-          :value="sequencePercent(vm) ?? 0"
-          tone="accent"
-          :height="3"
-          :label="`${vm.model} sequence progress`"
-        />
+        <span class="activity__prompt">{{ vm.model }}</span>
       </span>
-      <span v-if="sequencePercent(vm) !== null" class="activity__pct"
-        >{{ sequencePercent(vm) }}%</span
-      >
       <span class="activity__seq-actions">
         <button
           v-for="action in vm.actions"
@@ -389,73 +521,13 @@ const active = computed(
           v-if="attentionKeys.has(vm.key)"
           type="button"
           class="activity__cancel"
-          :data-test="`activity-seq-dismiss-${vm.kind === 'sequence' ? vm.jobId : ''}`"
+          :data-test="`activity-seq-dismiss-${vm.jobId}`"
           title="Hide this from Activity. The sequence stays in Library ▸ History."
           :aria-label="`Dismiss ${vm.model}`"
           @click.stop="dismissSequence(vm)"
         >
           <Icon name="close" :size="13" />
         </button>
-      </span>
-    </div>
-
-    <div v-if="nextQueued" class="activity__queued">
-      <span
-        :key="nextQueued.id"
-        class="activity__pill"
-        :data-test="`activity-queued-${nextQueued.id}`"
-        role="button"
-        tabindex="0"
-        @click="emit('open', nextQueued)"
-        @keydown.enter.prevent="emit('open', nextQueued)"
-        @keydown.space.prevent="emit('open', nextQueued)"
-      >
-        <span class="activity__pill-text">
-          <span
-            v-if="hostBadge(nextQueued)"
-            class="activity__host"
-            :data-test="`activity-host-${nextQueued.id}`"
-            >{{ hostBadge(nextQueued) }}</span
-          >
-          <span
-            class="activity__queue-position"
-            :data-test="`activity-queue-position-${nextQueued.id}`"
-            >{{ queueLabel(nextQueued) }}</span
-          >
-          {{ promptFor(nextQueued) }}
-          <span v-if="nextQueued.holdError" class="activity__hold-error">
-            · {{ nextQueued.holdError }}
-          </span>
-        </span>
-        <button
-          v-if="nextQueued.retryable"
-          type="button"
-          class="activity__seq-action"
-          :disabled="nextQueued.retrying"
-          :data-test="`activity-retry-${nextQueued.id}`"
-          @click.stop="emit('retry', nextQueued.id)"
-        >
-          {{ nextQueued.retrying ? "Retrying…" : "Retry" }}
-        </button>
-        <button
-          type="button"
-          class="activity__cancel"
-          :aria-label="`Cancel ${promptFor(nextQueued)}`"
-          :data-test="`activity-cancel-${nextQueued.id}`"
-          :disabled="nextQueued.cancelling"
-          @click.stop="emit('cancel', nextQueued.id)"
-        >
-          <span v-if="nextQueued.cancelling" class="data-mono">…</span>
-          <Icon v-else name="close" :size="12" />
-        </button>
-      </span>
-      <span
-        v-if="summarizedQueuedCount"
-        class="activity__queue-summary"
-        data-test="activity-queued-summary"
-      >
-        {{ summarizedQueuedCount }} other queued
-        {{ summarizedQueuedCount === 1 ? "print" : "prints" }}
       </span>
     </div>
 


### PR DESCRIPTION
## Summary
- preserve chronological submission order as queued work transitions into developing/running
- merge local, recovered fleet, and sequence rows into one ordered activity timeline across web, desktop, and mobile
- keep compact queue windows chronological, including held-memory jobs

## Verification
- `nix develop -c bun run check:frontend` (8,509 tests)
- web, desktop, and mobile production builds
- Prettier checks and `git diff --check`
- rendered desktop and 390x844 mobile browser QA with an older queued job above a newer running job; no console errors
- independent agent peer review completed; follow-up review found no actionable findings
