### PR TITLE
fix(expand): distinguish output failures from missing model

### DIFF
--- a/changelog.d/prompt-expansion-retry-classification.md
+++ b/changelog.d/prompt-expansion-retry-classification.md
@@ -1,0 +1,1 @@
+- **Keep prompt expansion retryable after short responses.** Exact-count failures now stay in the retry flow instead of incorrectly asking users to download an already installed expansion model.

--- a/crates/mold-inference/src/expand.rs
+++ b/crates/mold-inference/src/expand.rs
@@ -738,20 +738,20 @@ impl PromptExpander for LocalExpander {
                 },
             )
         })
-        .map_err(|error| {
-            if error.to_string().contains("expected exactly") {
-                anyhow::anyhow!(
-                    "{error}. The model may need re-downloading: mold pull qwen3-expand"
-                )
-            } else {
-                error
-            }
-        })?;
+        .map_err(local_expand_error_with_recovery)?;
 
         Ok(ExpandResult {
             original: prompt.to_string(),
             expanded,
         })
+    }
+}
+
+fn local_expand_error_with_recovery(error: anyhow::Error) -> anyhow::Error {
+    if error.to_string().contains("expected exactly") {
+        anyhow::anyhow!("{error}. Retry expansion or reduce the batch size.")
+    } else {
+        error
     }
 }
 
@@ -1152,5 +1152,16 @@ mod exact_plan_tests {
             expander.progress.checkpoint().is_ok(),
             "cancelled token leaked into the next attempt"
         );
+    }
+
+    #[test]
+    fn exact_count_failure_never_claims_the_model_is_missing() {
+        let message = local_expand_error_with_recovery(anyhow::anyhow!(
+            "expected exactly 10 distinct non-empty prompts, but the expansion backend returned 9"
+        ))
+        .to_string();
+
+        assert!(message.contains("Retry expansion or reduce the batch size"));
+        assert!(!message.contains("mold pull"), "{message}");
     }
 }

--- a/desktop/src/lib/expandErrors.test.ts
+++ b/desktop/src/lib/expandErrors.test.ts
@@ -24,9 +24,7 @@ describe("parseMissingExpandModel", () => {
   it("returns null for unrelated errors", () => {
     expect(parseMissingExpandModel("inference failed: out of memory")).toBeNull();
     expect(
-      parseMissingExpandModel(
-        "The model may need re-downloading: mold pull qwen3-expand",
-      ),
+      parseMissingExpandModel("The model may need re-downloading: mold pull qwen3-expand"),
     ).toBeNull();
   });
 });

--- a/desktop/src/lib/expandErrors.test.ts
+++ b/desktop/src/lib/expandErrors.test.ts
@@ -9,11 +9,24 @@ describe("parseMissingExpandModel", () => {
   });
 
   it("handles tagged and catalog ids", () => {
-    expect(parseMissingExpandModel("run: mold pull qwen3-expand:q4")).toBe("qwen3-expand:q4");
-    expect(parseMissingExpandModel("run: mold pull hf:org/repo")).toBe("hf:org/repo");
+    expect(
+      parseMissingExpandModel(
+        "local expand model 'qwen3-expand:q4' not found — run: mold pull qwen3-expand:q4",
+      ),
+    ).toBe("qwen3-expand:q4");
+    expect(
+      parseMissingExpandModel(
+        "local expand model 'hf:org/repo' not found — run: mold pull hf:org/repo",
+      ),
+    ).toBe("hf:org/repo");
   });
 
   it("returns null for unrelated errors", () => {
     expect(parseMissingExpandModel("inference failed: out of memory")).toBeNull();
+    expect(
+      parseMissingExpandModel(
+        "The model may need re-downloading: mold pull qwen3-expand",
+      ),
+    ).toBeNull();
   });
 });

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4941,6 +4941,26 @@ describe("MobileApp generation queue", () => {
     ).toBeUndefined();
   });
 
+  it("keeps exact-count failures out of the missing-model pull flow", async () => {
+    expandPrompt.mockRejectedValueOnce(
+      new Error(
+        "expected exactly 2 distinct non-empty prompts, but the expansion backend returned 1. " +
+          "The model may need re-downloading: mold pull qwen3-expand",
+      ),
+    );
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
+    await fieldControl("Prompt").setValue("lighthouse");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='mobile-pull-expansion']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-expansion-error']").text()).toContain(
+      "Expansion failed on Studio: expected exactly 2 distinct non-empty prompts",
+    );
+  });
+
   it("refuses a missing-model Remix pull after its frozen dimensions change", async () => {
     remixPrompt.mockRejectedValueOnce(
       new Error("local expand model not found, run: mold pull qwen3-expand:q8"),

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -1315,6 +1315,24 @@ describe("GenerateView prepared expansion batches", () => {
     );
   });
 
+  it("keeps exact-count failures out of the missing-model pull flow", async () => {
+    vi.mocked(expandPrompt).mockRejectedValue(
+      new Error(
+        "expected exactly 3 distinct non-empty prompts, but the expansion backend returned 2. " +
+          "The model may need re-downloading: mold pull qwen3-expand",
+      ),
+    );
+    const wrapper = mountView();
+    await flushPromises();
+    wrapper.findComponent(ExpandControl).vm.$emit("expand");
+    await flushPromises();
+
+    expect(wrapper.find('[data-test="expansion-pull-status"]').exists()).toBe(false);
+    expect(wrapper.get('[role="alert"]').text()).toContain(
+      "Expansion failed on This device: expected exactly 3 distinct non-empty prompts",
+    );
+  });
+
   it("keeps Batch 1 pull progress inline from connection through exact-job readiness", async () => {
     useGenerateFormStore().form.batchSize = 1;
     const stream = deferred<void>();

--- a/studio/lib/expansionRouting.test.ts
+++ b/studio/lib/expansionRouting.test.ts
@@ -3,6 +3,7 @@ import {
   DEFAULT_EXPAND_MODEL,
   expandModelId,
   expansionPolicyForSelection,
+  parseMissingExpandModel,
   resolveExpansionRoute,
   type ExpansionCandidate,
 } from "./expansionRouting";
@@ -178,6 +179,30 @@ describe("expansionPolicyForSelection", () => {
       kind: "pinned",
       hostId: "plato",
     });
+  });
+});
+
+describe("parseMissingExpandModel", () => {
+  it("extracts legacy and model-qualified missing-model errors", () => {
+    expect(
+      parseMissingExpandModel(
+        "local expand model not found — run: mold pull qwen3-expand",
+      ),
+    ).toBe("qwen3-expand");
+    expect(
+      parseMissingExpandModel(
+        "local expand model 'qwen3-expand:q8' not found — run: mold pull qwen3-expand:q8",
+      ),
+    ).toBe("qwen3-expand:q8");
+  });
+
+  it("does not turn output-count recovery advice into a missing-model state", () => {
+    expect(
+      parseMissingExpandModel(
+        "expected exactly 10 distinct non-empty prompts, but the expansion backend returned 9. " +
+          "The model may need re-downloading: mold pull qwen3-expand",
+      ),
+    ).toBeNull();
   });
 });
 

--- a/studio/lib/expansionRouting.ts
+++ b/studio/lib/expansionRouting.ts
@@ -120,12 +120,16 @@ export function expansionPolicyForSelection(
 }
 
 /**
- * The engine's missing-expansion-model error embeds its own fix:
- * "local expand model not found — run: mold pull qwen3-expand". Extract the
- * model name so any surface can offer that pull directly.
+ * The engine's definitive missing-expansion-model error embeds its own fix:
+ * "local expand model not found — run: mold pull qwen3-expand". Require both
+ * halves before offering a pull: other expansion failures may mention that
+ * command as recovery advice, but they do not prove the model is absent.
  */
 export function parseMissingExpandModel(message: string): string | null {
-  const match = /mold pull ([\w.:@/-]+)/.exec(message);
+  const match =
+    /local expand model(?:\s+'[^']+')?\s+not found[^\n]*?mold pull ([\w.:@/-]+)/i.exec(
+      message,
+    );
   return match?.[1] ?? null;
 }
 

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -2589,6 +2589,30 @@ describe("CreatePage layout and behavior", () => {
     expect(batchIds.size).toBe(1);
   });
 
+  it("does not offer a model pull for an exact-count expansion failure", async () => {
+    expandPromptMock.mockRejectedValueOnce(
+      new Error(
+        "expected exactly 3 distinct non-empty prompts, but the expansion backend returned 2. " +
+          "The model may need re-downloading: mold pull qwen3-expand",
+      ),
+    );
+    hostModelsMock.mockResolvedValue([installedModelRow("flux-dev:q4", "flux")]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = "flux-dev:q4";
+    form.state.value.modelFamily = "flux";
+    form.state.value.prompt = "a lighthouse";
+    form.state.value.batchSize = 3;
+    await nextTick();
+
+    await wrapper.get("[data-test='composer-expand']").trigger("click");
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='web-expansion-pull']").exists()).toBe(false);
+    expect(wrapper.getComponent({ name: "ResultCanvas" }).props("variations")).toEqual([]);
+  });
+
   it("blocks ordinary submit while variations are preparing and awaiting review", async () => {
     let releaseExpansion!: (value: {
       original: string;

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -2596,7 +2596,9 @@ describe("CreatePage layout and behavior", () => {
           "The model may need re-downloading: mold pull qwen3-expand",
       ),
     );
-    hostModelsMock.mockResolvedValue([installedModelRow("flux-dev:q4", "flux")]);
+    hostModelsMock.mockResolvedValue([
+      installedModelRow("flux-dev:q4", "flux"),
+    ]);
     const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
     await flushPromises();
     const form = useGenerateForm();
@@ -2609,8 +2611,12 @@ describe("CreatePage layout and behavior", () => {
     await wrapper.get("[data-test='composer-expand']").trigger("click");
     await flushPromises();
 
-    expect(wrapper.find("[data-test='web-expansion-pull']").exists()).toBe(false);
-    expect(wrapper.getComponent({ name: "ResultCanvas" }).props("variations")).toEqual([]);
+    expect(wrapper.find("[data-test='web-expansion-pull']").exists()).toBe(
+      false,
+    );
+    expect(
+      wrapper.getComponent({ name: "ResultCanvas" }).props("variations"),
+    ).toEqual([]);
   });
 
   it("blocks ordinary submit while variations are preparing and awaiting review", async () => {


### PR DESCRIPTION
## Summary

- stop treating prompt-count failures as proof that `qwen3-expand` is missing
- give exact-count failures accurate retry or smaller-batch recovery guidance
- keep genuine missing-model pull recovery shared across desktop, web, and mobile
- add regression coverage at the shared parser, backend, and every UI surface

## Root cause

The local expander appended `mold pull qwen3-expand` to exact-count failures. The shared client parser treated any error containing that command as a definitive missing-model response, so a successful pull followed by a malformed/short expansion response reopened the model-download UI.

## Validation

- `nix develop -c bun run check:frontend` (8,520 tests plus web and desktop production builds)
- `nix develop -c cargo test -p mold-ai-inference --features expand exact_count_failure_never_claims_the_model_is_missing`
- `nix develop -c cargo clippy -p mold-ai-inference --features expand -- -D warnings`
- targeted desktop, web, mobile, and shared parser regression tests
- rendered `/create` in the desktop Vite app; no console errors or framework overlay
- independent Codex subagent review: no actionable findings
- Claude Code Sonnet review: no actionable findings
