### PR TITLE
fix(studio): default source images to crop fill

### DIFF
--- a/changelog.d/default-source-crop-fit.md
+++ b/changelog.d/default-source-crop-fit.md
@@ -1,0 +1,3 @@
+- **Source images now default to Crop fill everywhere.** New uploads, gallery picks,
+  file drops, edit targets, and sequence opening images consistently preserve the
+  source proportions and crop overflow across web, desktop, iPhone, and Android.

--- a/desktop/src/components/create/SequenceOpeningImageWell.test.ts
+++ b/desktop/src/components/create/SequenceOpeningImageWell.test.ts
@@ -45,7 +45,7 @@ describe("SequenceOpeningImageWell", () => {
     expect(wrapper.text()).toContain("Applied to the opening image before clip 1 renders.");
   });
 
-  it("attaches a gallery pick and coerces the maskless source fit", async () => {
+  it("attaches a gallery pick with the shared crop-fill default", async () => {
     const draft = useSequenceDraftStore();
     const form = reactive(newGenerateForm());
     form.sourceFit = { mode: "pad-repaint" };
@@ -58,7 +58,7 @@ describe("SequenceOpeningImageWell", () => {
     await flushPromises();
 
     expect(draft.openingImage).toEqual({ filename: "opening.jpg", base64: "wire-bytes" });
-    expect(form.sourceFit).toEqual({ mode: "crop-fill", alignX: "center", alignY: "center" });
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(wrapper.get(".image-well__preview img").attributes("src")).toBe(
       "data:image/jpeg;base64,wire-bytes",
     );

--- a/desktop/src/components/create/SequenceOpeningImageWell.vue
+++ b/desktop/src/components/create/SequenceOpeningImageWell.vue
@@ -6,6 +6,7 @@ import type { ModelEntry } from "../../lib/api/types";
 import {
   SOURCE_FIT_OPTIONS,
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   sourceFitPolicyForMode,
   type SourceFitMode,
 } from "@studio/lib/sourceFit";
@@ -54,7 +55,7 @@ function onPickImage(images: PickedImage[]) {
   pickerOpen.value = false;
   if (!image) return;
   draft.openingImage = { filename: image.filename, base64: image.base64 };
-  props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
+  props.form.sourceFit = defaultSourceFitPolicy();
 }
 
 async function onOpeningImageFile(file: File) {
@@ -71,7 +72,7 @@ async function onOpeningImageFile(file: File) {
       width: dimensions.width,
       height: dimensions.height,
     };
-    props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
+    props.form.sourceFit = defaultSourceFitPolicy();
   } catch {
     toasts.push("Couldn't read the image.", "error");
   }

--- a/desktop/src/components/generate/SourceImageWell.test.ts
+++ b/desktop/src/components/generate/SourceImageWell.test.ts
@@ -89,7 +89,7 @@ describe("SourceImageWell", () => {
       form.sourceImage = "SRC";
       await flushPromises();
       const select = wrapper.get("[data-test='source-fit-policy']").element as HTMLSelectElement;
-      expect(select.value).toBe("pad-repaint");
+      expect(select.value).toBe("crop-fill");
       expect(Array.from(select.options).map((o) => o.value)).toEqual([
         "pad-repaint",
         "crop-fill",
@@ -131,7 +131,7 @@ describe("SourceImageWell", () => {
       expect(form.sourceFit).toEqual({
         mode: "upscale-then-fit",
         upscalerModel: "real-esrgan-x2plus:fp16",
-        fit: { mode: "pad-repaint" },
+        fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
       });
     });
 
@@ -148,7 +148,7 @@ describe("SourceImageWell", () => {
       expect(form.sourceFit).toEqual({
         mode: "upscale-then-fit",
         upscalerModel: "real-esrgan-x4plus:fp16",
-        fit: { mode: "pad-repaint" },
+        fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
       });
     });
   });
@@ -206,6 +206,7 @@ describe("SourceImageWell", () => {
 
     it("appends picks from the multi-select picker in order", async () => {
       const form = formFor("qwen-image-edit");
+      form.sourceFit = { mode: "pad-fit" };
       const wrapper = mount(SourceImageWell, { props: { form }, attachTo: document.body });
       await wrapper.get("[data-test='add-edit-image']").trigger("click");
       const picker = wrapper
@@ -218,6 +219,7 @@ describe("SourceImageWell", () => {
       ]);
       await flushPromises();
       expect(form.imageAttachments).toEqual(["A", "B"]);
+      expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     });
 
     it("removes a tile", async () => {

--- a/desktop/src/components/generate/SourceImageWell.vue
+++ b/desktop/src/components/generate/SourceImageWell.vue
@@ -29,8 +29,11 @@ import { strengthSemantics } from "@studio/lib/strengthSemantics";
 import { sourceConditioningLimitLabel } from "@studio/lib/sourceResolution";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   MASKLESS_SOURCE_FIT_OPTIONS,
   sourceFitHelp,
+  sourceFitPolicyForMode,
+  type SourceFitMode,
 } from "@studio/lib/sourceFit";
 import {
   appendMinimaxH3PickedImageReferences,
@@ -134,12 +137,17 @@ const dragIndex = ref<number | null>(null);
 
 function onEditPicked(picked: PickedImage[]) {
   if (picked.length === 0) return;
+  const establishesTarget =
+    plan.value.kind === "attachments" &&
+    plan.value.primary === "target" &&
+    props.form.imageAttachments.length === 0;
   const next = [...props.form.imageAttachments, ...picked.map((p) => p.base64)];
   props.form.imageAttachments = flux2Dev.value ? next.slice(0, 4) : next;
+  if (establishesTarget) props.form.sourceFit = defaultSourceFitPolicy();
 }
 function replaceEditTarget(base64: string) {
   props.form.imageAttachments = [base64, ...props.form.imageAttachments.slice(1)];
-  props.form.sourceFit = { mode: "lanczos-resize" };
+  props.form.sourceFit = defaultSourceFitPolicy();
 }
 function onTargetPicked(picked: PickedImage[]) {
   if (picked[0]) replaceEditTarget(picked[0].base64);
@@ -264,7 +272,7 @@ function setSlot(slot: Slot, b64: string | null, name: string | null = null) {
     props.form.sourceImage = b64;
     // The label lives and dies with the image (Reuse-settings restore).
     props.form.sourceImageName = b64 ? name : null;
-    if (b64) props.form.sourceFit = { mode: "lanczos-resize" };
+    if (b64) props.form.sourceFit = defaultSourceFitPolicy();
   } else if (slot === "end") {
     // The closing still keeps its own name: it ships as the second keyframe,
     // whose provenance is all saved metadata will ever hold of it.
@@ -347,28 +355,13 @@ function onH3Picked(images: PickedImage[]) {
 
 /** Port of the web SPA's `setSourceFitPolicy` mode→policy mapping. */
 function setSourceFitMode(e: Event) {
-  const raw = (e.target as HTMLSelectElement).value;
-  if (raw === "crop-fill") {
-    props.form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
-    return;
-  }
-  if (raw === "lanczos-resize") {
-    props.form.sourceFit = { mode: "lanczos-resize" };
-    return;
-  }
-  if (raw === "upscale-then-fit") {
-    props.form.sourceFit = {
-      mode: "upscale-then-fit",
+  props.form.sourceFit = sourceFitPolicyForMode(
+    (e.target as HTMLSelectElement).value as SourceFitMode,
+    {
+      supportsMask: caps.value.supportsMask,
       upscalerModel: props.form.upscaleModel || models.upscalers[0]?.name || "",
-      // Maskless families (video img2img) can't repaint pad bands — fill the
-      // canvas instead of padding it.
-      fit: caps.value.supportsMask
-        ? { mode: "pad-repaint" }
-        : { mode: "crop-fill", alignX: "center", alignY: "center" },
-    };
-    return;
-  }
-  props.form.sourceFit = { mode: raw === "pad-fit" ? "pad-fit" : "pad-repaint" };
+    },
+  );
 }
 </script>
 
@@ -552,7 +545,7 @@ function setSourceFitMode(e: Event) {
       <label class="mt-3 block text-caption text-ink-2" for="source-fit-policy">Source fit</label>
       <select
         id="source-fit-policy"
-        :value="form.sourceFit?.mode ?? 'pad-repaint'"
+        :value="form.sourceFit?.mode ?? defaultSourceFitPolicy().mode"
         data-test="source-fit-policy"
         class="border-edge mt-1 h-7 w-full rounded-control border bg-bath px-1.5 text-body text-ink"
         @change="setSourceFitMode"

--- a/desktop/src/lib/desktopImageDrop.test.ts
+++ b/desktop/src/lib/desktopImageDrop.test.ts
@@ -58,7 +58,7 @@ describe("applyDesktopImageDrop", () => {
     });
     expect(form.sourceImage).toBe("IMAGE_BYTES");
     expect(form.sourceImageName).toBe("reference.png");
-    expect(form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(form.sourceImageWidth).toBe(896);
     expect(form.sourceImageHeight).toBe(1152);
   });
@@ -88,6 +88,7 @@ describe("applyDesktopImageDrop", () => {
     expect(applyDesktopImageDrop(form, dropped(), [qwenEdit]).attached).toBe(true);
     expect(form.imageAttachments).toEqual(["IMAGE_BYTES"]);
     expect(form.sourceImage).toBeNull();
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it("still loads metadata when that model cannot accept a source image", () => {

--- a/desktop/src/lib/desktopImageDrop.ts
+++ b/desktop/src/lib/desktopImageDrop.ts
@@ -1,6 +1,7 @@
 import { generationCapabilitiesForFamily } from "./capabilities";
 import type { ModelEntry, OutputMetadata } from "./api/types";
 import { applyMetadataToForm, type GenerateForm } from "./generateForm";
+import { defaultSourceFitPolicy } from "@studio/lib/sourceFit";
 
 /** A local still read by the native desktop backend after an OS file drop. */
 export interface DesktopImageImport {
@@ -42,10 +43,10 @@ export function applyDesktopImageDrop(
     form.imageAttachments = [];
     form.sourceImage = image.base64;
     form.sourceImageName = image.filename;
-    form.sourceFit = { mode: "lanczos-resize" };
   } else {
     return { attached: false, metadataApplied };
   }
+  form.sourceFit = defaultSourceFitPolicy();
   form.sourceImageWidth = image.width;
   form.sourceImageHeight = image.height;
 

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -1664,8 +1664,8 @@ describe("buildRequest prompt provenance", () => {
 });
 
 describe("newGenerateForm source-fit default", () => {
-  it("starts on pad-repaint, matching the web SPA's default policy", () => {
-    expect(newGenerateForm().sourceFit).toEqual({ mode: "pad-repaint" });
+  it("starts on crop-fill, matching every source-image surface", () => {
+    expect(newGenerateForm().sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it("keeps the chosen policy across a model change (web parity)", () => {
@@ -2305,6 +2305,7 @@ describe("LTX-2 img2img (image-to-video)", () => {
   it("coerces a mask-dependent source-fit policy to crop-fill on entry", () => {
     const form = newGenerateForm();
     form.sourceImage = "SRC";
+    form.sourceFit = { mode: "pad-repaint" };
     expect(form.sourceFit).toEqual({ mode: "pad-repaint" });
     applyModelDefaults(form, ltx2Model());
     expect(form.sourceFit).toEqual({ mode: "crop-fill", alignX: "center", alignY: "center" });

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -26,6 +26,7 @@ import {
 } from "./capabilities";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   parseSourceFitPolicy,
   type SourceFitPolicy,
 } from "@studio/lib/sourceFit";
@@ -322,7 +323,7 @@ export function newGenerateForm(): GenerateForm {
     identityStartStep: null,
     identitySupported: null,
     imageAttachments: [],
-    sourceFit: { mode: "pad-repaint" },
+    sourceFit: defaultSourceFitPolicy(),
     maskImage: null,
     controlImage: null,
     controlModel: "",

--- a/desktop/src/lib/sequenceParams.test.ts
+++ b/desktop/src/lib/sequenceParams.test.ts
@@ -25,7 +25,7 @@ describe("sequenceParams", () => {
       steps: 8,
       guidance: 3,
       strength: 0.9,
-      sourceFitPolicy: { mode: "pad-repaint" },
+      sourceFitPolicy: { mode: "crop-fill" },
       upscalerModel: "",
       seed: "42",
     });

--- a/desktop/src/lib/sourceAttachment.test.ts
+++ b/desktop/src/lib/sourceAttachment.test.ts
@@ -9,7 +9,7 @@ describe("source attachment", () => {
     attachPickedImage(form, { filename: "source.png", base64: "QUJD" });
     expect(form.sourceImage).toBe("QUJD");
     expect(form.sourceImageName).toBe("source.png");
-    expect(form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it("attaches a gallery video to the existing LTX source-video field", () => {

--- a/desktop/src/lib/sourceAttachment.ts
+++ b/desktop/src/lib/sourceAttachment.ts
@@ -1,10 +1,11 @@
 import type { GenerateForm, PickedImage } from "./generateForm";
+import { defaultSourceFitPolicy } from "@studio/lib/sourceFit";
 
 /** One source-attachment policy shared by uploads, gallery picks, and Library. */
 export function attachPickedImage(form: GenerateForm, picked: PickedImage): void {
   form.sourceImage = picked.base64;
   form.sourceImageName = picked.filename || null;
-  form.sourceFit = { mode: "lanczos-resize" };
+  form.sourceFit = defaultSourceFitPolicy();
 }
 
 /** Video outputs become LTX source-video bytes, including cross-host reuse. */

--- a/desktop/src/lib/sourceFitPreprocess.test.ts
+++ b/desktop/src/lib/sourceFitPreprocess.test.ts
@@ -34,11 +34,10 @@ function fakeOps(size: { width: number; height: number }): SourceFitCanvasOps & 
 const TARGET = { width: 1024, height: 1024 };
 
 describe("drawableFitPolicy", () => {
-  it("falls back to pad-repaint when unset and honors upscale-then-fit's inner fit", () => {
-    expect(drawableFitPolicy(undefined)).toEqual({ mode: "pad-repaint" });
+  it("falls back to crop-fill when unset and honors upscale-then-fit's inner fit", () => {
+    expect(drawableFitPolicy(undefined)).toEqual({ mode: "crop-fill" });
     // The inner fit drives the draw — required so maskless (video) img2img can
-    // upscale-then-fit without pad bands it has no way to repaint. The UI's
-    // default inner fit is still pad-repaint, so image flows are unchanged.
+    // upscale-then-fit without pad bands it has no way to repaint.
     expect(
       drawableFitPolicy({
         mode: "upscale-then-fit",

--- a/desktop/src/lib/sourceFitPreprocess.ts
+++ b/desktop/src/lib/sourceFitPreprocess.ts
@@ -21,6 +21,7 @@
 import type { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   maskPaddingRectangles,
   resolveSourceFitTransform,
   type Size,
@@ -52,13 +53,10 @@ export interface SourceFitResult {
 
 /**
  * The policy actually used for the canvas draw. A missing policy falls back
- * to pad-repaint (web parity); `upscale-then-fit` draws its inner `fit` —
- * the UI defaults that inner fit to pad-repaint for image families, and
- * maskless (video) img2img coerces it away so no unrepaintable pad bands
- * are ever drawn.
+ * to the shared crop-fill default; `upscale-then-fit` draws its inner `fit`.
  */
 export function drawableFitPolicy(policy: SourceFitPolicy | undefined): SourceFitPolicy {
-  if (!policy) return { mode: "pad-repaint" };
+  if (!policy) return defaultSourceFitPolicy();
   if (policy.mode === "upscale-then-fit") return policy.fit;
   return policy;
 }

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9281,6 +9281,8 @@ describe("MobileApp gallery", () => {
 
     wrapper = mountMobileApp();
     await flushPromises();
+    const liveForm = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    liveForm.sourceFit = { mode: "lanczos-resize" };
     await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
     await flushPromises();
     await wrapper.get("[data-test='gallery-item']").trigger("click");
@@ -9300,6 +9302,7 @@ describe("MobileApp gallery", () => {
     expect(wrapper.get("[data-test='mobile-source-preview']").attributes("alt")).toBe(
       "source print.png",
     );
+    expect(liveForm.sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it("appends a gallery source to the selected Ref2VA partition", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -303,7 +303,11 @@ import { isGenerationModel } from "../stores/models";
 import type { HostRoute } from "../stores/hosts";
 import { domCanvasOps } from "@studio/lib/sourceFitCanvas";
 import { applySourceFitPreprocess } from "../lib/sourceFitPreprocess";
-import { coerceSourceFitForMaskless, parseSourceFitPolicy } from "@studio/lib/sourceFit";
+import {
+  coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
+  parseSourceFitPolicy,
+} from "@studio/lib/sourceFit";
 import { requestWarningsFromHeaders } from "@studio/lib/requestWarnings";
 import {
   persistGenerationSourceMedia,
@@ -1856,7 +1860,7 @@ watch(
     previousStillResolution = next.resolution;
     previousStillAutomaticResolution = next.automaticResolution;
     if (replaced && caps.value.sourceImageMode === "single") {
-      form.sourceFit = { mode: "lanczos-resize" };
+      form.sourceFit = defaultSourceFitPolicy();
     }
   },
   { immediate: true },
@@ -6330,7 +6334,7 @@ async function generate(): Promise<void> {
         filename: draft.sourceImageName ?? "Source image",
         width: draft.sourceImageWidth,
         height: draft.sourceImageHeight,
-        sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? { mode: "pad-repaint" },
+        sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? defaultSourceFitPolicy(),
       }
     : draft.h3Authoring?.firstFrame?.data
       ? {
@@ -6339,7 +6343,7 @@ async function generate(): Promise<void> {
           width: draft.h3Authoring.firstFrame.width,
           height: draft.h3Authoring.firstFrame.height,
           mime: draft.h3Authoring.firstFrame.mimeType,
-          sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? { mode: "pad-repaint" },
+          sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? defaultSourceFitPolicy(),
         }
       : null;
   const draftCaps = generationCapabilitiesForFamily(
@@ -7621,7 +7625,7 @@ async function restoreOrdinaryReusedSource(
     preserveRestoredSourceCanvas(stored.base64);
     form.sourceImage = stored.base64;
     form.sourceImageName = stored.filename;
-    // The normal source-change watcher selects Resize for a newly attached
+    // The normal source-change watcher selects Crop fill for a newly attached
     // image. Let that watcher settle, then reassert provenance attributes:
     // Library reuse is restoration, not a new pick.
     await nextTick();
@@ -7833,6 +7837,7 @@ async function useSelectedPrintAsSource(): Promise<void> {
         0,
         isFlux2DevModel(form.model) ? 4 : undefined,
       );
+      form.sourceFit = defaultSourceFitPolicy();
       setGenerationStatus(
         isFlux2DevModel(form.model)
           ? "Added gallery print as reference 1"
@@ -7841,6 +7846,7 @@ async function useSelectedPrintAsSource(): Promise<void> {
     } else {
       form.sourceImage = base64;
       form.sourceImageName = print.filename;
+      form.sourceFit = defaultSourceFitPolicy();
       setGenerationStatus("Gallery print selected as source");
     }
     selectedPrint.value = null;

--- a/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.test.ts
@@ -49,7 +49,9 @@ afterEach(() => {
 describe("MobileSequenceOpeningImage", () => {
   it("round-trips an attached opening image through the shared draft", async () => {
     const draft = useSequenceDraftStore();
-    mountOpeningImage();
+    const form = newGenerateForm();
+    form.sourceFit = { mode: "lanczos-resize" };
+    mountOpeningImage({ form });
     expect(wrapper!.find("[data-test='mobile-sequence-source-strength']").exists()).toBe(false);
 
     await wrapper!.get("[data-test='mobile-sequence-source-well']").trigger("click");
@@ -59,6 +61,7 @@ describe("MobileSequenceOpeningImage", () => {
     await wrapper!.vm.$nextTick();
 
     expect(draft.openingImage).toEqual({ filename: "opening.jpg", base64: "wire-bytes" });
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(wrapper!.get("[data-test='mobile-sequence-source-preview']").attributes("src")).toBe(
       "data:image/jpeg;base64,wire-bytes",
     );

--- a/desktop/src/mobile/MobileSequenceOpeningImage.vue
+++ b/desktop/src/mobile/MobileSequenceOpeningImage.vue
@@ -20,6 +20,7 @@ import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import {
   SOURCE_FIT_OPTIONS,
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   sourceFitPolicyForMode,
   type SourceFitMode,
 } from "@studio/lib/sourceFit";
@@ -65,7 +66,7 @@ function setSourceFit(mode: SourceFitMode): void {
 
 function setOpeningImage(image: MobilePickedImage): void {
   draft.openingImage = { filename: image.filename, base64: image.base64 };
-  props.form.sourceFit = coerceSourceFitForMaskless(props.form.sourceFit);
+  props.form.sourceFit = defaultSourceFitPolicy();
   imagePickerOpen.value = false;
 }
 

--- a/desktop/src/mobile/MobileSourceControls.test.ts
+++ b/desktop/src/mobile/MobileSourceControls.test.ts
@@ -258,7 +258,7 @@ describe("MobileSourceControls", () => {
 
     expect(form.sourceImage).toBe("R0FMTEVSWQ==");
     expect(form.sourceImageName).toBe("gallery-print.png");
-    expect(form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(picker.props("open")).toBe(false);
     expect(wrapper.find("[data-test='mobile-source-error']").exists()).toBe(false);
   });
@@ -364,6 +364,19 @@ describe("MobileSourceControls", () => {
     ]);
     await vi.waitFor(() => expect(form.imageAttachments).toHaveLength(3));
     expect(form.imageAttachments).toEqual(["EXISTING", "YQ==", "Yg=="]);
+  });
+
+  it("defaults the first Qwen edit target to crop fill", async () => {
+    const form = formFor("qwen-image-edit");
+    form.sourceFit = { mode: "lanczos-resize" };
+    const wrapper = mount(MobileSourceControls, { props: { form } });
+
+    await chooseFiles(wrapper, "[data-test='mobile-edit-input']", [
+      new File(["target"], "target.png", { type: "image/png" }),
+    ]);
+
+    await vi.waitFor(() => expect(form.imageAttachments).toEqual(["dGFyZ2V0"]));
+    expect(form.sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it("supports an SD1.5 ControlNet photo, known model, custom id, and scale", async () => {

--- a/desktop/src/mobile/MobileSourceControls.vue
+++ b/desktop/src/mobile/MobileSourceControls.vue
@@ -19,8 +19,11 @@ import {
 import { base64ToDataUrl, fileToBase64, isStillImageFile } from "../lib/image";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   MASKLESS_SOURCE_FIT_OPTIONS,
   sourceFitHelp,
+  sourceFitPolicyForMode,
+  type SourceFitMode,
 } from "@studio/lib/sourceFit";
 import { strengthSemantics } from "@studio/lib/strengthSemantics";
 import { sourceConditioningLimitLabel } from "@studio/lib/sourceResolution";
@@ -357,13 +360,13 @@ function pickSource(image: MobilePickedImage): void {
   error.value = "";
   props.form.sourceImage = image.base64;
   props.form.sourceImageName = image.filename || null;
-  props.form.sourceFit = { mode: "lanczos-resize" };
+  props.form.sourceFit = defaultSourceFitPolicy();
   sourcePickerOpen.value = false;
 }
 
 function replaceEditTarget(base64: string): void {
   props.form.imageAttachments = [base64, ...props.form.imageAttachments.slice(1)];
-  props.form.sourceFit = { mode: "lanczos-resize" };
+  props.form.sourceFit = defaultSourceFitPolicy();
 }
 
 function pickEditTarget(image: MobilePickedImage): void {
@@ -409,7 +412,7 @@ async function onSingleSourceFile(slot: SourceMediaSlot, file: File): Promise<vo
     if (slot === "source") {
       props.form.sourceImage = base64;
       props.form.sourceImageName = file.name;
-      props.form.sourceFit = { mode: "lanczos-resize" };
+      props.form.sourceFit = defaultSourceFitPolicy();
     } else {
       props.form.endFrame = { filename: file.name, base64 };
     }
@@ -444,8 +447,13 @@ function removeEndFrame(): void {
 async function pickEditImages(event: Event): Promise<void> {
   const picked = await readImages(event, true);
   if (picked.length === 0) return;
+  const establishesTarget =
+    plan.value.kind === "attachments" &&
+    plan.value.primary === "target" &&
+    props.form.imageAttachments.length === 0;
   const next = [...props.form.imageAttachments, ...picked.map((image) => image.b64)];
   props.form.imageAttachments = flux2Dev.value ? next.slice(0, 4) : next;
+  if (establishesTarget) props.form.sourceFit = defaultSourceFitPolicy();
 }
 
 async function pickMask(event: Event): Promise<void> {
@@ -482,24 +490,13 @@ function moveEditImage(index: number, delta: -1 | 1): void {
 }
 
 function setSourceFit(event: Event): void {
-  const mode = (event.target as HTMLSelectElement).value;
-  if (mode === "crop-fill") {
-    props.form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
-  } else if (mode === "pad-fit") {
-    props.form.sourceFit = { mode: "pad-fit" };
-  } else if (mode === "lanczos-resize") {
-    props.form.sourceFit = { mode: "lanczos-resize" };
-  } else if (mode === "upscale-then-fit") {
-    props.form.sourceFit = {
-      mode: "upscale-then-fit",
+  props.form.sourceFit = sourceFitPolicyForMode(
+    (event.target as HTMLSelectElement).value as SourceFitMode,
+    {
+      supportsMask: caps.value.supportsMask,
       upscalerModel: props.form.upscaleModel || props.upscalers[0]?.name || "",
-      fit: caps.value.supportsMask
-        ? { mode: "pad-repaint" }
-        : { mode: "crop-fill", alignX: "center", alignY: "center" },
-    };
-  } else {
-    props.form.sourceFit = { mode: "pad-repaint" };
-  }
+    },
+  );
 }
 
 function setControlModel(event: Event): void {

--- a/desktop/src/views/GenerateView.sequence.test.ts
+++ b/desktop/src/views/GenerateView.sequence.test.ts
@@ -281,7 +281,7 @@ describe("GenerateView — sequence output", () => {
     useContextMenuStore().activate(useAsSource!);
     expect(useGenerateFormStore().form.sourceImage).toBe("aW1hZ2U=");
     expect(useGenerateFormStore().form.sourceImageName).toBe("remote-print.png");
-    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "crop-fill" });
   });
 
   it.each([

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -156,7 +156,11 @@ import {
 } from "../lib/generateValidation";
 import { SourceFitPreprocessCache } from "@ui/lib/sourceFitPreprocessCache";
 import { applyH3BoundaryFit, applySourceFitPreprocess } from "../lib/sourceFitPreprocess";
-import { coerceSourceFitForMaskless, parseSourceFitPolicy } from "@studio/lib/sourceFit";
+import {
+  coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
+  parseSourceFitPolicy,
+} from "@studio/lib/sourceFit";
 import { expansionTaskForRequest } from "@studio/lib/expandTask";
 import { domCanvasOps } from "@studio/lib/sourceFitCanvas";
 import { upscaleImage } from "../lib/api/upscale";
@@ -3413,7 +3417,7 @@ async function generate() {
           filename: draft.sourceImageName ?? "Source image",
           width: draft.sourceImageWidth,
           height: draft.sourceImageHeight,
-          sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? { mode: "pad-repaint" },
+          sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? defaultSourceFitPolicy(),
         }
       : draft.h3Authoring?.firstFrame?.data
         ? {
@@ -3422,7 +3426,7 @@ async function generate() {
             width: draft.h3Authoring.firstFrame.width,
             height: draft.h3Authoring.firstFrame.height,
             mime: draft.h3Authoring.firstFrame.mimeType,
-            sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? { mode: "pad-repaint" },
+            sourceFit: parseSourceFitPolicy(draft.sourceFit) ?? defaultSourceFitPolicy(),
           }
         : null;
     const draftCaps = generationCapabilitiesForFamily(draft.family, draft.model);

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -256,7 +256,7 @@ describe("LibraryView delete keyboard handling", () => {
     );
     expect(useGenerateFormStore().form.sourceImage).toBe("QUJD");
     expect(useGenerateFormStore().form.sourceImageName).toBe("remote-source.png");
-    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(router.currentRoute.value.path).toBe("/create");
     expect(useToastStore().items.at(-1)?.message).toBe("Loaded as source");
     wrapper.unmount();
@@ -492,7 +492,7 @@ describe("LibraryView source reuse", () => {
 
     expect(fetchMock).toHaveBeenCalledWith("mold-local://localhost/first.png");
     expect(useGenerateFormStore().form.sourceImage).toBe("QUJD");
-    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "lanczos-resize" });
+    expect(useGenerateFormStore().form.sourceFit).toEqual({ mode: "crop-fill" });
     expect(router.currentRoute.value.path).toBe("/create");
     wrapper.unmount();
   });

--- a/studio/lib/sourceFit.test.ts
+++ b/studio/lib/sourceFit.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   describeSourceFit,
   maskPaddingRectangles,
   parseSourceFitPolicy,
@@ -8,7 +9,24 @@ import {
   sourceFitPolicyForMode,
 } from "./sourceFit";
 
+it("keeps crop fill as the cross-surface source-image default", () => {
+  expect(defaultSourceFitPolicy()).toEqual({ mode: "crop-fill" });
+});
+
 describe("sourceFitPolicyForMode", () => {
+  it("seeds upscale-then-fit with crop fill even when repaint is supported", () => {
+    expect(
+      sourceFitPolicyForMode("upscale-then-fit", {
+        supportsMask: true,
+        upscalerModel: "real-esrgan-x4plus:fp16",
+      }),
+    ).toEqual({
+      mode: "upscale-then-fit",
+      upscalerModel: "real-esrgan-x4plus:fp16",
+      fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
+    });
+  });
+
   it("builds maskless sequence policies without unrepaintable padding", () => {
     expect(
       sourceFitPolicyForMode("upscale-then-fit", {

--- a/studio/lib/sourceFit.ts
+++ b/studio/lib/sourceFit.ts
@@ -23,6 +23,11 @@ export type SourceFitPolicy =
 
 export type SourceFitMode = SourceFitPolicy["mode"];
 
+/** Intentional default for every newly attached source image on every surface. */
+export function defaultSourceFitPolicy(): SourceFitPolicy {
+  return { mode: "crop-fill" };
+}
+
 /**
  * Source-fit choices shared by every source-image surface. Sequence video is
  * maskless, so callers omit Pad + repaint and use the remaining four modes.
@@ -127,9 +132,7 @@ export function sourceFitPolicyForMode(
     return {
       mode,
       upscalerModel: options.upscalerModel ?? "",
-      fit: options.supportsMask
-        ? { mode: "pad-repaint" }
-        : { mode: "crop-fill", alignX: "center", alignY: "center" },
+      fit: { mode: "crop-fill", alignX: "center", alignY: "center" },
     };
   }
   if (mode === "pad-repaint" && !options.supportsMask) {

--- a/web/src/components/create/SequenceOpeningImagePanel.test.ts
+++ b/web/src/components/create/SequenceOpeningImagePanel.test.ts
@@ -47,7 +47,7 @@ describe("SequenceOpeningImagePanel — the primary-form opening frame", () => {
     ).toBe(true);
   });
 
-  it("stores a dropped PNG on the shared draft and coerces the maskless fit", async () => {
+  it("stores a dropped PNG with the shared crop-fill default", async () => {
     const wrapper = factory({ sourceFitPolicy: { mode: "pad-repaint" } });
     await wrapper
       .get("[data-test='sequence-opening-image-well']")

--- a/web/src/components/create/SequenceOpeningImagePanel.vue
+++ b/web/src/components/create/SequenceOpeningImagePanel.vue
@@ -7,6 +7,7 @@ import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import {
   SOURCE_FIT_OPTIONS,
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   sourceFitPolicyForMode,
   type SourceFitMode,
 } from "@studio/lib/sourceFit";
@@ -57,9 +58,7 @@ async function onFile(file: File) {
     height: dimensions.height,
   };
   patch({
-    sourceFitPolicy: coerceSourceFitForMaskless(
-      props.modelValue.sourceFitPolicy ?? { mode: "crop-fill" },
-    ),
+    sourceFitPolicy: defaultSourceFitPolicy(),
   });
 }
 

--- a/web/src/components/create/SourceMediaPanel.test.ts
+++ b/web/src/components/create/SourceMediaPanel.test.ts
@@ -428,6 +428,7 @@ describe("SourceMediaPanel — direct file uploads", () => {
       width: 7,
       height: 4,
     });
+    expect(next.sourceFitPolicy).toEqual({ mode: "crop-fill" });
   });
 
   it("refuses a dropped non-PNG/JPEG file with a visible error", async () => {

--- a/web/src/components/create/SourceMediaPanel.vue
+++ b/web/src/components/create/SourceMediaPanel.vue
@@ -16,6 +16,7 @@ import { sourceImageValidationError } from "@studio/lib/sourceImageCapability";
 import { submitsExtend } from "@studio/lib/extend";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   MASKLESS_SOURCE_FIT_OPTIONS,
   SOURCE_FIT_OPTIONS,
   sourceFitHelp,
@@ -166,14 +167,13 @@ async function onWellFile(slot: SourceMediaSlot, file: File) {
   const image = await fileToSourceImage(file);
   if (!image) return;
   if (slot === "source") {
-    // A source-matched canvas differs only by the model's pixel grid or a
-    // safe downscale — resize exactly instead of manufacturing repaint bands.
+    // Every newly selected source starts from the shared crop-fill policy.
     patch({
       imageAttachments:
         plan.value.kind === "attachments"
           ? [image, ...props.modelValue.imageAttachments.slice(1)]
           : [image],
-      sourceFitPolicy: { mode: "lanczos-resize" },
+      sourceFitPolicy: defaultSourceFitPolicy(),
     });
   } else {
     patch({ endFrame: image });
@@ -237,7 +237,7 @@ function setH3Authoring(value: typeof h3Authoring.value) {
 // ── Fit / strength / mask (single-source refinement) ──────────────────
 const fitOptions = SOURCE_FIT_OPTIONS;
 const fitMode = computed(
-  () => props.modelValue.sourceFitPolicy?.mode ?? "pad-repaint",
+  () => props.modelValue.sourceFitPolicy?.mode ?? defaultSourceFitPolicy().mode,
 );
 /** H3 has no repaint mask; pad-repaint is never offered for its boundaries. */
 const masklessFitOptions = MASKLESS_SOURCE_FIT_OPTIONS;

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -79,7 +79,7 @@ describe("useGenerateForm", () => {
     expect(form.state.value.outputFormat).toBe("png");
     expect(form.state.value.imageAttachments).toEqual([]);
     expect(form.state.value.icLoraControl).toBeNull();
-    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "pad-repaint" });
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
   });
 
   it("serializes a host-provided IC-LoRA control without replacing custom LoRAs", () => {
@@ -1234,7 +1234,7 @@ describe("useGenerateForm", () => {
     expect(form.state.value.scheduler).toBeNull();
     expect(form.state.value.cfgPlus).toBe(false);
     expect(form.state.value.outputFormat).toBe("png");
-    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "pad-repaint" });
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
     expect(form.state.value.imageAttachments).toEqual([]);
     expect(form.state.value.gifPreview).toBe(false);
   });

--- a/web/src/composables/useGenerateForm.ts
+++ b/web/src/composables/useGenerateForm.ts
@@ -27,7 +27,10 @@ import {
   supportsScheduler,
 } from "../lib/generateCapabilities";
 import { composeStyle } from "../lib/stylePresets";
-import { parseSourceFitPolicy } from "@studio/lib/sourceFit";
+import {
+  defaultSourceFitPolicy,
+  parseSourceFitPolicy,
+} from "@studio/lib/sourceFit";
 import {
   effectiveNegativeDefault,
   negativePromptOnDefaultChange,
@@ -164,7 +167,7 @@ function defaultForm(): GenerateFormState {
     cfgPlus: false,
     outputFormat: "png",
     expand: { enabled: false, variations: 1, familyOverride: null },
-    sourceFitPolicy: { mode: "pad-repaint" },
+    sourceFitPolicy: defaultSourceFitPolicy(),
     imageAttachments: [],
     maskImage: null,
     controlImage: null,
@@ -1422,7 +1425,7 @@ export function useGenerateForm(): UseGenerateForm {
         finalized.edit_images?.length ||
         finalized.keyframes?.length
       ) {
-        finalized.source_fit = s.sourceFitPolicy ?? { mode: "pad-repaint" };
+        finalized.source_fit = s.sourceFitPolicy ?? defaultSourceFitPolicy();
       }
       return finalized;
     },

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -2005,12 +2005,10 @@ describe("CreatePage layout and behavior", () => {
     form.state.value.sourceFitPolicy = { mode: "pad-fit" };
     await nextTick();
 
-    wrapper
-      .getComponent({ name: "ImagePickerModal" })
-      .vm.$emit("pick", [
-        { kind: "upload", filename: "target.png", base64: "TARGET" },
-        { kind: "upload", filename: "reference.png", base64: "REFERENCE" },
-      ]);
+    wrapper.getComponent({ name: "ImagePickerModal" }).vm.$emit("pick", [
+      { kind: "upload", filename: "target.png", base64: "TARGET" },
+      { kind: "upload", filename: "reference.png", base64: "REFERENCE" },
+    ]);
     await nextTick();
 
     expect(form.state.value.imageAttachments).toHaveLength(2);

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -807,16 +807,15 @@ describe("CreatePage layout and behavior", () => {
     });
     const wrapper = mount(CreatePage, { global: { stubs } });
     await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.sourceFitPolicy = { mode: "pad-fit" };
     await wrapper.get('[data-test="open-recent"]').trigger("click");
     await wrapper.get('[data-test="lightbox-upscale"]').trigger("click");
     await flushPromises();
 
-    expect(useGenerateForm().state.value.imageAttachments[0]?.filename).toBe(
-      entry.filename,
-    );
-    expect(useGenerateForm().state.value.upscaleModel).toBe(
-      "real-esrgan-x4plus:fp16",
-    );
+    expect(form.state.value.imageAttachments[0]?.filename).toBe(entry.filename);
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
+    expect(form.state.value.upscaleModel).toBe("real-esrgan-x4plus:fp16");
     globalThis.fetch = originalFetch;
   });
 
@@ -966,6 +965,12 @@ describe("CreatePage layout and behavior", () => {
     const wrapper = mount(CreatePage, { global: { stubs } });
     await flushPromises();
     const draft = enterSequenceMode();
+    const form = useGenerateForm();
+    form.state.value.sourceFitPolicy = {
+      mode: "upscale-then-fit",
+      upscalerModel: "real-esrgan-x4plus:fp16",
+      fit: { mode: "pad-fit" },
+    };
 
     await wrapper
       .get('[data-test="context-recent-sequence"]')
@@ -973,7 +978,8 @@ describe("CreatePage layout and behavior", () => {
     await wrapper.get('[data-test="recent-context-source"]').trigger("click");
     await flushPromises();
     expect(draft.openingImage).toMatchObject({ filename: entry.filename });
-    expect(useGenerateForm().state.value.imageAttachments).toHaveLength(0);
+    expect(form.state.value.imageAttachments).toHaveLength(0);
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
     wrapper.unmount();
     globalThis.fetch = originalFetch;
   });
@@ -1967,6 +1973,48 @@ describe("CreatePage layout and behavior", () => {
 
     expect(form.state.value.imageAttachments[0]?.filename).toBe("new.png");
     expect(form.state.value.maskImage).toBeNull();
+  });
+
+  it("defaults a sequence gallery pick to crop fill", async () => {
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.sourceFitPolicy = { mode: "lanczos-resize" };
+    const draft = enterSequenceMode();
+
+    wrapper
+      .getComponent({ name: "ImagePickerModal" })
+      .vm.$emit("pick", [
+        { kind: "upload", filename: "opening.png", base64: "OPENING" },
+      ]);
+    await nextTick();
+
+    expect(draft.openingImage).toMatchObject({ filename: "opening.png" });
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
+  });
+
+  it("defaults the first Qwen edit target to crop fill", async () => {
+    hostModelsMock.mockResolvedValue([
+      installedModelRow("qwen-image-edit:q4", "qwen-image-edit"),
+    ]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = "qwen-image-edit:q4";
+    form.state.value.modelFamily = "qwen-image-edit";
+    form.state.value.sourceFitPolicy = { mode: "pad-fit" };
+    await nextTick();
+
+    wrapper
+      .getComponent({ name: "ImagePickerModal" })
+      .vm.$emit("pick", [
+        { kind: "upload", filename: "target.png", base64: "TARGET" },
+        { kind: "upload", filename: "reference.png", base64: "REFERENCE" },
+      ]);
+    await nextTick();
+
+    expect(form.state.value.imageAttachments).toHaveLength(2);
+    expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
   });
 
   it("keeps the visible Output control synchronized with sequence mode", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -200,6 +200,7 @@ import {
 import { isStandaloneGenerationModel } from "../lib/modelFilters";
 import {
   coerceSourceFitForMaskless,
+  defaultSourceFitPolicy,
   maskPaddingRectangles,
   parseSourceFitPolicy,
   resolveSourceFitTransform,
@@ -808,7 +809,7 @@ function fittedSourceImage(
 function drawableFitPolicy(
   policy: SourceFitPolicy | undefined,
 ): SourceFitPolicy {
-  if (!policy) return { mode: "pad-repaint" };
+  if (!policy) return defaultSourceFitPolicy();
   if (policy.mode === "upscale-then-fit") return policy.fit;
   return policy;
 }
@@ -3042,7 +3043,7 @@ async function prepareStillSourceToRequest(
   const configuredPolicy =
     override?.settings?.policy ??
     form.state.value.sourceFitPolicy ??
-    ({ mode: "pad-repaint" } as const);
+    defaultSourceFitPolicy();
   const family =
     override?.settings?.family ??
     currentModel.value?.family ??
@@ -3899,9 +3900,8 @@ async function onSubmitInner(
   const originalSource = form.state.value.imageAttachments[0]
     ? {
         ...form.state.value.imageAttachments[0],
-        sourceFit: parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? {
-          mode: "pad-repaint",
-        },
+        sourceFit:
+          parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? defaultSourceFitPolicy(),
       }
     : form.state.value.h3Authoring?.firstFrame?.data
       ? {
@@ -3910,9 +3910,8 @@ async function onSubmitInner(
           width: form.state.value.h3Authoring.firstFrame.width,
           height: form.state.value.h3Authoring.firstFrame.height,
           mime: form.state.value.h3Authoring.firstFrame.mimeType,
-          sourceFit: parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? {
-            mode: "pad-repaint",
-          },
+          sourceFit:
+            parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? defaultSourceFitPolicy(),
         }
       : null;
   const copies = requestCopyCount(currentRequest);
@@ -4568,9 +4567,7 @@ async function onPickSource(v: SourceImageState[]) {
         width: first.width ?? undefined,
         height: first.height ?? undefined,
       };
-      form.state.value.sourceFitPolicy = coerceSourceFitForMaskless(
-        form.state.value.sourceFitPolicy ?? { mode: "crop-fill" },
-      );
+      form.state.value.sourceFitPolicy = defaultSourceFitPolicy();
     }
     composerError.value = null;
     return;
@@ -4581,6 +4578,11 @@ async function onPickSource(v: SourceImageState[]) {
     ) || form.state.value.model.startsWith("qwen-image-edit:");
   const flux2Dev = isFlux2DevModel(form.state.value.model);
   const referenceEdit = qwenEdit || flux2Dev;
+  const establishesTarget =
+    qwenEdit &&
+    !replaceTargetOnPick.value &&
+    form.state.value.imageAttachments.length === 0 &&
+    v.length > 0;
   if (
     !referenceEdit &&
     form.state.value.maskImage &&
@@ -4600,12 +4602,11 @@ async function onPickSource(v: SourceImageState[]) {
           )
         : v.slice(0, 1);
   if (
-    (!referenceEdit || (qwenEdit && replaceTargetOnPick.value)) &&
+    (!referenceEdit || (qwenEdit && replaceTargetOnPick.value) || establishesTarget) &&
     v.length > 0
   ) {
-    // A source-matched canvas differs only by the model's pixel grid or safe
-    // downscale. Resize exactly instead of manufacturing narrow repaint bands.
-    form.state.value.sourceFitPolicy = { mode: "lanczos-resize" };
+    // Every newly selected source starts from the shared crop-fill policy.
+    form.state.value.sourceFitPolicy = defaultSourceFitPolicy();
   }
   replaceTargetOnPick.value = false;
   composerError.value = null;
@@ -4799,7 +4800,7 @@ function openJob(job: Job) {
   };
   form.state.value.sourceFitPolicy = parseSourceFitPolicy(
     request.source_fit,
-  ) ?? { mode: "pad-repaint" };
+  ) ?? defaultSourceFitPolicy();
   form.state.value.cameraControl = null;
   form.state.value.model = request.model;
   const requestModel = models.value.find(
@@ -4878,9 +4879,7 @@ function openJob(job: Job) {
         form.state.value.height = request.height;
         form.state.value.sourceFitPolicy = parseSourceFitPolicy(
           request.source_fit,
-        ) ?? {
-          mode: "pad-repaint",
-        };
+        ) ?? defaultSourceFitPolicy();
       });
   }
   // Unlike saved metadata, a queued request still holds the face payload, so
@@ -5015,9 +5014,7 @@ async function attachLightboxSource(item: GalleryImage): Promise<boolean> {
           width: dimensions.width,
           height: dimensions.height,
         };
-        state.sourceFitPolicy = coerceSourceFitForMaskless(
-          state.sourceFitPolicy ?? { mode: "crop-fill" },
-        );
+        state.sourceFitPolicy = defaultSourceFitPolicy();
         return true;
       }
       const h3Task = minimaxH3TaskForModel(state.model);
@@ -5050,6 +5047,7 @@ async function attachLightboxSource(item: GalleryImage): Promise<boolean> {
         state.imageAttachments = [
           { kind: "gallery", filename: item.filename, base64 },
         ];
+        state.sourceFitPolicy = defaultSourceFitPolicy();
       }
     }
     return true;

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -3901,7 +3901,8 @@ async function onSubmitInner(
     ? {
         ...form.state.value.imageAttachments[0],
         sourceFit:
-          parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? defaultSourceFitPolicy(),
+          parseSourceFitPolicy(form.state.value.sourceFitPolicy) ??
+          defaultSourceFitPolicy(),
       }
     : form.state.value.h3Authoring?.firstFrame?.data
       ? {
@@ -3911,7 +3912,8 @@ async function onSubmitInner(
           height: form.state.value.h3Authoring.firstFrame.height,
           mime: form.state.value.h3Authoring.firstFrame.mimeType,
           sourceFit:
-            parseSourceFitPolicy(form.state.value.sourceFitPolicy) ?? defaultSourceFitPolicy(),
+            parseSourceFitPolicy(form.state.value.sourceFitPolicy) ??
+            defaultSourceFitPolicy(),
         }
       : null;
   const copies = requestCopyCount(currentRequest);
@@ -4602,7 +4604,9 @@ async function onPickSource(v: SourceImageState[]) {
           )
         : v.slice(0, 1);
   if (
-    (!referenceEdit || (qwenEdit && replaceTargetOnPick.value) || establishesTarget) &&
+    (!referenceEdit ||
+      (qwenEdit && replaceTargetOnPick.value) ||
+      establishesTarget) &&
     v.length > 0
   ) {
     // Every newly selected source starts from the shared crop-fill policy.
@@ -4798,9 +4802,8 @@ function openJob(job: Job) {
     variations: 1,
     familyOverride: null,
   };
-  form.state.value.sourceFitPolicy = parseSourceFitPolicy(
-    request.source_fit,
-  ) ?? defaultSourceFitPolicy();
+  form.state.value.sourceFitPolicy =
+    parseSourceFitPolicy(request.source_fit) ?? defaultSourceFitPolicy();
   form.state.value.cameraControl = null;
   form.state.value.model = request.model;
   const requestModel = models.value.find(
@@ -4877,9 +4880,8 @@ function openJob(job: Job) {
           return;
         form.state.value.width = request.width;
         form.state.value.height = request.height;
-        form.state.value.sourceFitPolicy = parseSourceFitPolicy(
-          request.source_fit,
-        ) ?? defaultSourceFitPolicy();
+        form.state.value.sourceFitPolicy =
+          parseSourceFitPolicy(request.source_fit) ?? defaultSourceFitPolicy();
       });
   }
   // Unlike saved metadata, a queued request still holds the face payload, so

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -780,6 +780,7 @@ describe("LibraryPage multi-host identity", () => {
   });
 
   it("fetches Use as source from the host that owns the print", async () => {
+    useGenerateForm().state.value.sourceFitPolicy = { mode: "lanczos-resize" };
     const wrapper = mountPage();
     await flushPromises();
 
@@ -796,6 +797,7 @@ describe("LibraryPage multi-host identity", () => {
       expect.objectContaining({ id: "studio-7680", apiKey: "studio-key" }),
       "twin.png",
     );
+    expect(useGenerateForm().state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
     expect(pushMock).toHaveBeenCalledWith({ name: "create" });
   });
 

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -797,7 +797,9 @@ describe("LibraryPage multi-host identity", () => {
       expect.objectContaining({ id: "studio-7680", apiKey: "studio-key" }),
       "twin.png",
     );
-    expect(useGenerateForm().state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
+    expect(useGenerateForm().state.value.sourceFitPolicy).toEqual({
+      mode: "crop-fill",
+    });
     expect(pushMock).toHaveBeenCalledWith({ name: "create" });
   });
 

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -66,6 +66,7 @@ import {
   type MergedCollection,
   type OrganizationMutation,
 } from "@studio/lib/libraryOrganization";
+import { defaultSourceFitPolicy } from "@studio/lib/sourceFit";
 import { useChainJobs } from "../composables/useChainJobs";
 import { blobToBase64 } from "../lib/base64";
 import { fetchGalleryBlob } from "../lib/galleryMedia";
@@ -1821,6 +1822,7 @@ async function setAsSource(item: GalleryImage): Promise<boolean> {
       state.imageAttachments = [
         { kind: "gallery", filename: item.filename, base64 },
       ];
+      state.sourceFitPolicy = defaultSourceFitPolicy();
     }
     return true;
   } catch (err) {


### PR DESCRIPTION
## Summary

- make Crop fill the shared fresh-source default across web, desktop, iPhone, and the shared Android surface
- apply the default to uploads, gallery picks, drops, edit targets, and sequence opening images while preserving restored explicit provenance
- add regression coverage for shared policy, every surface, Qwen first-target handling, lightbox paths, and sequence paths

## Validation

- `nix develop -c bun run test` in `web`: 108 files / 1,727 tests passed
- `nix develop -c bun run test` in `desktop`: 412 files / 5,331 tests passed
- `nix develop -c bunx vue-tsc -b` in `web` and `desktop`
- `nix develop -c fmt`
- `git diff --check`
- independent sub-agent peer review: no remaining findings
