### PR TITLE
fix(studio): restore live chain status from snapshots

### DIFF
--- a/.ua/fingerprints.json
+++ b/.ua/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "0ac04008eb0296736f9b033c37f8616a04fb9d45",
-  "generatedAt": "2026-08-28T04:29:56.609Z",
+  "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3",
+  "generatedAt": "2026-08-28T14:10:09.351Z",
   "files": {
     "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt": {
       "filePath": "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt",
@@ -50888,7 +50888,7 @@
     },
     "crates/mold-core/src/minimax_h3.rs": {
       "filePath": "crates/mold-core/src/minimax_h3.rs",
-      "contentHash": "49fa8f242ad5a22bb4d6160426e8f97caac98a2d869656eaa7e610f0e2221d67",
+      "contentHash": "aed04899819f14b27afa538281156717a176819b5d94e7178030000959e8e829",
       "functions": [
         {
           "name": "is_reviewed_compact_model",
@@ -50934,6 +50934,26 @@
           "returnType": "Option<&'static TurboManifestTier>",
           "exported": true,
           "lineCount": 6
+        },
+        {
+          "name": "qwen_vision_pad_rows_per_block",
+          "params": [
+            "width",
+            "height"
+          ],
+          "returnType": "u64",
+          "exported": true,
+          "lineCount": 3
+        },
+        {
+          "name": "qwen_vision_patch_rows_per_block",
+          "params": [
+            "width",
+            "height"
+          ],
+          "returnType": "u64",
+          "exported": true,
+          "lineCount": 3
         },
         {
           "name": "is_admitted_compact_canvas",
@@ -52041,6 +52061,8 @@
         "base_compact_model",
         "storage_identity",
         "turbo_tier_for_model",
+        "qwen_vision_pad_rows_per_block",
+        "qwen_vision_patch_rows_per_block",
         "is_admitted_compact_canvas",
         "reviewed_compact_max_pixels",
         "reviewed_compact_max_axis_pixels",
@@ -52116,7 +52138,7 @@
         "artifact_contract",
         "manifests"
       ],
-      "totalLines": 5887,
+      "totalLines": 5958,
       "hasStructuralAnalysis": true
     },
     "crates/mold-core/src/model_policy.rs": {
@@ -91246,7 +91268,7 @@
     },
     "crates/mold-inference/src/h3_factory.rs": {
       "filePath": "crates/mold-inference/src/h3_factory.rs",
-      "contentHash": "8825ce3ad6c775aabef7890c465dba19dd42ac9d66c93a96812329005670027b",
+      "contentHash": "671dfd0e6d4d2dc187d3ae15fe5137467bd0434736821b2641538bcf46c6a9f9",
       "functions": [
         {
           "name": "new",
@@ -91523,7 +91545,7 @@
           ],
           "returnType": "Result<H3ReferenceCharges>",
           "exported": false,
-          "lineCount": 279
+          "lineCount": 288
         },
         {
           "name": "validate_prepared_references",
@@ -92230,7 +92252,7 @@
             "native_host_bytes"
           ],
           "exported": true,
-          "lineCount": 44
+          "lineCount": 46
         },
         {
           "name": "H3FactoryPreparedRowsInput",
@@ -93110,7 +93132,7 @@
         "quantization",
         "validate_for_dispatch"
       ],
-      "totalLines": 8259,
+      "totalLines": 8309,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/identity/align.rs": {
@@ -116642,7 +116664,7 @@
     },
     "crates/mold-inference/src/minimax_h3/engine.rs": {
       "filePath": "crates/mold-inference/src/minimax_h3/engine.rs",
-      "contentHash": "eb0720a0a0eff91e615e16453335e0f95f08f4302446beb4b53f6758970cdbcb",
+      "contentHash": "6802ab7e3e0926244daff962f0dedb65336fa8d27ec53a47e0d9c743acb495aa",
       "functions": [
         {
           "name": "new_injected",
@@ -117677,7 +117699,7 @@
         "H3StreamedRef2VaPipelineBackend",
         "new"
       ],
-      "totalLines": 3121,
+      "totalLines": 3132,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/minimax_h3/metal_memory_guard.rs": {
@@ -119319,7 +119341,7 @@
     },
     "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs": {
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
-      "contentHash": "1d7ddda979bc2cf7092d9c32859d75dd8ea2c1d74176e5f777a5ceaf0aca085f",
+      "contentHash": "5eebed7dd6f17789a43477d3815aeac80a311db64103d7d5f51943838e843190",
       "functions": [
         {
           "name": "references",
@@ -119408,7 +119430,7 @@
           ],
           "returnType": "Result<H3StagedAvOutput>",
           "exported": true,
-          "lineCount": 375
+          "lineCount": 393
         },
         {
           "name": "validate_reference_bindings",
@@ -119448,7 +119470,7 @@
           ],
           "returnType": "Result<()>",
           "exported": false,
-          "lineCount": 26
+          "lineCount": 29
         },
         {
           "name": "reference_layout_spec",
@@ -119755,7 +119777,7 @@
         "prepare_resolved_request",
         "execute_staged"
       ],
-      "totalLines": 2140,
+      "totalLines": 2304,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs": {
@@ -121775,7 +121797,7 @@
     },
     "crates/mold-inference/src/minimax_h3/private_opened_evidence.rs": {
       "filePath": "crates/mold-inference/src/minimax_h3/private_opened_evidence.rs",
-      "contentHash": "0245ad72146c1093c1022263584856f9b8f632a44435494bc0564c742a0b0f7f",
+      "contentHash": "90110fc0c315a26981b6a0a61cb3dd6266c1a421f06e5fdba23942065bae069c",
       "functions": [
         {
           "name": "comfy_task_sources",
@@ -122818,7 +122840,7 @@
         "total_packed_rows",
         "qwen_activation_workspace_demand_bytes"
       ],
-      "totalLines": 3181,
+      "totalLines": 3188,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/minimax_h3/private_qualification.rs": {
@@ -125577,7 +125599,7 @@
     },
     "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs": {
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "contentHash": "38c76beff851c637df7da2624907d9b16dbe67ea1c58e2a1d3dacb0265f039b6",
+      "contentHash": "1325963a2df0603048449b2f5e69f61b33e13e0b837a808219f8f2e89bda5292",
       "functions": [
         {
           "name": "capture_process_observation",
@@ -125650,7 +125672,16 @@
           ],
           "returnType": "bool",
           "exported": false,
-          "lineCount": 11
+          "lineCount": 12
+        },
+        {
+          "name": "condition_encode_transient_bytes",
+          "params": [
+            "state"
+          ],
+          "returnType": "Result<u64>",
+          "exported": false,
+          "lineCount": 13
         },
         {
           "name": "observe_event",
@@ -125751,7 +125782,7 @@
           ],
           "returnType": "Result<H3PrivateRuntimeBoundObservation>",
           "exported": false,
-          "lineCount": 97
+          "lineCount": 99
         },
         {
           "name": "routed_qwen_workspace",
@@ -125995,7 +126026,7 @@
         "observe_aac_staging_capacity",
         "observe_mux_output_capacity"
       ],
-      "totalLines": 670,
+      "totalLines": 746,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/minimax_h3/private_runtime_qualification.rs": {
@@ -126548,7 +126579,7 @@
     },
     "crates/mold-inference/src/minimax_h3/private_server.rs": {
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
-      "contentHash": "ac0e03257d8105fb2fea9b28b1ed28c4e63d483ed8c407ce8999e8b576b3d1ce",
+      "contentHash": "6e16953171504f4f000064ee61e147eb9c6508ad49887f91a7e9fe49455a4da0",
       "functions": [
         {
           "name": "valid_stable_cuda_device_id",
@@ -128468,13 +128499,31 @@
           "lineCount": 32
         },
         {
+          "name": "reference_qwen_blocks",
+          "params": [
+            "shape"
+          ],
+          "returnType": "u64",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
           "name": "reference_qwen_vision_rows",
           "params": [
             "shape"
           ],
           "returnType": "u64",
           "exported": false,
-          "lineCount": 10
+          "lineCount": 6
+        },
+        {
+          "name": "reference_qwen_vision_pads",
+          "params": [
+            "shape"
+          ],
+          "returnType": "u64",
+          "exported": false,
+          "lineCount": 6
         },
         {
           "name": "ref2va_reference_rows",
@@ -128484,7 +128533,7 @@
           ],
           "returnType": "Result<Ref2VaReferenceRows>",
           "exported": false,
-          "lineCount": 31
+          "lineCount": 35
         },
         {
           "name": "public_ref2va_runtime_envelope_for_shape",
@@ -128496,7 +128545,7 @@
           ],
           "returnType": "H3PrivateRuntimeEnvelopeRecord",
           "exported": false,
-          "lineCount": 38
+          "lineCount": 40
         },
         {
           "name": "public_ref2va_runtime_bounds_for_shape",
@@ -128507,14 +128556,14 @@
           ],
           "returnType": "H3PrivateRuntimeBoundRecord",
           "exported": false,
-          "lineCount": 76
+          "lineCount": 79
         },
         {
           "name": "capture_runtime_envelope",
           "params": [],
           "returnType": "H3PrivateRuntimeEnvelopeRecord",
           "exported": false,
-          "lineCount": 24
+          "lineCount": 26
         },
         {
           "name": "public_style_generated_caps",
@@ -129799,10 +129848,11 @@
             "visual",
             "audio",
             "qwen_vision",
+            "qwen_vision_pads",
             "largest_canvas_pixels"
           ],
           "exported": false,
-          "lineCount": 13
+          "lineCount": 19
         },
         {
           "name": "H3PrivateReviewedRuntimeQualification",
@@ -130274,7 +130324,7 @@
         "validate_runtime_qualification_record_shape",
         "runtime_qualification_identity"
       ],
-      "totalLines": 11038,
+      "totalLines": 11099,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/minimax_h3/private_vae_adapter.rs": {
@@ -215667,7 +215717,7 @@
     },
     "desktop/src/components/create/ActivityStrip.test.ts": {
       "filePath": "desktop/src/components/create/ActivityStrip.test.ts",
-      "contentHash": "e64095f3d7eead80440122baf3921109266189ec582656634b3a2a898710f0bb",
+      "contentHash": "2a330108bff51d81d77c95585b84577e1ac2047aad100bc6a5e17eff1327960a",
       "functions": [
         {
           "name": "baseJob",
@@ -215774,7 +215824,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 552,
+      "totalLines": 589,
       "hasStructuralAnalysis": true
     },
     "desktop/src/components/create/AdvancedSettings.test.ts": {
@@ -219660,7 +219710,7 @@
     },
     "desktop/src/components/shell/NavRail.test.ts": {
       "filePath": "desktop/src/components/shell/NavRail.test.ts",
-      "contentHash": "ace965d1d20acbb1d301da26eec5a0830cfbb7bb119c0e67f78e37bd33b8a892",
+      "contentHash": "8471ecad005f36639ef462ebb0658c51e3b5a2af1fc6b4868854e7f5fe3a5fe9",
       "functions": [
         {
           "name": "makeRouter",
@@ -219785,7 +219835,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 641,
+      "totalLines": 683,
       "hasStructuralAnalysis": true
     },
     "desktop/src/components/shell/PanelResizeHandle.test.ts": {
@@ -230546,7 +230596,7 @@
     },
     "desktop/src/mobile/MobileApp.test.ts": {
       "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "contentHash": "1a192d7a3dace0b73064fc3fb070ba712b7cd364cd4aae4a47a69bd063268812",
+      "contentHash": "c82c010ef4ada2f4f6ad7b0e281421c39f427921d3171983433bd2fd41453095",
       "functions": [
         {
           "name": "plannedPlacement",
@@ -230816,7 +230866,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 13162,
+      "totalLines": 13212,
       "hasStructuralAnalysis": true
     },
     "desktop/src/mobile/MobileBatchControl.test.ts": {
@@ -238325,7 +238375,7 @@
     },
     "desktop/src/stores/generation.test.ts": {
       "filePath": "desktop/src/stores/generation.test.ts",
-      "contentHash": "4214315f486edf3e990d4b0e94b3120868ac89202d099127e5351504d99d670e",
+      "contentHash": "0269d41f6ffd91c7ae3f8d701604c01ea46324f84a35456417ca0fffee3c2a44",
       "functions": [],
       "classes": [],
       "imports": [
@@ -238357,12 +238407,12 @@
         }
       ],
       "exports": [],
-      "totalLines": 296,
+      "totalLines": 300,
       "hasStructuralAnalysis": true
     },
     "desktop/src/stores/generation.ts": {
       "filePath": "desktop/src/stores/generation.ts",
-      "contentHash": "60b4d7fb18c8a13763945c1c1cbb45e313814ca4d1da0a38d4c6a63083214635",
+      "contentHash": "4355fb4a870553082c7690891428782f26a8caf2ea180a2b4663e0ac8204faaf",
       "functions": [
         {
           "name": "suggestOutputFilename",
@@ -238429,7 +238479,7 @@
           ],
           "returnType": "Job[]",
           "exported": true,
-          "lineCount": 12
+          "lineCount": 5
         },
         {
           "name": "runWithConcurrency",
@@ -238860,7 +238910,7 @@
         "jobCanBeRemoved",
         "useGenerationStore"
       ],
-      "totalLines": 2064,
+      "totalLines": 2056,
       "hasStructuralAnalysis": true
     },
     "desktop/src/stores/generationQueue.test.ts": {
@@ -251227,7 +251277,7 @@
     },
     "studio/api/activity.test.ts": {
       "filePath": "studio/api/activity.test.ts",
-      "contentHash": "24192b46e486ae1693cb54dde0f5cb79c9e9f128625fffe2d98792d7e42be009",
+      "contentHash": "cd10fa10613d00b311fe01c3e6c8b0f8d8a33f3b255ddca3e299fee8e3500966",
       "functions": [],
       "classes": [],
       "imports": [
@@ -251249,12 +251299,12 @@
         }
       ],
       "exports": [],
-      "totalLines": 252,
+      "totalLines": 282,
       "hasStructuralAnalysis": true
     },
     "studio/api/activity.ts": {
       "filePath": "studio/api/activity.ts",
-      "contentHash": "46359e873a3a198097cf2f466b62a747804627a3786252bb2702371605966dea",
+      "contentHash": "b9b00a187f753a38abedb66a659cae99b75c522a776c79bc0902c2076e17dd8a",
       "functions": [
         {
           "name": "isRecord",
@@ -251300,7 +251350,7 @@
           ],
           "returnType": "FleetActiveWork[]",
           "exported": true,
-          "lineCount": 33
+          "lineCount": 29
         }
       ],
       "classes": [],
@@ -251319,7 +251369,7 @@
         "reconcileActivityHost",
         "mergeFleetActivity"
       ],
-      "totalLines": 188,
+      "totalLines": 184,
       "hasStructuralAnalysis": true
     },
     "studio/api/chains.test.ts": {
@@ -254434,7 +254484,7 @@
     },
     "studio/lib/activity.test.ts": {
       "filePath": "studio/lib/activity.test.ts",
-      "contentHash": "183b267d8c029ede525705b04ac3618f9759afa33e575d8e9978ed6678324f93",
+      "contentHash": "49c576e04587fc50781241266b004ac8665c9d03c586ec3d45a250e0df51bd25",
       "functions": [
         {
           "name": "print",
@@ -254503,7 +254553,7 @@
     },
     "studio/lib/activity.ts": {
       "filePath": "studio/lib/activity.ts",
-      "contentHash": "833ba8cc2385a1d32b7a127dfdcd105814ae8e4e76408ce3b9cd721f8cee148c",
+      "contentHash": "abcb74e26d9f5d9246826c6cc4cb03f8ec1e0c1e05fcc0d432a80191c5516847",
       "functions": [
         {
           "name": "sequenceActions",
@@ -254592,15 +254642,6 @@
           "lineCount": 5
         },
         {
-          "name": "isRunning",
-          "params": [
-            "vm"
-          ],
-          "returnType": "boolean",
-          "exported": false,
-          "lineCount": 5
-        },
-        {
           "name": "mergeActivity",
           "params": [
             "prints",
@@ -254608,7 +254649,7 @@
           ],
           "returnType": "ActivityJobVM[]",
           "exported": true,
-          "lineCount": 12
+          "lineCount": 11
         },
         {
           "name": "partitionActivity",
@@ -254672,7 +254713,7 @@
         "partitionActivity",
         "activityDigestLabel"
       ],
-      "totalLines": 347,
+      "totalLines": 341,
       "hasStructuralAnalysis": true
     },
     "studio/lib/api/chainTypes.ts": {
@@ -255172,7 +255213,7 @@
     },
     "studio/lib/chainJobProgress.test.ts": {
       "filePath": "studio/lib/chainJobProgress.test.ts",
-      "contentHash": "c3f09bdc6d8c790b3574c26c41722abd5202edfc93c28418fb419bc983131570",
+      "contentHash": "8fe256a200755e988cf251d9ff2369538565c9521c103f1c15a9de5516c543d6",
       "functions": [
         {
           "name": "detail",
@@ -255222,12 +255263,12 @@
         }
       ],
       "exports": [],
-      "totalLines": 219,
+      "totalLines": 258,
       "hasStructuralAnalysis": true
     },
     "studio/lib/chainJobProgress.ts": {
       "filePath": "studio/lib/chainJobProgress.ts",
-      "contentHash": "e17951180153666f912f9f0c7b18f590987346953164d0ad94ea6b3201747935",
+      "contentHash": "91c73de979b9dfdad09db86a4087d95cad90d84b505494d06c4e7d74ccca46eb",
       "functions": [
         {
           "name": "estimatedChainFrames",
@@ -255274,7 +255315,7 @@
           ],
           "returnType": "ChainJobFrameResult",
           "exported": true,
-          "lineCount": 93
+          "lineCount": 115
         }
       ],
       "classes": [],
@@ -255301,7 +255342,7 @@
         "estimatedChainFrames",
         "reduceChainJobFrame"
       ],
-      "totalLines": 191,
+      "totalLines": 213,
       "hasStructuralAnalysis": true
     },
     "studio/lib/chainRouting.ts": {
@@ -271700,7 +271741,7 @@
     },
     "web/src/components/create/ActivityStrip.test.ts": {
       "filePath": "web/src/components/create/ActivityStrip.test.ts",
-      "contentHash": "fd293d6fef05fef5a22ea4878cf0a63e7ffb907ffdab8e00a60c12dba1aa5663",
+      "contentHash": "cf3d0da757cfe124d77a6ddf27b5df213c15d633c9d6852fac565de7fff61a59",
       "functions": [
         {
           "name": "makeJob",
@@ -271788,7 +271829,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 623,
+      "totalLines": 686,
       "hasStructuralAnalysis": true
     },
     "web/src/components/create/AdvancedDrawer.test.ts": {
@@ -276083,7 +276124,7 @@
     },
     "web/src/composables/useGenerateStream.test.ts": {
       "filePath": "web/src/composables/useGenerateStream.test.ts",
-      "contentHash": "c67245fd6480c46f6f3c42670d51619fa3fe89d278ccf4a9d1e2524f16222ece",
+      "contentHash": "eb29298bf51843fb629530a868f8c28be6b228f4ef1f619a8f552d254b83ab45",
       "functions": [
         {
           "name": "persistedPayload",
@@ -276284,7 +276325,7 @@
         }
       ],
       "exports": [],
-      "totalLines": 1684,
+      "totalLines": 1710,
       "hasStructuralAnalysis": true
     },
     "web/src/composables/useGenerateStream.ts": {

--- a/.ua/knowledge-graph.json
+++ b/.ua/knowledge-graph.json
@@ -57,8 +57,8 @@
       "Vue"
     ],
     "description": "CLI-native local AI image and video generation for people, scripts, and agents. Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results.",
-    "analyzedAt": "2026-08-28T04:26:11.649Z",
-    "gitCommitHash": "0ac04008eb0296736f9b033c37f8616a04fb9d45"
+    "analyzedAt": "2026-08-28T14:10:08.933Z",
+    "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3"
   },
   "nodes": [
     {
@@ -19159,11 +19159,12 @@
       "type": "file",
       "name": "activity.ts",
       "filePath": "studio/api/activity.ts",
-      "summary": "Implements activity with 5 extracted structural definitions for the Mold codebase.",
+      "summary": "Defines and validates the cross-host active-work API contract, reconciles successful or stale host snapshots with authority fences, and produces stable fleet activity rows.",
       "tags": [
         "api-handler",
-        "rust-module",
-        "implementation",
+        "activity",
+        "validation",
+        "multi-host",
         "tested"
       ],
       "complexity": "moderate"
@@ -19177,11 +19178,11 @@
         44,
         80
       ],
-      "summary": "Provides the parseActiveWorkSnapshot operation within activity.ts.",
+      "summary": "Validates an untrusted active-work response and normalizes item cancellation and unavailable-kind fields.",
       "tags": [
-        "function",
-        "implementation",
-        "rust"
+        "validation",
+        "api-handler",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -19194,11 +19195,11 @@
         82,
         96
       ],
-      "summary": "Provides the listActiveWork operation within activity.ts.",
+      "summary": "Fetches a host's active-work snapshot with a bounded request timeout.",
       "tags": [
-        "function",
-        "implementation",
-        "rust"
+        "api-handler",
+        "activity",
+        "async"
       ],
       "complexity": "simple"
     },
@@ -19211,11 +19212,11 @@
         102,
         143
       ],
-      "summary": "Provides the reconcileActivityHost operation within activity.ts.",
+      "summary": "Reconciles a host response with its prior authority snapshot, retaining verified work as stale across failures or partial availability.",
       "tags": [
-        "function",
-        "implementation",
-        "rust"
+        "state-management",
+        "activity",
+        "multi-host"
       ],
       "complexity": "simple"
     },
@@ -19226,13 +19227,13 @@
       "filePath": "studio/api/activity.ts",
       "lineRange": [
         155,
-        187
+        183
       ],
-      "summary": "Provides the mergeFleetActivity operation within activity.ts.",
+      "summary": "Flattens host snapshots into stable fleet rows ordered by submission time rather than changing phase.",
       "tags": [
-        "function",
-        "implementation",
-        "rust"
+        "activity",
+        "multi-host",
+        "ordering"
       ],
       "complexity": "simple"
     },
@@ -19831,11 +19832,12 @@
       "type": "file",
       "name": "activity.test.ts",
       "filePath": "studio/lib/activity.test.ts",
-      "summary": "Exercises activity behavior with focused regression and integration coverage.",
+      "summary": "Tests shared print and sequence activity normalization, merge ordering, active-versus-attention partitioning, labels, actions, and queue-position decoration.",
       "tags": [
         "test",
-        "verification",
-        "regression"
+        "activity",
+        "sequence",
+        "queue-status"
       ],
       "complexity": "complex"
     },
@@ -19848,11 +19850,11 @@
         21,
         39
       ],
-      "summary": "Provides the print operation within activity.test.ts.",
+      "summary": "Builds an overridable normalized print activity view model for shared activity tests.",
       "tags": [
         "test",
-        "verification",
-        "behavior"
+        "factory",
+        "activity"
       ],
       "complexity": "simple"
     },
@@ -19865,11 +19867,11 @@
         41,
         53
       ],
-      "summary": "Provides the summary operation within activity.test.ts.",
+      "summary": "Builds an overridable sequence-job summary fixture for activity normalization tests.",
       "tags": [
         "test",
-        "verification",
-        "behavior"
+        "factory",
+        "sequence"
       ],
       "complexity": "simple"
     },
@@ -52739,13 +52741,16 @@
       "type": "file",
       "name": "private_runtime_observer.rs",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "summary": "Implements private runtime observer with 27 extracted structural definitions for the Mold codebase.",
+      "summary": "Captures process identity, CUDA runtime facts, phase memory observations, and transient host/device usage for one real MiniMax H3 attempt. The resulting evidence binds measured runtime bounds to the executable, environment, device, and pipeline phases.",
       "tags": [
-        "api-handler",
-        "rust-module",
-        "implementation"
+        "runtime-observation",
+        "memory-profiling",
+        "cuda",
+        "attestation",
+        "telemetry"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "Conditional compilation provides Linux CUDA attestation while preserving a fail-closed stub on unsupported targets."
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
@@ -52756,13 +52761,13 @@
         54,
         135
       ],
-      "summary": "Provides the capture_process_observation operation within private_runtime_observer.rs.",
+      "summary": "Captures capture process observation evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:sorted_environment",
@@ -52773,11 +52778,11 @@
         143,
         154
       ],
-      "summary": "Provides the sorted_environment operation within private_runtime_observer.rs.",
+      "summary": "Implements sorted environment behavior within runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -52790,13 +52795,13 @@
         250,
         289
       ],
-      "summary": "Provides the begin operation within private_runtime_observer.rs.",
+      "summary": "Implements begin behavior within runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "implementation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
@@ -52807,11 +52812,11 @@
         291,
         302
       ],
-      "summary": "Provides the finish operation within private_runtime_observer.rs.",
+      "summary": "Implements finish behavior within runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -52824,11 +52829,11 @@
         317,
         327
       ],
-      "summary": "Provides the finish_open_probes operation within private_runtime_observer.rs.",
+      "summary": "Implements finish open probes behavior within runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -52839,13 +52844,30 @@
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
         329,
-        339
+        340
       ],
-      "summary": "Provides the captured_phase operation within private_runtime_observer.rs.",
+      "summary": "Captures captured phase evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:condition_encode_transient_bytes",
+      "type": "function",
+      "name": "condition_encode_transient_bytes",
+      "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "lineRange": [
+        354,
+        366
+      ],
+      "summary": "Computes condition encode transient bytes for admission and resource accounting in runtime-bound observation.",
+      "tags": [
+        "function",
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -52855,16 +52877,16 @@
       "name": "observe_event",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        341,
-        388
+        368,
+        415
       ],
-      "summary": "Provides the observe_event operation within private_runtime_observer.rs.",
+      "summary": "Captures observe event evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:synchronize_boundary",
@@ -52872,14 +52894,14 @@
       "name": "synchronize_boundary",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        390,
-        407
+        417,
+        434
       ],
-      "summary": "Provides the synchronize_boundary operation within private_runtime_observer.rs.",
+      "summary": "Captures synchronize boundary evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -52889,14 +52911,14 @@
       "name": "observe_staged_host_bytes",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        419,
-        431
+        446,
+        458
       ],
-      "summary": "Provides the observe_staged_host_bytes operation within private_runtime_observer.rs.",
+      "summary": "Captures observe staged host bytes evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -52906,14 +52928,14 @@
       "name": "observe_aac_staging_capacity",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        433,
-        445
+        460,
+        472
       ],
-      "summary": "Provides the observe_aac_staging_capacity operation within private_runtime_observer.rs.",
+      "summary": "Captures observe aac staging capacity evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -52923,14 +52945,14 @@
       "name": "observe_mux_output_capacity",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        447,
-        450
+        474,
+        477
       ],
-      "summary": "Provides the observe_mux_output_capacity operation within private_runtime_observer.rs.",
+      "summary": "Captures observe mux output capacity evidence used to account for the real process, phase, and memory behavior of runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -52940,14 +52962,14 @@
       "name": "process_resident_bytes",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        470,
-        487
+        497,
+        514
       ],
-      "summary": "Provides the process_resident_bytes operation within private_runtime_observer.rs.",
+      "summary": "Computes process resident bytes for admission and resource accounting in runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -52957,14 +52979,14 @@
       "name": "process_peak_resident_bytes",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        489,
-        501
+        516,
+        528
       ],
-      "summary": "Provides the process_peak_resident_bytes operation within private_runtime_observer.rs.",
+      "summary": "Computes process peak resident bytes for admission and resource accounting in runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -52974,16 +52996,16 @@
       "name": "build_observation",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        503,
-        599
+        530,
+        628
       ],
-      "summary": "Provides the build_observation operation within private_runtime_observer.rs.",
+      "summary": "Constructs build observation data for runtime-bound observation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "preparation"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:routed_qwen_workspace",
@@ -52991,14 +53013,14 @@
       "name": "routed_qwen_workspace",
       "filePath": "crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
       "lineRange": [
-        601,
-        612
+        630,
+        641
       ],
-      "summary": "Provides the routed_qwen_workspace operation within private_runtime_observer.rs.",
+      "summary": "Computes routed qwen workspace for admission and resource accounting in runtime-bound observation.",
       "tags": [
         "function",
-        "implementation",
-        "rust"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -53011,11 +53033,11 @@
         39,
         51
       ],
-      "summary": "Defines H3PrivateRuntimeProcessObservation, a structured rust type used by private_runtime_observer.rs.",
+      "summary": "Tracks H3PrivateRuntimeProcessObservation measurements across runtime phases and converts them into durable bound evidence.",
       "tags": [
         "data-model",
-        "type-definition",
-        "implementation"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -53028,11 +53050,11 @@
         169,
         179
       ],
-      "summary": "Defines H3PrivateRuntimeAuthorityObservation, a structured rust type used by private_runtime_observer.rs.",
+      "summary": "Carries authenticated H3PrivateRuntimeAuthorityObservation facts that authorize a narrowly scoped private H3 operation.",
       "tags": [
         "data-model",
-        "type-definition",
-        "implementation"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -53045,11 +53067,11 @@
         183,
         198
       ],
-      "summary": "Defines H3PrivateRuntimeEnvelopeObservation, a structured rust type used by private_runtime_observer.rs.",
+      "summary": "Tracks H3PrivateRuntimeEnvelopeObservation measurements across runtime phases and converts them into durable bound evidence.",
       "tags": [
         "data-model",
-        "type-definition",
-        "implementation"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -53062,11 +53084,11 @@
         202,
         219
       ],
-      "summary": "Defines H3PrivateRuntimeBoundObservation, a structured rust type used by private_runtime_observer.rs.",
+      "summary": "Tracks H3PrivateRuntimeBoundObservation measurements across runtime phases and converts them into durable bound evidence.",
       "tags": [
         "data-model",
-        "type-definition",
-        "implementation"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -53079,11 +53101,11 @@
         244,
         247
       ],
-      "summary": "Defines H3PrivateRuntimeBoundCapture, a structured rust type used by private_runtime_observer.rs.",
+      "summary": "Tracks H3PrivateRuntimeBoundCapture measurements across runtime phases and converts them into durable bound evidence.",
       "tags": [
         "data-model",
-        "type-definition",
-        "implementation"
+        "rust",
+        "telemetry"
       ],
       "complexity": "simple"
     },
@@ -172729,13 +172751,12 @@
       "type": "file",
       "name": "ActivityStrip.test.ts",
       "filePath": "desktop/src/components/create/ActivityStrip.test.ts",
-      "summary": "Exercises activity strip.test behavior and regression contracts with focused automated coverage.",
+      "summary": "Exercises the desktop Create activity strip across local prints, durable sequences, recovered fleet work, queue labels, actions, and settled-attention behavior.",
       "tags": [
-        "code",
         "test",
-        "desktop",
-        "typescript",
-        "implementation"
+        "component",
+        "activity",
+        "queue-status"
       ],
       "complexity": "complex"
     },
@@ -172748,11 +172769,11 @@
         24,
         35
       ],
-      "summary": "base job performs a significant part of activity strip.test's test and desktop behavior.",
+      "summary": "Builds a representative desktop generation job fixture for activity-strip tests.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "generation"
       ],
       "complexity": "simple"
     },
@@ -172762,14 +172783,14 @@
       "name": "seqJob",
       "filePath": "desktop/src/components/create/ActivityStrip.test.ts",
       "lineRange": [
-        193,
-        204
+        230,
+        241
       ],
-      "summary": "seq job performs a significant part of activity strip.test's test and desktop behavior.",
+      "summary": "Builds an overridable durable sequence fixture for desktop activity assertions.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "sequence"
       ],
       "complexity": "simple"
     },
@@ -172778,12 +172799,12 @@
       "type": "file",
       "name": "ActivityStrip.vue",
       "filePath": "desktop/src/components/create/ActivityStrip.vue",
-      "summary": "Implements the activity strip Vue component for Mold's desktop interface.",
+      "summary": "Renders the desktop Create workspace's unified present-tense activity strip, merging local generation jobs, durable sequences, queue snapshots, and recovered fleet activity into stable actionable rows.",
       "tags": [
-        "code",
-        "desktop",
         "component",
-        "implementation",
+        "activity",
+        "queue-status",
+        "multi-host",
         "tested"
       ],
       "complexity": "complex"
@@ -173018,11 +173039,12 @@
       "type": "file",
       "name": "NavRail.test.ts",
       "filePath": "desktop/src/components/shell/NavRail.test.ts",
-      "summary": "Test suite verifying workspace navigation, collapsed sidebar behavior, and keyboard-accessible shell actions, including regression and edge-case contracts exercised by the surrounding surface.",
+      "summary": "Tests desktop navigation-rail routing, resizing, live print and sequence presentation, recovered host activity, context actions, and history limits.",
       "tags": [
         "test",
-        "regression",
-        "desktop"
+        "component",
+        "navigation",
+        "activity"
       ],
       "complexity": "complex"
     },
@@ -173035,12 +173057,11 @@
         25,
         35
       ],
-      "summary": "Builds router state for workspace navigation, collapsed sidebar behavior, and keyboard-accessible shell actions.",
+      "summary": "Creates the in-memory router used to mount and navigate the rail under test.",
       "tags": [
-        "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "navigation"
       ],
       "complexity": "simple"
     },
@@ -173053,11 +173074,11 @@
         39,
         53
       ],
-      "summary": "Implements mount at for workspace navigation, collapsed sidebar behavior, and keyboard-accessible shell actions.",
+      "summary": "Navigates to a requested route and mounts NavRail with its Pinia and router dependencies.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "component"
       ],
       "complexity": "simple"
     },
@@ -173066,11 +173087,12 @@
       "type": "file",
       "name": "NavRail.vue",
       "filePath": "desktop/src/components/shell/NavRail.vue",
-      "summary": "Implements workspace navigation, collapsed sidebar behavior, and keyboard-accessible shell actions as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Implements the resizable desktop workspace navigation rail and its Now Developing feed, combining print, sequence, and recovered fleet work with host-aware actions.",
       "tags": [
-        "desktop",
         "component",
-        "vue",
+        "navigation",
+        "activity",
+        "multi-host",
         "tested"
       ],
       "complexity": "complex"
@@ -173550,11 +173572,13 @@
       "type": "file",
       "name": "generation.ts",
       "filePath": "desktop/src/stores/generation.ts",
-      "summary": "Implements desktop generation job state, batch planning, routing, and lifecycle orchestration as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Owns desktop and mobile generation lifecycle state, durable batch admission and recovery, host routing, chain progress reduction, cancellation, result presentation, and bounded history.",
       "tags": [
-        "desktop",
-        "generation",
         "state-management",
+        "generation",
+        "durable-recovery",
+        "multi-host",
+        "event-handler",
         "tested"
       ],
       "complexity": "complex"
@@ -173568,11 +173592,11 @@
         132,
         144
       ],
-      "summary": "Implements suggest output filename for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Builds a timestamped, model- and seed-aware output filename for generated media.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "generation",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -173585,11 +173609,11 @@
         158,
         160
       ],
-      "summary": "Implements random seed for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Returns a random unsigned 32-bit generation seed.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "generation",
+        "randomness"
       ],
       "complexity": "simple"
     },
@@ -173602,12 +173626,11 @@
         169,
         175
       ],
-      "summary": "Implements needs host route for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Determines whether a generation request requires explicit host routing.",
       "tags": [
-        "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "utility",
+        "routing",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -173620,11 +173643,11 @@
         182,
         184
       ],
-      "summary": "Implements resolve base seed for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Resolves a fixed or randomly generated base seed for a batch.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "generation",
+        "batching"
       ],
       "complexity": "simple"
     },
@@ -173637,11 +173660,11 @@
         205,
         243
       ],
-      "summary": "Implements plan batch requests for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Expands one generation request into deterministic batch siblings with seed and prompt variations.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "generation",
+        "batching",
+        "factory"
       ],
       "complexity": "simple"
     },
@@ -173651,14 +173674,14 @@
       "name": "railOrder",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        251,
-        262
+        250,
+        254
       ],
-      "summary": "Implements rail order for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Orders generation jobs for stable display in the navigation rail.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "activity",
+        "ordering"
       ],
       "complexity": "simple"
     },
@@ -173668,14 +173691,14 @@
       "name": "runWithConcurrency",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        271,
-        290
+        263,
+        282
       ],
-      "summary": "Executes with concurrency for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Runs asynchronous tasks under a fixed worker limit while preserving result order.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "concurrency",
+        "async"
       ],
       "complexity": "simple"
     },
@@ -173685,14 +173708,14 @@
       "name": "originGalleryMetadata",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        331,
-        345
+        323,
+        337
       ],
-      "summary": "Implements origin gallery metadata for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Builds origin-host metadata used to retain remote gallery identity for completed outputs.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "gallery",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -173702,14 +173725,14 @@
       "name": "persistDurableRecords",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        366,
-        377
+        358,
+        369
       ],
-      "summary": "Implements persist durable records for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Persists active and recent durable generation records while dropping expired settled entries.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "durable-recovery",
+        "serialization",
+        "state-management"
       ],
       "complexity": "simple"
     },
@@ -173719,14 +173742,14 @@
       "name": "requestFormat",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        401,
-        417
+        393,
+        409
       ],
-      "summary": "Implements request format for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Infers an output format from a result filename with a request-format fallback.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "generation",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -173736,14 +173759,14 @@
       "name": "jobCanBeRemoved",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        423,
-        425
+        415,
+        417
       ],
-      "summary": "Implements job can be removed for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Reports whether a settled generation job is safe to remove from local history.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "generation",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -173753,14 +173776,14 @@
       "name": "releaseSettledJob",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        438,
-        452
+        430,
+        444
       ],
-      "summary": "Implements release settled job for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Releases retained result resources and settlement tracking for a completed local job.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "state-management",
+        "generation",
+        "cleanup"
       ],
       "complexity": "simple"
     },
@@ -173770,14 +173793,14 @@
       "name": "resultUrlExpiry",
       "filePath": "desktop/src/stores/generation.ts",
       "lineRange": [
-        462,
-        471
+        454,
+        463
       ],
-      "summary": "Implements result url expiry for desktop generation job state, batch planning, routing, and lifecycle orchestration.",
+      "summary": "Extracts an expiry timestamp from a ticketed result URL when available.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "utility",
+        "gallery",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -176696,14 +176719,16 @@
       "type": "file",
       "name": "h3_factory.rs",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
-      "summary": "Implements h3 factory model and inference behavior in Mold's local generation engine.",
+      "summary": "Implements the typed MiniMax H3 factory seam between server admission and the private Candle backend. It recomputes authority identities, reference charges, attention qualification, and conservative host/device memory budgets while keeping production activation fail-closed.",
       "tags": [
-        "rust",
-        "service",
-        "inference"
+        "factory",
+        "validation",
+        "memory-budget",
+        "runtime-authority",
+        "minimax-h3"
       ],
       "complexity": "complex",
-      "languageNotes": "Rust implementation uses explicit ownership and typed results to keep runtime boundaries fail-safe."
+      "languageNotes": "Strongly typed Rust authority records and deterministic hashing prevent caller-supplied paths, bytes, or unverified budget claims from activating H3 execution."
     },
     {
       "id": "function:crates/mold-inference/src/h3_factory.rs:new",
@@ -176714,11 +176739,12 @@
         49,
         61
       ],
-      "summary": "Implements new within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Constructs a validated new value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "implementation",
-        "factory"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176728,14 +176754,15 @@
       "name": "h3_factory_activation_prerequisites",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        330,
-        332
+        332,
+        334
       ],
-      "summary": "Implements h3 factory activation prerequisites within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements h3 factory activation prerequisites for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176745,14 +176772,15 @@
       "name": "update_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        505,
-        757
+        507,
+        759
       ],
-      "summary": "Implements update identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Feeds canonical identity fields into the deterministic MiniMax H3 identity hash.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "complex"
     },
@@ -176762,14 +176790,15 @@
       "name": "as_str",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        810,
-        812
+        812,
+        814
       ],
-      "summary": "Implements as str within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements as str for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176779,14 +176808,15 @@
       "name": "runtime_kind",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        814,
-        820
+        816,
+        822
       ],
-      "summary": "Implements runtime kind within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports runtime kind for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176796,14 +176826,15 @@
       "name": "from_runtime",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        822,
-        828
+        824,
+        830
       ],
-      "summary": "Implements from runtime within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports from runtime for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "factory"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176813,14 +176844,15 @@
       "name": "media_model_matches_h3_authority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        841,
-        853
+        843,
+        855
       ],
-      "summary": "Implements media model matches h3 authority within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements media model matches h3 authority for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176830,14 +176862,15 @@
       "name": "for_reviewed_tier",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        890,
-        912
+        892,
+        914
       ],
-      "summary": "Implements for reviewed tier within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements for reviewed tier for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176847,14 +176880,15 @@
       "name": "tier_stable_id",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        914,
-        916
+        916,
+        918
       ],
-      "summary": "Implements tier stable id within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements tier stable id for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176864,14 +176898,15 @@
       "name": "adapter_identity_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        918,
-        920
+        920,
+        922
       ],
-      "summary": "Implements adapter identity sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic adapter identity sha256 that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -176881,31 +176916,15 @@
       "name": "adapter_content_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        922,
-        924
+        924,
+        926
       ],
-      "summary": "Implements adapter content sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements adapter content sha256 for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
-      "type": "function",
-      "name": "sampler_kind",
-      "filePath": "crates/mold-inference/src/h3_factory.rs",
-      "lineRange": [
-        1180,
-        1188
-      ],
-      "summary": "Implements sampler kind within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176915,14 +176934,15 @@
       "name": "grid_points",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        930,
-        932
+        932,
+        934
       ],
-      "summary": "Implements grid points within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements grid points for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176932,14 +176952,15 @@
       "name": "reviewed_task",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        937,
-        945
+        939,
+        947
       ],
-      "summary": "Implements reviewed task within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements reviewed task for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -176949,14 +176970,15 @@
       "name": "resident_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        947,
-        949
+        949,
+        951
       ],
-      "summary": "Implements resident device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes resident device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -176966,14 +176988,15 @@
       "name": "device_staging_peak_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        954,
-        956
+        956,
+        958
       ],
-      "summary": "Implements device staging peak bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes device staging peak bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -176983,14 +177006,15 @@
       "name": "host_staging_peak_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        958,
-        960
+        960,
+        962
       ],
-      "summary": "Implements host staging peak bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes host staging peak bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177000,13 +177024,14 @@
       "name": "validate",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        967,
-        1039
+        969,
+        1041
       ],
-      "summary": "Implements validate within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates the containing MiniMax H3 authority record and its cross-field invariants.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -177017,31 +177042,15 @@
       "name": "resolved_sampler_kind",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1044,
-        1046
+        1046,
+        1048
       ],
-      "summary": "Implements resolved sampler kind within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements resolved sampler kind for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
-      "type": "function",
-      "name": "video_shift",
-      "filePath": "crates/mold-inference/src/h3_factory.rs",
-      "lineRange": [
-        1192,
-        1195
-      ],
-      "summary": "Implements video shift within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177051,14 +177060,51 @@
       "name": "turbo_adapter",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1165,
-        1170
+        1167,
+        1172
       ],
-      "summary": "Implements turbo adapter within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements turbo adapter for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
+      "type": "function",
+      "name": "sampler_kind",
+      "filePath": "crates/mold-inference/src/h3_factory.rs",
+      "lineRange": [
+        1182,
+        1190
+      ],
+      "summary": "Implements sampler kind for the MiniMax H3 typed factory authority and its deterministic budget contract.",
+      "tags": [
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
+      "type": "function",
+      "name": "video_shift",
+      "filePath": "crates/mold-inference/src/h3_factory.rs",
+      "lineRange": [
+        1194,
+        1197
+      ],
+      "summary": "Implements video shift for the MiniMax H3 typed factory authority and its deterministic budget contract.",
+      "tags": [
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177068,14 +177114,15 @@
       "name": "turbo_adapter_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1198,
-        1201
+        1200,
+        1203
       ],
-      "summary": "Implements turbo adapter device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes turbo adapter device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177085,14 +177132,15 @@
       "name": "turbo_adapter_device_staging_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1204,
-        1207
+        1206,
+        1209
       ],
-      "summary": "Implements turbo adapter device staging bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes turbo adapter device staging bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177102,14 +177150,15 @@
       "name": "turbo_adapter_host_staging_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1210,
-        1213
+        1212,
+        1215
       ],
-      "summary": "Implements turbo adapter host staging bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes turbo adapter host staging bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177119,14 +177168,15 @@
       "name": "freeze",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1385,
-        1398
+        1387,
+        1400
       ],
-      "summary": "Implements freeze within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Freezes freeze into immutable authority data that cannot change after scheduling.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177136,14 +177186,15 @@
       "name": "expected_h3_factory_reference_charges",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1473,
-        1484
+        1475,
+        1486
       ],
-      "summary": "Implements expected h3 factory reference charges within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory reference charges from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -177153,14 +177204,15 @@
       "name": "h3_reference_charges",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1520,
-        1798
+        1522,
+        1809
       ],
-      "summary": "Implements h3 reference charges within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives h3 reference charges under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "complex"
     },
@@ -177170,13 +177222,14 @@
       "name": "validate_prepared_references",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1802,
-        1870
+        1813,
+        1881
       ],
-      "summary": "Implements validate prepared references within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates prepared references against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -177187,13 +177240,14 @@
       "name": "validate_prepared_request",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1872,
-        2037
+        1883,
+        2048
       ],
-      "summary": "Implements validate prepared request within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates prepared request against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -177204,13 +177258,14 @@
       "name": "validate_raw_checkpoint",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        2039,
-        2097
+        2050,
+        2108
       ],
-      "summary": "Implements validate raw checkpoint within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates raw checkpoint against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -177221,13 +177276,14 @@
       "name": "validate_target_budget",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        2099,
-        3383
+        2110,
+        3394
       ],
-      "summary": "Implements validate target budget within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates target budget against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "complex"
@@ -177238,14 +177294,15 @@
       "name": "transformer_load_phase_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3424,
-        3456
+        3435,
+        3467
       ],
-      "summary": "Implements transformer load phase device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes transformer load phase device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177255,14 +177312,15 @@
       "name": "denoise_phase_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3481,
-        3519
+        3492,
+        3530
       ],
-      "summary": "Implements denoise phase device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes denoise phase device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177272,14 +177330,15 @@
       "name": "transformer_load_phase_host_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3534,
-        3558
+        3545,
+        3569
       ],
-      "summary": "Implements transformer load phase host bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes transformer load phase host bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177289,14 +177348,15 @@
       "name": "qwen_encode_phase_host_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3584,
-        3614
+        3595,
+        3625
       ],
-      "summary": "Implements qwen encode phase host bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen encode phase host bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "serialization"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177306,14 +177366,15 @@
       "name": "denoise_transient_workspace_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3616,
-        3621
+        3627,
+        3632
       ],
-      "summary": "Implements denoise transient workspace device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes denoise transient workspace device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177323,14 +177384,15 @@
       "name": "denoise_hidden_activation_device_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3642,
-        3648
+        3653,
+        3659
       ],
-      "summary": "Implements denoise hidden activation device bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes denoise hidden activation device bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177340,14 +177402,15 @@
       "name": "expected_h3_factory_prepared_request_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3650,
-        3715
+        3661,
+        3726
       ],
-      "summary": "Implements expected h3 factory prepared request identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory prepared request identity from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "moderate"
     },
@@ -177357,14 +177420,15 @@
       "name": "expected_h3_factory_raw_checkpoint_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3717,
-        3751
+        3728,
+        3762
       ],
-      "summary": "Implements expected h3 factory raw checkpoint identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory raw checkpoint identity from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "validation"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177374,14 +177438,15 @@
       "name": "update_reference_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3757,
-        3802
+        3768,
+        3813
       ],
-      "summary": "Implements update reference identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Feeds canonical reference identity fields into the deterministic MiniMax H3 identity hash.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177391,14 +177456,15 @@
       "name": "expected_h3_factory_reference_media_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3806,
-        3816
+        3817,
+        3827
       ],
-      "summary": "Implements expected h3 factory reference media identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory reference media identity from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177408,14 +177474,15 @@
       "name": "expected_h3_factory_target_budget_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3818,
-        3823
+        3829,
+        3834
       ],
-      "summary": "Implements expected h3 factory target budget identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory target budget identity from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177425,14 +177492,15 @@
       "name": "expected_h3_factory_prepared_attempt_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3825,
-        3834
+        3836,
+        3845
       ],
-      "summary": "Implements expected h3 factory prepared attempt identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical h3 factory prepared attempt identity from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177442,14 +177510,15 @@
       "name": "expected_prepared_attempt_identity_fields",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3845,
-        3858
+        3856,
+        3869
       ],
-      "summary": "Implements expected prepared attempt identity fields within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Recomputes the canonical prepared attempt identity fields from trusted typed inputs for identity or budget verification.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177459,13 +177528,14 @@
       "name": "validate_attention",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3925,
-        3980
+        3936,
+        3991
       ],
-      "summary": "Implements validate attention within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates attention against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -177476,14 +177546,15 @@
       "name": "new_contract_only",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3983,
-        4255
+        3994,
+        4266
       ],
-      "summary": "Implements new contract only within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Constructs a validated new contract only value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "implementation",
-        "factory"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "complex"
     },
@@ -177493,14 +177564,15 @@
       "name": "identity_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4257,
-        4259
+        4268,
+        4270
       ],
-      "summary": "Implements identity sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic identity sha256 that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177510,14 +177582,15 @@
       "name": "with_private_prepared_attempt",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4265,
-        4307
+        4276,
+        4318
       ],
-      "summary": "Implements with private prepared attempt within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements with private prepared attempt for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177527,14 +177600,15 @@
       "name": "component_set_identity_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4309,
-        4311
+        4320,
+        4322
       ],
-      "summary": "Implements component set identity sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic component set identity sha256 that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177544,14 +177618,15 @@
       "name": "backend_plan_identity_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4314,
-        4316
+        4325,
+        4327
       ],
-      "summary": "Implements backend plan identity sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic backend plan identity sha256 that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "scheduling"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177561,14 +177636,15 @@
       "name": "private_vae_adapter_authority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4319,
-        4338
+        4330,
+        4349
       ],
-      "summary": "Implements private vae adapter authority within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements private vae adapter authority for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177578,14 +177654,15 @@
       "name": "private_fl2va_runtime_authority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4345,
-        4365
+        4356,
+        4376
       ],
-      "summary": "Implements private fl2va runtime authority within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports private fl2va runtime authority for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177595,14 +177672,15 @@
       "name": "private_fl2va_runtime_authority_with_activation",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4373,
-        4392
+        4384,
+        4403
       ],
-      "summary": "Implements private fl2va runtime authority with activation within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports private fl2va runtime authority with activation for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177612,14 +177690,15 @@
       "name": "private_fl2va_runtime_authority_for_schema_tests",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4397,
-        4448
+        4408,
+        4459
       ],
-      "summary": "Implements private fl2va runtime authority for schema tests within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports private fl2va runtime authority for schema tests for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "moderate"
     },
@@ -177629,14 +177708,15 @@
       "name": "private_fl2va_runtime_authority_record",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4451,
-        4504
+        4462,
+        4515
       ],
-      "summary": "Implements private fl2va runtime authority record within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports private fl2va runtime authority record for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "moderate"
     },
@@ -177646,14 +177726,15 @@
       "name": "conditioner_component_authority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4512,
-        4514
+        4523,
+        4525
       ],
-      "summary": "Implements conditioner component authority within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements conditioner component authority for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177663,14 +177744,15 @@
       "name": "private_component_authority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4520,
-        4528
+        4531,
+        4539
       ],
-      "summary": "Implements private component authority within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements private component authority for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177680,14 +177762,15 @@
       "name": "canonical_model",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4540,
-        4542
+        4551,
+        4553
       ],
-      "summary": "Implements canonical model within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements canonical model for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177697,14 +177780,15 @@
       "name": "task",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4544,
-        4546
+        4555,
+        4557
       ],
-      "summary": "Implements task within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements task for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177714,14 +177798,15 @@
       "name": "device_id",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4548,
-        4550
+        4559,
+        4561
       ],
-      "summary": "Implements device id within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements device id for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177731,14 +177816,15 @@
       "name": "device_ordinal",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4552,
-        4554
+        4563,
+        4565
       ],
-      "summary": "Implements device ordinal within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements device ordinal for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177748,14 +177834,15 @@
       "name": "compute_capability",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4561,
-        4566
+        4572,
+        4577
       ],
-      "summary": "Implements compute capability within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Reports compute capability for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177765,14 +177852,15 @@
       "name": "execution_fingerprint",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4568,
-        4570
+        4579,
+        4581
       ],
-      "summary": "Implements execution fingerprint within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic execution fingerprint that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177782,14 +177870,15 @@
       "name": "prepared_target_attempt_identities",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4579,
-        4595
+        4590,
+        4606
       ],
-      "summary": "Implements prepared target attempt identities within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements prepared target attempt identities for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177799,14 +177888,15 @@
       "name": "attention_qualification_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4597,
-        4599
+        4608,
+        4610
       ],
-      "summary": "Implements attention qualification sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements attention qualification sha256 for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177816,14 +177906,15 @@
       "name": "attention_runtime_identity_sha256",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4601,
-        4605
+        4612,
+        4616
       ],
-      "summary": "Implements attention runtime identity sha256 within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic attention runtime identity sha256 that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -177833,14 +177924,15 @@
       "name": "attention_backend",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4607,
-        4609
+        4618,
+        4620
       ],
-      "summary": "Implements attention backend within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements attention backend for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177850,14 +177942,15 @@
       "name": "attention_chunk",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4611,
-        4613
+        4622,
+        4624
       ],
-      "summary": "Implements attention chunk within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements attention chunk for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177867,14 +177960,15 @@
       "name": "conditioner_placement",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4615,
-        4617
+        4626,
+        4628
       ],
-      "summary": "Implements conditioner placement within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements conditioner placement for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -177884,14 +177978,15 @@
       "name": "qwen_parameter_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4619,
-        4621
+        4630,
+        4632
       ],
-      "summary": "Implements qwen parameter bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen parameter bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177901,14 +177996,15 @@
       "name": "qwen_host_resident_parameter_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4623,
-        4625
+        4634,
+        4636
       ],
-      "summary": "Implements qwen host resident parameter bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen host resident parameter bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177918,14 +178014,15 @@
       "name": "qwen_device_resident_parameter_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4627,
-        4629
+        4638,
+        4640
       ],
-      "summary": "Implements qwen device resident parameter bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen device resident parameter bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177935,14 +178032,15 @@
       "name": "qwen_activation_workspace_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4631,
-        4633
+        4642,
+        4644
       ],
-      "summary": "Implements qwen activation workspace bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen activation workspace bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177952,14 +178050,15 @@
       "name": "qwen_maximum_tensor_staging_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4635,
-        4637
+        4646,
+        4648
       ],
-      "summary": "Implements qwen maximum tensor staging bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen maximum tensor staging bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177969,14 +178068,15 @@
       "name": "qwen_retained_raw_header_bytes",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4639,
-        4641
+        4650,
+        4652
       ],
-      "summary": "Implements qwen retained raw header bytes within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen retained raw header bytes for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -177986,14 +178086,15 @@
       "name": "qwen_output_text_rows",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4643,
-        4645
+        4654,
+        4656
       ],
-      "summary": "Implements qwen output text rows within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen output text rows for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178003,14 +178104,15 @@
       "name": "qwen_vision_rows",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4647,
-        4649
+        4658,
+        4660
       ],
-      "summary": "Implements qwen vision rows within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Computes qwen vision rows for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178020,14 +178122,15 @@
       "name": "resident_block_count",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4651,
-        4653
+        4662,
+        4664
       ],
-      "summary": "Implements resident block count within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements resident block count for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -178037,14 +178140,15 @@
       "name": "prefetch_depth",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4655,
-        4657
+        4666,
+        4668
       ],
-      "summary": "Implements prefetch depth within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements prefetch depth for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -178054,14 +178158,15 @@
       "name": "block_offload",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4659,
-        4661
+        4670,
+        4672
       ],
-      "summary": "Implements block offload within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements block offload for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -178071,13 +178176,14 @@
       "name": "validate_engine_seam",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4671,
-        4723
+        4682,
+        4734
       ],
-      "summary": "Implements validate engine seam within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates engine seam against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -178088,14 +178194,15 @@
       "name": "quantization",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4725,
-        4727
+        4736,
+        4738
       ],
-      "summary": "Implements quantization within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Implements quantization for the MiniMax H3 typed factory authority and its deterministic budget contract.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -178105,13 +178212,14 @@
       "name": "validate_frozen",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4729,
-        4839
+        4740,
+        4850
       ],
-      "summary": "Implements validate frozen within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates frozen against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -178122,13 +178230,14 @@
       "name": "validate_for_dispatch",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4841,
-        4923
+        4852,
+        4934
       ],
-      "summary": "Implements validate for dispatch within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Validates for dispatch against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "implementation",
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -178139,14 +178248,15 @@
       "name": "frozen_identity",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        4926,
-        5000
+        4937,
+        5011
       ],
-      "summary": "Implements frozen identity within the h3 factory workflow, keeping the operation isolated for reuse and testing.",
+      "summary": "Derives or exposes the deterministic frozen identity that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "implementation",
-        "business-logic"
+        "factory",
+        "runtime-authority",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "moderate"
     },
@@ -178159,11 +178269,12 @@
         34,
         39
       ],
-      "summary": "Encapsulates h3 factory component role state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Component Role models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178176,11 +178287,12 @@
         42,
         46
       ],
-      "summary": "Encapsulates h3 factory component authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Component Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178193,11 +178305,12 @@
         74,
         78
       ],
-      "summary": "Encapsulates h3 factory conditioner placement state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Conditioner Placement models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178210,11 +178323,12 @@
         81,
         84
       ],
-      "summary": "Encapsulates h3 factory endpoint anchor state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Endpoint Anchor models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178227,11 +178341,12 @@
         87,
         89
       ],
-      "summary": "Encapsulates h3 factory endpoint preprocess state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Endpoint Preprocess models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178244,11 +178359,12 @@
         92,
         102
       ],
-      "summary": "Encapsulates h3 factory endpoint input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Endpoint Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178261,11 +178377,12 @@
         108,
         112
       ],
-      "summary": "Encapsulates h3 factory reference kind state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Reference Kind models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178276,13 +178393,14 @@
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
         122,
-        165
+        167
       ],
-      "summary": "Encapsulates h3 factory reference input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Reference Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178292,14 +178410,15 @@
       "name": "H3FactoryPreparedRowsInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        168,
-        176
+        170,
+        178
       ],
-      "summary": "Encapsulates h3 factory prepared rows input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Prepared Rows Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178309,14 +178428,15 @@
       "name": "H3FactoryPreparedRequestInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        183,
-        213
+        185,
+        215
       ],
-      "summary": "Encapsulates h3 factory prepared request input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Prepared Request Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178326,14 +178446,15 @@
       "name": "H3FactoryBlockMemoryInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        216,
-        223
+        218,
+        225
       ],
-      "summary": "Encapsulates h3 factory block memory input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Block Memory Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178343,14 +178464,15 @@
       "name": "H3FactoryRawCheckpointInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        228,
-        245
+        230,
+        247
       ],
-      "summary": "Encapsulates h3 factory raw checkpoint input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Raw Checkpoint Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178360,14 +178482,15 @@
       "name": "H3FactoryTargetLoadDropPolicy",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        256,
-        269
+        258,
+        271
       ],
-      "summary": "Encapsulates h3 factory target load drop policy state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Target Load Drop Policy models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178377,14 +178500,15 @@
       "name": "H3FactoryTargetDenoiseCopyPolicy",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        272,
-        281
+        274,
+        283
       ],
-      "summary": "Encapsulates h3 factory target denoise copy policy state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Target Denoise Copy Policy models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178394,14 +178518,15 @@
       "name": "H3FactoryActivationPrerequisite",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        288,
-        316
+        290,
+        318
       ],
-      "summary": "Encapsulates h3 factory activation prerequisite state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Activation Prerequisite models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178411,14 +178536,15 @@
       "name": "H3FactoryArtifactHostRole",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        335,
-        341
+        337,
+        343
       ],
-      "summary": "Encapsulates h3 factory artifact host role state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Artifact Host Role models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178428,14 +178554,15 @@
       "name": "H3FactoryArtifactHostInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        344,
-        349
+        346,
+        351
       ],
-      "summary": "Encapsulates h3 factory artifact host input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Artifact Host Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178445,14 +178572,15 @@
       "name": "H3FactoryTargetBudgetInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        358,
-        497
+        360,
+        499
       ],
-      "summary": "Encapsulates h3 factory target budget input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Target Budget Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "moderate"
     },
@@ -178462,14 +178590,15 @@
       "name": "H3FactoryAttentionInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        761,
-        774
+        763,
+        776
       ],
-      "summary": "Encapsulates h3 factory attention input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Attention Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178479,14 +178608,15 @@
       "name": "H3FactoryPreparedAttemptInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        782,
-        788
+        784,
+        790
       ],
-      "summary": "Encapsulates h3 factory prepared attempt input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Prepared Attempt Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178496,14 +178626,15 @@
       "name": "H3FactoryPreparedAttemptAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        792,
-        798
+        794,
+        800
       ],
-      "summary": "Encapsulates h3 factory prepared attempt authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Prepared Attempt Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178513,14 +178644,15 @@
       "name": "H3FactorySamplerKind",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        803,
-        807
+        805,
+        809
       ],
-      "summary": "Encapsulates h3 factory sampler kind state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Sampler Kind models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178530,14 +178662,15 @@
       "name": "H3FactoryTurboAdapterAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        871,
-        881
+        873,
+        883
       ],
-      "summary": "Encapsulates h3 factory turbo adapter authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Turbo Adapter Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178547,14 +178680,15 @@
       "name": "H3FactoryQuantizationAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1094,
-        1104
+        1096,
+        1106
       ],
-      "summary": "Encapsulates h3 factory quantization authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Quantization Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178564,14 +178698,15 @@
       "name": "H3FactoryExecutionBudgetEchoInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1225,
-        1229
+        1227,
+        1231
       ],
-      "summary": "Encapsulates h3 factory execution budget echo input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Execution Budget Echo Input defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178581,14 +178716,15 @@
       "name": "H3FactoryAuthorityInput",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1237,
-        1284
+        1239,
+        1286
       ],
-      "summary": "Encapsulates h3 factory authority input state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Authority Input carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178598,14 +178734,15 @@
       "name": "FrozenH3FactoryAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1292,
-        1321
+        1294,
+        1323
       ],
-      "summary": "Encapsulates frozen h3 factory authority state and behavior for the h3 factory subsystem.",
+      "summary": "Frozen H3 Factory Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178615,14 +178752,15 @@
       "name": "H3PrivateVaeFactoryAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1327,
-        1336
+        1329,
+        1338
       ],
-      "summary": "Encapsulates h3 private vae factory authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Private Vae Factory Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178632,14 +178770,15 @@
       "name": "H3PrivateFl2VaFactoryAuthority",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1343,
-        1366
+        1345,
+        1368
       ],
-      "summary": "Encapsulates h3 private fl2 va factory authority state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Private Fl2 Va Factory Authority carries immutable, digest-bound evidence used to validate and freeze a MiniMax H3 execution route.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "runtime-authority"
       ],
       "complexity": "simple"
     },
@@ -178649,14 +178788,15 @@
       "name": "H3FactoryReferenceCharges",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1459,
-        1465
+        1461,
+        1467
       ],
-      "summary": "Encapsulates h3 factory reference charges state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Factory Reference Charges records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178666,14 +178806,15 @@
       "name": "H3ReferenceMediaTotals",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        1501,
-        1510
+        1503,
+        1512
       ],
-      "summary": "Encapsulates h3 reference media totals state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Reference Media Totals records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -178683,14 +178824,15 @@
       "name": "H3TransformerLoadDeviceTerms",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3410,
-        3422
+        3421,
+        3433
       ],
-      "summary": "Encapsulates h3 transformer load device terms state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Transformer Load Device Terms records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178700,14 +178842,15 @@
       "name": "H3DenoiseDeviceTerms",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3463,
-        3479
+        3474,
+        3490
       ],
-      "summary": "Encapsulates h3 denoise device terms state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Denoise Device Terms records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178717,14 +178860,15 @@
       "name": "H3TransformerLoadHostTerms",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3523,
-        3532
+        3534,
+        3543
       ],
-      "summary": "Encapsulates h3 transformer load host terms state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Transformer Load Host Terms records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -178734,14 +178878,15 @@
       "name": "H3QwenEncodeHostTerms",
       "filePath": "crates/mold-inference/src/h3_factory.rs",
       "lineRange": [
-        3574,
-        3582
+        3585,
+        3593
       ],
-      "summary": "Encapsulates h3 qwen encode host terms state and behavior for the h3 factory subsystem.",
+      "summary": "H3 Qwen Encode Host Terms records conservative host/device resource terms for a reviewed MiniMax H3 execution phase.",
       "tags": [
         "data-model",
-        "class",
-        "state-management"
+        "factory",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -187842,14 +187987,16 @@
       "type": "file",
       "name": "engine.rs",
       "filePath": "crates/mold-inference/src/minimax_h3/engine.rs",
-      "summary": "Implements shared inference engine contracts, model loading, and generation request execution as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Provides the legal-neutral MiniMax H3 FL2VA/Ref2VA engine adapter and streamed pipeline seam used by injected test runtimes. It validates frozen routing authority, bridges pipeline phases into user progress, and consumes independently loaded transformer blocks without registering a production loader.",
       "tags": [
-        "inference",
-        "minimax-h3",
-        "rust",
-        "application"
+        "inference-engine",
+        "streaming",
+        "progress",
+        "runtime-seam",
+        "minimax-h3"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "Trait-based dependency injection and consuming boxed sessions enforce per-attempt runtime ownership; progress observers translate pipeline phases into the shared inference event protocol."
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/engine.rs:new_injected",
@@ -187860,10 +188007,11 @@
         135,
         154
       ],
-      "summary": "Implements new injected for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Constructs a validated new injected value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -187877,10 +188025,11 @@
         157,
         176
       ],
-      "summary": "Implements new ref2va injected for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Constructs a validated new ref2va injected value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -187894,10 +188043,11 @@
         179,
         205
       ],
-      "summary": "Implements new task injected for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Constructs a validated new task injected value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -187911,10 +188061,11 @@
         207,
         223
       ],
-      "summary": "Implements from factory request for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Constructs a validated from factory request value for the MiniMax H3 factory or streamed runtime seam.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -187928,12 +188079,12 @@
         225,
         234
       ],
-      "summary": "Validates runtime echo and returns actionable failure details.",
+      "summary": "Validates runtime echo against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -187946,10 +188097,11 @@
         236,
         261
       ],
-      "summary": "Implements construct attempt runtime for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Reports construct attempt runtime for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -187963,12 +188115,12 @@
         263,
         289
       ],
-      "summary": "Validates output and returns actionable failure details.",
+      "summary": "Validates output against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -187981,10 +188133,11 @@
         291,
         353
       ],
-      "summary": "Implements generate bound for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Runs generate bound through the frozen MiniMax H3 route while preserving reference bindings, progress, and output validation.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "moderate"
@@ -187998,11 +188151,12 @@
         358,
         379
       ],
-      "summary": "Implements ref2va reference fingerprint for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Derives or exposes the deterministic ref2va reference fingerprint that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -188015,29 +188169,12 @@
         381,
         412
       ],
-      "summary": "Validates ref2va bindings and returns actionable failure details.",
+      "summary": "Validates ref2va bindings against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "validation",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
-      "type": "function",
-      "name": "new",
-      "filePath": "crates/mold-inference/src/minimax_h3/engine.rs",
-      "lineRange": [
-        1005,
-        1025
-      ],
-      "summary": "Constructs the shared inference engine contracts, model loading, and generation request execution state with validated defaults.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -188050,11 +188187,12 @@
         502,
         569
       ],
-      "summary": "Implements observe for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Translates MiniMax H3 streamed pipeline state into the shared user-visible progress protocol.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "progress"
       ],
       "complexity": "moderate"
     },
@@ -188067,11 +188205,12 @@
         572,
         606
       ],
-      "summary": "Implements pipeline phase name for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Translates MiniMax H3 streamed pipeline state into the shared user-visible progress protocol.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "progress"
       ],
       "complexity": "simple"
     },
@@ -188084,13 +188223,14 @@
         658,
         707
       ],
-      "summary": "Implements generate for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Runs generate through the frozen MiniMax H3 route while preserving reference bindings, progress, and output validation.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
-      "complexity": "moderate"
+      "complexity": "simple"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/engine.rs:h3_engine_output_from_pipeline",
@@ -188101,10 +188241,11 @@
         793,
         823
       ],
-      "summary": "Implements h3 engine output from pipeline for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Implements h3 engine output from pipeline for the injected MiniMax H3 streamed engine and pipeline adapter.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -188118,10 +188259,11 @@
         910,
         944
       ],
-      "summary": "Implements denoise for shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "Implements denoise for the injected MiniMax H3 streamed engine and pipeline adapter.",
       "tags": [
-        "function",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -188135,11 +188277,29 @@
         973,
         989
       ],
-      "summary": "Validates point and returns actionable failure details.",
+      "summary": "Implements checkpoint for the injected MiniMax H3 streamed engine and pipeline adapter.",
       "tags": [
-        "function",
-        "validation",
-        "business-logic",
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "crates/mold-inference/src/minimax_h3/engine.rs",
+      "lineRange": [
+        1005,
+        1025
+      ],
+      "summary": "Constructs a validated new value for the MiniMax H3 factory or streamed runtime seam.",
+      "tags": [
+        "inference-engine",
+        "streaming",
+        "minimax-h3",
         "utility"
       ],
       "complexity": "simple"
@@ -188153,12 +188313,12 @@
         59,
         66
       ],
-      "summary": "Defines h3 runtime load request, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Runtime Load Request defines typed MiniMax H3 inputs whose geometry, identity, and resource claims are recomputed before admission.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188171,11 +188331,12 @@
         72,
         78
       ],
-      "summary": "Defines h3 runtime loader, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Runtime Loader defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188188,11 +188349,12 @@
         84,
         95
       ],
-      "summary": "Defines h3 runtime session, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Runtime Session defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188205,11 +188367,12 @@
         98,
         114
       ],
-      "summary": "Defines h3 engine output, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Engine Output defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188222,11 +188385,12 @@
         122,
         131
       ],
-      "summary": "Defines h3 fl2 va engine, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Fl2 Va Engine defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188239,11 +188403,12 @@
         483,
         488
       ],
-      "summary": "Defines h3 engine progress observer, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Engine Progress Observer defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188256,11 +188421,12 @@
         609,
         613
       ],
-      "summary": "Defines h3 pipeline runtime, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Pipeline Runtime defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188273,11 +188439,12 @@
         618,
         620
       ],
-      "summary": "Defines h3 streamed fl2 va backend, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Fl2 Va Backend defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188290,11 +188457,12 @@
         712,
         716
       ],
-      "summary": "Defines h3 ref2 va pipeline runtime, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Ref2 Va Pipeline Runtime defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188307,11 +188475,12 @@
         718,
         720
       ],
-      "summary": "Defines h3 streamed ref2 va backend, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Ref2 Va Backend defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188324,11 +188493,12 @@
         829,
         850
       ],
-      "summary": "Defines h3 streamed transformer executor, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Transformer Executor models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188341,11 +188511,12 @@
         852,
         860
       ],
-      "summary": "Defines h3 streamed denoiser, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Denoiser models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188358,11 +188529,12 @@
         862,
         871
       ],
-      "summary": "Defines h3 block streamed denoiser, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Block Streamed Denoiser models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188375,11 +188547,12 @@
         994,
         998
       ],
-      "summary": "Defines h3 streamed pipeline backend, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Pipeline Backend defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188392,11 +188565,12 @@
         1107,
         1111
       ],
-      "summary": "Defines h3 streamed ref2 va pipeline backend, a core type used by shared inference engine contracts, model loading, and generation request execution.",
+      "summary": "H3 Streamed Ref2 Va Pipeline Backend defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "inference-engine",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -188405,14 +188579,16 @@
       "type": "file",
       "name": "ref2va.rs",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
-      "summary": "Implements MiniMax H3 Ref2VA conditioning and diffusion pipeline execution as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Defines the runtime-neutral MiniMax H3 Ref2VA pipeline, validating ordered reference media and packing text, visual, and audio conditioning before denoise and decode. The backend trait keeps device-bound media and model ownership behind an admission-frozen execution boundary.",
       "tags": [
-        "inference",
-        "minimax-h3",
-        "rust",
-        "application"
+        "video-generation",
+        "reference-conditioning",
+        "pipeline",
+        "validation",
+        "orchestration"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "Rust traits isolate the orchestration contract from the private backend while payload-free structs preserve reference ordering and provenance."
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:references",
@@ -188423,11 +188599,11 @@
         32,
         34
       ],
-      "summary": "Implements references for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements references behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188440,11 +188616,11 @@
         36,
         38
       ],
-      "summary": "Implements prompt for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements prompt behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188457,11 +188633,11 @@
         40,
         42
       ],
-      "summary": "Implements seed for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements seed behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188474,11 +188650,11 @@
         44,
         46
       ],
-      "summary": "Implements grid points for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements grid points behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188491,11 +188667,11 @@
         48,
         50
       ],
-      "summary": "Implements geometry for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements geometry behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188508,11 +188684,11 @@
         52,
         54
       ],
-      "summary": "Implements reference fingerprint for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Derives the content-bound reference fingerprint used to prevent authority or artifact substitution in the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -188525,11 +188701,11 @@
         240,
         246
       ],
-      "summary": "Builds request state for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Constructs prepare request data for the Ref2VA pipeline from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -188542,11 +188718,11 @@
         248,
         254
       ],
-      "summary": "Builds resolved request state for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Constructs prepare resolved request data for the Ref2VA pipeline from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -188559,11 +188735,11 @@
         256,
         314
       ],
-      "summary": "Builds request with authority state for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Constructs prepare request with authority data for the Ref2VA pipeline from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "moderate"
     },
@@ -188574,13 +188750,13 @@
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
         316,
-        690
+        708
       ],
-      "summary": "Executes staged for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Orchestrates execute staged while preserving cancellation, resource ownership, and evidence contracts for the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "complex"
     },
@@ -188590,17 +188766,16 @@
       "name": "validate_reference_bindings",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        692,
-        726
+        710,
+        744
       ],
-      "summary": "Validates reference bindings and returns actionable failure details.",
+      "summary": "Validates validate reference bindings invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:validate_decoded_reference",
@@ -188608,14 +188783,14 @@
       "name": "validate_decoded_reference",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        728,
-        784
+        746,
+        802
       ],
-      "summary": "Validates decoded reference and returns actionable failure details.",
+      "summary": "Validates validate decoded reference invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "serialization"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -188625,17 +188800,16 @@
       "name": "validate_reference_presentation",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        786,
-        832
+        804,
+        850
       ],
-      "summary": "Validates reference presentation and returns actionable failure details.",
+      "summary": "Validates validate reference presentation invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:validate_text_vision_rows",
@@ -188643,17 +188817,16 @@
       "name": "validate_text_vision_rows",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        834,
-        859
+        871,
+        899
       ],
-      "summary": "Validates text vision rows and returns actionable failure details.",
+      "summary": "Validates validate text vision rows invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:reference_layout_spec",
@@ -188661,14 +188834,14 @@
       "name": "reference_layout_spec",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        861,
-        930
+        901,
+        970
       ],
-      "summary": "Implements reference layout spec for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements reference layout spec behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "moderate"
     },
@@ -188678,14 +188851,14 @@
       "name": "build_packed_sequence",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        932,
-        1140
+        972,
+        1180
       ],
-      "summary": "Builds packed sequence state for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Constructs build packed sequence data for the Ref2VA pipeline from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "complex"
     },
@@ -188695,16 +188868,16 @@
       "name": "fill_audio_positions",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1142,
-        1167
+        1182,
+        1207
       ],
-      "summary": "Implements fill audio positions for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements fill audio positions behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:validate_visual_condition",
@@ -188712,17 +188885,16 @@
       "name": "validate_visual_condition",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1169,
-        1198
+        1209,
+        1238
       ],
-      "summary": "Validates visual condition and returns actionable failure details.",
+      "summary": "Validates validate visual condition invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:validate_audio_condition",
@@ -188730,17 +188902,16 @@
       "name": "validate_audio_condition",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1200,
-        1225
+        1240,
+        1265
       ],
-      "summary": "Validates audio condition and returns actionable failure details.",
+      "summary": "Validates validate audio condition invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:validate_packed_tensors",
@@ -188748,15 +188919,14 @@
       "name": "validate_packed_tensors",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1227,
-        1247
+        1267,
+        1287
       ],
-      "summary": "Validates packed tensors and returns actionable failure details.",
+      "summary": "Validates validate packed tensors invariants so the Ref2VA pipeline rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -188766,16 +188936,16 @@
       "name": "reference_provenance",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1256,
-        1283
+        1296,
+        1323
       ],
-      "summary": "Implements reference provenance for MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Implements reference provenance behavior within the Ref2VA pipeline.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs:ensure_ref_identity",
@@ -188783,15 +188953,14 @@
       "name": "ensure_ref_identity",
       "filePath": "crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
       "lineRange": [
-        1285,
-        1303
+        1325,
+        1343
       ],
-      "summary": "Validates ref identity and returns actionable failure details.",
+      "summary": "Derives the content-bound ensure ref identity used to prevent authority or artifact substitution in the Ref2VA pipeline.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -188804,12 +188973,11 @@
         22,
         29
       ],
-      "summary": "Defines h3 prepared ref2 va request, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Packages H3PreparedRef2VaRequest state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188822,11 +188990,11 @@
         58,
         62
       ],
-      "summary": "Defines h3 prepared reference, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Represents H3PreparedReference state within the MiniMax H3 pipeline.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188839,11 +189007,11 @@
         65,
         69
       ],
-      "summary": "Defines h3 decoded audio facts, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Records payload-free H3DecodedAudioFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188856,11 +189024,11 @@
         75,
         83
       ],
-      "summary": "Defines h3 decoded reference facts, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Records payload-free H3DecodedReferenceFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188873,11 +189041,11 @@
         86,
         89
       ],
-      "summary": "Defines h3 reference presentation, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Represents H3ReferencePresentation state within the MiniMax H3 pipeline.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188890,11 +189058,11 @@
         92,
         96
       ],
-      "summary": "Defines h3 audio condition encode mode, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Represents H3AudioConditionEncodeMode state within the MiniMax H3 pipeline.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -188907,27 +189075,29 @@
         101,
         206
       ],
-      "summary": "Defines h3 ref2 va backend, a core type used by MiniMax H3 Ref2VA conditioning and diffusion pipeline execution.",
+      "summary": "Defines the H3Ref2VaBackend execution boundary, keeping device and model operations behind a validated backend contract.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "resource-management"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "file:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs",
       "type": "file",
       "name": "private_opened_evidence.rs",
       "filePath": "crates/mold-inference/src/minimax_h3/private_opened_evidence.rs",
-      "summary": "Implements validation and attestation of privately opened MiniMax H3 artifacts as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Builds opaque, authenticated MiniMax H3 preparation evidence from securely opened model artifacts, task configuration, and frozen runtime budgets. It resolves private FL2VA and Ref2VA inputs without leaking paths, issuing scheduler authority, or bypassing admission checks.",
       "tags": [
-        "inference",
-        "minimax-h3",
-        "rust",
-        "application"
+        "security",
+        "artifact-validation",
+        "admission",
+        "memory-budget",
+        "preparation"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "Content-addressed identities and descriptor revalidation form a fail-closed Rust authority chain around private model artifacts."
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:from_metadata",
@@ -188938,11 +189108,11 @@
         122,
         138
       ],
-      "summary": "Implements from metadata for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs from metadata data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -188955,14 +189125,13 @@
         149,
         177
       ],
-      "summary": "Implements open for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Resolves open through the authenticated artifact and runtime boundaries used by private opened-evidence preparation.",
       "tags": [
         "function",
-        "io",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:revalidate",
@@ -188973,14 +189142,13 @@
         1092,
         1134
       ],
-      "summary": "Implements revalidate for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Validates revalidate invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:resolve",
@@ -188991,13 +189159,13 @@
         236,
         270
       ],
-      "summary": "Implements resolve for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Resolves resolve through the authenticated artifact and runtime boundaries used by private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:transformer_path",
@@ -189008,11 +189176,11 @@
         272,
         274
       ],
-      "summary": "Implements transformer path for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements transformer path behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189025,11 +189193,11 @@
         279,
         281
       ],
-      "summary": "Implements models root for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements models root behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189042,11 +189210,11 @@
         283,
         285
       ],
-      "summary": "Implements qwen weights path for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements qwen weights path behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189059,11 +189227,11 @@
         287,
         289
       ],
-      "summary": "Implements task config path for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements task config path behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189076,11 +189244,11 @@
         291,
         293
       ],
-      "summary": "Implements identity sha256 for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Derives the content-bound identity sha256 used to prevent authority or artifact substitution in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -189093,11 +189261,11 @@
         295,
         303
       ],
-      "summary": "Implements vae plan for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements vae plan behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189110,14 +189278,13 @@
         305,
         335
       ],
-      "summary": "Implements open task config for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Resolves open task config through the authenticated artifact and runtime boundaries used by private opened-evidence preparation.",
       "tags": [
         "function",
-        "io",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:validate_opened_components",
@@ -189128,13 +189295,13 @@
         346,
         373
       ],
-      "summary": "Validates opened components and returns actionable failure details.",
+      "summary": "Validates validate opened components invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "io"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:opened_activation_facts",
@@ -189145,14 +189312,13 @@
         375,
         417
       ],
-      "summary": "Implements opened activation facts for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Resolves opened activation facts through the authenticated artifact and runtime boundaries used by private opened-evidence preparation.",
       "tags": [
         "function",
-        "io",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:validate",
@@ -189163,14 +189329,13 @@
         419,
         453
       ],
-      "summary": "Validates  and returns actionable failure details.",
+      "summary": "Validates validate invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:private_comfy_manifest",
@@ -189181,11 +189346,11 @@
         456,
         474
       ],
-      "summary": "Implements private comfy manifest for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements private comfy manifest behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189198,11 +189363,11 @@
         476,
         499
       ],
-      "summary": "Implements resolve component for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Resolves resolve component through the authenticated artifact and runtime boundaries used by private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -189215,12 +189380,11 @@
         501,
         524
       ],
-      "summary": "Validates storage root and returns actionable failure details.",
+      "summary": "Validates validate storage root invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -189233,11 +189397,11 @@
         526,
         541
       ],
-      "summary": "Implements storage authority identity for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Derives the content-bound storage authority identity used to prevent authority or artifact substitution in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -189250,11 +189414,11 @@
         605,
         611
       ],
-      "summary": "Implements seed for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements seed behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189267,11 +189431,11 @@
         617,
         623
       ],
-      "summary": "Implements grid points for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements grid points behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189284,13 +189448,13 @@
         672,
         759
       ],
-      "summary": "Builds  state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepare data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:into_factory_inputs",
@@ -189301,11 +189465,11 @@
         769,
         776
       ],
-      "summary": "Implements into factory inputs for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs into factory inputs data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189318,11 +189482,11 @@
         788,
         845
       ],
-      "summary": "Implements ref2va factory references for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements ref2va factory references behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "moderate"
     },
@@ -189335,11 +189499,11 @@
         849,
         912
       ],
-      "summary": "Implements ref2va prepared request input for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements ref2va prepared request input behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "moderate"
     },
@@ -189352,11 +189516,11 @@
         927,
         942
       ],
-      "summary": "Builds private ref2va admission request state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepare private ref2va admission request data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -189369,13 +189533,13 @@
         963,
         1009
       ],
-      "summary": "Builds private ref2va request input state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepare private ref2va request input data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:prepare_private_fl2va_admission_request",
@@ -189386,11 +189550,11 @@
         1011,
         1029
       ],
-      "summary": "Builds private fl2va admission request state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepare private fl2va admission request data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -189403,13 +189567,13 @@
         1032,
         1068
       ],
-      "summary": "Builds private fl2va admission attempt state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs build private fl2va admission attempt data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:prepare_private_fl2va_request_input",
@@ -189420,11 +189584,11 @@
         1070,
         1086
       ],
-      "summary": "Builds private fl2va request input state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepare private fl2va request input data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -189437,11 +189601,11 @@
         1136,
         1138
       ],
-      "summary": "Builds d attempt identity sha256 state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepared attempt identity sha256 data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -189454,11 +189618,11 @@
         1140,
         1142
       ],
-      "summary": "Implements target budget identity sha256 for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Derives the content-bound target budget identity sha256 used to prevent authority or artifact substitution in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -189471,11 +189635,11 @@
         1144,
         1146
       ],
-      "summary": "Implements execution fingerprint for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Derives the content-bound execution fingerprint used to prevent authority or artifact substitution in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -189488,11 +189652,11 @@
         1148,
         1152
       ],
-      "summary": "Implements predicted device peak bytes for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Computes predicted device peak bytes for admission and resource accounting in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -189505,11 +189669,11 @@
         1154,
         1158
       ],
-      "summary": "Implements predicted host increment bytes for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Computes predicted host increment bytes for admission and resource accounting in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -189522,11 +189686,11 @@
         1160,
         1162
       ],
-      "summary": "Implements factory attempt input for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements factory attempt input behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189539,13 +189703,13 @@
         1376,
         1490
       ],
-      "summary": "Builds d request input state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs prepared request input data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:budget_echo_input",
@@ -189556,11 +189720,11 @@
         1168,
         1170
       ],
-      "summary": "Implements budget echo input for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Computes budget echo input for admission and resource accounting in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -189573,11 +189737,11 @@
         1180,
         1194
       ],
-      "summary": "Implements into runtime parts for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs into runtime parts data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -189590,11 +189754,11 @@
         1230,
         1233
       ],
-      "summary": "Implements denoise forward count for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements denoise forward count behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189607,11 +189771,11 @@
         1238,
         1241
       ],
-      "summary": "Implements total packed rows for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Computes total packed rows for admission and resource accounting in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -189624,12 +189788,11 @@
         1244,
         1323
       ],
-      "summary": "Validates prepared runtime request and returns actionable failure details.",
+      "summary": "Validates validate prepared runtime request invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -189642,14 +189805,13 @@
         1348,
         1374
       ],
-      "summary": "Validates prepared ref2va runtime request and returns actionable failure details.",
+      "summary": "Validates validate prepared ref2va runtime request invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:raw_checkpoint_input",
@@ -189660,12 +189822,11 @@
         1492,
         1544
       ],
-      "summary": "Implements raw checkpoint input for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements raw checkpoint input behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "moderate"
     },
@@ -189678,11 +189839,11 @@
         1548,
         1561
       ],
-      "summary": "Implements expected published transformer for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Implements expected published transformer behavior within private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -189695,13 +189856,13 @@
         1611,
         1651
       ],
-      "summary": "Implements qwen activation workspace demand bytes for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Computes qwen activation workspace demand bytes for admission and resource accounting in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:build_canonical_private_fl2va_target_budget",
@@ -189712,11 +189873,11 @@
         1654,
         2441
       ],
-      "summary": "Builds canonical private fl2va target budget state for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Constructs build canonical private fl2va target budget data for private opened-evidence preparation from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "complex"
     },
@@ -189729,11 +189890,11 @@
         2443,
         2455
       ],
-      "summary": "Implements conditioning fingerprint for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Derives the content-bound conditioning fingerprint used to prevent authority or artifact substitution in private opened-evidence preparation.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -189746,11 +189907,11 @@
         2471,
         2480
       ],
-      "summary": "Implements require sha256 for validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Validates require sha256 invariants so private opened-evidence preparation rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -189763,11 +189924,11 @@
         79,
         84
       ],
-      "summary": "Defines h3 private storage root identity, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Represents H3PrivateStorageRootIdentity state within the MiniMax H3 pipeline.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189780,12 +189941,11 @@
         141,
         146
       ],
-      "summary": "Defines h3 private opened task config authority, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Carries authenticated H3PrivateOpenedTaskConfigAuthority facts that authorize a narrowly scoped private H3 operation.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -189798,11 +189958,11 @@
         202,
         214
       ],
-      "summary": "Defines h3 private comfy storage authority, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Carries authenticated H3PrivateComfyStorageAuthority facts that authorize a narrowly scoped private H3 operation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -189815,11 +189975,11 @@
         221,
         233
       ],
-      "summary": "Defines h3 private opened activation facts, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Records payload-free H3PrivateOpenedActivationFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189832,11 +189992,11 @@
         547,
         561
       ],
-      "summary": "Defines h3 private qualified runtime bounds, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Models H3PrivateQualifiedRuntimeBounds limits and identities used by admission and runtime qualification.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -189849,12 +190009,11 @@
         598,
         602
       ],
-      "summary": "Defines h3 private prepared task request, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Packages H3PrivatePreparedTaskRequest state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189867,11 +190026,11 @@
         628,
         635
       ],
-      "summary": "Defines h3 private prepared fl2 va attempt, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Packages H3PrivatePreparedFl2VaAttempt state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189884,12 +190043,11 @@
         640,
         651
       ],
-      "summary": "Defines h3 private fl2 va admission prepared request, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Packages H3PrivateFl2VaAdmissionPreparedRequest state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189902,11 +190060,11 @@
         653,
         658
       ],
-      "summary": "Defines h3 private prepared fl2 va factory inputs, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Packages H3PrivatePreparedFl2VaFactoryInputs state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -189919,11 +190077,11 @@
         664,
         668
       ],
-      "summary": "Defines h3 private prepared fl2 va retention, a core type used by validation and attestation of privately opened MiniMax H3 artifacts.",
+      "summary": "Represents H3PrivatePreparedFl2VaRetention state within the MiniMax H3 pipeline.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -190656,13 +190814,16 @@
       "type": "file",
       "name": "private_server.rs",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
-      "summary": "Implements private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Implements the server-facing authority boundary for private MiniMax H3 admission, qualification, resource leasing, execution, and evidence authentication. It validates exact artifact, device, memory, scheduler, and cancellation identities before allowing FL2VA or Ref2VA work to run.",
       "tags": [
-        "server",
-        "inference",
-        "minimax-h3"
+        "server-boundary",
+        "admission",
+        "runtime-qualification",
+        "resource-leasing",
+        "security"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "A large feature-gated Rust authority graph uses content-addressed records and RAII leases to make private CUDA execution fail closed."
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_stable_cuda_device_id",
@@ -190673,11 +190834,11 @@
         121,
         129
       ],
-      "summary": "Implements valid stable cuda device id for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates valid stable cuda device id invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -190690,12 +190851,11 @@
         148,
         150
       ],
-      "summary": "Implements reviewed h3 private runtime available for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements reviewed h3 private runtime available behavior within private H3 server execution.",
       "tags": [
         "function",
-        "presentation",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -190708,12 +190868,11 @@
         156,
         179
       ],
-      "summary": "Implements reviewed h3 private runtime available for task for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements reviewed h3 private runtime available for task behavior within private H3 server execution.",
       "tags": [
         "function",
-        "presentation",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -190726,11 +190885,11 @@
         205,
         207
       ],
-      "summary": "Implements canonical model for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements canonical model behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -190743,11 +190902,11 @@
         209,
         211
       ],
-      "summary": "Implements task for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements task behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -190760,11 +190919,11 @@
         213,
         215
       ],
-      "summary": "Implements device id for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements device id behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -190777,11 +190936,11 @@
         217,
         219
       ],
-      "summary": "Implements device ordinal for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements device ordinal behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -190794,11 +190953,11 @@
         221,
         223
       ],
-      "summary": "Implements compute capability for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements compute capability behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -190811,14 +190970,13 @@
         1168,
         1212
       ],
-      "summary": "Validates  and returns actionable failure details.",
+      "summary": "Validates validate invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_with_adapter",
@@ -190829,12 +190987,11 @@
         279,
         284
       ],
-      "summary": "Validates with adapter and returns actionable failure details.",
+      "summary": "Validates validate with adapter invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -190847,12 +191004,11 @@
         290,
         292
       ],
-      "summary": "Validates for task and returns actionable failure details.",
+      "summary": "Validates validate for task invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -190865,12 +191021,11 @@
         301,
         321
       ],
-      "summary": "Validates for task with adapter and returns actionable failure details.",
+      "summary": "Validates validate for task with adapter invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -190883,13 +191038,13 @@
         328,
         362
       ],
-      "summary": "Validates for task with reviewed steps and returns actionable failure details.",
+      "summary": "Validates validate for task with reviewed steps invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "presentation"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_shape",
@@ -190900,14 +191055,13 @@
         364,
         404
       ],
-      "summary": "Validates shape and returns actionable failure details.",
+      "summary": "Validates validate shape invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_prepared_with_adapter",
@@ -190918,12 +191072,11 @@
         412,
         487
       ],
-      "summary": "Validates prepared with adapter and returns actionable failure details.",
+      "summary": "Validates validate prepared with adapter invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -190936,11 +191089,11 @@
         497,
         550
       ],
-      "summary": "Implements conditioning mismatches for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements conditioning mismatches behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "moderate"
     },
@@ -190953,13 +191106,13 @@
         563,
         600
       ],
-      "summary": "Implements row cap mismatches for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements row cap mismatches behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:update_identity",
@@ -190970,11 +191123,11 @@
         602,
         621
       ],
-      "summary": "Updates identity while preserving the module's lifecycle invariants.",
+      "summary": "Derives the content-bound update identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -190987,11 +191140,11 @@
         655,
         665
       ],
-      "summary": "Implements private h3 admission device floor bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes private h3 admission device floor bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191004,11 +191157,11 @@
         675,
         691
       ],
-      "summary": "Implements private h3 admission host floor bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes private h3 admission host floor bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191021,14 +191174,13 @@
         707,
         747
       ],
-      "summary": "Implements precheck private h3 admission capacity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Checks precheck private h3 admission capacity before allocation or execution can proceed in private H3 server execution.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_prepared_rows",
@@ -191039,14 +191191,13 @@
         769,
         795
       ],
-      "summary": "Implements precheck private h3 prepared rows for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Checks precheck private h3 prepared rows before allocation or execution can proceed in private H3 server execution.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_record_canvas",
@@ -191057,12 +191208,11 @@
         807,
         820
       ],
-      "summary": "Implements precheck private h3 record canvas for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Checks precheck private h3 record canvas before allocation or execution can proceed in private H3 server execution.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191075,14 +191225,13 @@
         830,
         865
       ],
-      "summary": "Validates private h3 target budget fits and returns actionable failure details.",
+      "summary": "Checks check private h3 target budget fits before allocation or execution can proceed in private H3 server execution.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_unified_target_peak_bytes",
@@ -191093,11 +191242,11 @@
         874,
         940
       ],
-      "summary": "Implements private h3 unified target peak bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes private h3 unified target peak bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "moderate"
     },
@@ -191110,12 +191259,11 @@
         943,
         960
       ],
-      "summary": "Implements private h3 qwen route for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements private h3 qwen route behavior within private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191128,11 +191276,11 @@
         962,
         978
       ],
-      "summary": "Implements into authority for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs into authority data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191145,11 +191293,11 @@
         1096,
         1098
       ],
-      "summary": "Implements admission evidence identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound admission evidence identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191162,11 +191310,11 @@
         1100,
         1102
       ],
-      "summary": "Implements artifact qualification identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound artifact qualification identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191179,11 +191327,11 @@
         1104,
         1106
       ],
-      "summary": "Executes time qualification identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates runtime qualification identity sha256 while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191196,11 +191344,11 @@
         1108,
         1110
       ],
-      "summary": "Implements work identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound work identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191213,11 +191361,11 @@
         1112,
         1114
       ],
-      "summary": "Implements cancellation scope identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound cancellation scope identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191230,11 +191378,11 @@
         1116,
         1118
       ],
-      "summary": "Implements memory ledger sequence for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements memory ledger sequence behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191247,11 +191395,11 @@
         1120,
         1122
       ],
-      "summary": "Implements consumption identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound consumption identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191264,12 +191412,11 @@
         1124,
         1143
       ],
-      "summary": "Validates against binding and returns actionable failure details.",
+      "summary": "Validates validate against binding invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -191282,11 +191429,11 @@
         1391,
         1393
       ],
-      "summary": "Implements fixed runtime host bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes fixed runtime host bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191299,11 +191446,11 @@
         1395,
         1397
       ],
-      "summary": "Implements fixed runtime device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes fixed runtime device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191316,11 +191463,11 @@
         1399,
         1401
       ],
-      "summary": "Implements qwen activation workspace bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes qwen activation workspace bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191333,11 +191480,11 @@
         1403,
         1405
       ],
-      "summary": "Implements vae construction device workspace bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes vae construction device workspace bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191350,11 +191497,11 @@
         1407,
         1409
       ],
-      "summary": "Implements condition vae workspace device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes condition vae workspace device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191367,11 +191514,11 @@
         1411,
         1413
       ],
-      "summary": "Implements attention workspace device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes attention workspace device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191384,11 +191531,11 @@
         1415,
         1417
       ],
-      "summary": "Implements ffn workspace device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes ffn workspace device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191401,12 +191548,11 @@
         1419,
         1421
       ],
-      "summary": "Parses and validates r tile workspace device bytes input.",
+      "summary": "Computes decoder tile workspace device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "serialization",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191419,12 +191565,11 @@
         1423,
         1425
       ],
-      "summary": "Implements audio decode workspace device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes audio decode workspace device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "serialization",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191437,12 +191582,11 @@
         1427,
         1429
       ],
-      "summary": "Implements encoded video host bytes bound for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes encoded video host bytes bound for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "serialization",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191455,11 +191599,11 @@
         1431,
         1433
       ],
-      "summary": "Implements thumbnail host bytes bound for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes thumbnail host bytes bound for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191472,11 +191616,11 @@
         1435,
         1437
       ],
-      "summary": "Implements mux output host bytes bound for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes mux output host bytes bound for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191489,11 +191633,11 @@
         1439,
         1441
       ],
-      "summary": "Implements aac mux staging host bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes aac mux staging host bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191506,11 +191650,11 @@
         1445,
         1461
       ],
-      "summary": "Implements from for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs from data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191523,11 +191667,11 @@
         1497,
         1499
       ],
-      "summary": "Implements identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191540,11 +191684,11 @@
         1509,
         1511
       ],
-      "summary": "Implements mode for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements mode behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191557,12 +191701,11 @@
         1525,
         1527
       ],
-      "summary": "Implements admitted available device bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes admitted available device bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191575,12 +191718,11 @@
         1529,
         1531
       ],
-      "summary": "Implements admitted host headroom bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes admitted host headroom bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191593,11 +191735,11 @@
         1533,
         1535
       ],
-      "summary": "Implements base factory authority for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements base factory authority behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191610,11 +191752,11 @@
         1537,
         1539
       ],
-      "summary": "Implements execution fingerprint for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound execution fingerprint used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191627,11 +191769,11 @@
         1541,
         1543
       ],
-      "summary": "Implements component set identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound component set identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191644,11 +191786,11 @@
         1545,
         1547
       ],
-      "summary": "Builds d request identity sha256 state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepared request identity sha256 data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -191661,11 +191803,11 @@
         1549,
         1551
       ],
-      "summary": "Builds d attempt identity sha256 state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepared attempt identity sha256 data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -191678,11 +191820,11 @@
         1553,
         1555
       ],
-      "summary": "Implements target budget identity sha256 for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound target budget identity sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191695,11 +191837,11 @@
         1565,
         1567
       ],
-      "summary": "Implements predicted device peak bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes predicted device peak bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191712,11 +191854,11 @@
         1569,
         1571
       ],
-      "summary": "Implements predicted host increment bytes for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes predicted host increment bytes for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191729,11 +191871,11 @@
         1573,
         1575
       ],
-      "summary": "Implements seed for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements seed behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191746,11 +191888,11 @@
         1577,
         1579
       ],
-      "summary": "Implements attention for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements attention behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191763,11 +191905,11 @@
         1581,
         1583
       ],
-      "summary": "Executes time bounds for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates runtime bounds while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -191780,11 +191922,11 @@
         1588,
         1603
       ],
-      "summary": "Implements resolve request for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Resolves resolve request through the authenticated artifact and runtime boundaries used by private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -191797,12 +191939,11 @@
         1605,
         1612
       ],
-      "summary": "Validates resolved request and returns actionable failure details.",
+      "summary": "Validates validate resolved request invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -191815,12 +191956,11 @@
         1618,
         1685
       ],
-      "summary": "Validates for and returns actionable failure details.",
+      "summary": "Validates validate for invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -191833,12 +191973,11 @@
         1708,
         1720
       ],
-      "summary": "Implements admitted h3 route for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements admitted h3 route behavior within private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -191851,13 +191990,13 @@
         1727,
         1758
       ],
-      "summary": "Builds h3 private fl2va admission state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepare h3 private fl2va admission data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
@@ -191868,13 +192007,13 @@
         4834,
         4862
       ],
-      "summary": "Constructs the private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics state with validated defaults.",
+      "summary": "Implements new behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_reviewed_h3_private_fl2va_admission",
@@ -191885,12 +192024,11 @@
         1825,
         2364
       ],
-      "summary": "Builds reviewed h3 private fl2va admission state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepare reviewed h3 private fl2va admission data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "presentation",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "complex"
     },
@@ -191903,11 +192041,11 @@
         2384,
         2393
       ],
-      "summary": "Implements private h3 request identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 request identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191920,13 +192058,13 @@
         2396,
         2499
       ],
-      "summary": "Implements private h3 component digests for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 component digests used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_vae_artifact_binding_identity",
@@ -191937,11 +192075,11 @@
         2502,
         2519
       ],
-      "summary": "Implements private h3 vae artifact binding identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 vae artifact binding identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191954,11 +192092,11 @@
         2522,
         2534
       ],
-      "summary": "Implements private h3 component digest for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 component digest used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -191971,14 +192109,13 @@
         2537,
         2561
       ],
-      "summary": "Validates owner component digests and returns actionable failure details.",
+      "summary": "Validates validate owner component digests invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_role",
@@ -191989,11 +192126,11 @@
         2564,
         2580
       ],
-      "summary": "Implements private h3 component role for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements private h3 component role behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192006,11 +192143,11 @@
         2593,
         2613
       ],
-      "summary": "Updates private h3 qualified artifact while preserving the module's lifecycle invariants.",
+      "summary": "Implements update private h3 qualified artifact behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192023,13 +192160,13 @@
         2617,
         2661
       ],
-      "summary": "Implements private h3 admission execution fingerprint for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 admission execution fingerprint used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_pruned_adaln_identity",
@@ -192040,11 +192177,11 @@
         2664,
         2685
       ],
-      "summary": "Implements private h3 pruned adaln identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 pruned adaln identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -192057,11 +192194,11 @@
         2687,
         2747
       ],
-      "summary": "Implements private h3 admission evidence identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 admission evidence identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "moderate"
     },
@@ -192074,11 +192211,11 @@
         2827,
         2838
       ],
-      "summary": "Implements fmt for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements fmt behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192091,14 +192228,13 @@
         2929,
         2962
       ],
-      "summary": "Implements revalidate for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates revalidate invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_context",
@@ -192109,12 +192245,11 @@
         2964,
         2973
       ],
-      "summary": "Validates context and returns actionable failure details.",
+      "summary": "Validates validate context invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -192127,11 +192262,11 @@
         2976,
         2994
       ],
-      "summary": "Implements private h3 consumption binding identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound private h3 consumption binding identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -192144,11 +192279,11 @@
         3025,
         3027
       ],
-      "summary": "Implements facts for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements facts behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192161,11 +192296,11 @@
         3029,
         3046
       ],
-      "summary": "Executes once for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates run once while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192178,11 +192313,11 @@
         3049,
         3058
       ],
-      "summary": "Implements from runner for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs from runner data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192195,11 +192330,11 @@
         3068,
         3087
       ],
-      "summary": "Builds h3 private fl2va attempt state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepare h3 private fl2va attempt data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -192212,12 +192347,11 @@
         3090,
         3517
       ],
-      "summary": "Builds reviewed h3 private fl2va attempt state for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs prepare reviewed h3 private fl2va attempt data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "presentation",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
       "complexity": "complex"
     },
@@ -192230,11 +192364,11 @@
         3520,
         3531
       ],
-      "summary": "Implements private h3 project owner fence budget for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes private h3 project owner fence budget for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -192247,12 +192381,11 @@
         3534,
         3557
       ],
-      "summary": "Validates base factory and returns actionable failure details.",
+      "summary": "Validates validate base factory invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -192265,14 +192398,13 @@
         3591,
         3617
       ],
-      "summary": "Validates frozen reopen route and returns actionable failure details.",
+      "summary": "Validates validate frozen reopen route invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "orchestration",
-        "io"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:exact_qualified_qwen_artifact",
@@ -192283,11 +192415,11 @@
         3620,
         3640
       ],
-      "summary": "Implements exact qualified qwen artifact for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Resolves exact qualified qwen artifact through the authenticated artifact and runtime boundaries used by private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192300,11 +192432,11 @@
         3643,
         3660
       ],
-      "summary": "Implements private lease id for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Resolves private lease id through the authenticated artifact and runtime boundaries used by private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192317,14 +192449,13 @@
         3882,
         3965
       ],
-      "summary": "Implements from opened for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs from opened data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "io",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:checkpoint",
@@ -192335,12 +192466,11 @@
         4139,
         4159
       ],
-      "summary": "Validates point and returns actionable failure details.",
+      "summary": "Checks checkpoint before allocation or execution can proceed in private H3 server execution.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192353,11 +192483,11 @@
         4172,
         4192
       ],
-      "summary": "Implements with private h3 cuda execution attempt for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates with private h3 cuda execution attempt while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192370,11 +192500,11 @@
         4237,
         4258
       ],
-      "summary": "Executes time envelope conditioning for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates runtime envelope conditioning while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192387,11 +192517,11 @@
         4261,
         4281
       ],
-      "summary": "Executes time envelope observation for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates runtime envelope observation while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192404,11 +192534,11 @@
         4289,
         4489
       ],
-      "summary": "Executes  for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates run while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "complex"
     },
@@ -192421,13 +192551,13 @@
         4493,
         4610
       ],
-      "summary": "Implements private run output for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements private run output behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_private_sampler_provenance",
@@ -192438,12 +192568,11 @@
         4613,
         4626
       ],
-      "summary": "Validates private sampler provenance and returns actionable failure details.",
+      "summary": "Validates validate private sampler provenance invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -192456,11 +192585,11 @@
         4684,
         4693
       ],
-      "summary": "Implements attempt facts for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements attempt facts behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192473,14 +192602,13 @@
         4695,
         4723
       ],
-      "summary": "Implements attempt facts with scheduler budget for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes attempt facts with scheduler budget for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:commit_once",
@@ -192491,11 +192619,11 @@
         4814,
         4825
       ],
-      "summary": "Implements commit once for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates commit once while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192508,11 +192636,11 @@
         4827,
         4829
       ],
-      "summary": "Implements is committed for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements is committed behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192525,12 +192653,11 @@
         4927,
         4944
       ],
-      "summary": "Implements scheduler ledger identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound scheduler ledger identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "orchestration",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -192543,13 +192670,13 @@
         4947,
         5027
       ],
-      "summary": "Implements derive for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Constructs derive data for private H3 server execution from already validated inputs and frozen authority.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "preparation"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_for",
@@ -192560,12 +192687,11 @@
         5029,
         5084
       ],
-      "summary": "Implements revalidate for for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates revalidate for invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -192578,13 +192704,13 @@
         5087,
         5116
       ],
-      "summary": "Implements activation evidence identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Derives the content-bound activation evidence identity used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:activation_prerequisite_id",
@@ -192595,11 +192721,11 @@
         5118,
         5130
       ],
-      "summary": "Implements activation prerequisite id for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements activation prerequisite id behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "implementation"
       ],
       "complexity": "simple"
     },
@@ -192612,11 +192738,11 @@
         5162,
         5164
       ],
-      "summary": "Updates file sha256 while preserving the module's lifecycle invariants.",
+      "summary": "Derives the content-bound record file sha256 used to prevent authority or artifact substitution in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "simple"
     },
@@ -192629,11 +192755,11 @@
         5182,
         5184
       ],
-      "summary": "Implements bounds for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes bounds for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -192646,11 +192772,11 @@
         5373,
         5439
       ],
-      "summary": "Implements public runtime bounds for shape for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes public runtime bounds for shape for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "moderate"
     },
@@ -192663,11 +192789,11 @@
         5503,
         5517
       ],
-      "summary": "Implements compact envelope rows for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes compact envelope rows for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -192680,11 +192806,11 @@
         5561,
         5583
       ],
-      "summary": "Implements public runtime envelope for shape for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes public runtime envelope for shape for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192697,11 +192823,11 @@
         5601,
         5618
       ],
-      "summary": "Implements public runtime profile identities for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements public runtime profile identities behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192714,31 +192840,13 @@
         5623,
         5654
       ],
-      "summary": "Validates public runtime profile with turbo and returns actionable failure details.",
+      "summary": "Validates validate public runtime profile with turbo invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reference_qwen_vision_rows",
-      "type": "function",
-      "name": "reference_qwen_vision_rows",
-      "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
-      "lineRange": [
-        5735,
-        5744
-      ],
-      "summary": "Implements reference qwen vision rows for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ref2va_reference_rows",
@@ -192746,16 +192854,16 @@
       "name": "ref2va_reference_rows",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        5756,
-        5786
+        5787,
+        5821
       ],
-      "summary": "Implements ref2va reference rows for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes ref2va reference rows for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_envelope_for_shape",
@@ -192763,16 +192871,16 @@
       "name": "public_ref2va_runtime_envelope_for_shape",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        5797,
-        5834
+        5832,
+        5871
       ],
-      "summary": "Implements public ref2va runtime envelope for shape for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes public ref2va runtime envelope for shape for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_bounds_for_shape",
@@ -192780,14 +192888,14 @@
       "name": "public_ref2va_runtime_bounds_for_shape",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        5869,
-        5944
+        5906,
+        5984
       ],
-      "summary": "Implements public ref2va runtime bounds for shape for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes public ref2va runtime bounds for shape for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "moderate"
     },
@@ -192797,16 +192905,16 @@
       "name": "capture_runtime_envelope",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        5972,
-        5995
+        6012,
+        6037
       ],
-      "summary": "Implements capture runtime envelope for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Captures capture runtime envelope evidence used to account for the real process, phase, and memory behavior of private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "telemetry"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_bounds",
@@ -192814,16 +192922,16 @@
       "name": "capture_runtime_bounds",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6138,
-        6168
+        6180,
+        6210
       ],
-      "summary": "Implements capture runtime bounds for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Captures capture runtime bounds evidence used to account for the real process, phase, and memory behavior of private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "telemetry"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_capture_runtime_profile",
@@ -192831,15 +192939,14 @@
       "name": "validate_capture_runtime_profile",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6171,
-        6188
+        6213,
+        6230
       ],
-      "summary": "Validates capture runtime profile and returns actionable failure details.",
+      "summary": "Validates validate capture runtime profile invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -192849,14 +192956,14 @@
       "name": "capture_runtime_qualification",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6199,
-        6269
+        6241,
+        6311
       ],
-      "summary": "Implements capture runtime qualification for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Captures capture runtime qualification evidence used to account for the real process, phase, and memory behavior of private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "telemetry"
       ],
       "complexity": "moderate"
     },
@@ -192866,16 +192973,16 @@
       "name": "h3_capture_bound_report",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6274,
-        6308
+        6316,
+        6350
       ],
-      "summary": "Implements h3 capture bound report for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Computes h3 capture bound report for admission and resource accounting in private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "telemetry"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_qualification",
@@ -192883,16 +192990,16 @@
       "name": "public_runtime_qualification",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6312,
-        6440
+        6354,
+        6482
       ],
-      "summary": "Implements public runtime qualification for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements public runtime qualification behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
-      "complexity": "moderate"
+      "complexity": "complex"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_runtime_qualification_file",
@@ -192900,17 +193007,16 @@
       "name": "revalidate_runtime_qualification_file",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6447,
-        6472
+        6489,
+        6514
       ],
-      "summary": "Implements revalidate runtime qualification file for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates revalidate runtime qualification file invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_route",
@@ -192918,14 +193024,14 @@
       "name": "validate_route",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6596,
-        6615
+        6638,
+        6657
       ],
-      "summary": "Validates route and returns actionable failure details.",
+      "summary": "Validates validate route invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "orchestration"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -192935,16 +193041,16 @@
       "name": "authenticate",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6513,
-        6546
+        6555,
+        6588
       ],
-      "summary": "Implements authenticate for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_runtime_qualification_source",
@@ -192952,14 +193058,14 @@
       "name": "private_runtime_qualification_source",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6570,
-        6588
+        6612,
+        6630
       ],
-      "summary": "Implements private runtime qualification source for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Implements private runtime qualification source behavior within private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "orchestration"
       ],
       "complexity": "simple"
     },
@@ -192969,14 +193075,14 @@
       "name": "open_reviewed_h3_private_runtime_qualification",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6687,
-        6703
+        6729,
+        6745
       ],
-      "summary": "Implements open reviewed h3 private runtime qualification for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Resolves open reviewed h3 private runtime qualification through the authenticated artifact and runtime boundaries used by private H3 server execution.",
       "tags": [
         "function",
-        "io",
-        "presentation"
+        "rust",
+        "preparation"
       ],
       "complexity": "simple"
     },
@@ -192986,14 +193092,14 @@
       "name": "open_reviewed_h3_private_runtime_qualification_for_source",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6705,
-        6780
+        6747,
+        6822
       ],
-      "summary": "Implements open reviewed h3 private runtime qualification for source for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Resolves open reviewed h3 private runtime qualification for source through the authenticated artifact and runtime boundaries used by private H3 server execution.",
       "tags": [
         "function",
-        "io",
-        "presentation"
+        "rust",
+        "preparation"
       ],
       "complexity": "moderate"
     },
@@ -193003,16 +193109,16 @@
       "name": "authenticate_h3_private_presentation",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6787,
-        6813
+        6829,
+        6855
       ],
-      "summary": "Implements authenticate h3 private presentation for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private presentation invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_public_presentation",
@@ -193020,16 +193126,16 @@
       "name": "authenticate_h3_public_presentation",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6821,
-        6852
+        6863,
+        6894
       ],
-      "summary": "Implements authenticate h3 public presentation for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 public presentation invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation_with_scope",
@@ -193037,14 +193143,14 @@
       "name": "authenticate_h3_private_presentation_with_scope",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6854,
-        6925
+        6896,
+        6967
       ],
-      "summary": "Implements authenticate h3 private presentation with scope for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private presentation with scope invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -193054,17 +193160,16 @@
       "name": "authenticate_h3_private_presentation_for_test",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6929,
-        6956
+        6971,
+        6998
       ],
-      "summary": "Implements authenticate h3 private presentation for test for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private presentation for test invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "test",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification",
@@ -193072,14 +193177,14 @@
       "name": "authenticate_h3_private_runtime_qualification",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6965,
-        6986
+        7007,
+        7028
       ],
-      "summary": "Implements authenticate h3 private runtime qualification for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private runtime qualification invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -193089,14 +193194,14 @@
       "name": "authenticate_h3_private_runtime_qualification_with_allowlist",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6989,
-        7009
+        7031,
+        7051
       ],
-      "summary": "Implements authenticate h3 private runtime qualification with allowlist for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private runtime qualification with allowlist invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -193106,16 +193211,16 @@
       "name": "authenticate_h3_private_runtime_qualification_for_source",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        7013,
-        7041
+        7055,
+        7083
       ],
-      "summary": "Implements authenticate h3 private runtime qualification for source for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates authenticate h3 private runtime qualification for source invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_binding",
@@ -193123,17 +193228,16 @@
       "name": "validate_runtime_qualification_record_binding",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        7044,
-        7078
+        7086,
+        7120
       ],
-      "summary": "Validates runtime qualification record binding and returns actionable failure details.",
+      "summary": "Validates validate runtime qualification record binding invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_shape",
@@ -193141,15 +193245,14 @@
       "name": "validate_runtime_qualification_record_shape",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        7080,
-        7150
+        7122,
+        7192
       ],
-      "summary": "Validates runtime qualification record shape and returns actionable failure details.",
+      "summary": "Validates validate runtime qualification record shape invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "validation",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "moderate"
     },
@@ -193159,14 +193262,14 @@
       "name": "runtime_qualification_identity",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        7152,
-        7210
+        7194,
+        7252
       ],
-      "summary": "Executes time qualification identity for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Orchestrates runtime qualification identity while preserving cancellation, resource ownership, and evidence contracts for private H3 server execution.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "identity"
       ],
       "complexity": "moderate"
     },
@@ -193176,14 +193279,14 @@
       "name": "valid_runtime_evidence_relative_path",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        7246,
-        7258
+        7288,
+        7300
       ],
-      "summary": "Implements valid runtime evidence relative path for private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Validates valid runtime evidence relative path invariants so private H3 server execution rejects stale, mismatched, or unauthorized state.",
       "tags": [
         "function",
-        "business-logic",
-        "utility"
+        "rust",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -193196,11 +193299,11 @@
         185,
         190
       ],
-      "summary": "Defines h3 private presentation route, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivatePresentationRoute state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193213,11 +193316,11 @@
         196,
         202
       ],
-      "summary": "Defines h3 private presentation authority, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Carries authenticated H3PrivatePresentationAuthority facts that authorize a narrowly scoped private H3 operation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193230,12 +193333,11 @@
         246,
         261
       ],
-      "summary": "Defines h3 private runtime envelope record, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Models H3PrivateRuntimeEnvelopeRecord limits and identities used by admission and runtime qualification.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -193248,12 +193350,11 @@
         626,
         644
       ],
-      "summary": "Defines h3 private runtime bound record, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Models H3PrivateRuntimeBoundRecord limits and identities used by admission and runtime qualification.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193266,11 +193367,11 @@
         1035,
         1039
       ],
-      "summary": "Defines h3 private runtime evidence artifact, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateRuntimeEvidenceArtifact evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193283,14 +193384,13 @@
         1043,
         1069
       ],
-      "summary": "Defines h3 private runtime qualification record, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Models H3PrivateRuntimeQualificationRecord limits and identities used by admission and runtime qualification.",
       "tags": [
         "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAttemptFacts",
@@ -193301,11 +193401,11 @@
         1076,
         1093
       ],
-      "summary": "Defines h3 private fl2 va attempt facts, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateFl2VaAttemptFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193318,11 +193418,11 @@
         1147,
         1165
       ],
-      "summary": "Defines h3 private fl2 va media contract, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateFl2VaMediaContract state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193335,11 +193435,11 @@
         1216,
         1233
       ],
-      "summary": "Defines h3 private fl2 va terminal identity echo, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateFl2VaTerminalIdentityEcho state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193352,11 +193452,11 @@
         1236,
         1239
       ],
-      "summary": "Defines h3 private fl2 va run output, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateFl2VaRunOutput state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193369,11 +193469,11 @@
         1259,
         1264
       ],
-      "summary": "Defines h3 private host headroom shortfall, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateHostHeadroomShortfall state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193386,11 +193486,11 @@
         1283,
         1290
       ],
-      "summary": "Defines h3 private device headroom shortfall, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateDeviceHeadroomShortfall state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193403,12 +193503,11 @@
         1293,
         1307
       ],
-      "summary": "Defines h3 private fl2 va prepare error, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateFl2VaPrepareError state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "error-handling",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193421,11 +193520,11 @@
         1312,
         1329
       ],
-      "summary": "Defines h3 private fl2 va prepare input, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateFl2VaPrepareInput state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193438,11 +193537,11 @@
         1335,
         1340
       ],
-      "summary": "Defines h3 private fl2 va uat paths, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateFl2VaUatPaths state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193455,11 +193554,11 @@
         1347,
         1369
       ],
-      "summary": "Defines h3 private fl2 va admission input, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateFl2VaAdmissionInput state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193472,11 +193571,11 @@
         1374,
         1388
       ],
-      "summary": "Defines h3 private fl2 va runtime bounds, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Models H3PrivateFl2VaRuntimeBounds limits and identities used by admission and runtime qualification.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -193489,13 +193588,13 @@
         1469,
         1494
       ],
-      "summary": "Defines h3 private fl2 va admission evidence, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateFl2VaAdmissionEvidence evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3AdmittedRoute",
@@ -193506,11 +193605,11 @@
         1702,
         1706
       ],
-      "summary": "Defines h3 admitted route, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3AdmittedRoute state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193523,11 +193622,11 @@
         2771,
         2786
       ],
-      "summary": "Defines h3 private fl2 va owner fence facts, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateFl2VaOwnerFenceFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193540,11 +193639,11 @@
         2818,
         2824
       ],
-      "summary": "Defines h3 private fl2 va run context, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateFl2VaRunContext state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193557,11 +193656,11 @@
         2886,
         2898
       ],
-      "summary": "Defines h3 private attempt consumption binding, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateAttemptConsumptionBinding state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193574,11 +193673,11 @@
         2996,
         3005
       ],
-      "summary": "Defines h3 private fl2 va prepared runner, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateFl2VaPreparedRunner state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "resource-management"
       ],
       "complexity": "simple"
     },
@@ -193591,11 +193690,11 @@
         3009,
         3012
       ],
-      "summary": "Defines h3 private fl2 va prepared attempt, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateFl2VaPreparedAttempt state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193608,11 +193707,11 @@
         3663,
         3670
       ],
-      "summary": "Defines h3 private server conditioner lease, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Owns the H3PrivateServerConditionerLease resource lease and exposes its frozen identity for the duration of one execution attempt.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "rust",
+        "resource-management"
       ],
       "complexity": "simple"
     },
@@ -193625,11 +193724,11 @@
         3733,
         3744
       ],
-      "summary": "Defines h3 private server execution lease, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Owns the H3PrivateServerExecutionLease resource lease and exposes its frozen identity for the duration of one execution attempt.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "rust",
+        "resource-management"
       ],
       "complexity": "simple"
     },
@@ -193642,11 +193741,11 @@
         3799,
         3809
       ],
-      "summary": "Defines h3 private server qwen artifact lease, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Owns the H3PrivateServerQwenArtifactLease resource lease and exposes its frozen identity for the duration of one execution attempt.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "rust",
+        "resource-management"
       ],
       "complexity": "simple"
     },
@@ -193659,13 +193758,13 @@
         3854,
         3878
       ],
-      "summary": "Defines h3 private server fl2 va artifact lease, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Owns the H3PrivateServerFl2VaArtifactLease resource lease and exposes its frozen identity for the duration of one execution attempt.",
       "tags": [
         "data-model",
-        "service",
-        "orchestration"
+        "rust",
+        "resource-management"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePreparationCheckpoint",
@@ -193676,11 +193775,11 @@
         4086,
         4088
       ],
-      "summary": "Defines h3 private preparation checkpoint, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivatePreparationCheckpoint state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193693,13 +193792,13 @@
         4200,
         4228
       ],
-      "summary": "Defines h3 private concrete prepared runner, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Packages H3PrivateConcretePreparedRunner state used to prepare or execute one authenticated H3 generation attempt.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "resource-management"
       ],
-      "complexity": "simple"
+      "complexity": "moderate"
     },
     {
       "id": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFacts",
@@ -193710,11 +193809,11 @@
         4632,
         4654
       ],
-      "summary": "Defines h3 private fl2 va owner facts, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateFl2VaOwnerFacts evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193727,11 +193826,11 @@
         4734,
         4746
       ],
-      "summary": "Defines h3 private scheduler ledger identity, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateSchedulerLedgerIdentity state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193744,11 +193843,11 @@
         4754,
         4774
       ],
-      "summary": "Defines h3 private factory activation evidence, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Records payload-free H3PrivateFactoryActivationEvidence evidence for later identity binding and fail-closed validation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193761,11 +193860,11 @@
         4792,
         4795
       ],
-      "summary": "Defines h3 private allocation commit, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateAllocationCommit state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -193778,11 +193877,11 @@
         5137,
         5145
       ],
-      "summary": "Defines h3 private runtime qualification authority, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Carries authenticated H3PrivateRuntimeQualificationAuthority facts that authorize a narrowly scoped private H3 operation.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193795,11 +193894,11 @@
         5208,
         5228
       ],
-      "summary": "Defines runtime qualification storage, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents RuntimeQualificationStorage state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193809,14 +193908,14 @@
       "name": "H3PrivateReviewedRuntimeQualification",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6478,
-        6482
+        6520,
+        6524
       ],
-      "summary": "Defines h3 private reviewed runtime qualification, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateReviewedRuntimeQualification state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -193826,14 +193925,14 @@
       "name": "H3PrivateRuntimeQualificationSource",
       "filePath": "crates/mold-inference/src/minimax_h3/private_server.rs",
       "lineRange": [
-        6561,
-        6567
+        6603,
+        6609
       ],
-      "summary": "Defines h3 private runtime qualification source, a core type used by private MiniMax H3 worker protocol, process lifecycle, admission, and diagnostics.",
+      "summary": "Represents H3PrivateRuntimeQualificationSource state within the private H3 server boundary.",
       "tags": [
         "data-model",
-        "rust-type",
-        "domain-model"
+        "rust",
+        "security"
       ],
       "complexity": "simple"
     },
@@ -196683,12 +196782,13 @@
       "type": "file",
       "name": "MobileApp.test.ts",
       "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "summary": "Test suite verifying the remote-only mobile Mold Studio application and its cross-workspace orchestration, including regression and edge-case contracts exercised by the surrounding surface.",
+      "summary": "Provides the comprehensive behavior suite for the remote-only mobile application, covering generation routing, durable recovery, sequences, hosts, models, library organization, media, identity, and native bridges.",
       "tags": [
         "test",
-        "regression",
         "mobile",
-        "desktop"
+        "generation",
+        "durable-recovery",
+        "multi-host"
       ],
       "complexity": "complex"
     },
@@ -196701,11 +196801,11 @@
         127,
         144
       ],
-      "summary": "Implements planned placement for the remote-only mobile Mold Studio application and its cross-workspace orchestration.",
+      "summary": "Creates a deterministic multi-host placement-plan fixture for mobile routing tests.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "routing"
       ],
       "complexity": "simple"
     },
@@ -196718,11 +196818,11 @@
         226,
         256
       ],
-      "summary": "Implements durable batch response for the remote-only mobile Mold Studio application and its cross-workspace orchestration.",
+      "summary": "Builds a durable generation batch response with overridable child records and states.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "durable-recovery"
       ],
       "complexity": "simple"
     },
@@ -196735,11 +196835,11 @@
         274,
         303
       ],
-      "summary": "Implements durable api fallback for the remote-only mobile Mold Studio application and its cross-workspace orchestration.",
+      "summary": "Implements the test API fallback that simulates durable generation endpoints and records admissions.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "api-handler",
+        "durable-recovery"
       ],
       "complexity": "simple"
     },
@@ -196752,11 +196852,12 @@
         359,
         441
       ],
-      "summary": "Implements held admissions for the remote-only mobile Mold Studio application and its cross-workspace orchestration.",
+      "summary": "Installs controllable deferred durable-admission responses so tests can exercise concurrency, cancellation, and ordering races.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "concurrency",
+        "durable-recovery"
       ],
       "complexity": "moderate"
     },
@@ -196769,11 +196870,11 @@
         479,
         501
       ],
-      "summary": "Defines fake intersection observer, a core type used by the remote-only mobile Mold Studio application and its cross-workspace orchestration.",
+      "summary": "Provides a controllable IntersectionObserver substitute for mobile component visibility tests.",
       "tags": [
-        "data-model",
-        "service",
-        "orchestration"
+        "test",
+        "mock",
+        "browser-api"
       ],
       "complexity": "simple"
     },
@@ -196782,12 +196883,13 @@
       "type": "file",
       "name": "MobileApp.vue",
       "filePath": "desktop/src/mobile/MobileApp.vue",
-      "summary": "Implements the remote-only mobile Mold Studio application and its cross-workspace orchestration as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Orchestrates Mold's shared iOS and Android remote client, including host discovery and pairing, generation and sequence submission, durable recovery, live activity, model management, and the unified mobile library.",
       "tags": [
-        "mobile",
-        "desktop",
         "component",
-        "vue",
+        "mobile",
+        "generation",
+        "multi-host",
+        "orchestrator",
         "tested"
       ],
       "complexity": "complex"
@@ -199637,11 +199739,12 @@
       "type": "file",
       "name": "ActivityStrip.test.ts",
       "filePath": "web/src/components/create/ActivityStrip.test.ts",
-      "summary": "Test suite verifying active and historical generation progress in the web Create workspace, including regression and edge-case contracts exercised by the surrounding surface.",
+      "summary": "Exercises the web Create activity strip's running and queued print display, sequence rows, recovered fleet work, progress, host badges, and user actions.",
       "tags": [
         "test",
-        "regression",
-        "web-client"
+        "component",
+        "activity",
+        "queue-status"
       ],
       "complexity": "complex"
     },
@@ -199654,11 +199757,11 @@
         12,
         43
       ],
-      "summary": "Builds job state for active and historical generation progress in the web Create workspace.",
+      "summary": "Builds a complete overridable web generation job fixture for activity-strip tests.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "generation"
       ],
       "complexity": "simple"
     },
@@ -199671,11 +199774,11 @@
         47,
         66
       ],
-      "summary": "Builds sequence vm state for active and historical generation progress in the web Create workspace.",
+      "summary": "Builds a host-aware durable sequence activity view model for web component tests.",
       "tags": [
-        "function",
-        "business-logic",
-        "utility"
+        "test",
+        "factory",
+        "sequence"
       ],
       "complexity": "simple"
     },
@@ -199684,11 +199787,12 @@
       "type": "file",
       "name": "ActivityStrip.vue",
       "filePath": "web/src/components/create/ActivityStrip.vue",
-      "summary": "Implements active and historical generation progress in the web Create workspace as part of Mold's local generation engine and multi-surface application.",
+      "summary": "Renders web Create's unified present-tense activity strip with running and queued prints, sequence progress, recovered fleet rows, failures, and compact history navigation.",
       "tags": [
-        "web-client",
         "component",
-        "vue",
+        "activity",
+        "queue-status",
+        "multi-host",
         "tested"
       ],
       "complexity": "complex"
@@ -200194,13 +200298,13 @@
       "type": "file",
       "name": "useGenerateStream.test.ts",
       "filePath": "web/src/composables/useGenerateStream.test.ts",
-      "summary": "Exercises use generate stream.test behavior and regression contracts with focused automated coverage.",
+      "summary": "Provides broad coverage of web generation streaming, durable admission and recovery, automatic host routing, chain-backed long-video progress, cancellation, and artifact settlement.",
       "tags": [
-        "code",
         "test",
-        "web",
         "generation",
-        "typescript"
+        "streaming",
+        "durable-recovery",
+        "multi-host"
       ],
       "complexity": "complex"
     },
@@ -200213,11 +200317,11 @@
         98,
         115
       ],
-      "summary": "chain job detail performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Builds the canonical chain-job detail snapshot used by long-video stream tests.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "sequence"
       ],
       "complexity": "simple"
     },
@@ -200230,11 +200334,11 @@
         117,
         127
       ],
-      "summary": "chain decision performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Builds an overridable routing decision that selects chain-backed generation.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "routing"
       ],
       "complexity": "simple"
     },
@@ -200247,11 +200351,11 @@
         129,
         145
       ],
-      "summary": "single gen performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Builds an overridable single-generation request for stream tests.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "generation"
       ],
       "complexity": "simple"
     },
@@ -200264,11 +200368,11 @@
         169,
         202
       ],
-      "summary": "durable batch performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Builds durable batch snapshots with configurable child states and metadata.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "durable-recovery"
       ],
       "complexity": "simple"
     },
@@ -200281,11 +200385,11 @@
         228,
         242
       ],
-      "summary": "submit durable performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Submits a durable request through the composable and flushes asynchronous persistence work.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "generation",
+        "durable-recovery"
       ],
       "complexity": "simple"
     },
@@ -200298,11 +200402,11 @@
         244,
         260
       ],
-      "summary": "gallery row performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Builds a gallery row fixture for durable artifact reconciliation.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "factory",
+        "gallery"
       ],
       "complexity": "simple"
     },
@@ -200315,11 +200419,11 @@
         270,
         288
       ],
-      "summary": "settle durable performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Applies a durable terminal state and waits for the composable to reconcile its artifacts.",
       "tags": [
-        "function",
-        "typescript",
-        "job-lifecycle"
+        "test",
+        "durable-recovery",
+        "async"
       ],
       "complexity": "simple"
     },
@@ -200332,11 +200436,11 @@
         290,
         310
       ],
-      "summary": "script chain performs a significant part of use generate stream.test's test and web behavior.",
+      "summary": "Scripts chain admission and event-stream API responses for long-video generation tests.",
       "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
+        "test",
+        "sequence",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -212832,13 +212936,16 @@
       "type": "file",
       "name": "minimax_h3.rs",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
-      "summary": "Implements minimax h3 behavior within Mold's local AI generation system and multi-surface application.",
+      "summary": "Defines the shared, immutable MiniMax H3 model, geometry, reference, runtime-admission, artifact, and manifest contracts used by acquisition and inference layers. It pins reviewed model identities and validates FL2VA/Ref2VA requests without activating a backend.",
       "tags": [
-        "code",
-        "rust",
-        "implementation"
+        "contract",
+        "validation",
+        "model-manifest",
+        "minimax-h3",
+        "capabilities"
       ],
-      "complexity": "complex"
+      "complexity": "complex",
+      "languageNotes": "Rust enums and structs encode fail-closed admission policy, while deterministic SHA-256 identities bind artifacts and prepared request geometry."
     },
     {
       "id": "function:crates/mold-core/src/minimax_h3.rs:is_reviewed_compact_model",
@@ -212849,11 +212956,12 @@
         77,
         82
       ],
-      "summary": "is reviewed compact model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements is reviewed compact model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212866,11 +212974,12 @@
         150,
         155
       ],
-      "summary": "base compact model for task performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements base compact model for task within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212883,11 +212992,12 @@
         166,
         178
       ],
-      "summary": "base compact model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements base compact model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212900,11 +213010,12 @@
         199,
         213
       ],
-      "summary": "storage identity performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives or exposes the deterministic storage identity that binds a MiniMax H3 execution attempt to its reviewed inputs.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "serialization"
       ],
       "complexity": "simple"
     },
@@ -212917,11 +213028,48 @@
         216,
         221
       ],
-      "summary": "turbo tier for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements turbo tier for model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_pad_rows_per_block",
+      "type": "function",
+      "name": "qwen_vision_pad_rows_per_block",
+      "filePath": "crates/mold-core/src/minimax_h3.rs",
+      "lineRange": [
+        261,
+        263
+      ],
+      "summary": "Computes qwen vision pad rows per block for MiniMax H3 shape validation and conservative runtime memory accounting.",
+      "tags": [
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "memory-budget"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_patch_rows_per_block",
+      "type": "function",
+      "name": "qwen_vision_patch_rows_per_block",
+      "filePath": "crates/mold-core/src/minimax_h3.rs",
+      "lineRange": [
+        268,
+        270
+      ],
+      "summary": "Computes qwen vision patch rows per block for MiniMax H3 shape validation and conservative runtime memory accounting.",
+      "tags": [
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -212931,14 +213079,15 @@
       "name": "is_admitted_compact_canvas",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        302,
-        317
+        339,
+        354
       ],
-      "summary": "is admitted compact canvas performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives is admitted compact canvas under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212948,14 +213097,15 @@
       "name": "reviewed_compact_max_pixels",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        320,
-        322
+        357,
+        359
       ],
-      "summary": "reviewed compact max pixels performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements reviewed compact max pixels within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212965,14 +213115,15 @@
       "name": "reviewed_compact_max_axis_pixels",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        331,
-        341
+        368,
+        378
       ],
-      "summary": "reviewed compact max axis pixels performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements reviewed compact max axis pixels within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212982,14 +213133,15 @@
       "name": "reviewed_compact_min_axis_pixels",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        352,
-        354
+        389,
+        391
       ],
-      "summary": "reviewed compact min axis pixels performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements reviewed compact min axis pixels within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -212999,14 +213151,15 @@
       "name": "reviewed_compact_aspect_bounds",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        357,
-        359
+        394,
+        396
       ],
-      "summary": "reviewed compact aspect bounds performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements reviewed compact aspect bounds within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213016,14 +213169,15 @@
       "name": "largest_admitted_compact_canvas",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        375,
-        400
+        412,
+        437
       ],
-      "summary": "largest admitted compact canvas performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives largest admitted compact canvas under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213033,14 +213187,15 @@
       "name": "qualified_canvases_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        407,
-        409
+        444,
+        446
       ],
-      "summary": "qualified canvases for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives qualified canvases for model under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213050,14 +213205,15 @@
       "name": "valid_dimensions_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        414,
-        420
+        451,
+        457
       ],
-      "summary": "valid dimensions for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Checks whether dimensions for model satisfies the reviewed MiniMax H3 contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -213067,14 +213223,15 @@
       "name": "recommended_dimensions_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        425,
-        436
+        462,
+        473
       ],
-      "summary": "recommended dimensions for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Returns the reviewed dimensions for model recommendation for the selected MiniMax H3 model or request.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213084,14 +213241,15 @@
       "name": "capabilities",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        711,
-        754
+        748,
+        791
       ],
-      "summary": "capabilities performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports capabilities for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213101,14 +213259,15 @@
       "name": "layout_runtime_available",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        779,
-        789
+        816,
+        826
       ],
-      "summary": "layout runtime available performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports layout runtime available for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213118,14 +213277,15 @@
       "name": "engine_is_built",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        797,
-        799
+        834,
+        836
       ],
-      "summary": "engine is built performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements engine is built within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213135,14 +213295,15 @@
       "name": "task_runtime_available",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        809,
-        811
+        846,
+        848
       ],
-      "summary": "task runtime available performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports task runtime available for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213152,14 +213313,15 @@
       "name": "message",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        833,
-        848
+        870,
+        885
       ],
-      "summary": "message performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements message within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213169,14 +213331,15 @@
       "name": "is_available",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        859,
-        861
+        896,
+        898
       ],
-      "summary": "is available performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports is available for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213186,14 +213349,15 @@
       "name": "reason",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        863,
-        868
+        900,
+        905
       ],
-      "summary": "reason performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements reason within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213203,14 +213367,15 @@
       "name": "runtime_availability_for",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        877,
-        888
+        914,
+        925
       ],
-      "summary": "runtime availability for performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports runtime availability for for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213220,14 +213385,15 @@
       "name": "model_runtime_availability",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        896,
-        901
+        933,
+        938
       ],
-      "summary": "model runtime availability performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports model runtime availability for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213237,14 +213403,15 @@
       "name": "capability_contract_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        909,
-        919
+        946,
+        956
       ],
-      "summary": "capability contract for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports capability contract for model for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213254,14 +213421,15 @@
       "name": "runnable_capability_contract_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        923,
-        926
+        960,
+        963
       ],
-      "summary": "runnable capability contract for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Reports runnable capability contract for model for fail-closed MiniMax H3 admission and routing.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213271,14 +213439,15 @@
       "name": "canonical_family",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        928,
-        933
+        965,
+        970
       ],
-      "summary": "canonical family performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements canonical family within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213288,14 +213457,15 @@
       "name": "is_family",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        935,
-        937
+        972,
+        974
       ],
-      "summary": "is family performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements is family within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213305,14 +213475,15 @@
       "name": "repo_revision",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        939,
-        946
+        976,
+        983
       ],
-      "summary": "repo revision performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements repo revision within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213322,14 +213493,15 @@
       "name": "file_revision",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        953,
-        962
+        990,
+        999
       ],
-      "summary": "file revision performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements file revision within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213339,14 +213511,15 @@
       "name": "task_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        964,
-        973
+        1001,
+        1010
       ],
-      "summary": "task for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements task for model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213356,14 +213529,15 @@
       "name": "uses_reviewed_compact_envelope",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        986,
-        988
+        1023,
+        1025
       ],
-      "summary": "uses reviewed compact envelope performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements uses reviewed compact envelope within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213373,14 +213547,15 @@
       "name": "layout_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        990,
-        1007
+        1027,
+        1044
       ],
-      "summary": "layout for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements layout for model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213390,14 +213565,15 @@
       "name": "resolve_model_name",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1009,
-        1025
+        1046,
+        1062
       ],
-      "summary": "resolve model name performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements resolve model name within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213407,14 +213583,15 @@
       "name": "canonicalize_request_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1033,
-        1042
+        1070,
+        1079
       ],
-      "summary": "canonicalize request model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements canonicalize request model within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213424,14 +213601,15 @@
       "name": "valid_frame_count",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1044,
-        1049
+        1081,
+        1086
       ],
-      "summary": "valid frame count performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Checks whether frame count satisfies the reviewed MiniMax H3 contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -213441,14 +213619,15 @@
       "name": "video_latent_frames",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1073,
-        1076
+        1110,
+        1113
       ],
-      "summary": "video latent frames performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives video latent frames under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213458,14 +213637,15 @@
       "name": "rows_per_video_latent",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1081,
-        1086
+        1118,
+        1123
       ],
-      "summary": "rows per video latent performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes rows per video latent for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -213475,14 +213655,15 @@
       "name": "target_video_rows",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1089,
-        1091
+        1126,
+        1128
       ],
-      "summary": "target video rows performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes target video rows for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "host-routing"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -213492,14 +213673,15 @@
       "name": "audio_latents_per_channel",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1097,
-        1102
+        1134,
+        1139
       ],
-      "summary": "audio latents per channel performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes audio latents per channel for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213509,14 +213691,15 @@
       "name": "target_audio_rows",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1105,
-        1107
+        1142,
+        1144
       ],
-      "summary": "target audio rows performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes target audio rows for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "host-routing"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "memory-budget"
       ],
       "complexity": "simple"
     },
@@ -213526,14 +213709,15 @@
       "name": "audio_samples_per_channel",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1113,
-        1118
+        1150,
+        1155
       ],
-      "summary": "audio samples per channel performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes audio samples per channel for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213543,14 +213727,15 @@
       "name": "vocoder_audio_samples_per_channel",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1128,
-        1130
+        1165,
+        1167
       ],
-      "summary": "vocoder audio samples per channel performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Computes vocoder audio samples per channel for MiniMax H3 shape validation and conservative runtime memory accounting.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213560,14 +213745,15 @@
       "name": "fixed_frames_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1140,
-        1142
+        1177,
+        1179
       ],
-      "summary": "fixed frames for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives fixed frames for model under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213577,14 +213763,15 @@
       "name": "recommended_frames_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1148,
-        1150
+        1185,
+        1187
       ],
-      "summary": "recommended frames for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Returns the reviewed frames for model recommendation for the selected MiniMax H3 model or request.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213594,14 +213781,15 @@
       "name": "valid_frame_count_for_model",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1154,
-        1159
+        1191,
+        1196
       ],
-      "summary": "valid frame count for model performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Checks whether frame count for model satisfies the reviewed MiniMax H3 contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -213611,14 +213799,15 @@
       "name": "recommended_frames",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1161,
-        1175
+        1198,
+        1212
       ],
-      "summary": "recommended frames performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Returns the reviewed frames recommendation for the selected MiniMax H3 model or request.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213628,14 +213817,15 @@
       "name": "source_fit_dimensions",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1189,
-        1194
+        1226,
+        1231
       ],
-      "summary": "source fit dimensions performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives source fit dimensions under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213645,14 +213835,15 @@
       "name": "recommended_dimensions",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1196,
-        1220
+        1233,
+        1257
       ],
-      "summary": "recommended dimensions performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Returns the reviewed dimensions recommendation for the selected MiniMax H3 model or request.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213662,14 +213853,15 @@
       "name": "reference_violation",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1249,
-        1267
+        1286,
+        1304
       ],
-      "summary": "reference violation performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference violation under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213679,13 +213871,14 @@
       "name": "validate_reference_provenance",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1273,
-        1436
+        1310,
+        1473
       ],
-      "summary": "validate reference provenance performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates reference provenance against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "moderate"
@@ -213696,13 +213889,14 @@
       "name": "validate_reference_duration",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1438,
-        1454
+        1475,
+        1491
       ],
-      "summary": "validate reference duration performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates reference duration against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "simple"
@@ -213713,14 +213907,15 @@
       "name": "checked_duration_sum",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1456,
-        1470
+        1493,
+        1507
       ],
-      "summary": "checked duration sum performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements checked duration sum within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "validation"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -213730,14 +213925,15 @@
       "name": "aligned_dimension",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1472,
-        1484
+        1509,
+        1521
       ],
-      "summary": "aligned dimension performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives aligned dimension under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213747,14 +213943,15 @@
       "name": "reference_image_dimensions",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1486,
-        1501
+        1523,
+        1538
       ],
-      "summary": "reference image dimensions performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference image dimensions under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213764,14 +213961,15 @@
       "name": "reference_video_dimensions",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1503,
-        1530
+        1540,
+        1567
       ],
-      "summary": "reference video dimensions performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference video dimensions under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213781,14 +213979,15 @@
       "name": "normalized_reference_video_frames",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1532,
-        1591
+        1569,
+        1628
       ],
-      "summary": "normalized reference video frames performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives normalized reference video frames under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "moderate"
     },
@@ -213798,14 +213997,15 @@
       "name": "exact_reference_frame_count",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1593,
-        1605
+        1630,
+        1642
       ],
-      "summary": "exact reference frame count performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives exact reference frame count under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213815,14 +214015,15 @@
       "name": "audio_shape",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1607,
-        1659
+        1644,
+        1696
       ],
-      "summary": "audio shape performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements audio shape within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "moderate"
     },
@@ -213832,14 +214033,15 @@
       "name": "reference_prepared_shape_at",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1661,
-        1767
+        1698,
+        1804
       ],
-      "summary": "reference prepared shape at performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference prepared shape at under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "moderate"
     },
@@ -213849,14 +214051,15 @@
       "name": "reference_prepared_shape",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1769,
-        1773
+        1806,
+        1810
       ],
-      "summary": "reference prepared shape performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference prepared shape under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213866,14 +214069,15 @@
       "name": "reference_prepared_shape_for_target",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1778,
-        1791
+        1815,
+        1828
       ],
-      "summary": "reference prepared shape for target performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference prepared shape for target under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "host-routing"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213883,14 +214087,15 @@
       "name": "reference_prepared_shapes",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1793,
-        1801
+        1830,
+        1838
       ],
-      "summary": "reference prepared shapes performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference prepared shapes under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213900,14 +214105,15 @@
       "name": "reference_prepared_shapes_for_target",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1803,
-        1820
+        1840,
+        1857
       ],
-      "summary": "reference prepared shapes for target performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Derives reference prepared shapes for target under the reviewed MiniMax H3 geometry and reference-media rules.",
       "tags": [
-        "function",
-        "rust",
-        "host-routing"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "media-geometry"
       ],
       "complexity": "simple"
     },
@@ -213917,13 +214123,14 @@
       "name": "validate_references",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1824,
-        1828
+        1861,
+        1865
       ],
-      "summary": "validate references performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates references against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "simple"
@@ -213934,13 +214141,14 @@
       "name": "validate_reference_descriptors",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1833,
-        1837
+        1870,
+        1874
       ],
-      "summary": "validate reference descriptors performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates reference descriptors against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "simple"
@@ -213951,13 +214159,14 @@
       "name": "validate_reference_set",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1839,
-        2114
+        1876,
+        2151
       ],
-      "summary": "validate reference set performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates reference set against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "complex"
@@ -213968,13 +214177,14 @@
       "name": "validate_request_contract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2138,
-        2140
+        2175,
+        2177
       ],
-      "summary": "validate request contract performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates request contract against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "simple"
@@ -213985,15 +214195,15 @@
       "name": "validate_reviewed_canvas",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2160,
-        2177
+        2197,
+        2214
       ],
-      "summary": "validate reviewed canvas performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates reviewed canvas against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
-        "validation",
-        "ui"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -214003,13 +214213,14 @@
       "name": "validate_resolved_request_contract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2179,
-        2184
+        2216,
+        2221
       ],
-      "summary": "validate resolved request contract performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates resolved request contract against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "simple"
@@ -214020,13 +214231,14 @@
       "name": "validate_request_contract_with_reference_authority",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2186,
-        2429
+        2223,
+        2466
       ],
-      "summary": "validate request contract with reference authority performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Validates request contract with reference authority against the immutable MiniMax H3 authority and fails closed on any mismatch.",
       "tags": [
-        "function",
-        "rust",
+        "contract",
+        "model-policy",
+        "minimax-h3",
         "validation"
       ],
       "complexity": "complex"
@@ -214037,14 +214249,15 @@
       "name": "manifest_contract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2463,
-        2508
+        2500,
+        2545
       ],
-      "summary": "manifest contract performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Constructs the pinned MiniMax H3 manifest contract data exposed to model acquisition and validation.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214054,14 +214267,15 @@
       "name": "artifact_contract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2533,
-        2645
+        2570,
+        2682
       ],
-      "summary": "artifact contract performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements artifact contract within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "moderate"
     },
@@ -214071,14 +214285,15 @@
       "name": "file",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2647,
-        2662
+        2684,
+        2699
       ],
-      "summary": "file performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements file within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -214088,14 +214303,15 @@
       "name": "official_shared_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2841,
-        2998
+        2878,
+        3035
       ],
-      "summary": "official shared files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned official shared files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "moderate"
     },
@@ -214105,14 +214321,15 @@
       "name": "official_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3000,
-        3031
+        3037,
+        3068
       ],
-      "summary": "official files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned official files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214122,14 +214339,15 @@
       "name": "official_task_config",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3037,
-        3049
+        3074,
+        3086
       ],
-      "summary": "official task config performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned official task config artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -214139,14 +214357,15 @@
       "name": "official_runtime_support_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3058,
-        3072
+        3095,
+        3109
       ],
-      "summary": "official runtime support files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned official runtime support files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214156,14 +214375,15 @@
       "name": "compact_shared_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3082,
-        3109
+        3119,
+        3146
       ],
-      "summary": "compact shared files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned compact shared files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214173,14 +214393,15 @@
       "name": "comfy_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3111,
-        3131
+        3148,
+        3168
       ],
-      "summary": "comfy files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned comfy files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214190,14 +214411,15 @@
       "name": "nvfp4_files",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3138,
-        3160
+        3175,
+        3197
       ],
-      "summary": "nvfp4 files performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Builds the pinned nvfp4 files artifact list used by MiniMax H3 manifests and verification.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "simple"
     },
@@ -214207,14 +214429,15 @@
       "name": "defaults_with_steps",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3171,
-        3190
+        3208,
+        3227
       ],
-      "summary": "defaults with steps performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Implements defaults with steps within the shared MiniMax H3 model and request contract.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "utility"
       ],
       "complexity": "simple"
     },
@@ -214224,14 +214447,15 @@
       "name": "manifests",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        3196,
-        3274
+        3233,
+        3311
       ],
-      "summary": "manifests performs a significant part of minimax h3's rust and implementation behavior.",
+      "summary": "Constructs the pinned MiniMax H3 manifests data exposed to model acquisition and validation.",
       "tags": [
-        "function",
-        "rust",
-        "domain-logic"
+        "contract",
+        "model-policy",
+        "minimax-h3",
+        "model-manifest"
       ],
       "complexity": "moderate"
     },
@@ -214244,11 +214468,12 @@
         98,
         111
       ],
-      "summary": "TurboManifestTier encapsulates minimax h3 state and behavior.",
+      "summary": "Turbo Manifest Tier models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214258,14 +214483,15 @@
       "name": "GenerationReferencePreparedShape",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        542,
-        558
+        579,
+        595
       ],
-      "summary": "GenerationReferencePreparedShape encapsulates minimax h3 state and behavior.",
+      "summary": "Generation Reference Prepared Shape models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214275,14 +214501,15 @@
       "name": "NoiseSeedSource",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        571,
-        576
+        608,
+        613
       ],
-      "summary": "NoiseSeedSource encapsulates minimax h3 state and behavior.",
+      "summary": "Noise Seed Source models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214292,14 +214519,15 @@
       "name": "NoiseDrawCardinality",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        579,
-        582
+        616,
+        619
       ],
-      "summary": "NoiseDrawCardinality encapsulates minimax h3 state and behavior.",
+      "summary": "Noise Draw Cardinality models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214309,14 +214537,15 @@
       "name": "NoiseDrawContract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        585,
-        589
+        622,
+        626
       ],
-      "summary": "NoiseDrawContract encapsulates minimax h3 state and behavior.",
+      "summary": "Noise Draw Contract encodes a reviewed MiniMax H3 model, request, or runtime capability contract.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214326,14 +214555,15 @@
       "name": "Task",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        620,
-        623
+        657,
+        660
       ],
-      "summary": "Task encapsulates minimax h3 state and behavior.",
+      "summary": "Task models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214343,14 +214573,15 @@
       "name": "Layout",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        626,
-        637
+        663,
+        674
       ],
-      "summary": "Layout encapsulates minimax h3 state and behavior.",
+      "summary": "Layout models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214360,14 +214591,15 @@
       "name": "Mode",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        640,
-        646
+        677,
+        683
       ],
-      "summary": "Mode encapsulates minimax h3 state and behavior.",
+      "summary": "Mode models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214377,14 +214609,15 @@
       "name": "BackendQualification",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        649,
-        660
+        686,
+        697
       ],
-      "summary": "BackendQualification encapsulates minimax h3 state and behavior.",
+      "summary": "Backend Qualification defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -214394,14 +214627,15 @@
       "name": "BackendApplicability",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        663,
-        667
+        700,
+        704
       ],
-      "summary": "BackendApplicability encapsulates minimax h3 state and behavior.",
+      "summary": "Backend Applicability defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -214411,14 +214645,15 @@
       "name": "Capabilities",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        670,
-        694
+        707,
+        731
       ],
-      "summary": "Capabilities encapsulates minimax h3 state and behavior.",
+      "summary": "Capabilities encodes a reviewed MiniMax H3 model, request, or runtime capability contract.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214428,14 +214663,15 @@
       "name": "ModelCapabilityContract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        764,
-        769
+        801,
+        806
       ],
-      "summary": "ModelCapabilityContract encapsulates minimax h3 state and behavior.",
+      "summary": "Model Capability Contract encodes a reviewed MiniMax H3 model, request, or runtime capability contract.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214445,14 +214681,15 @@
       "name": "RuntimeUnavailableReason",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        821,
-        828
+        858,
+        865
       ],
-      "summary": "RuntimeUnavailableReason encapsulates minimax h3 state and behavior across 1 extracted methods.",
+      "summary": "Runtime Unavailable Reason defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -214462,14 +214699,15 @@
       "name": "RuntimeAvailability",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        853,
-        856
+        890,
+        893
       ],
-      "summary": "RuntimeAvailability encapsulates minimax h3 state and behavior across 2 extracted methods.",
+      "summary": "Runtime Availability defines part of the injected, streamed MiniMax H3 inference execution seam.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "streaming"
       ],
       "complexity": "simple"
     },
@@ -214479,14 +214717,15 @@
       "name": "ContractError",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1223,
-        1228
+        1260,
+        1265
       ],
-      "summary": "ContractError encapsulates minimax h3 state and behavior across 1 extracted methods.",
+      "summary": "Contract Error represents a typed MiniMax H3 contract violation with actionable validation context.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -214496,14 +214735,15 @@
       "name": "ReferenceContractError",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        1232,
-        1239
+        1269,
+        1276
       ],
-      "summary": "ReferenceContractError encapsulates minimax h3 state and behavior across 1 extracted methods.",
+      "summary": "Reference Contract Error represents a typed MiniMax H3 contract violation with actionable validation context.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "validation"
       ],
       "complexity": "simple"
     },
@@ -214513,14 +214753,15 @@
       "name": "ArtifactRole",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2432,
-        2444
+        2469,
+        2481
       ],
-      "summary": "ArtifactRole encapsulates minimax h3 state and behavior.",
+      "summary": "Artifact Role models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214530,14 +214771,15 @@
       "name": "ManifestContract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2447,
-        2461
+        2484,
+        2498
       ],
-      "summary": "ManifestContract encapsulates minimax h3 state and behavior.",
+      "summary": "Manifest Contract encodes a reviewed MiniMax H3 model, request, or runtime capability contract.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214547,14 +214789,15 @@
       "name": "ArtifactIdentity",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2511,
-        2516
+        2548,
+        2553
       ],
-      "summary": "ArtifactIdentity encapsulates minimax h3 state and behavior.",
+      "summary": "Artifact Identity models a typed MiniMax H3 policy or execution domain used by validation and routing.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -214564,14 +214807,15 @@
       "name": "ArtifactContract",
       "filePath": "crates/mold-core/src/minimax_h3.rs",
       "lineRange": [
-        2519,
-        2527
+        2556,
+        2564
       ],
-      "summary": "ArtifactContract encapsulates minimax h3 state and behavior.",
+      "summary": "Artifact Contract encodes a reviewed MiniMax H3 model, request, or runtime capability contract.",
       "tags": [
-        "class",
-        "rust",
-        "domain-logic"
+        "data-model",
+        "contract",
+        "minimax-h3",
+        "type-definition"
       ],
       "complexity": "simple"
     },
@@ -270370,13 +270614,12 @@
       "type": "file",
       "name": "generation.test.ts",
       "filePath": "desktop/src/stores/generation.test.ts",
-      "summary": "Exercises generation.test behavior and regression contracts with focused automated coverage.",
+      "summary": "Tests core desktop generation-store utilities and state transitions including batch seed planning, concurrency limits, ordering, progress presentation, and removal eligibility.",
       "tags": [
-        "code",
         "test",
-        "desktop",
+        "state-management",
         "generation",
-        "typescript"
+        "batching"
       ],
       "complexity": "complex"
     },
@@ -301125,11 +301368,75 @@
       "weight": 0.7
     },
     {
-      "source": "file:desktop/src/composables/useOpenLiveWork.ts",
-      "target": "file:studio/api/activity.ts",
+      "source": "file:studio/api/activity.ts",
+      "target": "file:studio/api/client.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:parseActiveWorkSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:parseActiveWorkSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:listActiveWork",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:listActiveWork",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:reconcileActivityHost",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:reconcileActivityHost",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:mergeFleetActivity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "function:studio/api/activity.ts:mergeFleetActivity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/api/activity.ts",
+      "target": "file:studio/api/activity.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
     },
     {
       "source": "file:desktop/src/lib/api/catalog.test.ts",
@@ -306004,13 +306311,6 @@
       "weight": 1
     },
     {
-      "source": "file:desktop/src/stores/liveActivity.ts",
-      "target": "file:studio/api/activity.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/stores/models.ts",
       "target": "function:desktop/src/stores/models.ts:isGenerationModel",
       "type": "contains",
@@ -306655,83 +306955,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:studio/api/activity.test.ts",
-      "target": "file:studio/api/activity.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:parseActiveWorkSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:parseActiveWorkSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:listActiveWork",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:listActiveWork",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:reconcileActivityHost",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:reconcileActivityHost",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:mergeFleetActivity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "function:studio/api/activity.ts:mergeFleetActivity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:studio/api/activity.ts:listActiveWork",
-      "target": "function:studio/api/activity.ts:parseActiveWorkSnapshot",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/api/activity.ts",
-      "target": "file:studio/api/client.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:studio/api/chains.test.ts",
       "target": "file:studio/api/chains.ts",
       "type": "imports",
@@ -307146,6 +307369,27 @@
     },
     {
       "source": "file:studio/lib/activity.test.ts",
+      "target": "file:studio/lib/activity.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/activity.test.ts",
+      "target": "file:studio/lib/api/chainTypes.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/activity.test.ts",
+      "target": "file:studio/lib/queuePosition.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/activity.test.ts",
       "target": "function:studio/lib/activity.test.ts:print",
       "type": "contains",
       "direction": "forward",
@@ -307159,11 +307403,12 @@
       "weight": 1
     },
     {
-      "source": "file:studio/lib/activity.test.ts",
-      "target": "file:studio/lib/activity.ts",
-      "type": "imports",
+      "source": "file:studio/lib/activity.ts",
+      "target": "file:studio/lib/activity.test.ts",
+      "type": "tested_by",
       "direction": "forward",
-      "weight": 0.7
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
     },
     {
       "source": "file:studio/lib/activity.ts",
@@ -333563,8 +333808,239 @@
       "weight": 0.7
     },
     {
-      "source": "file:crates/mold-inference/src/minimax_h3/mod.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:sorted_environment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish_open_probes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:captured_phase",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:condition_encode_transient_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:synchronize_boundary",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_staged_host_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_staged_host_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_aac_staging_capacity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_aac_staging_capacity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_mux_output_capacity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_mux_output_capacity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_resident_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_peak_resident_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:routed_qwen_workspace",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeProcessObservation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeProcessObservation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeAuthorityObservation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeAuthorityObservation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeEnvelopeObservation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeEnvelopeObservation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundObservation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundObservation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundCapture",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundCapture",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
+      "target": "file:crates/mold-inference/src/device.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -337786,328 +338262,6 @@
     {
       "source": "file:crates/mold-inference/src/minimax_h3/private_runtime.rs",
       "target": "file:crates/mold-inference/src/attention.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:sorted_environment",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish_open_probes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:captured_phase",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:synchronize_boundary",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_staged_host_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_staged_host_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_aac_staging_capacity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_aac_staging_capacity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_mux_output_capacity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_mux_output_capacity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_resident_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_peak_resident_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:routed_qwen_workspace",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeProcessObservation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeProcessObservation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeAuthorityObservation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeAuthorityObservation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeEnvelopeObservation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeEnvelopeObservation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundObservation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundObservation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundCapture",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:H3PrivateRuntimeBoundCapture",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:capture_process_observation",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:sorted_environment",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_resident_bytes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:begin",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish_open_probes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish_open_probes",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:captured_phase",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:synchronize_boundary",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_resident_bytes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:observe_event",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:process_peak_resident_bytes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish_open_probes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:finish",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:build_observation",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs:routed_qwen_workspace",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime_observer.rs",
-      "target": "file:crates/mold-inference/src/device.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -424179,14 +424333,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:studio/api/activity.ts",
-      "target": "file:studio/api/activity.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:studio/api/chains.ts",
       "target": "file:studio/api/chains.test.ts",
       "type": "tested_by",
@@ -424229,14 +424375,6 @@
     {
       "source": "file:studio/components/QueuePlanWorkList.vue",
       "target": "file:studio/components/QueuePlanWorkList.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:studio/lib/activity.ts",
-      "target": "file:studio/lib/activity.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -428923,55 +429061,6 @@
     },
     {
       "source": "file:desktop/src/components/create/ActivityStrip.test.ts",
-      "target": "function:desktop/src/components/create/ActivityStrip.test.ts:baseJob",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/create/ActivityStrip.test.ts",
-      "target": "function:desktop/src/components/create/ActivityStrip.test.ts:seqJob",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
-      "target": "function:desktop/src/components/machines/HostQueuePanel.test.ts:queued",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
-      "target": "function:desktop/src/components/machines/HostQueuePanel.test.ts:mountPanel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
-      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:entry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
-      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:seed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
-      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:mountColumn",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/create/ActivityStrip.test.ts",
       "target": "file:desktop/src/components/create/ActivityStrip.vue",
       "type": "imports",
       "direction": "forward",
@@ -429034,6 +429123,55 @@
       "weight": 0.7
     },
     {
+      "source": "file:desktop/src/components/create/ActivityStrip.test.ts",
+      "target": "function:desktop/src/components/create/ActivityStrip.test.ts:baseJob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/create/ActivityStrip.test.ts",
+      "target": "function:desktop/src/components/create/ActivityStrip.test.ts:seqJob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
+      "target": "function:desktop/src/components/machines/HostQueuePanel.test.ts:queued",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
+      "target": "function:desktop/src/components/machines/HostQueuePanel.test.ts:mountPanel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
+      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:entry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
+      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:seed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
+      "target": "function:desktop/src/components/machines/QueueColumn.test.ts:mountColumn",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
       "source": "file:desktop/src/components/generate/ImagePickerModal.test.ts",
       "target": "file:desktop/src/components/generate/ImagePickerModal.vue",
       "type": "imports",
@@ -429083,11 +429221,348 @@
       "weight": 0.7
     },
     {
-      "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/api/client.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/api/errors.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/api/sse.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/chainRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/durableGeneration.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/durableGenerationPresentation.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/gallery/media.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/generationJob.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/generationRecovery.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/ipc.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/lib/notify.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/stores/appPrefs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/stores/gallery.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/stores/hosts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/stores/toasts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/api/generationAdmission.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/api/ownPrintPreview.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/api/queuePlan.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/api/referenceUploads.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/api/chainTypes.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/base64.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/chainJobProgress.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/generationLifecycle.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/generationPresentation.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/requestWarnings.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:studio/lib/targetStreamSlots.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:suggestOutputFilename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:suggestOutputFilename",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:randomSeed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:randomSeed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:needsHostRoute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:needsHostRoute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:resolveBaseSeed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:resolveBaseSeed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:planBatchRequests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:planBatchRequests",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:railOrder",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:railOrder",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:runWithConcurrency",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:runWithConcurrency",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:originGalleryMetadata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:persistDurableRecords",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:requestFormat",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:jobCanBeRemoved",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:jobCanBeRemoved",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:releaseSettledJob",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "function:desktop/src/stores/generation.ts:resultUrlExpiry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/stores/generation.ts",
+      "target": "file:desktop/src/stores/generation.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
     },
     {
       "source": "file:desktop/src/components/machines/HostQueuePanel.test.ts",
@@ -429126,13 +429601,6 @@
     },
     {
       "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/machines/QueueColumn.test.ts",
       "target": "file:desktop/src/stores/jobs.ts",
       "type": "imports",
       "direction": "forward",
@@ -429144,34 +429612,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/shell/NavRail.test.ts",
-      "target": "function:desktop/src/components/shell/NavRail.test.ts:makeRouter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/shell/NavRail.test.ts",
-      "target": "function:desktop/src/components/shell/NavRail.test.ts:mountAt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/components/settings/AdvancedSection.test.ts",
-      "target": "file:desktop/src/components/settings/AdvancedSection.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/settings/AdvancedSection.test.ts",
-      "target": "file:desktop/src/stores/connection.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:desktop/src/components/shell/NavRail.test.ts",
@@ -429253,6 +429693,34 @@
     {
       "source": "file:desktop/src/components/shell/NavRail.test.ts",
       "target": "file:desktop/src/stores/liveActivity.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/shell/NavRail.test.ts",
+      "target": "function:desktop/src/components/shell/NavRail.test.ts:makeRouter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/shell/NavRail.test.ts",
+      "target": "function:desktop/src/components/shell/NavRail.test.ts:mountAt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/components/settings/AdvancedSection.test.ts",
+      "target": "file:desktop/src/components/settings/AdvancedSection.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/settings/AdvancedSection.test.ts",
+      "target": "file:desktop/src/stores/connection.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -429755,153 +430223,6 @@
       "weight": 1
     },
     {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:suggestOutputFilename",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:suggestOutputFilename",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:randomSeed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:randomSeed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:needsHostRoute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:needsHostRoute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:resolveBaseSeed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:resolveBaseSeed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:planBatchRequests",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:planBatchRequests",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:railOrder",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:railOrder",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:runWithConcurrency",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:runWithConcurrency",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:originGalleryMetadata",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:persistDurableRecords",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:requestFormat",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:jobCanBeRemoved",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:jobCanBeRemoved",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:releaseSettledJob",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "function:desktop/src/stores/generation.ts:resultUrlExpiry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:desktop/src/stores/hosts.test.ts",
       "target": "function:desktop/src/stores/hosts.test.ts:device",
       "type": "contains",
@@ -429966,13 +430287,6 @@
     },
     {
       "source": "file:desktop/src/stores/generation.concurrency.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.concurrency.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -430008,210 +430322,7 @@
     },
     {
       "source": "file:desktop/src/stores/generation.multihost.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.multihost.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/api/client.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/api/errors.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/api/sse.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/chainRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/durableGeneration.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/durableGenerationPresentation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/gallery/media.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/generationJob.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/generationRecovery.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/ipc.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/lib/notify.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/stores/appPrefs.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/stores/gallery.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/stores/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/api/generationAdmission.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/api/ownPrintPreview.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/api/queuePlan.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/api/referenceUploads.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/api/chainTypes.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/base64.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/chainJobProgress.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/generationLifecycle.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/generationPresentation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/requestWarnings.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:studio/lib/targetStreamSlots.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/generationQueue.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -430512,13 +430623,6 @@
     },
     {
       "source": "file:desktop/src/stores/pullResume.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/stores/pullResume.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -430611,13 +430715,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.missingModel.test.ts",
       "target": "file:desktop/src/stores/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.missingModel.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -430765,13 +430862,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
       "target": "file:desktop/src/stores/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -430981,13 +431071,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.sourceConditioning.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sourceConditioning.test.ts",
       "target": "file:desktop/src/stores/hostModels.ts",
       "type": "imports",
       "direction": "forward",
@@ -431058,13 +431141,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.sourcefit.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sourcefit.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -431115,13 +431191,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.style.test.ts",
       "target": "file:desktop/src/stores/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.style.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -433003,11 +433072,2006 @@
       "weight": 0.8
     },
     {
-      "source": "function:crates/mold-inference/src/engine.rs:validate",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
-      "type": "calls",
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_stable_cuda_device_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_stable_cuda_device_id",
+      "type": "exports",
       "direction": "forward",
       "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available_for_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available_for_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:canonical_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:canonical_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_ordinal",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_ordinal",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compute_capability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compute_capability",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_with_adapter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_with_adapter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_adapter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_adapter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_reviewed_steps",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_prepared_with_adapter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:conditioning_mismatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:row_cap_mismatches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:update_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_device_floor_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_device_floor_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_host_floor_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_host_floor_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_admission_capacity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_prepared_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_record_canvas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:check_private_h3_target_budget_fits",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_unified_target_peak_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_qwen_route",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:into_authority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admission_evidence_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admission_evidence_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:artifact_qualification_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:artifact_qualification_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:work_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:work_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:cancellation_scope_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:cancellation_scope_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:memory_ledger_sequence",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:memory_ledger_sequence",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:consumption_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:consumption_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_against_binding",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_host_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_host_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:qwen_activation_workspace_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:qwen_activation_workspace_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:vae_construction_device_workspace_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:vae_construction_device_workspace_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:condition_vae_workspace_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:condition_vae_workspace_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention_workspace_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention_workspace_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ffn_workspace_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ffn_workspace_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:decoder_tile_workspace_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:decoder_tile_workspace_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:audio_decode_workspace_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:audio_decode_workspace_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:encoded_video_host_bytes_bound",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:encoded_video_host_bytes_bound",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:thumbnail_host_bytes_bound",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:thumbnail_host_bytes_bound",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mux_output_host_bytes_bound",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mux_output_host_bytes_bound",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:aac_mux_staging_host_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:aac_mux_staging_host_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_available_device_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_available_device_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_host_headroom_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_host_headroom_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:base_factory_authority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:base_factory_authority",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:execution_fingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:execution_fingerprint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:component_set_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:component_set_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_request_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_request_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_attempt_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_attempt_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:target_budget_identity_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:target_budget_identity_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_device_peak_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_device_peak_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_host_increment_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_host_increment_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:seed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:seed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_bounds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_bounds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:resolve_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:resolve_request",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_resolved_request",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_resolved_request",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_h3_route",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_h3_route",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_admission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_admission",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_reviewed_h3_private_fl2va_admission",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_request_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_digests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_vae_artifact_binding_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_digest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_owner_component_digests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_role",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:update_private_h3_qualified_artifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_execution_fingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_pruned_adaln_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_evidence_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fmt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_context",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_consumption_binding_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:facts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:facts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run_once",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run_once",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from_runner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_attempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_attempt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_reviewed_h3_private_fl2va_attempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_project_owner_fence_budget",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_base_factory",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_frozen_reopen_route",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:exact_qualified_qwen_artifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_lease_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from_opened",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:checkpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:with_private_h3_cuda_execution_attempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_envelope_conditioning",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_envelope_observation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_run_output",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_private_sampler_provenance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attempt_facts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attempt_facts_with_scheduler_budget",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:commit_once",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:commit_once",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:is_committed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:is_committed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:scheduler_ledger_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:derive",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:derive",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:activation_evidence_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:activation_prerequisite_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:record_file_sha256",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:record_file_sha256",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:bounds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:bounds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_bounds_for_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compact_envelope_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_envelope_for_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_profile_identities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_public_runtime_profile_with_turbo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ref2va_reference_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_envelope_for_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_bounds_for_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_envelope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_bounds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_capture_runtime_profile",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_qualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:h3_capture_bound_report",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:h3_capture_bound_report",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_qualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_runtime_qualification_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_route",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_runtime_qualification_source",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:open_reviewed_h3_private_runtime_qualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:open_reviewed_h3_private_runtime_qualification_for_source",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_public_presentation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_public_presentation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation_with_scope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation_for_test",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification_with_allowlist",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification_for_source",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_binding",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_shape",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_runtime_evidence_relative_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationRoute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationRoute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationAuthority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationAuthority",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEnvelopeRecord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEnvelopeRecord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeBoundRecord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeBoundRecord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEvidenceArtifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEvidenceArtifact",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationRecord",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationRecord",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAttemptFacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAttemptFacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaMediaContract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaMediaContract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaTerminalIdentityEcho",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaTerminalIdentityEcho",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunOutput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunOutput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateHostHeadroomShortfall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateHostHeadroomShortfall",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateDeviceHeadroomShortfall",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateDeviceHeadroomShortfall",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaUatPaths",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaUatPaths",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRuntimeBounds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRuntimeBounds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionEvidence",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionEvidence",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3AdmittedRoute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3AdmittedRoute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFenceFacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFenceFacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunContext",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunContext",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAttemptConsumptionBinding",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedRunner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedAttempt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedAttempt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerConditionerLease",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerExecutionLease",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerQwenArtifactLease",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerFl2VaArtifactLease",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePreparationCheckpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePreparationCheckpoint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateConcretePreparedRunner",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateSchedulerLedgerIdentity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateSchedulerLedgerIdentity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFactoryActivationEvidence",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFactoryActivationEvidence",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAllocationCommit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAllocationCommit",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationAuthority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationAuthority",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:RuntimeQualificationStorage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateReviewedRuntimeQualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationSource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "file:crates/mold-inference/src/attention.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "file:crates/mold-inference/src/engine.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "file:crates/mold-inference/src/h3_factory.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "target": "file:crates/mold-inference/src/progress.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
     },
     {
       "source": "function:crates/mold-inference/src/engine.rs:validate",
@@ -433165,20 +435229,6 @@
     },
     {
       "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
       "target": "function:crates/mold-inference/src/h3_factory.rs:grid_points",
       "type": "contains",
       "direction": "forward",
@@ -433270,28 +435320,42 @@
     },
     {
       "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:turbo_adapter",
       "type": "contains",
       "direction": "forward",
       "weight": 1
     },
     {
       "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:turbo_adapter",
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
     },
     {
       "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:turbo_adapter",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
       "type": "contains",
       "direction": "forward",
       "weight": 1
     },
     {
       "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:turbo_adapter",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:sampler_kind",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "function:crates/mold-inference/src/h3_factory.rs:video_shift",
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
@@ -434599,6 +436663,55 @@
       "weight": 0.8
     },
     {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/attention.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/backend.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/offload.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/sampler.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/h3_factory.rs",
+      "target": "file:crates/mold-inference/src/minimax_h3/vae_runtime.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
       "source": "file:crates/mold-inference/src/image.rs",
       "target": "function:crates/mold-inference/src/image.rs:build_output_metadata",
       "type": "contains",
@@ -434702,55 +436815,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/attention.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/backend.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/offload.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/sampler.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/h3_factory.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/vae_runtime.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:crates/mold-inference/src/lib.rs",
@@ -434986,13 +437050,6 @@
     {
       "source": "file:crates/mold-inference/src/lib.rs",
       "target": "file:crates/mold-inference/src/flux2/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/lib.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -440802,20 +442859,6 @@
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
       "target": "function:crates/mold-inference/src/minimax_h3/engine.rs:observe",
       "type": "contains",
       "direction": "forward",
@@ -440855,6 +442898,20 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
+      "target": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/engine.rs",
@@ -441079,13 +443136,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/engine.rs:new",
-      "target": "function:crates/mold-inference/src/minimax_h3/mod.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs",
@@ -442110,34 +444160,6 @@
       "weight": 0.7
     },
     {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:grid_points",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:grid_points",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:identity_sha256",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:identity_sha256",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:execution_fingerprint",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:execution_fingerprint",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs:prepare",
-      "target": "function:crates/mold-inference/src/minimax_h3/mod.rs:prepare",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-inference/src/minimax_h3/private_qualification.rs",
       "target": "function:crates/mold-inference/src/minimax_h3/private_qualification.rs:authorization_record_sha256",
       "type": "contains",
@@ -442507,2106 +444529,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_stable_cuda_device_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_stable_cuda_device_id",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available_for_task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reviewed_h3_private_runtime_available_for_task",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:canonical_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:canonical_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:task",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_id",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_ordinal",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_ordinal",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compute_capability",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compute_capability",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_with_adapter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_with_adapter",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_adapter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_adapter",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for_task_with_reviewed_steps",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_prepared_with_adapter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:conditioning_mismatches",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:row_cap_mismatches",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:update_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_device_floor_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_device_floor_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_host_floor_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_host_floor_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_admission_capacity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_prepared_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:precheck_private_h3_record_canvas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:check_private_h3_target_budget_fits",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_unified_target_peak_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_qwen_route",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:into_authority",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admission_evidence_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admission_evidence_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:artifact_qualification_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:artifact_qualification_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:work_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:work_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:cancellation_scope_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:cancellation_scope_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:memory_ledger_sequence",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:memory_ledger_sequence",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:consumption_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:consumption_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_against_binding",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_host_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_host_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fixed_runtime_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:qwen_activation_workspace_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:qwen_activation_workspace_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:vae_construction_device_workspace_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:vae_construction_device_workspace_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:condition_vae_workspace_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:condition_vae_workspace_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention_workspace_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention_workspace_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ffn_workspace_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ffn_workspace_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:decoder_tile_workspace_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:decoder_tile_workspace_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:audio_decode_workspace_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:audio_decode_workspace_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:encoded_video_host_bytes_bound",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:encoded_video_host_bytes_bound",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:thumbnail_host_bytes_bound",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:thumbnail_host_bytes_bound",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mux_output_host_bytes_bound",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mux_output_host_bytes_bound",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:aac_mux_staging_host_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:aac_mux_staging_host_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:mode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_available_device_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_available_device_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_host_headroom_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_host_headroom_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:base_factory_authority",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:base_factory_authority",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:execution_fingerprint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:execution_fingerprint",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:component_set_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:component_set_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_request_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_request_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_attempt_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepared_attempt_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:target_budget_identity_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:target_budget_identity_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_device_peak_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_device_peak_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_host_increment_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:predicted_host_increment_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:seed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:seed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_bounds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_bounds",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:resolve_request",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:resolve_request",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_resolved_request",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_resolved_request",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_h3_route",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:admitted_h3_route",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_admission",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_admission",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_reviewed_h3_private_fl2va_admission",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_request_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_digests",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_vae_artifact_binding_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_digest",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_owner_component_digests",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_component_role",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:update_private_h3_qualified_artifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_execution_fingerprint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_pruned_adaln_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_admission_evidence_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:fmt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_context",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_consumption_binding_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:facts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:facts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run_once",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run_once",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from_runner",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_attempt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_h3_private_fl2va_attempt",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:prepare_reviewed_h3_private_fl2va_attempt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_h3_project_owner_fence_budget",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_base_factory",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_frozen_reopen_route",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:exact_qualified_qwen_artifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_lease_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:from_opened",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:checkpoint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:with_private_h3_cuda_execution_attempt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_envelope_conditioning",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_envelope_observation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:run",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_run_output",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_private_sampler_provenance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attempt_facts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attempt_facts_with_scheduler_budget",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:commit_once",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:commit_once",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:is_committed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:is_committed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:scheduler_ledger_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:derive",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:derive",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:activation_evidence_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:activation_prerequisite_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:record_file_sha256",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:record_file_sha256",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:bounds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:bounds",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_bounds_for_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compact_envelope_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_envelope_for_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_profile_identities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_public_runtime_profile_with_turbo",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:reference_qwen_vision_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:ref2va_reference_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_envelope_for_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_ref2va_runtime_bounds_for_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_envelope",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_bounds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_capture_runtime_profile",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:capture_runtime_qualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:h3_capture_bound_report",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:h3_capture_bound_report",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:public_runtime_qualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:revalidate_runtime_qualification_file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_route",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:private_runtime_qualification_source",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:open_reviewed_h3_private_runtime_qualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:open_reviewed_h3_private_runtime_qualification_for_source",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_public_presentation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_public_presentation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation_with_scope",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_presentation_for_test",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification_with_allowlist",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:authenticate_h3_private_runtime_qualification_for_source",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_binding",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate_runtime_qualification_record_shape",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:runtime_qualification_identity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "function:crates/mold-inference/src/minimax_h3/private_server.rs:valid_runtime_evidence_relative_path",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationRoute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationRoute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationAuthority",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePresentationAuthority",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEnvelopeRecord",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEnvelopeRecord",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeBoundRecord",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeBoundRecord",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEvidenceArtifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeEvidenceArtifact",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationRecord",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationRecord",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAttemptFacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAttemptFacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaMediaContract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaMediaContract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaTerminalIdentityEcho",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaTerminalIdentityEcho",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunOutput",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunOutput",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateHostHeadroomShortfall",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateHostHeadroomShortfall",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateDeviceHeadroomShortfall",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateDeviceHeadroomShortfall",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareInput",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPrepareInput",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaUatPaths",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaUatPaths",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionInput",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionInput",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRuntimeBounds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRuntimeBounds",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionEvidence",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaAdmissionEvidence",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3AdmittedRoute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3AdmittedRoute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFenceFacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFenceFacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunContext",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaRunContext",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAttemptConsumptionBinding",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedRunner",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedAttempt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaPreparedAttempt",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerConditionerLease",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerExecutionLease",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerQwenArtifactLease",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateServerFl2VaArtifactLease",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePreparationCheckpoint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivatePreparationCheckpoint",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateConcretePreparedRunner",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFl2VaOwnerFacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateSchedulerLedgerIdentity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateSchedulerLedgerIdentity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFactoryActivationEvidence",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateFactoryActivationEvidence",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAllocationCommit",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateAllocationCommit",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationAuthority",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationAuthority",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:RuntimeQualificationStorage",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateReviewedRuntimeQualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "class:crates/mold-inference/src/minimax_h3/private_server.rs:H3PrivateRuntimeQualificationSource",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "file:crates/mold-inference/src/attention.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "file:crates/mold-inference/src/engine.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
-      "target": "file:crates/mold-inference/src/progress.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:attention",
-      "target": "function:crates/mold-inference/src/attention.rs:attention",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:validate",
-      "target": "function:crates/mold-inference/src/engine.rs:validate",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:identity_sha256",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:identity_sha256",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:component_set_identity_sha256",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:component_set_identity_sha256",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:canonical_model",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:canonical_model",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:task",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:task",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_id",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:device_id",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:device_ordinal",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:device_ordinal",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:compute_capability",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:compute_capability",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:execution_fingerprint",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:execution_fingerprint",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:qwen_activation_workspace_bytes",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:qwen_activation_workspace_bytes",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/private_server.rs:new",
-      "target": "function:crates/mold-inference/src/minimax_h3/mod.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/reference_media.rs",
@@ -445552,34 +445474,6 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/vae_runtime.rs:new",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/vae_runtime.rs:identity_sha256",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:identity_sha256",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/vae_runtime.rs:canonical_model",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:canonical_model",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/minimax_h3/vae_runtime.rs:task",
-      "target": "function:crates/mold-inference/src/h3_factory.rs:task",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "function:crates/mold-inference/src/minimax_h3/vae_runtime.rs:new",
@@ -446717,6 +446611,125 @@
     },
     {
       "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/api/client.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/generationTemplates.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/testSupport/memoryLocalStorage.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileApp.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileLoraControls.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileTemplates.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/galleryCache.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileDownloads.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileGenerationRecovery.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileTemplateStorage.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/components/IdentityPhotoWell.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/lib/libraryOrganization.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/stores/sequenceDraft.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
       "target": "function:desktop/src/mobile/MobileApp.test.ts:plannedPlacement",
       "type": "contains",
       "direction": "forward",
@@ -446998,125 +447011,6 @@
     {
       "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
       "target": "file:ui/lib/sourceFitPreprocessCache.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/api/client.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/generationTemplates.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/testSupport/memoryLocalStorage.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileApp.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileLoraControls.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileTemplates.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/galleryCache.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileDownloads.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileGenerationRecovery.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileTemplateStorage.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/components/IdentityPhotoWell.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/lib/libraryOrganization.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/stores/sequenceDraft.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -449118,6 +449012,34 @@
     },
     {
       "source": "file:web/src/components/create/ActivityStrip.test.ts",
+      "target": "file:web/src/components/create/ActivityStrip.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/ActivityStrip.test.ts",
+      "target": "file:web/src/composables/useGenerateStream.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/ActivityStrip.test.ts",
+      "target": "file:web/src/lib/hostRegistry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/ActivityStrip.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/ActivityStrip.test.ts",
       "target": "function:web/src/components/create/ActivityStrip.test.ts:makeJob",
       "type": "contains",
       "direction": "forward",
@@ -449160,34 +449082,6 @@
     },
     {
       "source": "file:web/src/api.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/ActivityStrip.test.ts",
-      "target": "file:web/src/components/create/ActivityStrip.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/ActivityStrip.test.ts",
-      "target": "file:web/src/composables/useGenerateStream.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/ActivityStrip.test.ts",
-      "target": "file:web/src/lib/hostRegistry.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/ActivityStrip.test.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -449468,6 +449362,41 @@
     },
     {
       "source": "file:web/src/composables/useGenerateStream.test.ts",
+      "target": "file:web/src/api.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.test.ts",
+      "target": "file:web/src/composables/useGenerateStream.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.test.ts",
+      "target": "file:web/src/lib/chainRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.test.ts",
+      "target": "file:web/src/lib/hostRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.test.ts",
       "target": "function:web/src/composables/useGenerateStream.test.ts:chainJobDetail",
       "type": "contains",
       "direction": "forward",
@@ -449521,6 +449450,14 @@
       "type": "contains",
       "direction": "forward",
       "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateStream.ts",
+      "target": "file:web/src/composables/useGenerateStream.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
     },
     {
       "source": "file:web/src/composables/useGenerateStream.ts",
@@ -449909,41 +449846,6 @@
     },
     {
       "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateStream.test.ts",
-      "target": "file:web/src/api.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateStream.test.ts",
-      "target": "file:web/src/composables/useGenerateStream.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateStream.test.ts",
-      "target": "file:web/src/lib/chainRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateStream.test.ts",
-      "target": "file:web/src/lib/hostRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateStream.test.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -456635,8 +456537,1310 @@
       "weight": 0.7
     },
     {
-      "source": "file:crates/mold-core/src/lib.rs",
-      "target": "file:crates/mold-core/src/minimax_h3.rs",
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_reviewed_compact_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_reviewed_compact_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model_for_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model_for_task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:storage_identity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:storage_identity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:turbo_tier_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:turbo_tier_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_pad_rows_per_block",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_pad_rows_per_block",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_patch_rows_per_block",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qwen_vision_patch_rows_per_block",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_admitted_compact_canvas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_admitted_compact_canvas",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_pixels",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_pixels",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_axis_pixels",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_axis_pixels",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_min_axis_pixels",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_min_axis_pixels",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_aspect_bounds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_aspect_bounds",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:largest_admitted_compact_canvas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:largest_admitted_compact_canvas",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qualified_canvases_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:qualified_canvases_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_dimensions_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_dimensions_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:capabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_runtime_available",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_runtime_available",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:engine_is_built",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:engine_is_built",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:task_runtime_available",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:task_runtime_available",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_available",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_available",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reason",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reason",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:runtime_availability_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:runtime_availability_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:model_runtime_availability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:model_runtime_availability",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:capability_contract_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:capability_contract_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:runnable_capability_contract_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:runnable_capability_contract_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:canonical_family",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:canonical_family",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_family",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:is_family",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:repo_revision",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:repo_revision",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:file_revision",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:file_revision",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:task_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:task_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:uses_reviewed_compact_envelope",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:uses_reviewed_compact_envelope",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:resolve_model_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:resolve_model_name",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:canonicalize_request_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:canonicalize_request_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:video_latent_frames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:video_latent_frames",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:rows_per_video_latent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:rows_per_video_latent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:target_video_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:target_video_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_latents_per_channel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_latents_per_channel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:target_audio_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:target_audio_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_samples_per_channel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_samples_per_channel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:vocoder_audio_samples_per_channel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:vocoder_audio_samples_per_channel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:fixed_frames_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:fixed_frames_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count_for_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:source_fit_dimensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:source_fit_dimensions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_violation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_provenance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_duration",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:checked_duration_sum",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:aligned_dimension",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_image_dimensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_video_dimensions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:normalized_reference_video_frames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:exact_reference_frame_count",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_at",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_for_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_for_target",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes_for_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes_for_target",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_references",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_references",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_descriptors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_descriptors",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_set",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reviewed_canvas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reviewed_canvas",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_resolved_request_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_resolved_request_contract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract_with_reference_authority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:manifest_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:manifest_contract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:artifact_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:artifact_contract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:official_shared_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:official_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:official_task_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:official_runtime_support_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:compact_shared_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:comfy_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:nvfp4_files",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:defaults_with_steps",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:manifests",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "function:crates/mold-core/src/minimax_h3.rs:manifests",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:TurboManifestTier",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:TurboManifestTier",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:GenerationReferencePreparedShape",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:GenerationReferencePreparedShape",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseSeedSource",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseSeedSource",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawCardinality",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawCardinality",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawContract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawContract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Task",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Layout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Layout",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Mode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Mode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendQualification",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendQualification",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendApplicability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendApplicability",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:Capabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ModelCapabilityContract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ModelCapabilityContract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeUnavailableReason",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeUnavailableReason",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeAvailability",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeAvailability",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ContractError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ContractError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ReferenceContractError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ReferenceContractError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactRole",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactRole",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ManifestContract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ManifestContract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactIdentity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactIdentity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactContract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactContract",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/minimax_h3.rs",
+      "target": "file:crates/mold-core/src/manifest.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -458798,1280 +460002,6 @@
       "weight": 1
     },
     {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_reviewed_compact_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_reviewed_compact_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model_for_task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model_for_task",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:base_compact_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:storage_identity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:storage_identity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:turbo_tier_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:turbo_tier_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_admitted_compact_canvas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_admitted_compact_canvas",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_pixels",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_pixels",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_axis_pixels",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_max_axis_pixels",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_min_axis_pixels",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_min_axis_pixels",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_aspect_bounds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reviewed_compact_aspect_bounds",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:largest_admitted_compact_canvas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:largest_admitted_compact_canvas",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:qualified_canvases_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:qualified_canvases_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_dimensions_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_dimensions_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:capabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_runtime_available",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_runtime_available",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:engine_is_built",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:engine_is_built",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:task_runtime_available",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:task_runtime_available",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:message",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_available",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_available",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reason",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reason",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:runtime_availability_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:runtime_availability_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:model_runtime_availability",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:model_runtime_availability",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:capability_contract_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:capability_contract_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:runnable_capability_contract_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:runnable_capability_contract_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:canonical_family",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:canonical_family",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_family",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:is_family",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:repo_revision",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:repo_revision",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:file_revision",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:file_revision",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:task_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:task_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:uses_reviewed_compact_envelope",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:uses_reviewed_compact_envelope",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:layout_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:resolve_model_name",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:resolve_model_name",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:canonicalize_request_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:canonicalize_request_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:video_latent_frames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:video_latent_frames",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:rows_per_video_latent",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:rows_per_video_latent",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:target_video_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:target_video_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_latents_per_channel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_latents_per_channel",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:target_audio_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:target_audio_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_samples_per_channel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_samples_per_channel",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:vocoder_audio_samples_per_channel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:vocoder_audio_samples_per_channel",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:fixed_frames_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:fixed_frames_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:valid_frame_count_for_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_frames",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:source_fit_dimensions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:source_fit_dimensions",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:recommended_dimensions",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_violation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_provenance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_duration",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:checked_duration_sum",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:aligned_dimension",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_image_dimensions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_video_dimensions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:normalized_reference_video_frames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:exact_reference_frame_count",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:audio_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_at",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_for_target",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shape_for_target",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes_for_target",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:reference_prepared_shapes_for_target",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_references",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_references",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_descriptors",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_descriptors",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reference_set",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reviewed_canvas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_reviewed_canvas",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_resolved_request_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_resolved_request_contract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:validate_request_contract_with_reference_authority",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:manifest_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:manifest_contract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:artifact_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:artifact_contract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:official_shared_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:official_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:official_task_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:official_runtime_support_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:compact_shared_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:comfy_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:nvfp4_files",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:defaults_with_steps",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:manifests",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "function:crates/mold-core/src/minimax_h3.rs:manifests",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:TurboManifestTier",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:TurboManifestTier",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:GenerationReferencePreparedShape",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:GenerationReferencePreparedShape",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseSeedSource",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseSeedSource",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawCardinality",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawCardinality",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawContract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:NoiseDrawContract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Task",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Layout",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Layout",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Mode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Mode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendQualification",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendQualification",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendApplicability",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:BackendApplicability",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:Capabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ModelCapabilityContract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ModelCapabilityContract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeUnavailableReason",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeUnavailableReason",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeAvailability",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:RuntimeAvailability",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ContractError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ContractError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ReferenceContractError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ReferenceContractError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactRole",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactRole",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ManifestContract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ManifestContract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactIdentity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactIdentity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactContract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "class:crates/mold-core/src/minimax_h3.rs:ArtifactContract",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-core/src/manifest.rs",
       "target": "file:crates/mold-core/src/config.rs",
       "type": "imports",
@@ -460081,13 +460011,6 @@
     {
       "source": "file:crates/mold-core/src/manifest.rs",
       "target": "file:crates/mold-core/src/types.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/minimax_h3.rs",
-      "target": "file:crates/mold-core/src/manifest.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -510202,14 +510125,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:web/src/composables/useGenerateStream.ts",
-      "target": "file:web/src/composables/useGenerateStream.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:web/src/composables/useHostRouting.ts",
       "target": "file:web/src/composables/useHostRouting.test.ts",
       "type": "tested_by",
@@ -510356,14 +510271,6 @@
     {
       "source": "file:desktop/src/mobile/mobileGenerationRecovery.ts",
       "target": "file:desktop/src/mobile/mobileGenerationRecovery.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:desktop/src/stores/generation.ts",
-      "target": "file:desktop/src/stores/generation.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -511051,31 +510958,7 @@
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/mod.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/engine.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/mod.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/private_opened_evidence.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/mod.rs",
       "target": "file:crates/mold-inference/src/minimax_h3/private_qualification.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/mod.rs",
-      "target": "file:crates/mold-inference/src/minimax_h3/private_server.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511139,14 +511022,6 @@
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_fl2va_runtime.rs",
       "target": "file:crates/mold-inference/src/progress.rs",
       "type": "imports",
       "direction": "forward",
@@ -511179,14 +511054,6 @@
     },
     {
       "source": "file:crates/mold-inference/src/minimax_h3/private_runtime.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_runtime.rs",
       "target": "file:crates/mold-inference/src/progress.rs",
       "type": "imports",
       "direction": "forward",
@@ -511196,22 +511063,6 @@
     {
       "source": "file:crates/mold-inference/src/minimax_h3/private_vae_adapter.rs",
       "target": "file:crates/mold-inference/src/engine.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/private_vae_adapter.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/minimax_h3/turbo.rs",
-      "target": "file:crates/mold-inference/src/h3_factory.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -512227,14 +512078,6 @@
     },
     {
       "source": "file:desktop/src/components/shell/CommandPalette.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/shell/CommandPalette.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -512244,14 +512087,6 @@
     {
       "source": "file:desktop/src/components/shell/CommandPalette.test.ts",
       "target": "file:desktop/src/stores/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/shell/StatusPopover.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513115,14 +512950,6 @@
     },
     {
       "source": "file:desktop/src/mobile/main.ts",
-      "target": "file:desktop/src/mobile/MobileApp.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/main.ts",
       "target": "file:desktop/src/mobile/mobile.css",
       "type": "imports",
       "direction": "forward",
@@ -513314,24 +513141,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/stores/events.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/stores/events.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/stores/events.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513435,14 +513246,6 @@
     },
     {
       "source": "file:desktop/src/stores/jobs.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/stores/jobs.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -513460,14 +513263,6 @@
     {
       "source": "file:desktop/src/stores/jobs.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/stores/jobs.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513532,14 +513327,6 @@
     {
       "source": "file:desktop/src/stores/pullResume.test.ts",
       "target": "file:desktop/src/stores/downloads.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/stores/pullResume.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513619,14 +513406,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.expansionStyle.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.expansionStyle.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -513644,14 +513423,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.persistence.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.persistence.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513708,14 +513479,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/generation.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513892,22 +513655,6 @@
     {
       "source": "file:studio/components/QueuePlanWorkList.test.ts",
       "target": "file:studio/api/queuePlan.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:studio/lib/activity.test.ts",
-      "target": "file:studio/lib/api/chainTypes.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:studio/lib/activity.test.ts",
-      "target": "file:studio/lib/queuePosition.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-08-28T14:10:08.933Z",
-  "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3",
+  "lastAnalyzedAt": "2026-08-28T14:18:27.000Z",
+  "gitCommitHash": "92e2ba496f507ac27216b6a1c1296e88df5220d9",
   "version": "1.0.0",
   "analyzedFiles": 2294
 }

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-08-28T12:03:12.000Z",
-  "gitCommitHash": "3a400633b658883a05508bc8eb24e194ef5cb03d",
+  "lastAnalyzedAt": "2026-08-28T14:10:08.933Z",
+  "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3",
   "version": "1.0.0",
-  "analyzedFiles": 2290
+  "analyzedFiles": 2294
 }

--- a/changelog.d/chain-snapshot-live-status.md
+++ b/changelog.d/chain-snapshot-live-status.md
@@ -1,1 +1,1 @@
-Auto-chained video snapshots now restore an already-running clip or finalization phase instead of leaving desktop, web, and mobile activity rows stuck on Queued.
+- **Live sequence status.** Auto-chained video snapshots now restore an already-running clip or finalization phase instead of leaving desktop, web, and mobile activity rows stuck on Queued.

--- a/changelog.d/chain-snapshot-live-status.md
+++ b/changelog.d/chain-snapshot-live-status.md
@@ -1,0 +1,1 @@
+Auto-chained video snapshots now restore an already-running clip or finalization phase instead of leaving desktop, web, and mobile activity rows stuck on Queued.

--- a/desktop/src/stores/generation.multihost.test.ts
+++ b/desktop/src/stores/generation.multihost.test.ts
@@ -38,7 +38,7 @@ const primary = vi.hoisted(() => ({
 const apiFetchTo = vi.fn().mockResolvedValue(new Response(null, { status: 200 }));
 
 /** The opening snapshot a chain job's own event stream sends. */
-function chainSnapshot(): Record<string, unknown> {
+function chainSnapshot(activeStage: number | null = null): Record<string, unknown> {
   return {
     id: "chain-job-1",
     state: "running",
@@ -49,7 +49,11 @@ function chainSnapshot(): Record<string, unknown> {
     updated_at_unix_ms: 2,
     error: null,
     ephemeral: true,
-    stages: [0, 1, 2].map((idx) => ({ idx, state: "pending" })),
+    execution_phase: activeStage === null ? "queued" : "running",
+    stages: [0, 1, 2].map((idx) => ({
+      idx,
+      state: idx === activeStage ? "running" : "pending",
+    })),
     script: { chain: {}, stages: [{ frames: 97 }, { frames: 97 }, { frames: 47 }] },
   };
 }
@@ -507,6 +511,33 @@ describe("generation store multi-host routing", () => {
       method: "POST",
     });
     expect(jobs[0]).toMatchObject({ status: "error", error: "Cancelled" });
+  });
+
+  it("restores a running automatic chain from its opening snapshot", async () => {
+    sseStream.mockImplementation(
+      (_path: string, opts: { signal: AbortSignal; onEvent: (e: string, d: string) => void }) => {
+        opts.onEvent("chain_job", JSON.stringify({ type: "snapshot", job: chainSnapshot(1) }));
+        return new Promise<void>((resolve) => {
+          opts.signal.addEventListener("abort", () => resolve());
+        });
+      },
+    );
+    const store = useGenerationStore();
+    const { jobs } = store.submitBatch(
+      { ...request(), model: "ltx-2.3-22b-distilled:fp8", frames: 241, fps: 24 },
+      1,
+      halRoute,
+      chainDecision,
+    );
+
+    await flushPromises();
+
+    expect(jobs[0]).toMatchObject({
+      status: "loading",
+      chainStageIndex: 1,
+      stage: "Preparing clip 2 of 3",
+    });
+    await store.cancel(jobs[0]!.clientId);
   });
 
   it("rejects a defensive reject decision before creating jobs", () => {

--- a/studio/lib/chainJobProgress.test.ts
+++ b/studio/lib/chainJobProgress.test.ts
@@ -51,6 +51,45 @@ function run(events: ChainJobEvent[]): {
 }
 
 describe("reduceChainJobFrame", () => {
+  it("replays an already-running stage from the opening snapshot", () => {
+    const job = detail();
+    job.state = "running";
+    job.execution_phase = "running";
+    job.current_stage = 1;
+    job.stages[1] = { ...job.stages[1]!, state: "running" };
+
+    const result = reduceChainJobFrame(emptyChainJobLive(), {
+      type: "snapshot",
+      job,
+    });
+
+    expect(result.progress).toEqual([
+      { type: "chain_start", stage_count: 2, estimated_total_frames: 194 },
+      { type: "stage_start", stage_idx: 1 },
+    ]);
+  });
+
+  it("replays finalization from the opening snapshot", () => {
+    const job = detail();
+    job.state = "running";
+    job.execution_phase = "finalizing";
+    job.current_stage = 1;
+    job.stages = job.stages.map((stage) => ({
+      ...stage,
+      state: "completed",
+    }));
+
+    const result = reduceChainJobFrame(emptyChainJobLive(), {
+      type: "snapshot",
+      job,
+    });
+
+    expect(result.progress).toEqual([
+      { type: "chain_start", stage_count: 2, estimated_total_frames: 194 },
+      { type: "stitching", total_frames: 194 },
+    ]);
+  });
+
   it("opens with chain_start built from the snapshot, not a synthesized frame", () => {
     const { progress } = run([{ type: "snapshot", job: detail() }]);
     expect(progress).toEqual([

--- a/studio/lib/chainJobProgress.ts
+++ b/studio/lib/chainJobProgress.ts
@@ -54,7 +54,7 @@ export interface ChainJobTerminal {
 
 export interface ChainJobFrameResult {
   live: ChainJobLive;
-  /** Zero or one progress frame; `yielded` produces none. */
+  /** Ordered surface frames; a resumed snapshot can produce two. */
   progress: ChainJobProgressFrame[];
   finalized: ChainJobFinalized | null;
   terminal: ChainJobTerminal | null;
@@ -107,16 +107,37 @@ export function reduceChainJobFrame(
     terminal: null,
   };
   switch (event.type) {
-    case "snapshot":
+    case "snapshot": {
+      // Subscribe happens before the server reads this snapshot, but a stage
+      // may already have started before the HTTP event stream was opened.
+      // The snapshot's running stage is durable truth: replay that transition
+      // so every one-shot chain leaves its optimistic Queued state even when
+      // the original stage_start delta was published before this subscriber
+      // existed. A reconnect deliberately reasserts the snapshot's durable
+      // phase too: a brief Preparing label is more truthful than retaining a
+      // stale denoise step while the stream catches up. The same applies to a
+      // job already stitching its output.
+      const resumedProgress: ChainJobProgressFrame[] = [
+        {
+          type: "chain_start",
+          stage_count: event.job.stage_count,
+          estimated_total_frames: estimatedChainFrames(live),
+        },
+      ];
+      if (live.activeStage !== null) {
+        resumedProgress.push({
+          type: "stage_start",
+          stage_idx: live.activeStage,
+        });
+      } else if (event.job.execution_phase === "finalizing") {
+        resumedProgress.push({
+          type: "stitching",
+          total_frames: estimatedChainFrames(live),
+        });
+      }
       return {
         ...base,
-        progress: [
-          {
-            type: "chain_start",
-            stage_count: event.job.stage_count,
-            estimated_total_frames: estimatedChainFrames(live),
-          },
-        ],
+        progress: resumedProgress,
         // A job that is already terminal when we attach still has to settle,
         // and its print is then in the manifest's last finalize record — the
         // only place the gallery filename exists after the stream is gone.
@@ -127,6 +148,7 @@ export function reduceChainJobFrame(
           ? { state: event.job.state, error: event.job.error ?? null }
           : null,
       };
+    }
     case "stage_start":
       return {
         ...base,

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -626,6 +626,32 @@ describe("workStarted tracking", () => {
     expect(job.progress.stage).toBe("Stitching 241 frames…");
   });
 
+  it("restores active work when the opening chain snapshot is already running", async () => {
+    const stream = useGenerateStream();
+    const id = stream.submit(singleGen({ frames: 241 }), chainDecision());
+    await vi.waitFor(() =>
+      expect(
+        (fetchEventSource.mock.calls as unknown[][]).some((entry) =>
+          String(entry[0]).includes("/api/chain-jobs/"),
+        ),
+      ).toBe(true),
+    );
+    const job = stream.jobs.value.find((candidate) => candidate.id === id)!;
+    const snapshot = chainJobDetail();
+    snapshot.execution_phase = "running";
+    snapshot.current_stage = 1;
+    snapshot.stages = [
+      { idx: 0, state: "completed" },
+      { idx: 1, state: "running" },
+      { idx: 2, state: "pending" },
+    ];
+
+    emitChainJobEvent({ type: "snapshot", job: snapshot });
+
+    expect(job.workStarted).toBe(true);
+    expect(job.progress.stage).toBe("Preparing clip 2/3");
+  });
+
   it("returns to automatic canvas selection when new work is submitted", async () => {
     const stream = useGenerateStream();
     const inspected = await submitDurable(


### PR DESCRIPTION
## Summary

- restore active clip status when an auto-chained generation subscribes after its stage already started
- restore finalization status from durable snapshots instead of leaving activity rows queued
- cover the shared reducer plus web and desktop surface integration paths

## Root cause

The durable chain event stream opens with a snapshot. When a WAN stage started before the client subscription opened, that snapshot correctly contained a running stage, but the progress adapter emitted only `chain_start`. Every activity surface therefore reduced the job back to Queued until a later denoise event arrived.

The shared adapter now emits the ordered snapshot truth: chain shape followed by the running stage or finalization phase. Desktop, web, and the mobile generation store consume this shared path.

## Validation

- live `plato` scheduler, queue plan, and chain-job state inspection
- `nix develop -c bun run test:studio -- studio/lib/chainJobProgress.test.ts`
- `nix develop -c bun run test:web -- src/composables/useGenerateStream.test.ts`
- `nix develop -c bun run test:desktop -- src/stores/generation.multihost.test.ts`
- `nix develop -c bun run check:frontend`
- Claude Sonnet peer review: no blocking findings; documentation and desktop coverage follow-ups addressed
