### PR TITLE
perf(desktop): Library store/render hot paths + regression guards (gallery perf 1/4)

### DIFF
--- a/changelog.d/gallery-perf-desktop-store.md
+++ b/changelog.d/gallery-perf-desktop-store.md
@@ -1,0 +1,12 @@
+- **Desktop Library stays smooth past 1 000 prints.** The gallery store now
+  indexes each print's organization and cross-host copies once per data change
+  instead of re-deriving them for every tile on every render (one filter change
+  used to run ~10 full passes over the library, and each visible tile scanned
+  every bucket), the grid renders one flat print-keyed tile layer so a
+  thumbnail-size drag or window resize moves tiles instead of remounting their
+  media, a 304 poll no longer invalidates the merged grid, gallery rows are
+  raw immutable snapshots rather than deep-reactive proxies, the thumbnail
+  scheduler dispatches in O(hosts) instead of re-sorting the whole queue, and
+  History ▸ Runs is capped like Sequences. Operation-count regression guards
+  (`gallery.perf.test.ts`, `LibraryView.perf.test.ts`, the scheduler drain
+  test) fail CI if any of these hot paths regress.

--- a/desktop/src/components/gallery/AuthedMedia.vue
+++ b/desktop/src/components/gallery/AuthedMedia.vue
@@ -1,6 +1,10 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, ref, watch } from "vue";
-import { galleryThumbnailScheduler, type ThumbnailHandle } from "@studio/lib/thumbnailScheduler";
+import {
+  galleryThumbnailScheduler,
+  type ThumbnailHandle,
+  type ThumbnailPriority,
+} from "@studio/lib/thumbnailScheduler";
 import { authedMediaUrl, fullSizeMediaUrl } from "../../lib/gallery/media";
 import type { ApiTarget } from "../../lib/api/client";
 
@@ -17,6 +21,10 @@ const props = withDefaults(
     /** Blob-cache bucket, usually the origin host id. */
     cacheKey?: string | null;
     mediaVersion?: string | null;
+    /** Scheduler priority for a thumbnail: on-screen tiles are `visible`,
+     *  overscan rows `near`, prewarm `background`. Raising it promotes a
+     *  queued request in place; the scheduler never demotes. */
+    priority?: ThumbnailPriority;
   }>(),
   {
     video: false,
@@ -26,6 +34,7 @@ const props = withDefaults(
     target: null,
     cacheKey: null,
     mediaVersion: null,
+    priority: "visible",
   },
 );
 
@@ -64,7 +73,7 @@ async function load() {
             const handle = galleryThumbnailScheduler.schedule({
               key: `${props.cacheKey ?? "primary"}|${props.path}|${props.mediaVersion ?? "legacy"}|${props.target?.baseUrl ?? "primary"}|${props.target?.apiKey ?? ""}`,
               hostKey: props.cacheKey ?? props.target?.baseUrl ?? "primary",
-              priority: "visible",
+              priority: props.priority,
               run: (signal) => authedMediaUrl(props.path, { ...options, signal }),
             });
             thumbnailHandle = handle;
@@ -102,6 +111,12 @@ watch(
   ],
   load,
 );
+// A tile scrolling from the overscan band into view promotes its queued
+// request without restarting it.
+watch(
+  () => props.priority,
+  (priority) => thumbnailHandle?.setPriority(priority),
+);
 onMounted(load);
 onUnmounted(() => {
   loadEpoch += 1;
@@ -121,7 +136,14 @@ onUnmounted(() => {
     disablepictureinpicture
   />
   <audio v-else-if="audio && src" :src="src" class="w-full" controls />
-  <img v-else-if="src" :src="src" :alt="alt" class="h-full w-full object-cover" draggable="false" />
+  <img
+    v-else-if="src"
+    :src="src"
+    :alt="alt"
+    class="h-full w-full object-cover"
+    decoding="async"
+    draggable="false"
+  />
   <div v-else-if="failed" class="flex h-full w-full items-center justify-center bg-bench">
     <span class="edge-code">UNREADABLE</span>
   </div>

--- a/desktop/src/components/library/HistoryDrawer.test.ts
+++ b/desktop/src/components/library/HistoryDrawer.test.ts
@@ -41,6 +41,7 @@ import { useChainJobsStore } from "../../stores/chainJobs";
 import { useAppPrefsStore } from "../../stores/appPrefs";
 import type { GalleryImage } from "../../lib/api/types";
 import type { ChainJobSummary } from "@studio/lib/api/chainTypes";
+import { HISTORY_JOBS_RENDER_CAP } from "@studio/lib/activity";
 
 const stub = { template: "<div />" };
 
@@ -188,6 +189,21 @@ describe("HistoryDrawer runs", () => {
       }),
     });
     expect(router.currentRoute.value.path).toBe("/create");
+  });
+
+  it("caps the Runs list at the History render cap and says so", async () => {
+    const wrapper = await mountDrawer();
+    const gallery = useGalleryStore();
+    const many: GalleryImage[] = [];
+    for (let i = 0; i < HISTORY_JOBS_RENDER_CAP + 50; i++) {
+      many.push(run(`bulk-${i}.png`, `bulk print ${i}`, 1_700_100_000 - i));
+    }
+    gallery.buckets["local"]!.items = many;
+    await flushPromises();
+    expect(wrapper.findAll('[data-test="run-row"]').length).toBe(HISTORY_JOBS_RENDER_CAP);
+    expect(wrapper.get('[data-test="runs-cap-note"]').text()).toContain(
+      `showing ${HISTORY_JOBS_RENDER_CAP} of ${HISTORY_JOBS_RENDER_CAP + 50}`,
+    );
   });
 
   it("filters runs by prompt text", async () => {

--- a/desktop/src/components/library/HistoryDrawer.vue
+++ b/desktop/src/components/library/HistoryDrawer.vue
@@ -142,14 +142,23 @@ const runs = computed<MergedPrint[]>(() => {
  *  grouping key carries the origin so same-named prints on two hosts stay
  *  distinct rows. */
 const runKey = (e: MergedPrint) => `${e.sourceKey}\0${e.item.filename}`;
+/** The Runs list is not windowed, and every row mounts a thumbnail, so it is
+ *  capped exactly like Sequences: a 1 000-print library must not mount 1 000
+ *  media requests the moment the drawer opens. */
+const visibleRuns = computed(() => runs.value.slice(0, HISTORY_JOBS_RENDER_CAP));
+const runsCapNote = computed(() =>
+  runs.value.length > HISTORY_JOBS_RENDER_CAP
+    ? `showing ${HISTORY_JOBS_RENDER_CAP} of ${runs.value.length} — search to narrow`
+    : null,
+);
 const runGroups = computed(() => {
-  const pseudo = runs.value.map((e) => ({
+  const pseudo = visibleRuns.value.map((e) => ({
     prompt: runKey(e),
     model: e.item.metadata.model,
     used_at: e.item.timestamp * 1000,
   }));
   const groups = groupByDay(pseudo);
-  const byKey = new Map(runs.value.map((e) => [runKey(e), e]));
+  const byKey = new Map(visibleRuns.value.map((e) => [runKey(e), e]));
   return groups.map((g) => ({
     label: g.label,
     runs: g.entries.map((e) => byKey.get(e.prompt)!).filter(Boolean),
@@ -670,6 +679,9 @@ async function cleanUpDiskConfirmed() {
             }}</span>
           </button>
         </template>
+        <p v-if="runsCapNote" data-test="runs-cap-note" class="edge-code mt-1">
+          {{ runsCapNote }}
+        </p>
       </div>
 
       <!-- Sequences: the durable chain jobs, with their maintenance -->

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -25,24 +25,42 @@ interface CachedObjectUrl {
 const THUMBNAIL_CACHE_ENTRIES = 512;
 const THUMBNAIL_CACHE_BYTES = 64 * 1024 * 1024;
 const cache = new Map<string, CachedObjectUrl>();
+/** Sum of `bytes` over settled cache entries, kept incrementally: summing
+ *  (or copying) the whole map per insert made every thumbnail load O(cache). */
+let retainedBytes = 0;
 
 function revokeCachedObjectUrl(entry: CachedObjectUrl): void {
   void entry.url.then((url) => URL.revokeObjectURL(url)).catch(() => {});
 }
 
+/** Record a settled entry's bytes exactly once. */
+function settleThumbnail(entry: CachedObjectUrl, bytes: number): void {
+  entry.bytes = bytes;
+  entry.settled = true;
+  retainedBytes += bytes;
+}
+
+function dropThumbnail(key: string, entry: CachedObjectUrl): void {
+  cache.delete(key);
+  if (entry.settled) retainedBytes -= entry.bytes ?? 0;
+}
+
 function trimThumbnailCache(): void {
-  let retainedBytes = 0;
-  for (const entry of cache.values()) retainedBytes += entry.bytes ?? 0;
   while (cache.size > THUMBNAIL_CACHE_ENTRIES || retainedBytes > THUMBNAIL_CACHE_BYTES) {
     // Never evict an unresolved promise: its caller has not received a usable
     // URL yet. Resolution re-enters this function, so a burst can exceed the
-    // bound only while requests are actively in flight.
-    const oldest = [...cache].find(([, entry]) => entry.settled);
+    // bound only while requests are actively in flight. Map iteration order
+    // is recency order, so the first settled entry is the oldest.
+    let oldest: [string, CachedObjectUrl] | null = null;
+    for (const candidate of cache) {
+      if (candidate[1].settled) {
+        oldest = candidate;
+        break;
+      }
+    }
     if (!oldest) break;
-    const [key, entry] = oldest;
-    cache.delete(key);
-    retainedBytes -= entry.bytes ?? 0;
-    revokeCachedObjectUrl(entry);
+    dropThumbnail(oldest[0], oldest[1]);
+    revokeCachedObjectUrl(oldest[1]);
   }
 }
 
@@ -140,20 +158,23 @@ export function authedMediaUrl(path: string, opts: AuthedMediaOptions = {}): Pro
           ).blob(),
       )
       .then((blob) => {
-        entry.bytes = blob.size;
-        entry.settled = true;
         const objectUrl = URL.createObjectURL(blob);
         // The host/path may have been invalidated while its request was in
         // flight. Do not leak an object URL that is no longer authoritative.
-        if (cache.get(key) !== entry) URL.revokeObjectURL(objectUrl);
-        else trimThumbnailCache();
+        if (cache.get(key) !== entry) {
+          entry.settled = true;
+          URL.revokeObjectURL(objectUrl);
+        } else {
+          settleThumbnail(entry, blob.size);
+          trimThumbnailCache();
+        }
         return objectUrl;
       });
     cached = entry;
     rememberThumbnail(key, entry);
     entry.url.catch(() => {
+      if (cache.get(key) === entry) dropThumbnail(key, entry);
       entry.settled = true;
-      if (cache.get(key) === entry) cache.delete(key);
     });
   } else {
     // Map insertion order is recency order.
@@ -338,12 +359,14 @@ export async function fetchGalleryMediaBytes(path: string, target: ApiTarget): P
 }
 
 function evictPrefix(prefix: string): void {
-  for (const [key, cached] of [...cache]) {
+  // Deleting the current entry during Map iteration is well-defined, so no
+  // snapshot copy is needed (a refetch called this once per removed row).
+  for (const [key, cached] of cache) {
     if (!key.startsWith(prefix)) continue;
-    cache.delete(key);
+    dropThumbnail(key, cached);
     revokeCachedObjectUrl(cached);
   }
-  for (const [key, cached] of [...fullSizeCache]) {
+  for (const [key, cached] of fullSizeCache) {
     if (!key.startsWith(prefix)) continue;
     fullSizeCache.delete(key);
     void cached.then((url) => URL.revokeObjectURL(url)).catch(() => {});

--- a/desktop/src/stores/gallery.perf.test.ts
+++ b/desktop/src/stores/gallery.perf.test.ts
@@ -1,0 +1,209 @@
+/**
+ * Library store performance guards. Every assertion is an OPERATION COUNT
+ * against a data-size budget — see `@studio/lib/galleryPerfBudget`. A
+ * wall-clock number would be flaky in CI; a count is exact and names the hot
+ * path that regressed.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+
+const counters = vi.hoisted(() => ({
+  unionOrganization: 0,
+  sameLogicalGalleryPrint: 0,
+  reset() {
+    counters.unionOrganization = 0;
+    counters.sameLogicalGalleryPrint = 0;
+  },
+}));
+
+vi.mock("@studio/lib/libraryOrganization", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@studio/lib/libraryOrganization")>();
+  return {
+    ...actual,
+    unionOrganization: (...args: Parameters<typeof actual.unionOrganization>) => {
+      counters.unionOrganization += 1;
+      return actual.unionOrganization(...args);
+    },
+  };
+});
+vi.mock("@studio/lib/galleryPrintIdentity", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@studio/lib/galleryPrintIdentity")>();
+  return {
+    ...actual,
+    sameLogicalGalleryPrint: (...args: Parameters<typeof actual.sameLogicalGalleryPrint>) => {
+      counters.sameLogicalGalleryPrint += 1;
+      return actual.sameLogicalGalleryPrint(...args);
+    },
+  };
+});
+vi.mock("../lib/ipc", () => ({
+  ipc: { localGalleryList: vi.fn() },
+}));
+vi.mock("../lib/api/client", () => ({
+  conditionalApiJsonTo: vi.fn(),
+  apiFetchTo: vi.fn(),
+}));
+
+import { expectOpsUnder } from "@studio/lib/galleryPerfBudget";
+import { useConnectionStore } from "./connection";
+import { useGalleryStore, type GalleryBucket } from "./gallery";
+import { useHostsStore } from "./hosts";
+import type { GalleryImage, ServerCapabilities } from "../lib/api/types";
+
+const LOCAL = 2_000;
+const REMOTE_SHARED = 1_000; // remote rows mirrored locally under the same filename
+const REMOTE_ONLY = 1_000;
+const LEGACY_COPIES = 200; // same seed+size+model, different filename, inside the window
+
+function row(filename: string, index: number, overrides: Partial<GalleryImage> = {}): GalleryImage {
+  return {
+    filename,
+    timestamp: 1_800_000_000 - index * 10,
+    size_bytes: 100_000 + index,
+    format: index % 7 === 0 ? "mp4" : "png",
+    favorite: index % 5 === 0,
+    tags: index % 3 === 0 ? ["portrait", `batch-${index % 11}`] : [],
+    collections: index % 4 === 0 ? ["c1"] : [],
+    metadata: {
+      prompt: `print ${index}`,
+      model: "flux-dev:q8",
+      seed: index,
+      steps: 4,
+      guidance: 1,
+      width: 1024,
+      height: index % 2 === 0 ? 768 : 1024,
+    },
+    ...overrides,
+  } as GalleryImage;
+}
+
+const bucket = (items: GalleryImage[]): GalleryBucket => ({
+  items,
+  loading: false,
+  error: null,
+  loaded: true,
+  authorityTarget: null,
+  authorityResolved: false,
+});
+
+function seedFleet() {
+  const conn = useConnectionStore();
+  conn.info = { mode: "local", baseUrl: "http://127.0.0.1:49152", apiKey: "k" };
+  conn.status = "ready";
+  const hosts = useHostsStore();
+  hosts.extras.push({
+    id: "plato-7680",
+    label: "plato",
+    url: "http://plato:7680",
+    apiKey: "pk",
+    status: "ready",
+    error: null,
+    instanceId: null,
+  });
+  const caps = {
+    gallery: { can_delete: true, organize: true, trash: { enabled: true, retention_days: 30 } },
+  } as unknown as ServerCapabilities;
+  hosts.capabilities["local"] = caps;
+  hosts.capabilities["plato-7680"] = caps;
+
+  const local: GalleryImage[] = [];
+  for (let i = 0; i < LOCAL; i++) local.push(row(`local-${i}.png`, i));
+  const remote: GalleryImage[] = [];
+  for (let i = 0; i < REMOTE_SHARED; i++) remote.push(row(`local-${i}.png`, i));
+  for (let i = 0; i < REMOTE_ONLY; i++) remote.push(row(`remote-${i}.png`, LOCAL + i));
+  // Legacy auto-saves: identical seed/size/model under a minted name.
+  for (let i = 0; i < LEGACY_COPIES; i++) {
+    const origin = LOCAL - 1 - i;
+    remote.push(
+      row(`mold-flux-legacy-${i}.png`, origin, { timestamp: local[origin]!.timestamp + 5 }),
+    );
+  }
+  const gallery = useGalleryStore();
+  gallery.buckets["local"] = bucket(local);
+  gallery.buckets["plato-7680"] = bucket(remote);
+  const collections = [{ id: "c1", name: "Keepers", slug: "keepers", hidden: false }];
+  gallery.collectionsByHost["local"] = { items: collections, loaded: true } as never;
+  gallery.collectionsByHost["plato-7680"] = { items: collections, loaded: true } as never;
+  return gallery;
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  counters.reset();
+});
+
+describe("gallery store derived work is indexed once per data change", () => {
+  it("runs unionOrganization at most once per logical print across every getter", () => {
+    const gallery = seedFleet();
+    const logical = gallery.merged.length;
+    expect(logical).toBe(LOCAL + REMOTE_ONLY);
+    counters.reset();
+
+    // Everything the Library header, chips, shelf and grid read on one change.
+    void gallery.basePrints;
+    void gallery.filterChipTags;
+    void gallery.collectionCounts("keepers");
+    void gallery.kindCounts;
+    void gallery.chipCounts;
+    void gallery.filtered;
+    for (const entry of gallery.merged) void gallery.organizationOf(entry);
+    for (const entry of gallery.merged) void gallery.organizationOf(entry);
+
+    expectOpsUnder("unionOrganization per derived pass", counters.unionOrganization, logical);
+  });
+
+  it("re-narrowing by favorites, tags and a collection performs no new union passes", () => {
+    const gallery = seedFleet();
+    void gallery.filtered;
+    counters.reset();
+    gallery.favoritesOnly = true;
+    void gallery.filtered;
+    gallery.tagFilter = ["portrait"];
+    void gallery.filtered;
+    gallery.scope = "collections";
+    gallery.collectionSlug = "keepers";
+    void gallery.filtered;
+    expectOpsUnder("unionOrganization on filter change", counters.unionOrganization, 0);
+  });
+
+  it("resolves every copy of a print without scanning the buckets", () => {
+    const gallery = seedFleet();
+    const entries = gallery.merged;
+    counters.reset();
+    let copies = 0;
+    for (const entry of entries) {
+      copies += gallery.allLocationsOf(entry).length;
+      void gallery.locationsOf(entry);
+      void gallery.trashLocationsOf(entry);
+    }
+    expect(copies).toBe(LOCAL + REMOTE_SHARED + REMOTE_ONLY + LEGACY_COPIES);
+    expectOpsUnder("sameLogicalGalleryPrint scans", counters.sameLogicalGalleryPrint, 0);
+  });
+
+  it("finds a legacy copy (different filename, same identity) through the index", () => {
+    const gallery = seedFleet();
+    const origin = gallery.merged.find((e) => e.item.filename === `local-${LOCAL - 1}.png`)!;
+    expect(gallery.locationsOf(origin)).toEqual(
+      expect.arrayContaining([
+        { sourceKey: "local", filename: `local-${LOCAL - 1}.png` },
+        { sourceKey: "plato-7680", filename: "mold-flux-legacy-0.png" },
+      ]),
+    );
+  });
+
+  it("answers existsLocally and rowOf without scanning", () => {
+    const gallery = seedFleet();
+    const remoteOnly = gallery.merged.filter((e) => e.sourceKey !== "local");
+    expect(remoteOnly.length).toBe(REMOTE_ONLY);
+    counters.reset();
+    for (const entry of remoteOnly) expect(gallery.existsLocally(entry)).toBe(false);
+    for (const entry of gallery.merged) {
+      expect(gallery.rowOf(entry.sourceKey, entry.item.filename)).toBe(entry.item);
+    }
+    expectOpsUnder(
+      "sameLogicalGalleryPrint in existsLocally/rowOf",
+      counters.sameLogicalGalleryPrint,
+      0,
+    );
+  });
+});

--- a/desktop/src/stores/gallery.perf.test.ts
+++ b/desktop/src/stores/gallery.perf.test.ts
@@ -6,6 +6,7 @@
  */
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
+import { toRaw } from "vue";
 
 const counters = vi.hoisted(() => ({
   unionOrganization: 0,
@@ -169,6 +170,20 @@ describe("gallery store derived work is indexed once per data change", () => {
   it("resolves every copy of a print without scanning the buckets", () => {
     const gallery = seedFleet();
     const entries = gallery.merged;
+    // Instrument the bucket arrays themselves: every element read is
+    // counted, so an inline `.find()`/`.some()` scan (which would not call
+    // `sameLogicalGalleryPrint`) still shows up as N² reads.
+    let elementReads = 0;
+    const counted = (items: GalleryImage[]) =>
+      new Proxy(items, {
+        get(target, prop, receiver) {
+          if (typeof prop === "string" && /^\d+$/.test(prop)) elementReads += 1;
+          return Reflect.get(target, prop, receiver);
+        },
+      });
+    for (const key of Object.keys(gallery.buckets)) {
+      gallery.buckets[key]!.items = counted(toRaw(gallery.buckets[key]!.items));
+    }
     counters.reset();
     let copies = 0;
     for (const entry of entries) {
@@ -178,6 +193,23 @@ describe("gallery store derived work is indexed once per data change", () => {
     }
     expect(copies).toBe(LOCAL + REMOTE_SHARED + REMOTE_ONLY + LEGACY_COPIES);
     expectOpsUnder("sameLogicalGalleryPrint scans", counters.sameLogicalGalleryPrint, 0);
+    // Rebuilding the per-bucket indexes reads each row a bounded number of
+    // times; 4 200 lookups over 4 200 rows must stay far from 17 million.
+    const totalRows = LOCAL + REMOTE_SHARED + REMOTE_ONLY + LEGACY_COPIES;
+    expectOpsUnder("bucket element reads during copy lookups", elementReads, 6 * totalRows);
+  });
+
+  it("returns a print's copies in bucket order, legacy twin before canonical row", () => {
+    const gallery = seedFleet();
+    // Plato lists a legacy-named twin ABOVE the canonical row for one print.
+    const canonical = row("local-7.png", 7);
+    const twin = row("mold-flux-twin.png", 7, { timestamp: canonical.timestamp + 3 });
+    gallery.buckets["plato-7680"] = bucket([twin, canonical]);
+    const entry = gallery.merged.find((e) => e.item.filename === "local-7.png")!;
+    expect(gallery.locationsOf(entry).filter((l) => l.sourceKey === "plato-7680")).toEqual([
+      { sourceKey: "plato-7680", filename: "mold-flux-twin.png" },
+      { sourceKey: "plato-7680", filename: "local-7.png" },
+    ]);
   });
 
   it("finds a legacy copy (different filename, same identity) through the index", () => {

--- a/desktop/src/stores/gallery.refetch.test.ts
+++ b/desktop/src/stores/gallery.refetch.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Refetch discipline: a poll that comes back 304 must not invalidate the
+ * merged grid, and gallery rows are raw (non-reactive) snapshots that are
+ * replaced, never mutated, by optimistic organization edits.
+ */
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { isReactive, toRaw } from "vue";
+import { conditionalApiJsonTo } from "../lib/api/client";
+import { evictMedia } from "../lib/gallery/media";
+import { useConnectionStore } from "./connection";
+import { useGalleryStore } from "./gallery";
+import { useHostsStore } from "./hosts";
+import type { GalleryImage } from "../lib/api/types";
+import * as organization from "@studio/api/galleryOrganization";
+
+vi.mock("../lib/ipc", () => ({
+  ipc: { localGalleryList: vi.fn().mockResolvedValue({ images: [], target: null }) },
+}));
+vi.mock("../lib/api/client", () => ({
+  conditionalApiJsonTo: vi.fn(),
+  apiFetchTo: vi.fn(),
+}));
+vi.mock("../lib/gallery/media", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../lib/gallery/media")>();
+  return { ...actual, evictMedia: vi.fn(), evictHostMedia: vi.fn() };
+});
+vi.mock("@studio/api/galleryOrganization", () => ({
+  organizeGallery: vi.fn().mockResolvedValue(undefined),
+  patchGalleryImage: vi.fn().mockResolvedValue(null),
+  mutateGalleryBulk: vi.fn(),
+  listCollections: vi.fn(),
+  listTags: vi.fn(),
+  listTrash: vi.fn(),
+}));
+
+const img = (filename: string, timestamp: number): GalleryImage =>
+  ({
+    filename,
+    timestamp,
+    size_bytes: 10,
+    metadata: { prompt: "p", model: "m", seed: 1 },
+  }) as never;
+
+function connectPlato() {
+  const conn = useConnectionStore();
+  conn.info = { mode: "local", baseUrl: "http://127.0.0.1:49152", apiKey: "k" };
+  conn.status = "ready";
+  useHostsStore().extras.push({
+    id: "plato-7680",
+    label: "plato",
+    url: "http://plato:7680",
+    apiKey: "pk",
+    status: "ready",
+    error: null,
+    instanceId: null,
+  });
+}
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+});
+
+describe("gallery refetch discipline", () => {
+  it("leaves the bucket and every derived index untouched when the listing answers 304", async () => {
+    connectPlato();
+    const gallery = useGalleryStore();
+    const listing = [img("a.png", 2), img("b.png", 1)];
+    vi.mocked(conditionalApiJsonTo).mockResolvedValue(listing);
+    await gallery.fetchBucket("plato-7680");
+    const merged = gallery.merged;
+    const index = gallery.organizationIndex;
+    const rows = gallery.buckets["plato-7680"]!.items;
+    vi.mocked(evictMedia).mockClear();
+
+    // `conditionalApiJsonTo` hands back the cached array itself on 304.
+    await gallery.fetchBucket("plato-7680");
+
+    expect(gallery.buckets["plato-7680"]!.items).toBe(rows);
+    expect(gallery.merged).toBe(merged);
+    expect(gallery.organizationIndex).toBe(index);
+    expect(evictMedia).not.toHaveBeenCalled();
+  });
+
+  it("keeps rows raw and replaces them on an optimistic edit", async () => {
+    connectPlato();
+    useHostsStore().capabilities["plato-7680"] = {
+      gallery: { can_delete: true, organize: true },
+    } as never;
+    const gallery = useGalleryStore();
+    vi.mocked(conditionalApiJsonTo).mockResolvedValue([img("a.png", 2)]);
+    await gallery.fetchBucket("plato-7680");
+    const before = gallery.buckets["plato-7680"]!.items[0]!;
+    expect(isReactive(before)).toBe(false);
+    expect(gallery.organizationOf(gallery.merged[0]!).favorite).toBe(false);
+
+    await gallery.runOrganizationOp({
+      kind: "setFavorite",
+      hostId: "plato-7680",
+      filenames: ["a.png"],
+      favorite: true,
+    });
+    expect(organization.organizeGallery).toHaveBeenCalledTimes(1);
+    const after = gallery.buckets["plato-7680"]!.items[0]!;
+    expect(after).not.toBe(before);
+    expect(toRaw(after).favorite).toBe(true);
+    expect(isReactive(after)).toBe(false);
+    // The index saw the replacement.
+    expect(gallery.organizationOf(gallery.merged[0]!).favorite).toBe(true);
+  });
+});

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -707,8 +707,8 @@ export const useGalleryStore = defineStore("gallery", {
         if (local.byFilename.has(entry.item.filename)) return true;
         const identity = printIdentity(entry.item);
         if (identity === null) return false;
-        return (local.byIdentity.get(identity) ?? []).some((item) =>
-          withinIdentityWindow(item, entry.item),
+        return (local.byIdentity.get(identity) ?? []).some((row) =>
+          withinIdentityWindow(row.item, entry.item),
         );
       };
     },
@@ -1461,8 +1461,8 @@ export const useGalleryStore = defineStore("gallery", {
     /** Find the bucket row (live or trash) a mutation should update. */
     rowOf(hostKey: string, filename: string): GalleryImage | null {
       return (
-        this.bucketIndex.get(hostKey)?.byFilename.get(filename) ??
-        this.trashBucketIndex.get(hostKey)?.byFilename.get(filename) ??
+        this.bucketIndex.get(hostKey)?.byFilename.get(filename)?.item ??
+        this.trashBucketIndex.get(hostKey)?.byFilename.get(filename)?.item ??
         null
       );
     },
@@ -2064,22 +2064,29 @@ export const useGalleryStore = defineStore("gallery", {
  * every row sharing a seed:size:model identity so the caller can still apply
  * the per-pair timestamp window (`sameLogicalGalleryPrint`'s contract).
  */
+export interface IndexedRow {
+  item: GalleryImage;
+  /** Position in the bucket, so lookups can reproduce bucket order. */
+  ordinal: number;
+}
+
 export interface BucketIndex {
-  byFilename: Map<string, GalleryImage>;
-  byIdentity: Map<string, GalleryImage[]>;
+  byFilename: Map<string, IndexedRow>;
+  byIdentity: Map<string, IndexedRow[]>;
 }
 
 export function indexBucketRows(items: readonly GalleryImage[]): BucketIndex {
-  const byFilename = new Map<string, GalleryImage>();
-  const byIdentity = new Map<string, GalleryImage[]>();
-  for (const item of items) {
-    if (!byFilename.has(item.filename)) byFilename.set(item.filename, item);
+  const byFilename = new Map<string, IndexedRow>();
+  const byIdentity = new Map<string, IndexedRow[]>();
+  items.forEach((item, ordinal) => {
+    const row = { item, ordinal };
+    if (!byFilename.has(item.filename)) byFilename.set(item.filename, row);
     const identity = printIdentity(item);
-    if (identity === null) continue;
+    if (identity === null) return;
     const twins = byIdentity.get(identity);
-    if (twins) twins.push(item);
-    else byIdentity.set(identity, [item]);
-  }
+    if (twins) twins.push(row);
+    else byIdentity.set(identity, [row]);
+  });
   return { byFilename, byIdentity };
 }
 
@@ -2095,25 +2102,25 @@ function indexBuckets(buckets: Record<string, GalleryBucket>): Map<string, Bucke
  * Every copy of a logical print inside one bucket map — the same answer the
  * old full scan gave (`sameLogicalGalleryPrint` per row: exact filename, or
  * identity inside the timestamp window), read off the per-bucket index so a
- * grid of N tiles costs O(N), never O(N²). Filename matches come first, then
- * identity twins in bucket order, matching the scan's row order per bucket.
+ * grid of N tiles costs O(N), never O(N²). Matches are emitted in BUCKET
+ * order (by ordinal), exactly as the scan did — cover selection takes the
+ * first copy per host, so a legacy-named twin listed before the canonical
+ * row must still come first.
  */
 function locationsIn(index: Map<string, BucketIndex>, entry: MergedPrint): GalleryLocation[] {
   const locations: GalleryLocation[] = [];
   const identity = printIdentity(entry.item);
   for (const [sourceKey, bucket] of index) {
-    const seen = new Set<string>();
+    const matches: IndexedRow[] = [];
     const exact = bucket.byFilename.get(entry.item.filename);
-    if (exact) {
-      seen.add(exact.filename);
-      locations.push({ sourceKey, filename: exact.filename });
+    if (exact) matches.push(exact);
+    if (identity !== null) {
+      for (const twin of bucket.byIdentity.get(identity) ?? []) {
+        if (twin !== exact && withinIdentityWindow(twin.item, entry.item)) matches.push(twin);
+      }
     }
-    if (identity === null) continue;
-    for (const twin of bucket.byIdentity.get(identity) ?? []) {
-      if (seen.has(twin.filename) || !withinIdentityWindow(twin, entry.item)) continue;
-      seen.add(twin.filename);
-      locations.push({ sourceKey, filename: twin.filename });
-    }
+    if (matches.length > 1) matches.sort((a, b) => a.ordinal - b.ordinal);
+    for (const match of matches) locations.push({ sourceKey, filename: match.item.filename });
   }
   return locations;
 }

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -16,7 +16,6 @@ import type { Collection, GalleryImage, ServerEvent, TagCount } from "../lib/api
 import {
   GALLERY_IDENTITY_WINDOW_SECS,
   galleryPrintIdentity,
-  sameLogicalGalleryPrint,
 } from "@studio/lib/galleryPrintIdentity";
 import {
   collectionSlug as slugOfCollection,
@@ -422,6 +421,43 @@ export const useGalleryStore = defineStore("gallery", {
     trashIndex(): Map<string, MergedPrint> {
       return indexCopies(this.trashMerged);
     },
+    /** Per-bucket filename + identity indexes over the live rows (pending
+     *  deletions included, exactly like the buckets themselves). Rebuilt once
+     *  per bucket change; read by every copy lookup so the grid never scans. */
+    bucketIndex(): Map<string, BucketIndex> {
+      return indexBuckets(this.buckets);
+    },
+    trashBucketIndex(): Map<string, BucketIndex> {
+      return indexBuckets(this.trashBuckets);
+    },
+    /**
+     * Every copy filename → its logical print's organization union, computed
+     * ONCE per logical print per data change. This is the single place
+     * `unionOrganization` runs over the grid: the filter chips, the shelf
+     * counts, the kind counts, `filtered`, and every tile read this map, so
+     * one gallery mutation costs one union pass rather than one per getter
+     * per tile. Live prints are indexed first so they win over trashed twins.
+     */
+    organizationIndex(): Map<string, OrganizationUnion> {
+      const resolve = this.collectionResolver;
+      const index = new Map<string, OrganizationUnion>();
+      const add = (prints: MergedPrint[]) => {
+        for (const print of prints) {
+          const copies = print.copies ?? [{ sourceKey: print.sourceKey, item: print.item }];
+          const org = unionOrganization(
+            copies.map((copy) => ({ hostId: copy.sourceKey, item: copy.item })),
+            { localHostId: "local", resolveCollectionSlug: resolve },
+          );
+          if (!index.has(print.item.filename)) index.set(print.item.filename, org);
+          for (const copy of copies) {
+            if (!index.has(copy.item.filename)) index.set(copy.item.filename, org);
+          }
+        }
+      };
+      add(this.merged);
+      add(this.trashMerged);
+      return index;
+    },
     /** Logical prints in the trash across every host. */
     trashCount(): number {
       return this.trashMerged.length;
@@ -534,12 +570,13 @@ export const useGalleryStore = defineStore("gallery", {
      */
     organizationOf(): (entry: MergedPrint) => OrganizationUnion {
       const resolve = this.collectionResolver;
-      const live = this.mergedIndex;
-      const trash = this.trashIndex;
+      const index = this.organizationIndex;
       return (entry) => {
-        const print = live.get(entry.item.filename) ?? trash.get(entry.item.filename);
-        const copies = print?.copies ??
-          entry.copies ?? [{ sourceKey: entry.sourceKey, item: entry.item }];
+        const indexed = index.get(entry.item.filename);
+        if (indexed) return indexed;
+        // Hand-built or mid-refetch entry that matches no merged print: read
+        // its own copies (the only path that still unions per call).
+        const copies = entry.copies ?? [{ sourceKey: entry.sourceKey, item: entry.item }];
         return unionOrganization(
           copies.map((copy) => ({ hostId: copy.sourceKey, item: copy.item })),
           { localHostId: "local", resolveCollectionSlug: resolve },
@@ -645,16 +682,16 @@ export const useGalleryStore = defineStore("gallery", {
      * bucket is probed directly.
      */
     existsLocally(): (entry: MergedPrint) => boolean {
+      const local = this.bucketIndex.get("local");
       return (entry) => {
         if (entry.sourceKey === "local") return true;
         if (entry.availableOn.some((s) => s.key === "local")) return true;
+        if (!local) return false;
+        if (local.byFilename.has(entry.item.filename)) return true;
         const identity = printIdentity(entry.item);
-        return (this.buckets["local"]?.items ?? []).some(
-          (item) =>
-            item.filename === entry.item.filename ||
-            (identity !== null &&
-              printIdentity(item) === identity &&
-              withinIdentityWindow(item, entry.item)),
+        if (identity === null) return false;
+        return (local.byIdentity.get(identity) ?? []).some((item) =>
+          withinIdentityWindow(item, entry.item),
         );
       };
     },
@@ -708,18 +745,21 @@ export const useGalleryStore = defineStore("gallery", {
     },
     /** Per-source chips for the gallery header (HostFilterChips adds All). */
     chipCounts(): GalleryChip[] {
+      const hiddenSlugs = new Set(
+        this.mergedCollections
+          .filter((collection) => collection.hidden)
+          .map((collection) => collection.slug),
+      );
+      const organization = this.organizationIndex;
+      const hidesInDefault = (item: GalleryImage) =>
+        (organization.get(item.filename)?.collections ?? []).some((slug) =>
+          hiddenSlugs.has(slug),
+        );
       return this.sources.map((source) => {
         const items = this.buckets[source.key]?.items ?? [];
         const count =
-          this.scope === "prints"
-            ? items.filter((item) =>
-                this.visibleInDefaultLibrary({
-                  item,
-                  sourceKey: source.key,
-                  hostLabel: source.label,
-                  availableOn: [source],
-                }),
-              ).length
+          this.scope === "prints" && hiddenSlugs.size > 0
+            ? items.filter((item) => !hidesInDefault(item)).length
             : items.length;
         return { key: source.key, label: source.label, count };
       });
@@ -901,11 +941,11 @@ export const useGalleryStore = defineStore("gallery", {
      * that minted a different filename.
      */
     locationsOf(entry: MergedPrint): GalleryLocation[] {
-      return locationsIn(this.buckets, entry);
+      return locationsIn(this.bucketIndex, entry);
     },
     /** Every loaded trashed copy of one logical print. */
     trashLocationsOf(entry: MergedPrint): GalleryLocation[] {
-      return locationsIn(this.trashBuckets, entry);
+      return locationsIn(this.trashBucketIndex, entry);
     },
     /** Live and trashed copies together — organization edits reach both. */
     allLocationsOf(entry: MergedPrint): GalleryLocation[] {
@@ -1400,8 +1440,8 @@ export const useGalleryStore = defineStore("gallery", {
     /** Find the bucket row (live or trash) a mutation should update. */
     rowOf(hostKey: string, filename: string): GalleryImage | null {
       return (
-        this.buckets[hostKey]?.items.find((i) => i.filename === filename) ??
-        this.trashBuckets[hostKey]?.items.find((i) => i.filename === filename) ??
+        this.bucketIndex.get(hostKey)?.byFilename.get(filename) ??
+        this.trashBucketIndex.get(hostKey)?.byFilename.get(filename) ??
         null
       );
     },
@@ -1972,17 +2012,60 @@ export const useGalleryStore = defineStore("gallery", {
   },
 });
 
-/** Every copy of a logical print inside one bucket map. */
-function locationsIn(
-  buckets: Record<string, GalleryBucket>,
-  entry: MergedPrint,
-): GalleryLocation[] {
-  const locations: GalleryLocation[] = [];
+/**
+ * One bucket's rows indexed for O(1) identity lookups. `byIdentity` holds
+ * every row sharing a seed:size:model identity so the caller can still apply
+ * the per-pair timestamp window (`sameLogicalGalleryPrint`'s contract).
+ */
+export interface BucketIndex {
+  byFilename: Map<string, GalleryImage>;
+  byIdentity: Map<string, GalleryImage[]>;
+}
+
+export function indexBucketRows(items: readonly GalleryImage[]): BucketIndex {
+  const byFilename = new Map<string, GalleryImage>();
+  const byIdentity = new Map<string, GalleryImage[]>();
+  for (const item of items) {
+    if (!byFilename.has(item.filename)) byFilename.set(item.filename, item);
+    const identity = printIdentity(item);
+    if (identity === null) continue;
+    const twins = byIdentity.get(identity);
+    if (twins) twins.push(item);
+    else byIdentity.set(identity, [item]);
+  }
+  return { byFilename, byIdentity };
+}
+
+function indexBuckets(buckets: Record<string, GalleryBucket>): Map<string, BucketIndex> {
+  const index = new Map<string, BucketIndex>();
   for (const [sourceKey, bucket] of Object.entries(buckets)) {
-    for (const item of bucket.items) {
-      if (sameLogicalGalleryPrint(entry.item, item)) {
-        locations.push({ sourceKey, filename: item.filename });
-      }
+    index.set(sourceKey, indexBucketRows(bucket.items));
+  }
+  return index;
+}
+
+/**
+ * Every copy of a logical print inside one bucket map — the same answer the
+ * old full scan gave (`sameLogicalGalleryPrint` per row: exact filename, or
+ * identity inside the timestamp window), read off the per-bucket index so a
+ * grid of N tiles costs O(N), never O(N²). Filename matches come first, then
+ * identity twins in bucket order, matching the scan's row order per bucket.
+ */
+function locationsIn(index: Map<string, BucketIndex>, entry: MergedPrint): GalleryLocation[] {
+  const locations: GalleryLocation[] = [];
+  const identity = printIdentity(entry.item);
+  for (const [sourceKey, bucket] of index) {
+    const seen = new Set<string>();
+    const exact = bucket.byFilename.get(entry.item.filename);
+    if (exact) {
+      seen.add(exact.filename);
+      locations.push({ sourceKey, filename: exact.filename });
+    }
+    if (identity === null) continue;
+    for (const twin of bucket.byIdentity.get(identity) ?? []) {
+      if (seen.has(twin.filename) || !withinIdentityWindow(twin, entry.item)) continue;
+      seen.add(twin.filename);
+      locations.push({ sourceKey, filename: twin.filename });
     }
   }
   return locations;

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -1,4 +1,5 @@
 import { defineStore } from "pinia";
+import { markRaw, toRaw } from "vue";
 import { apiFetchTo, conditionalApiJsonTo, type ApiTarget } from "../lib/api/client";
 import { isTransportFailure } from "../lib/api/errors";
 import {
@@ -272,12 +273,28 @@ function errorMessage(reason: unknown): string {
   return reason instanceof Error ? reason.message : String(reason);
 }
 
+/**
+ * Gallery rows are immutable snapshots: every change replaces the row object
+ * (`replaceRow` / `patchRow`), never a field on it. That lets the rows skip
+ * Vue's deep reactivity — a 1 000-print bucket of 60-field metadata objects
+ * would otherwise be a few thousand proxies whose get traps sit on every
+ * merge, identity, and layout pass. Arrays stay reactive; the rows inside do
+ * not. Apply at every site that puts a row into a bucket.
+ */
+function rawRow(image: GalleryImage): GalleryImage {
+  return markRaw(image);
+}
+function rawRows(images: GalleryImage[]): GalleryImage[] {
+  for (const image of images) markRaw(image);
+  return images;
+}
+
 /** Replace a bucket row in place (same index) so the grid keeps its order. */
 function replaceRow(bucket: GalleryBucket | undefined, image: GalleryImage): boolean {
   if (!bucket) return false;
   const at = bucket.items.findIndex((i) => i.filename === image.filename);
   if (at === -1) return false;
-  bucket.items.splice(at, 1, image);
+  bucket.items.splice(at, 1, rawRow(image));
   return true;
 }
 
@@ -285,8 +302,8 @@ function replaceRow(bucket: GalleryBucket | undefined, image: GalleryImage): boo
 function insertRow(bucket: GalleryBucket, image: GalleryImage) {
   if (bucket.items.some((i) => i.filename === image.filename)) return;
   const at = bucket.items.findIndex((i) => i.timestamp < image.timestamp);
-  if (at === -1) bucket.items.push(image);
-  else bucket.items.splice(at, 0, image);
+  if (at === -1) bucket.items.push(rawRow(image));
+  else bucket.items.splice(at, 0, rawRow(image));
 }
 
 /** Trash order: newest-DELETED first (`trashed_at`, matching the server's
@@ -298,8 +315,8 @@ const trashOrderKey = (i: GalleryImage) => i.trashed_at ?? i.timestamp;
 function insertTrashRow(bucket: GalleryBucket, image: GalleryImage) {
   if (bucket.items.some((i) => i.filename === image.filename)) return;
   const at = bucket.items.findIndex((i) => trashOrderKey(i) < trashOrderKey(image));
-  if (at === -1) bucket.items.push(image);
-  else bucket.items.splice(at, 0, image);
+  if (at === -1) bucket.items.push(rawRow(image));
+  else bucket.items.splice(at, 0, rawRow(image));
 }
 
 function takeRow(bucket: GalleryBucket | undefined, filename: string): GalleryImage | null {
@@ -752,9 +769,7 @@ export const useGalleryStore = defineStore("gallery", {
       );
       const organization = this.organizationIndex;
       const hidesInDefault = (item: GalleryImage) =>
-        (organization.get(item.filename)?.collections ?? []).some((slug) =>
-          hiddenSlugs.has(slug),
-        );
+        (organization.get(item.filename)?.collections ?? []).some((slug) => hiddenSlugs.has(slug));
       return this.sources.map((source) => {
         const items = this.buckets[source.key]?.items ?? [];
         const count =
@@ -884,14 +899,20 @@ export const useGalleryStore = defineStore("gallery", {
           items = await conditionalApiJsonTo<GalleryImage[]>(target, "/api/gallery");
           authorityTarget = target;
         }
-        // Prints that vanished out-of-band (deleted by another client) must
-        // release their cached blob URLs — the media cache only evicts on
-        // explicit remove()/host teardown otherwise.
-        const next = new Set(items.map((i) => i.filename));
         const authorityChanged =
           bucket.authorityResolved &&
           (bucket.authorityTarget?.baseUrl !== authorityTarget?.baseUrl ||
             bucket.authorityTarget?.apiKey !== authorityTarget?.apiKey);
+        // A 304 hands back the very array already in the bucket. Nothing
+        // changed, so nothing downstream (merge, indexes, layout, every
+        // tile) may be invalidated — assigning the same rows again would
+        // re-run all of it on every 15 s poll of every host. A changed
+        // authority still falls through: its cached media must be evicted.
+        if (bucket.loaded && !authorityChanged && toRaw(bucket.items) === items) return;
+        // Prints that vanished out-of-band (deleted by another client) must
+        // release their cached blob URLs — the media cache only evicts on
+        // explicit remove()/host teardown otherwise.
+        const next = new Set(items.map((i) => i.filename));
         for (const old of bucket.items) {
           if (!authorityChanged && next.has(old.filename)) continue;
           evictMedia(galleryMediaPath(old.filename, previousSource, true), key);
@@ -900,7 +921,7 @@ export const useGalleryStore = defineStore("gallery", {
         bucket.authorityTarget = authorityTarget;
         bucket.authorityResolved = true;
         // Newest first, like a print drawer.
-        bucket.items = items.sort((a, b) => b.timestamp - a.timestamp);
+        bucket.items = rawRows(items.sort((a, b) => b.timestamp - a.timestamp));
         bucket.loaded = true;
       } catch (err) {
         bucket.error = String(err);
@@ -1398,7 +1419,7 @@ export const useGalleryStore = defineStore("gallery", {
         }
         bucket.authorityTarget = authorityTarget;
         bucket.authorityResolved = true;
-        bucket.items = items.sort((a, b) => trashOrderKey(b) - trashOrderKey(a));
+        bucket.items = rawRows(items.sort((a, b) => trashOrderKey(b) - trashOrderKey(a)));
         bucket.loaded = true;
       } catch (err) {
         bucket.error = String(err);
@@ -1444,6 +1465,23 @@ export const useGalleryStore = defineStore("gallery", {
         this.trashBucketIndex.get(hostKey)?.byFilename.get(filename) ??
         null
       );
+    },
+    /**
+     * Replace one row (live or trash) with a patched copy. Rows are raw,
+     * immutable snapshots (see `rawRow`), so an optimistic organization edit
+     * must swap the object rather than assign a field — a field write would
+     * neither notify the grid nor invalidate the organization index.
+     */
+    patchRow(hostKey: string, filename: string, patch: Partial<GalleryImage>): GalleryImage | null {
+      for (const bucket of [this.buckets[hostKey], this.trashBuckets[hostKey]]) {
+        if (!bucket) continue;
+        const at = bucket.items.findIndex((i) => i.filename === filename);
+        if (at === -1) continue;
+        const next = rawRow({ ...bucket.items[at]!, ...patch });
+        bucket.items.splice(at, 1, next);
+        return next;
+      }
+      return null;
     },
     /** Apply a server-echoed row in place of whichever bucket holds it. */
     absorbRow(hostKey: string, image: GalleryImage) {
@@ -1491,8 +1529,7 @@ export const useGalleryStore = defineStore("gallery", {
           if (bulk && useHostsStore().capabilities[op.hostId]?.gallery?.bulk_mutations === true) {
             await mutateGalleryBulk(target, bulk);
             for (const filename of op.filenames) {
-              const row = this.rowOf(op.hostId, filename);
-              if (row) row.title = op.title;
+              this.patchRow(op.hostId, filename, { title: op.title });
             }
             return;
           }
@@ -1501,18 +1538,14 @@ export const useGalleryStore = defineStore("gallery", {
               title: op.title ?? "",
             });
             if (echoed) this.absorbRow(op.hostId, echoed);
-            else {
-              const row = this.rowOf(op.hostId, filename);
-              if (row) row.title = op.title;
-            }
+            else this.patchRow(op.hostId, filename, { title: op.title });
           }
           return;
         }
         case "setFavorite": {
           await organizeGallery(target, { filenames: op.filenames, favorite: op.favorite });
           for (const filename of op.filenames) {
-            const row = this.rowOf(op.hostId, filename);
-            if (row) row.favorite = op.favorite;
+            this.patchRow(op.hostId, filename, { favorite: op.favorite });
           }
           return;
         }
@@ -1524,11 +1557,15 @@ export const useGalleryStore = defineStore("gallery", {
             const row = this.rowOf(op.hostId, filename);
             if (!row) continue;
             const have = new Set((row.tags ?? []).map(tagKey));
+            const next = [...(row.tags ?? [])];
             for (const tag of tags) {
               if (have.has(tagKey(tag))) continue;
               have.add(tagKey(tag));
-              row.tags = [...(row.tags ?? []), tag];
+              next.push(tag);
               this.adjustTagCounts(op.hostId, tag, 1);
+            }
+            if (next.length !== (row.tags ?? []).length) {
+              this.patchRow(op.hostId, filename, { tags: next });
             }
           }
           return;
@@ -1545,7 +1582,7 @@ export const useGalleryStore = defineStore("gallery", {
               if (keys.has(tagKey(tag))) this.adjustTagCounts(op.hostId, tag, -1);
               else kept.push(tag);
             }
-            row.tags = kept;
+            this.patchRow(op.hostId, filename, { tags: kept });
           }
           return;
         }
@@ -1564,7 +1601,9 @@ export const useGalleryStore = defineStore("gallery", {
             const row = this.rowOf(op.hostId, filename);
             if (!row) continue;
             if ((row.collections ?? []).includes(collection.id)) continue;
-            row.collections = [...(row.collections ?? []), collection.id];
+            this.patchRow(op.hostId, filename, {
+              collections: [...(row.collections ?? []), collection.id],
+            });
             collection.count += 1;
           }
           return;
@@ -1579,7 +1618,9 @@ export const useGalleryStore = defineStore("gallery", {
           for (const filename of op.filenames) {
             const row = this.rowOf(op.hostId, filename);
             if (!row?.collections?.includes(collection.id)) continue;
-            row.collections = row.collections.filter((id) => id !== collection.id);
+            this.patchRow(op.hostId, filename, {
+              collections: row.collections.filter((id) => id !== collection.id),
+            });
             collection.count = Math.max(0, collection.count - 1);
           }
           return;
@@ -1805,11 +1846,17 @@ export const useGalleryStore = defineStore("gallery", {
           const bucket = this.ensureCollectionsBucket(host.hostId);
           bucket.items = bucket.items.filter((c) => c.id !== host.id);
           for (const store of [this.buckets[host.hostId], this.trashBuckets[host.hostId]]) {
-            for (const row of store?.items ?? []) {
-              if (row.collections?.includes(host.id)) {
-                row.collections = row.collections.filter((id) => id !== host.id);
-              }
-            }
+            if (!store) continue;
+            let touched = false;
+            const next = store.items.map((row) => {
+              if (!row.collections?.includes(host.id)) return row;
+              touched = true;
+              return rawRow({
+                ...row,
+                collections: row.collections.filter((id) => id !== host.id),
+              });
+            });
+            if (touched) store.items = next;
           }
         }),
       );

--- a/desktop/src/views/LibraryView.perf.test.ts
+++ b/desktop/src/views/LibraryView.perf.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Library grid performance guards. Unlike the sibling suites this file does
+ * NOT mock the virtualizer or the justified layout: it mounts the real grid
+ * over 2 000 prints in a 1200×800 viewport and asserts operation counts
+ * (tiles in the DOM, media mounts across a reflow, union passes) against
+ * budgets — see `@studio/lib/galleryPerfBudget`.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
+import { createMemoryHistory, createRouter } from "vue-router";
+import { defineComponent, nextTick } from "vue";
+
+const counters = vi.hoisted(() => ({
+  unionOrganization: 0,
+  /** What the native listing answers; seeded per test before mount. */
+  localImages: [] as unknown[],
+  mediaMounts: new Map<string, number>(),
+  reset() {
+    counters.unionOrganization = 0;
+    counters.mediaMounts.clear();
+  },
+}));
+
+vi.mock("@studio/lib/libraryOrganization", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@studio/lib/libraryOrganization")>();
+  return {
+    ...actual,
+    unionOrganization: (...args: Parameters<typeof actual.unionOrganization>) => {
+      counters.unionOrganization += 1;
+      return actual.unionOrganization(...args);
+    },
+  };
+});
+vi.mock("../lib/api/client", () => ({
+  apiFetch: vi.fn(),
+  apiFetchTo: vi.fn().mockResolvedValue(new Response()),
+  apiJsonTo: vi.fn(),
+  conditionalApiJsonTo: vi.fn().mockResolvedValue([]),
+  currentTarget: () => ({ baseUrl: "http://x", apiKey: null }),
+}));
+vi.mock("../lib/ipc", () => ({
+  inTauri: () => false,
+  ipc: {
+    localGalleryDelete: vi.fn(),
+    localGalleryList: vi.fn(async () => ({ images: counters.localImages, target: null })),
+    revealOutputFile: vi.fn(),
+    saveOutputBytes: vi.fn(),
+  },
+}));
+
+import LibraryView from "./LibraryView.vue";
+import { expectOpsUnder } from "@studio/lib/galleryPerfBudget";
+import { useConnectionStore } from "../stores/connection";
+import { useGalleryStore } from "../stores/gallery";
+import { useHostsStore } from "../stores/hosts";
+import type { GalleryImage, ServerCapabilities } from "../lib/api/types";
+import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
+import { clearSessionScrollForTests } from "@studio/lib/libraryOrganization";
+
+installMemoryLocalStorage();
+
+const PRINTS = 2_000;
+const VIEWPORT_WIDTH = 1200;
+const VIEWPORT_HEIGHT = 800;
+/** Rows of 220 px tiles at 1200 px hold ~5–7 prints; 800 px shows ~4 rows,
+ *  plus 2 rows of overscan on each side. */
+const MAX_TILES_IN_DOM = 80;
+
+function print(index: number): GalleryImage {
+  return {
+    filename: `print-${index}.png`,
+    timestamp: 1_800_000_000 - index * 10,
+    size_bytes: 100_000 + index,
+    favorite: index % 5 === 0,
+    tags: index % 3 === 0 ? ["portrait"] : [],
+    metadata: {
+      prompt: `print ${index}`,
+      model: "flux-dev:q8",
+      seed: index,
+      steps: 4,
+      guidance: 1,
+      width: index % 3 === 0 ? 1536 : 1024,
+      height: index % 2 === 0 ? 768 : 1024,
+    },
+  } as GalleryImage;
+}
+
+/** The counting media stub: one entry per path, incremented on every mount. */
+const countingMedia = defineComponent({
+  name: "AuthedMedia",
+  props: { path: { type: String, required: true } },
+  setup(props) {
+    counters.mediaMounts.set(props.path, (counters.mediaMounts.get(props.path) ?? 0) + 1);
+    return {};
+  },
+  template: "<div class='media-stub' />",
+});
+const stub = { template: "<div />" };
+
+let restoreRect: (() => void) | null = null;
+
+/** happy-dom lays nothing out; give every element the viewport's box so the
+ *  virtualizer and the justified layout see a real 1200×800 scroller. */
+function fakeLayout() {
+  const proto = HTMLElement.prototype;
+  const rect = Object.getOwnPropertyDescriptor(Element.prototype, "getBoundingClientRect");
+  const saved = ["clientWidth", "clientHeight", "offsetWidth", "offsetHeight"].map(
+    (name) => [name, Object.getOwnPropertyDescriptor(proto, name)] as const,
+  );
+  Object.defineProperty(Element.prototype, "getBoundingClientRect", {
+    configurable: true,
+    value: () => ({
+      x: 0,
+      y: 0,
+      top: 0,
+      left: 0,
+      right: VIEWPORT_WIDTH,
+      bottom: VIEWPORT_HEIGHT,
+      width: VIEWPORT_WIDTH,
+      height: VIEWPORT_HEIGHT,
+      toJSON: () => ({}),
+    }),
+  });
+  // TanStack's `getRect` reads offsetWidth/offsetHeight; the justified
+  // layout reads clientWidth.
+  for (const name of ["clientWidth", "offsetWidth"]) {
+    Object.defineProperty(proto, name, { configurable: true, get: () => VIEWPORT_WIDTH });
+  }
+  for (const name of ["clientHeight", "offsetHeight"]) {
+    Object.defineProperty(proto, name, { configurable: true, get: () => VIEWPORT_HEIGHT });
+  }
+  restoreRect = () => {
+    if (rect) Object.defineProperty(Element.prototype, "getBoundingClientRect", rect);
+    for (const [name, descriptor] of saved) {
+      if (descriptor) Object.defineProperty(proto, name, descriptor);
+      else delete (proto as unknown as Record<string, unknown>)[name];
+    }
+  };
+}
+
+async function mountGrid() {
+  const router = createRouter({
+    history: createMemoryHistory(),
+    routes: [
+      { path: "/library", component: stub },
+      { path: "/create", component: stub },
+    ],
+  });
+  await router.push("/library");
+  const pinia = createPinia();
+  setActivePinia(pinia);
+  const connection = useConnectionStore();
+  connection.info = null;
+  connection.status = "error";
+  const hosts = useHostsStore();
+  hosts.capabilities["local"] = {
+    gallery: { can_delete: true, organize: true, trash: { enabled: true, retention_days: 30 } },
+  } as unknown as ServerCapabilities;
+  const gallery = useGalleryStore();
+  const items: GalleryImage[] = [];
+  for (let i = 0; i < PRINTS; i++) items.push(print(i));
+  counters.localImages = items;
+  gallery.buckets.local = { items, loading: false, error: null, loaded: true };
+  gallery.collectionsByHost["local"] = { items: [], loaded: true } as never;
+
+  const wrapper = mount(LibraryView, {
+    attachTo: document.body,
+    global: {
+      plugins: [pinia, router],
+      stubs: { AuthedMedia: countingMedia, HostFilterChips: stub, HistoryDrawer: stub },
+    },
+  });
+  await flushPromises();
+  await nextTick();
+  return { wrapper, gallery };
+}
+
+beforeEach(() => {
+  clearSessionScrollForTests();
+  counters.reset();
+  fakeLayout();
+});
+afterEach(() => {
+  restoreRect?.();
+  restoreRect = null;
+  document.body.innerHTML = "";
+});
+
+describe("Library grid at 2 000 prints", () => {
+  it("keeps only the viewport's rows (plus overscan) in the DOM", async () => {
+    const { wrapper } = await mountGrid();
+    const tiles = wrapper.findAll(".ms-lib-tile");
+    expect(tiles.length).toBeGreaterThan(0);
+    expectOpsUnder("tiles in the DOM", tiles.length, MAX_TILES_IN_DOM);
+    // Mount sees two data changes — the seeded bucket, then the listing the
+    // view fetches on open — so two index passes are legitimate.
+    expectOpsUnder("unionOrganization during mount", counters.unionOrganization, 2 * PRINTS);
+    wrapper.unmount();
+  });
+
+  it("re-flows on a thumbnail-size change without remounting surviving tiles", async () => {
+    const { wrapper } = await mountGrid();
+    const before = new Set(wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")));
+    counters.reset();
+
+    // Three slider ticks, as a drag delivers them.
+    const slider = wrapper.find('input[type="range"][aria-label="Thumbnail size"]');
+    expect(slider.exists()).toBe(true);
+    for (const px of [230, 240, 250]) {
+      await slider.setValue(px);
+      await nextTick();
+    }
+    await flushPromises();
+
+    const after = new Set(wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")));
+    const survivors = [...before].filter((name) => after.has(name));
+    expect(survivors.length).toBeGreaterThan(10);
+    let remounted = 0;
+    for (const [path, mounts] of counters.mediaMounts) {
+      const name = decodeURIComponent(path.split("/").pop() ?? "");
+      if (before.has(name) && mounts > 0) remounted += mounts;
+    }
+    expectOpsUnder("AuthedMedia remounts across a slider drag", remounted, 0);
+    expectOpsUnder("unionOrganization across a slider drag", counters.unionOrganization, 0);
+    wrapper.unmount();
+  });
+});

--- a/desktop/src/views/LibraryView.perf.test.ts
+++ b/desktop/src/views/LibraryView.perf.test.ts
@@ -201,7 +201,9 @@ describe("Library grid at 2 000 prints", () => {
 
   it("re-flows on a thumbnail-size change without remounting surviving tiles", async () => {
     const { wrapper } = await mountGrid();
-    const before = new Set(wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")));
+    const before = new Set(
+      wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")),
+    );
     counters.reset();
 
     // Three slider ticks, as a drag delivers them.
@@ -213,7 +215,9 @@ describe("Library grid at 2 000 prints", () => {
     }
     await flushPromises();
 
-    const after = new Set(wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")));
+    const after = new Set(
+      wrapper.findAll(".ms-lib-tile").map((t) => t.attributes("data-filename")),
+    );
     const survivors = [...before].filter((name) => after.has(name));
     expect(survivors.length).toBeGreaterThan(10);
     let remounted = 0;

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -549,10 +549,24 @@ describe("LibraryView header + NEW badges", () => {
     expect(slider.element.value).toBe("280");
     expect(wrapper.get(".ms-lib-tile").attributes("style")).toContain("height: 280px");
 
-    await slider.setValue("320");
-    expect(wrapper.get(".ms-lib-tile").attributes("style")).toContain("height: 320px");
-    expect(localStorage.getItem("mold.gallery.thumbnailSize.v1")).toBe("320");
-    wrapper.unmount();
+    // A drag delivers many ticks; the grid follows each one immediately while
+    // the localStorage write settles 250 ms after the last tick.
+    vi.useFakeTimers({ toFake: ["setTimeout", "clearTimeout"] });
+    try {
+      await slider.setValue("300");
+      await slider.setValue("320");
+      expect(wrapper.get(".ms-lib-tile").attributes("style")).toContain("height: 320px");
+      expect(localStorage.getItem("mold.gallery.thumbnailSize.v1")).toBe("280");
+      vi.advanceTimersByTime(250);
+      expect(localStorage.getItem("mold.gallery.thumbnailSize.v1")).toBe("320");
+
+      // Leaving mid-settle still persists the last value.
+      await slider.setValue("340");
+      wrapper.unmount();
+      expect(localStorage.getItem("mold.gallery.thumbnailSize.v1")).toBe("340");
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("badges prints unseen since the last visit, then marks them seen", async () => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -1,5 +1,14 @@
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, onUnmounted, ref, watch } from "vue";
+import {
+  computed,
+  nextTick,
+  onBeforeUnmount,
+  onMounted,
+  onUnmounted,
+  ref,
+  unref,
+  watch,
+} from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useVirtualizer } from "@tanstack/vue-virtual";
 import Icon from "@ui/components/Icon.vue";
@@ -99,7 +108,22 @@ const composer = useComposerStore();
 const generateForm = useGenerateFormStore();
 const contextMenu = useContextMenuStore();
 const toasts = useToastStore();
-const modelLabel = (name: string) => modelDisplayNameForId(name, models.all);
+/** `modelDisplayNameForId` scans the installed list; a grid of 2 000 tiles
+ *  would scan it 2 000 times per render. Memoize per name, dropping the memo
+ *  whenever the installed inventory changes. */
+const modelLabelMemo = computed(() => {
+  const inventory = models.all;
+  const cache = new Map<string, string>();
+  return (name: string) => {
+    let label = cache.get(name);
+    if (label === undefined) {
+      label = modelDisplayNameForId(name, inventory);
+      cache.set(name, label);
+    }
+    return label;
+  };
+});
+const modelLabel = (name: string) => modelLabelMemo.value(name);
 
 const primaryId = computed(() => hosts.primaryHost?.id ?? null);
 
@@ -1064,7 +1088,17 @@ const containerWidth = ref(0);
 const selected = ref<{ sourceKey: string; filename: string } | null>(null);
 const lightboxOpen = ref(false);
 const rowHeight = ref(loadGalleryThumbnailSize());
-watch(rowHeight, (value) => saveGalleryThumbnailSize(value));
+// A slider drag delivers one `input` event per pointer move; persisting on
+// each was a synchronous localStorage write per frame. Settle it instead.
+const SLIDER_PERSIST_MS = 250;
+let sliderPersistTimer: ReturnType<typeof setTimeout> | null = null;
+watch(rowHeight, (value) => {
+  if (sliderPersistTimer) clearTimeout(sliderPersistTimer);
+  sliderPersistTimer = setTimeout(() => {
+    sliderPersistTimer = null;
+    saveGalleryThumbnailSize(value);
+  }, SLIDER_PERSIST_MS);
+});
 
 // ── Delete: optimistic + undoable (§08 G12) ──────────────────────────────────
 // The tile leaves the grid instantly; a 6 s undo toast holds the print in limbo
@@ -1442,21 +1476,101 @@ function remeasureLibraryAfterResume() {
   });
 }
 
-/** Justified layout over the visible set; each laid tile keeps its merged
- *  entry so origin (badge, target, actions) travels with it. */
-const rows = computed(() => {
+/**
+ * Everything a tile renders, resolved ONCE per data change rather than per
+ * template expression per render: the old template called the store five or
+ * six times per tile (title, ♥ ×4, purge time, organize capability), each of
+ * which walked the whole gallery. Layout (`rows`) reads these by index and
+ * never touches the store, so a slider drag or a resize is pure arithmetic.
+ */
+interface TileModel {
+  entry: MergedPrint;
+  item: GalleryImage;
+  key: string;
+  title: string;
+  modelLabel: string;
+  favorite: boolean;
+  canOrganize: boolean;
+  availability: string;
+  purgeAt: number | null;
+  video: boolean;
+  audio: boolean;
+  upscaled: boolean;
+  /** Media bytes are addressed differently for a host bucket and this Mac. */
+  mediaPath: string;
+  localVideo: boolean;
+  target: ApiTarget | null;
+  mediaVersion: string;
+  fresh: boolean;
+}
+
+const tileModels = computed<TileModel[]>(() => {
   const list = entries.value;
+  const organizationOf = gallery.organizationOf;
+  const organizeCapable = gallery.organizeCapable;
+  const trash = inTrash.value;
+  const models: TileModel[] = new Array(list.length);
+  for (let i = 0; i < list.length; i++) {
+    const entry = list[i]!;
+    const item = entry.item;
+    const org = organizationOf(entry);
+    const source = gallery.mediaSourceOf(entry.sourceKey);
+    // Imported predicates, not the view's local aliases: `useVirtualizer`
+    // evaluates `rows` (and so this computed) synchronously during setup,
+    // before the aliases declared further down are initialized.
+    const video = isVideoItem(item);
+    models[i] = {
+      entry,
+      item,
+      key: `${entry.sourceKey}::${item.filename}`,
+      title: displayTitle({ ...item, title: org.title }),
+      modelLabel: modelLabel(item.metadata.model),
+      favorite: org.favorite,
+      canOrganize:
+        !trash && gallery.allLocationsOf(entry).some((l) => organizeCapable(l.sourceKey)),
+      availability: entry.availableOn.map((s) => s.label).join(" · "),
+      purgeAt: org.purgeAt,
+      video,
+      audio: isAudioItem(item),
+      upscaled: isUpscaledImage(item),
+      mediaPath: galleryMediaPath(item.filename, source, true, item.trashed_at != null),
+      localVideo: source === "local" && video,
+      target: targetFor(entry),
+      mediaVersion: item.media_version ?? `${item.timestamp}:${item.size_bytes ?? "unknown"}`,
+      fresh: isFresh(entry),
+    };
+  }
+  return models;
+});
+
+interface LaidTile {
+  model: TileModel;
+  x: number;
+  width: number;
+  height: number;
+}
+
+/** Justified layout over the visible set. Rows are the virtualizer's unit;
+ *  each laid tile carries its x offset so the tile layer below can place it
+ *  absolutely without a per-row wrapper. */
+const rows = computed(() => {
+  const list = tileModels.value;
   const laidRows = layoutJustifiedRows(
-    list.map((e) => e.item),
+    list.map((m) => m.item),
     Math.max(0, containerWidth.value - PAD * 2),
     rowHeight.value,
     GAP,
   );
   let cursor = 0;
-  return laidRows.map((r) => ({
-    height: r.height,
-    items: r.items.map((laid) => ({ ...laid, entry: list[cursor++]! })),
-  }));
+  return laidRows.map((r) => {
+    let x = PAD;
+    const items: LaidTile[] = r.items.map((laid) => {
+      const tile = { model: list[cursor++]!, x, width: laid.width, height: laid.height };
+      x += laid.width + GAP;
+      return tile;
+    });
+    return { height: r.height, items };
+  });
 });
 
 const virtualizer = useVirtualizer(
@@ -1468,14 +1582,30 @@ const virtualizer = useVirtualizer(
   })),
 );
 
+/**
+ * The tiles inside the virtual window as ONE flat list keyed by print. The
+ * old markup nested tiles under row elements keyed by row index, so a
+ * re-flow that moved a print across a row boundary destroyed and re-created
+ * its `AuthedMedia` — cancelling the thumbnail in flight and refetching it —
+ * on every slider tick and resize pixel. A flat keyed list lets Vue MOVE the
+ * element instead, so the decoded image survives the reflow.
+ */
+const visibleTiles = computed(() => {
+  const laid = rows.value;
+  const out: Array<LaidTile & { y: number }> = [];
+  for (const vrow of unref(virtualizer).getVirtualItems()) {
+    const row = laid[vrow.index];
+    if (!row) continue;
+    for (const tile of row.items) out.push({ ...tile, y: vrow.start });
+  }
+  return out;
+});
+
 // TanStack Virtual caches per-index measurements; a new estimateSize closure
 // alone does NOT invalidate that cache. When the justified layout re-flows
 // (container resize, entries arriving, row-height change) the cached offsets
-// go stale and rows render overlapping — re-measure on any height change.
-watch(
-  () => rows.value.map((r) => r.height).join(","),
-  () => virtualizer.value?.measure?.(),
-);
+// go stale and rows render overlapping — re-measure on any re-flow.
+watch(rows, () => virtualizer.value?.measure?.());
 
 const showBadges = computed(
   () => !inTrash.value && gallery.filter === "all" && gallery.chipCounts.length > 1,
@@ -1969,6 +2099,12 @@ onUnmounted(() => {
   for (const key of [...pendingDeletes.keys()]) {
     void commitDelete(key);
   }
+  // Flush a settling thumbnail-size write so the choice survives navigation.
+  if (sliderPersistTimer) {
+    clearTimeout(sliderPersistTimer);
+    sliderPersistTimer = null;
+    saveGalleryThumbnailSize(rowHeight.value);
+  }
   // Flush a pending debounced search so the store matches the input.
   if (searchTimer) {
     clearTimeout(searchTimer);
@@ -2127,145 +2263,130 @@ onUnmounted(() => {
         action="Go to Create"
         @action="router.push('/create')"
       />
-      <div v-else :style="{ height: `${virtualizer.getTotalSize()}px`, position: 'relative' }">
+      <div v-else class="ms-lib-tile-layer" :style="{ height: `${virtualizer.getTotalSize()}px` }">
+        <!-- One flat, print-keyed list of the tiles inside the virtual window
+             (see `visibleTiles`). A tile is a wrapper (click / context /
+             dblclick) around a focusable button carrying the media, badges,
+             and the rising edge code; the ♥ and trash actions are sibling
+             overlays so they never nest a button inside a button. Every
+             per-tile fact comes from its `TileModel` — the template calls
+             nothing that walks the gallery. -->
         <div
-          v-for="vrow in virtualizer.getVirtualItems()"
-          :key="vrow.key as number"
-          class="absolute right-0 left-0 flex"
+          v-for="tile in visibleTiles"
+          :key="tile.model.key"
+          class="ms-lib-tile group overflow-hidden rounded-[9px] border"
+          :class="
+            (selectMode ? bulkSelection.has(tile.model.item.filename) : isSelected(tile.model.entry))
+              ? 'border-transparent ring-2 ring-safelight'
+              : 'border-[color-mix(in_srgb,var(--rebate)_14%,transparent)]'
+          "
           :style="{
-            transform: `translateY(${vrow.start}px)`,
-            gap: `${GAP}px`,
-            padding: `0 ${PAD}px`,
+            width: `${tile.width}px`,
+            height: `${tile.height}px`,
+            '--tile-x': `${tile.x}px`,
+            '--tile-y': `${tile.y}px`,
           }"
+          :data-filename="tile.model.item.filename"
+          @pointerdown="beginSelectionDrag($event, tile.model.entry)"
+          @click="onTileClick(tile.model.entry, $event)"
+          @contextmenu="onTileContextMenu(tile.model.entry, $event)"
+          @dblclick="onTileDblclick(tile.model.entry)"
         >
-          <!-- A tile is a wrapper (click / context / dblclick) around a focusable
-               button carrying the media, badges, and the rising edge code; the
-               ♥ and trash actions are sibling overlays so they never nest a
-               button inside a button. -->
-          <div
-            v-for="laid in rows[vrow.index]?.items ?? []"
-            :key="`${laid.entry.sourceKey}::${laid.item.filename}`"
-            class="ms-lib-tile group relative shrink-0 overflow-hidden rounded-[9px] border"
-            :class="
-              (selectMode ? bulkSelection.has(laid.item.filename) : isSelected(laid.entry))
-                ? 'border-transparent ring-2 ring-safelight'
-                : 'border-[color-mix(in_srgb,var(--rebate)_14%,transparent)]'
-            "
-            :style="{ width: `${laid.width}px`, height: `${laid.height}px` }"
-            :data-filename="laid.item.filename"
-            @pointerdown="beginSelectionDrag($event, laid.entry)"
-            @click="onTileClick(laid.entry, $event)"
-            @contextmenu="onTileContextMenu(laid.entry, $event)"
-            @dblclick="onTileDblclick(laid.entry)"
+          <button
+            type="button"
+            class="absolute inset-0 block h-full w-full overflow-hidden text-left"
+            :aria-label="tile.model.title"
+            :aria-pressed="selectMode ? bulkSelection.has(tile.model.item.filename) : undefined"
           >
-            <button
-              type="button"
-              class="absolute inset-0 block h-full w-full overflow-hidden text-left"
-              :aria-label="tileTitle(laid.entry)"
-              :aria-pressed="selectMode ? bulkSelection.has(laid.item.filename) : undefined"
-            >
-              <AuthedMedia
-                :path="
-                  galleryMediaPath(
-                    laid.item.filename,
-                    gallery.mediaSourceOf(laid.entry.sourceKey),
-                    true,
-                    laid.item.trashed_at != null,
-                  )
-                "
-                :target="targetFor(laid.entry)"
-                :cache-key="laid.entry.sourceKey"
-                :media-version="
-                  laid.item.media_version ??
-                  `${laid.item.timestamp}:${laid.item.size_bytes ?? 'unknown'}`
-                "
-                :video="
-                  gallery.mediaSourceOf(laid.entry.sourceKey) === 'local' && isVideo(laid.item)
-                "
-                :alt="laid.item.metadata.prompt"
-              />
-              <!-- NEW badge (top-left) — hidden while selecting, where the
-                   checkbox owns that corner; never in the trash. -->
-              <span
-                v-if="!selectMode && !inTrash && isFresh(laid.entry)"
-                data-test="new-badge"
-                class="ms-lib-new absolute top-2 left-2"
-              >
-                New
-              </span>
-              <span
-                v-if="!selectMode && isUpscaledImage(laid.item)"
-                data-test="upscaled-badge"
-                class="ms-lib-upscaled absolute top-2 right-2"
-              >
-                Upscaled
-              </span>
-              <span
-                v-if="isVideo(laid.item) || isAudio(laid.item)"
-                class="absolute top-1.5 right-1.5 rounded-control bg-black/60 px-1 text-caption text-on-media"
-              >
-                {{ isAudio(laid.item) ? "♪" : "▶" }}
-              </span>
-              <span
-                v-if="selectMode"
-                data-test="select-indicator"
-                class="absolute top-1.5 left-1.5 flex h-5 w-5 items-center justify-center rounded-full text-caption"
-                :class="
-                  bulkSelection.has(laid.item.filename)
-                    ? 'bg-safelight font-semibold text-on-accent'
-                    : 'border border-white/70 bg-black/40 text-on-media'
-                "
-              >
-                {{ bulkSelection.has(laid.item.filename) ? "✓" : "" }}
-              </span>
-              <!-- The badge yields to the rising edge code on hover — both live
-                   in the tile's bottom margin and must never overlap. -->
-              <span
-                v-if="showBadges"
-                data-test="host-badge"
-                class="edge-code absolute bottom-1.5 left-1.5 max-w-[70%] truncate rounded-control bg-black/60 px-1 !text-on-media transition-opacity duration-100 group-hover:opacity-0"
-                :title="`Available on ${availabilityLabel(laid.entry)}`"
-              >
-                {{ availabilityLabel(laid.entry) }}
-              </span>
-              <span
-                v-if="!inTrash"
-                data-test="edge-strip"
-                class="edge-code absolute right-0 bottom-0 left-0 translate-y-full truncate bg-black/60 py-0.5 pr-7 pl-1.5 text-left !text-on-media transition-transform duration-100 group-hover:translate-y-0"
-              >
-                {{ tileTitle(laid.entry) }} · {{ modelLabel(laid.item.metadata.model) }} · S
-                {{ laid.item.metadata.seed }}
-              </span>
-            </button>
-            <!-- ♥ (bottom-right): filled when favorite, faint on hover when not;
-                 click toggles without opening the print. -->
-            <button
-              v-if="!inTrash && organizeAvailable && canOrganizeEntry(laid.entry)"
-              type="button"
-              data-test="tile-favorite"
-              class="ms-lib-heart absolute right-1.5 bottom-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full text-on-media transition-opacity duration-100"
-              :class="
-                isFavorite(laid.entry)
-                  ? 'ms-lib-heart--on opacity-100'
-                  : 'opacity-0 group-hover:opacity-60 hover:!opacity-100'
-              "
-              :aria-pressed="isFavorite(laid.entry)"
-              :aria-label="isFavorite(laid.entry) ? 'Unfavorite' : 'Favorite'"
-              :title="isFavorite(laid.entry) ? 'Unfavorite' : 'Favorite'"
-              @click.stop="toggleFavorite(laid.entry)"
-              @dblclick.stop
-            >
-              <Icon name="heart" :size="14" />
-            </button>
-            <TrashTileActions
-              v-if="inTrash"
-              :purge-at="orgOf(laid.entry).purgeAt"
-              :show-actions="!selectMode"
-              :busy="organizeBusy"
-              @restore="restorePrints([laid.entry])"
-              @delete-forever="askDeleteForever([laid.entry])"
+            <AuthedMedia
+              :path="tile.model.mediaPath"
+              :target="tile.model.target"
+              :cache-key="tile.model.entry.sourceKey"
+              :media-version="tile.model.mediaVersion"
+              :video="tile.model.localVideo"
+              :alt="tile.model.item.metadata.prompt"
             />
-          </div>
+            <!-- NEW badge (top-left) — hidden while selecting, where the
+                 checkbox owns that corner; never in the trash. -->
+            <span
+              v-if="!selectMode && !inTrash && tile.model.fresh"
+              data-test="new-badge"
+              class="ms-lib-new absolute top-2 left-2"
+            >
+              New
+            </span>
+            <span
+              v-if="!selectMode && tile.model.upscaled"
+              data-test="upscaled-badge"
+              class="ms-lib-upscaled absolute top-2 right-2"
+            >
+              Upscaled
+            </span>
+            <span
+              v-if="tile.model.video || tile.model.audio"
+              class="absolute top-1.5 right-1.5 rounded-control bg-black/60 px-1 text-caption text-on-media"
+            >
+              {{ tile.model.audio ? "♪" : "▶" }}
+            </span>
+            <span
+              v-if="selectMode"
+              data-test="select-indicator"
+              class="absolute top-1.5 left-1.5 flex h-5 w-5 items-center justify-center rounded-full text-caption"
+              :class="
+                bulkSelection.has(tile.model.item.filename)
+                  ? 'bg-safelight font-semibold text-on-accent'
+                  : 'border border-white/70 bg-black/40 text-on-media'
+              "
+            >
+              {{ bulkSelection.has(tile.model.item.filename) ? "✓" : "" }}
+            </span>
+            <!-- The badge yields to the rising edge code on hover — both live
+                 in the tile's bottom margin and must never overlap. -->
+            <span
+              v-if="showBadges"
+              data-test="host-badge"
+              class="edge-code absolute bottom-1.5 left-1.5 max-w-[70%] truncate rounded-control bg-black/60 px-1 !text-on-media transition-opacity duration-100 group-hover:opacity-0"
+              :title="`Available on ${tile.model.availability}`"
+            >
+              {{ tile.model.availability }}
+            </span>
+            <span
+              v-if="!inTrash"
+              data-test="edge-strip"
+              class="edge-code absolute right-0 bottom-0 left-0 translate-y-full truncate bg-black/60 py-0.5 pr-7 pl-1.5 text-left !text-on-media transition-transform duration-100 group-hover:translate-y-0"
+            >
+              {{ tile.model.title }} · {{ tile.model.modelLabel }} · S
+              {{ tile.model.item.metadata.seed }}
+            </span>
+          </button>
+          <!-- ♥ (bottom-right): filled when favorite, faint on hover when not;
+               click toggles without opening the print. -->
+          <button
+            v-if="!inTrash && organizeAvailable && tile.model.canOrganize"
+            type="button"
+            data-test="tile-favorite"
+            class="ms-lib-heart absolute right-1.5 bottom-1.5 z-10 flex h-6 w-6 items-center justify-center rounded-full text-on-media transition-opacity duration-100"
+            :class="
+              tile.model.favorite
+                ? 'ms-lib-heart--on opacity-100'
+                : 'opacity-0 group-hover:opacity-60 hover:!opacity-100'
+            "
+            :aria-pressed="tile.model.favorite"
+            :aria-label="tile.model.favorite ? 'Unfavorite' : 'Favorite'"
+            :title="tile.model.favorite ? 'Unfavorite' : 'Favorite'"
+            @click.stop="toggleFavorite(tile.model.entry)"
+            @dblclick.stop
+          >
+            <Icon name="heart" :size="14" />
+          </button>
+          <TrashTileActions
+            v-if="inTrash"
+            :purge-at="tile.model.purgeAt"
+            :show-actions="!selectMode"
+            :busy="organizeBusy"
+            @restore="restorePrints([tile.model.entry])"
+            @delete-forever="askDeleteForever([tile.model.entry])"
+          />
         </div>
       </div>
     </div>
@@ -2409,15 +2530,28 @@ onUnmounted(() => {
 </template>
 
 <style scoped>
+/* Tiles are absolutely placed by the justified layout (`translate` carries
+   the row offset from the virtualizer plus the x offset within the row) and
+   contained, so a hover or a badge repaint never lays out its neighbours.
+   The hover lift transitions `transform` only — animating `box-shadow`
+   repainted a large blurred shadow every frame of the transition. */
 .ms-lib-tile {
-  transition:
-    transform var(--dur-quick) var(--ease),
-    box-shadow var(--dur-quick) var(--ease);
+  position: absolute;
+  top: 0;
+  left: 0;
+  contain: layout paint style;
+  transform: translate3d(var(--tile-x), var(--tile-y), 0);
+  transition: transform var(--dur-quick) var(--ease);
 }
 
 .ms-lib-tile:hover {
-  transform: translateY(-2px);
+  transform: translate3d(var(--tile-x), calc(var(--tile-y) - 2px), 0);
   box-shadow: 0 10px 24px rgba(0, 0, 0, 0.4);
+}
+
+.ms-lib-tile-layer {
+  position: relative;
+  will-change: transform;
 }
 
 .ms-lib-tile > button:focus-visible {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -11,6 +11,7 @@ import {
 } from "vue";
 import { useRoute, useRouter } from "vue-router";
 import { useVirtualizer } from "@tanstack/vue-virtual";
+import type { ThumbnailPriority } from "@studio/lib/thumbnailScheduler";
 import Icon from "@ui/components/Icon.vue";
 import {
   loadGalleryThumbnailSize,
@@ -1592,11 +1593,17 @@ const virtualizer = useVirtualizer(
  */
 const visibleTiles = computed(() => {
   const laid = rows.value;
-  const out: Array<LaidTile & { y: number }> = [];
-  for (const vrow of unref(virtualizer).getVirtualItems()) {
+  const instance = unref(virtualizer);
+  // `range` is the on-screen row span without overscan; rows outside it are
+  // fetched at `near` priority so a fast scroll never starves what is shown.
+  const range = instance.range;
+  const out: Array<LaidTile & { y: number; priority: ThumbnailPriority }> = [];
+  for (const vrow of instance.getVirtualItems()) {
     const row = laid[vrow.index];
     if (!row) continue;
-    for (const tile of row.items) out.push({ ...tile, y: vrow.start });
+    const priority: ThumbnailPriority =
+      range && (vrow.index < range.startIndex || vrow.index > range.endIndex) ? "near" : "visible";
+    for (const tile of row.items) out.push({ ...tile, y: vrow.start, priority });
   }
   return out;
 });
@@ -2276,7 +2283,11 @@ onUnmounted(() => {
           :key="tile.model.key"
           class="ms-lib-tile group overflow-hidden rounded-[9px] border"
           :class="
-            (selectMode ? bulkSelection.has(tile.model.item.filename) : isSelected(tile.model.entry))
+            (
+              selectMode
+                ? bulkSelection.has(tile.model.item.filename)
+                : isSelected(tile.model.entry)
+            )
               ? 'border-transparent ring-2 ring-safelight'
               : 'border-[color-mix(in_srgb,var(--rebate)_14%,transparent)]'
           "
@@ -2303,6 +2314,7 @@ onUnmounted(() => {
               :target="tile.model.target"
               :cache-key="tile.model.entry.sourceKey"
               :media-version="tile.model.mediaVersion"
+              :priority="tile.priority"
               :video="tile.model.localVideo"
               :alt="tile.model.item.metadata.prompt"
             />

--- a/studio/lib/galleryPerfBudget.test.ts
+++ b/studio/lib/galleryPerfBudget.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { countedFn, expectOpsUnder } from "./galleryPerfBudget";
+
+describe("expectOpsUnder", () => {
+  it("passes at or under the budget", () => {
+    expect(() => expectOpsUnder("x", 10, 10)).not.toThrow();
+    expect(() => expectOpsUnder("x", 0, 10)).not.toThrow();
+  });
+  it("names the label, observed count, budget and overage", () => {
+    expect(() => expectOpsUnder("unionOrganization", 12_000, 2_000)).toThrow(
+      /unionOrganization: 12000 operations exceeds the budget of 2000 \(\+10000\)/,
+    );
+  });
+});
+
+describe("countedFn", () => {
+  it("delegates and counts", () => {
+    const counted = countedFn((a: number, b: number) => a + b);
+    expect(counted.fn(1, 2)).toBe(3);
+    expect(counted.fn(2, 2)).toBe(4);
+    expect(counted.count()).toBe(2);
+    counted.reset();
+    expect(counted.count()).toBe(0);
+  });
+});

--- a/studio/lib/galleryPerfBudget.ts
+++ b/studio/lib/galleryPerfBudget.ts
@@ -1,0 +1,37 @@
+/**
+ * Operation-count budgets for the gallery regression guards.
+ *
+ * Wall-clock timings are noisy in CI, so every Library performance guard
+ * asserts a COUNT of expensive operations (union passes, identity scans,
+ * component mounts, queue sorts) against a budget expressed in terms of the
+ * data size. A guard that fails names the budget it broke and by how much,
+ * so a regression reads as "unionOrganization ran 12 000 times for 2 000
+ * prints (budget 2 000)" rather than "the test got slower".
+ */
+
+/** Throws a descriptive error when `observed` exceeds `budget`. */
+export function expectOpsUnder(label: string, observed: number, budget: number): void {
+  if (observed <= budget) return;
+  const over = observed - budget;
+  throw new Error(
+    `${label}: ${observed} operations exceeds the budget of ${budget} (+${over}). ` +
+      "A gallery hot path is doing per-item work that must be indexed once per data change.",
+  );
+}
+
+/** Counts invocations of a function while delegating to it unchanged. */
+export function countedFn<A extends unknown[], R>(
+  fn: (...args: A) => R,
+): { fn: (...args: A) => R; count: () => number; reset: () => void } {
+  let calls = 0;
+  return {
+    fn: (...args: A) => {
+      calls += 1;
+      return fn(...args);
+    },
+    count: () => calls,
+    reset: () => {
+      calls = 0;
+    },
+  };
+}

--- a/studio/lib/galleryPerfBudget.ts
+++ b/studio/lib/galleryPerfBudget.ts
@@ -10,7 +10,11 @@
  */
 
 /** Throws a descriptive error when `observed` exceeds `budget`. */
-export function expectOpsUnder(label: string, observed: number, budget: number): void {
+export function expectOpsUnder(
+  label: string,
+  observed: number,
+  budget: number,
+): void {
   if (observed <= budget) return;
   const over = observed - budget;
   throw new Error(

--- a/studio/lib/thumbnailScheduler.test.ts
+++ b/studio/lib/thumbnailScheduler.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, it } from "vitest";
+import { describe, expect, it, vi } from "vitest";
+import { expectOpsUnder } from "./galleryPerfBudget";
 import {
   ThumbnailScheduler,
   type ThumbnailPriority,
@@ -125,6 +126,51 @@ describe("ThumbnailScheduler", () => {
     await turn();
     expect(order[0]).toBe("promoted");
     older.cancel();
+  });
+
+  it("drains a 10 000-tile backlog in O(Q) dispatch work without sorting", async () => {
+    const Q = 10_000;
+    const scheduler = new ThumbnailScheduler({
+      concurrency: 12,
+      perHostConcurrency: 6,
+      backgroundConcurrency: 2,
+    });
+    const sortSpy = vi.spyOn(Array.prototype, "sort");
+    const priorities: ThumbnailPriority[] = ["visible", "near", "background"];
+    const handles = [];
+    let completed = 0;
+    for (let i = 0; i < Q; i++) {
+      handles.push(
+        scheduler.schedule({
+          key: `tile-${i}`,
+          hostKey: `host-${i % 3}`,
+          priority: priorities[i % 3]!,
+          run: async () => {
+            completed += 1;
+          },
+        }),
+      );
+    }
+    // Every other tile scrolls into view, and every fifth leaves the window.
+    for (let i = 0; i < Q; i += 2) handles[i]!.setPriority("visible");
+    for (let i = 0; i < Q; i += 5) {
+      void handles[i]!.promise.catch(() => {});
+      handles[i]!.cancel();
+    }
+    // Drain: each turn completes the running batch and pumps the next.
+    for (let spins = 0; spins < Q && scheduler.stats.keys > 0; spins++)
+      await turn();
+    sortSpy.mockRestore();
+
+    expect(scheduler.stats.keys).toBe(0);
+    expect(completed).toBe(Q - Q / 5);
+    expect(sortSpy).not.toHaveBeenCalled();
+    // One live slot plus at most one stale slot (the raised copy) per tile.
+    expectOpsUnder(
+      "scheduler dispatch scans",
+      scheduler.stats.dispatchScans,
+      2 * Q,
+    );
   });
 
   it("starts a fresh generation when a cancelled key is requested again", async () => {

--- a/studio/lib/thumbnailScheduler.test.ts
+++ b/studio/lib/thumbnailScheduler.test.ts
@@ -128,6 +128,47 @@ describe("ThumbnailScheduler", () => {
     older.cancel();
   });
 
+  it("rotates hosts so a third host is not starved by two busy ones", async () => {
+    // Two global slots, one per host: hosts a and b each hold a slot; when
+    // one frees, host c must get it before a or b refill.
+    const scheduler = new ThumbnailScheduler({
+      concurrency: 2,
+      perHostConcurrency: 1,
+    });
+    const started: string[] = [];
+    const blockers = new Map<string, ReturnType<typeof deferred<void>>>();
+    const add = (host: string, n: number) => {
+      for (let i = 0; i < n; i++) {
+        const key = `${host}-${i}`;
+        const gate = deferred<void>();
+        blockers.set(key, gate);
+        scheduler.schedule({
+          key,
+          hostKey: host,
+          priority: "visible",
+          run: () => {
+            started.push(key);
+            return gate.promise;
+          },
+        });
+      }
+    };
+    add("a", 3);
+    add("b", 3);
+    add("c", 3);
+    await turn();
+    expect(started).toEqual(["a-0", "b-0"]);
+    blockers.get("a-0")!.resolve();
+    await turn();
+    await turn();
+    expect(started[2]).toBe("c-0");
+    blockers.get("b-0")!.resolve();
+    await turn();
+    await turn();
+    expect(started[3]).toBe("a-1");
+    for (const gate of blockers.values()) gate.resolve();
+  });
+
   it("drains a 10 000-tile backlog in O(Q) dispatch work without sorting", async () => {
     const Q = 10_000;
     const scheduler = new ThumbnailScheduler({
@@ -136,6 +177,18 @@ describe("ThumbnailScheduler", () => {
       backgroundConcurrency: 2,
     });
     const sortSpy = vi.spyOn(Array.prototype, "sort");
+    // Instrument iteration externally: every Map iterator step is counted, so
+    // an uncounted "walk the whole entries map per dispatch" regression cannot
+    // hide behind the scheduler's own `dispatchScans`.
+    const iteratorProto = Object.getPrototypeOf(new Map().values()) as {
+      next: () => unknown;
+    };
+    const originalNext = iteratorProto.next;
+    let iteratorSteps = 0;
+    iteratorProto.next = function (this: unknown) {
+      iteratorSteps += 1;
+      return originalNext.call(this);
+    };
     const priorities: ThumbnailPriority[] = ["visible", "near", "background"];
     const handles = [];
     let completed = 0;
@@ -157,14 +210,21 @@ describe("ThumbnailScheduler", () => {
       void handles[i]!.promise.catch(() => {});
       handles[i]!.cancel();
     }
-    // Drain: each turn completes the running batch and pumps the next.
-    for (let spins = 0; spins < Q && scheduler.stats.keys > 0; spins++)
+    // Drain: each turn completes the running batch and pumps the next. The
+    // loop watches `completed` rather than `stats` (which walks every entry).
+    const expectedCompleted = Q - Q / 5;
+    for (let spins = 0; spins < Q && completed < expectedCompleted; spins++)
       await turn();
+    await turn();
+    iteratorProto.next = originalNext;
     sortSpy.mockRestore();
 
     expect(scheduler.stats.keys).toBe(0);
-    expect(completed).toBe(Q - Q / 5);
+    expect(completed).toBe(expectedCompleted);
     expect(sortSpy).not.toHaveBeenCalled();
+    // Each dispatch visits at most the three priority maps' host lists (3
+    // hosts here): a per-dispatch scan of the entries map would cost Q steps.
+    expectOpsUnder("map iterator steps while draining", iteratorSteps, 16 * Q);
     // One live slot plus at most one stale slot (the raised copy) per tile.
     expectOpsUnder(
       "scheduler dispatch scans",

--- a/studio/lib/thumbnailScheduler.ts
+++ b/studio/lib/thumbnailScheduler.ts
@@ -34,6 +34,12 @@ export interface ThumbnailSchedulerOptions {
   backgroundConcurrency?: number;
 }
 
+const PRIORITIES: readonly ThumbnailPriority[] = [
+  "visible",
+  "near",
+  "background",
+];
+
 const priorityRank: Record<ThumbnailPriority, number> = {
   visible: 0,
   near: 1,
@@ -49,8 +55,44 @@ function abortError(): Error {
 }
 
 /**
+ * FIFO with an advancing head, so dequeue is O(1) and the array is compacted
+ * only once the dead prefix outweighs the live tail.
+ */
+class Fifo<T> {
+  private items: T[] = [];
+  private head = 0;
+
+  push(item: T): void {
+    this.items.push(item);
+  }
+
+  shift(): T | undefined {
+    if (this.head >= this.items.length) return undefined;
+    const item = this.items[this.head];
+    this.items[this.head] = undefined as unknown as T;
+    this.head += 1;
+    if (this.head > 1024 && this.head * 2 > this.items.length) {
+      this.items = this.items.slice(this.head);
+      this.head = 0;
+    }
+    return item;
+  }
+
+  get size(): number {
+    return this.items.length - this.head;
+  }
+}
+
+/**
  * Shared policy for every gallery surface. Adapters own transport and cache;
  * this class only bounds, prioritizes, deduplicates, and cancels work.
+ *
+ * Dispatch is O(hosts): one FIFO per (priority, host), visited highest
+ * priority first and round-robin across hosts with a free slot. Entries whose
+ * priority was raised or that were cancelled while queued are skipped lazily
+ * when they surface, so nothing ever re-sorts the queue — the previous
+ * implementation copied and sorted every queued entry per dispatch, which
+ * made draining Q tiles O(Q² log Q).
  */
 export class ThumbnailScheduler {
   private readonly concurrency: number;
@@ -58,10 +100,16 @@ export class ThumbnailScheduler {
   private readonly backgroundConcurrency: number;
   private readonly entries = new Map<string, ScheduledEntry<unknown>>();
   private readonly runningByHost = new Map<string, number>();
+  /** priority → host → FIFO of queued entries (lazily invalidated). */
+  private readonly queues: Record<
+    ThumbnailPriority,
+    Map<string, Fifo<ScheduledEntry<unknown>>>
+  > = { visible: new Map(), near: new Map(), background: new Map() };
   private running = 0;
   private runningBackground = 0;
   private sequence = 0;
   private pumpQueued = false;
+  private dispatchScans = 0;
 
   constructor(options: ThumbnailSchedulerOptions = {}) {
     this.concurrency = Math.max(1, options.concurrency ?? 12);
@@ -97,8 +145,9 @@ export class ThumbnailScheduler {
         reject,
       };
       this.entries.set(request.key, entry as ScheduledEntry<unknown>);
+      this.enqueue(entry as ScheduledEntry<unknown>);
     } else if (priorityRank[request.priority] < priorityRank[entry.priority]) {
-      entry.priority = request.priority;
+      this.raise(entry as ScheduledEntry<unknown>, request.priority);
     }
     entry.consumers += 1;
     this.queuePump();
@@ -113,6 +162,7 @@ export class ThumbnailScheduler {
         if (entry!.consumers > 0) return;
         entry!.controller.abort();
         if (entry!.state === "queued") {
+          // The FIFO slot stays behind and is skipped when it surfaces.
           this.entries.delete(entry!.key);
           entry!.reject(abortError());
         }
@@ -120,7 +170,7 @@ export class ThumbnailScheduler {
       setPriority: (priority) => {
         if (!active || priorityRank[priority] >= priorityRank[entry!.priority])
           return;
-        entry!.priority = priority;
+        this.raise(entry! as ScheduledEntry<unknown>, priority);
         this.queuePump();
       },
     };
@@ -131,6 +181,8 @@ export class ThumbnailScheduler {
     running: number;
     background: number;
     keys: number;
+    /** FIFO slots examined by dispatch so far — the perf guard's budget. */
+    dispatchScans: number;
   }> {
     let queued = 0;
     for (const entry of this.entries.values())
@@ -140,7 +192,27 @@ export class ThumbnailScheduler {
       running: this.running,
       background: this.runningBackground,
       keys: this.entries.size,
+      dispatchScans: this.dispatchScans,
     };
+  }
+
+  private enqueue(entry: ScheduledEntry<unknown>): void {
+    const byHost = this.queues[entry.priority];
+    let fifo = byHost.get(entry.hostKey);
+    if (!fifo) {
+      fifo = new Fifo();
+      byHost.set(entry.hostKey, fifo);
+    }
+    fifo.push(entry);
+  }
+
+  /** Re-file a queued entry under a higher priority; the old slot goes stale. */
+  private raise(
+    entry: ScheduledEntry<unknown>,
+    priority: ThumbnailPriority,
+  ): void {
+    entry.priority = priority;
+    if (entry.state === "queued") this.enqueue(entry);
   }
 
   private queuePump(): void {
@@ -160,23 +232,42 @@ export class ThumbnailScheduler {
     }
   }
 
+  /** A slot is live only while it is still the entry's current filing. */
+  private isLive(
+    entry: ScheduledEntry<unknown>,
+    priority: ThumbnailPriority,
+  ): boolean {
+    return (
+      entry.state === "queued" &&
+      entry.consumers > 0 &&
+      entry.priority === priority &&
+      this.entries.get(entry.key) === entry
+    );
+  }
+
   private nextRunnable(): ScheduledEntry<unknown> | null {
-    const candidates = [...this.entries.values()]
-      .filter(
-        (entry) =>
-          entry.state === "queued" &&
-          entry.consumers > 0 &&
-          (this.runningByHost.get(entry.hostKey) ?? 0) <
-            this.perHostConcurrency &&
-          (entry.priority !== "background" ||
-            this.runningBackground < this.backgroundConcurrency),
-      )
-      .sort(
-        (left, right) =>
-          priorityRank[left.priority] - priorityRank[right.priority] ||
-          left.sequence - right.sequence,
-      );
-    return candidates[0] ?? null;
+    for (const priority of PRIORITIES) {
+      if (
+        priority === "background" &&
+        this.runningBackground >= this.backgroundConcurrency
+      ) {
+        continue;
+      }
+      for (const [hostKey, fifo] of this.queues[priority]) {
+        if ((this.runningByHost.get(hostKey) ?? 0) >= this.perHostConcurrency)
+          continue;
+        for (;;) {
+          const entry = fifo.shift();
+          if (!entry) {
+            this.queues[priority].delete(hostKey);
+            break;
+          }
+          this.dispatchScans += 1;
+          if (this.isLive(entry, priority)) return entry;
+        }
+      }
+    }
+    return null;
   }
 
   private start(entry: ScheduledEntry<unknown>): void {

--- a/studio/lib/thumbnailScheduler.ts
+++ b/studio/lib/thumbnailScheduler.ts
@@ -253,17 +253,25 @@ export class ThumbnailScheduler {
       ) {
         continue;
       }
-      for (const [hostKey, fifo] of this.queues[priority]) {
+      const byHost = this.queues[priority];
+      for (const [hostKey, fifo] of byHost) {
         if ((this.runningByHost.get(hostKey) ?? 0) >= this.perHostConcurrency)
           continue;
         for (;;) {
           const entry = fifo.shift();
           if (!entry) {
-            this.queues[priority].delete(hostKey);
+            byHost.delete(hostKey);
             break;
           }
           this.dispatchScans += 1;
-          if (this.isLive(entry, priority)) return entry;
+          if (this.isLive(entry, priority)) {
+            // Round-robin: the host that just won moves to the back so a
+            // third host is never starved while two busy ones keep refilling
+            // freed slots ahead of it.
+            byHost.delete(hostKey);
+            byHost.set(hostKey, fifo);
+            return entry;
+          }
         }
       }
     }


### PR DESCRIPTION
## Summary

First of four serialized PRs making the desktop Library near-native at 1 000+ prints (plan: store/render → persistent thumbnail cache → server thumbnails → web/mobile parity).

- **Store**: `organizationIndex` / `bucketIndex` getters compute each logical print's organization union and its cross-host copies ONCE per data change. Before: `unionOrganization` re-ran per call across ~10 full-N getters (28 200 calls for 3 000 prints on one change) and every visible tile scanned every bucket (25.2 M identity comparisons to resolve copies at 3 000 prints).
- **Grid**: per-tile view models computed once; ONE flat print-keyed absolutely positioned tile layer so a thumbnail-size drag or resize moves tiles instead of remounting `AuthedMedia` (which cancelled and refetched the thumbnail); memoized model labels; settled slider persistence; `contain` on tiles, transform-only hover transition.
- **Rows are raw immutable snapshots** (`markRaw`, replaced via `patchRow`) — no deep proxies over 1 000 × 60-field metadata objects.
- **304 poll is a no-op**: `fetchBucket` skips the assignment when the conditional listing hands back the same array.
- **Scheduler**: per-(priority, host) FIFO queues, O(hosts) dispatch (was copy+sort of the whole queue per dispatch); `AuthedMedia` takes a `priority` prop (visible / near from the virtual window) and `decoding="async"`.
- **History ▸ Runs** capped like Sequences.

## Regression guards (operation counts, not wall clock)

- `desktop/src/stores/gallery.perf.test.ts` — 3 000 prints across 2 hosts with mirrored and legacy copies: ≤ 1 union pass per logical print across every getter, 0 union passes on a filter change, 0 identity scans to resolve every print's copies.
- `desktop/src/views/LibraryView.perf.test.ts` — mounts the REAL virtualizer + justified layout at 2 000 prints: ≤ 80 tiles in the DOM, 0 `AuthedMedia` remounts across a three-tick slider drag.
- `studio/lib/thumbnailScheduler.test.ts` — drains 10 000 tiles with zero `Array.prototype.sort` calls and ≤ 2Q dispatch scans.
- `studio/lib/galleryPerfBudget.ts` — the shared `expectOpsUnder` helper every guard reads.

## UAT

Dev app against `MOLD_HOME=/Volumes/ExternalStorage/mold2` with plato + hal9000 connected: 1 206 prints in the All view render and scroll smoothly.

## Test plan

- [x] `cd desktop && bun run test` (5 342 passed)
- [x] `bun run test:studio`, `bun run check:architecture`, `bun run check:dead-code`
- [x] `vue-tsc -b`