### PR TITLE
feat(cli): manage existing library prints

### DIFF
--- a/.ua/fingerprints.json
+++ b/.ua/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "6a18814b6081fd954d1c7471565d741594b19ad5",
-  "generatedAt": "2026-08-28T15:45:52.694Z",
+  "gitCommitHash": "3db4501d931196954bb80290797c4cc6c004bc5b",
+  "generatedAt": "2026-08-28T16:27:44.501Z",
   "files": {
     "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt": {
       "filePath": "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt",
@@ -202700,7 +202700,7 @@
     },
     "crates/mold-tui/src/app.rs": {
       "filePath": "crates/mold-tui/src/app.rs",
-      "contentHash": "3cb2eba8782e2a6f970e1e4993ea930cc3ea209f4c3a15637ee54427e5936b47",
+      "contentHash": "b70250acd2a46fd5c8414fa3709d051aad08a74fea294b36d5b774f406d20689",
       "functions": [
         {
           "name": "clear",
@@ -202717,12 +202717,14 @@
         {
           "name": "generation_elapsed",
           "params": [],
+          "returnType": "Option<std::time::Duration>",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "stage_elapsed",
           "params": [],
+          "returnType": "Option<std::time::Duration>",
           "exported": true,
           "lineCount": 3
         },
@@ -202743,12 +202745,14 @@
         {
           "name": "is_downloading",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "download_status_text",
           "params": [],
+          "returnType": "&str",
           "exported": true,
           "lineCount": 15
         },
@@ -202772,6 +202776,7 @@
           "params": [
             "has_negative"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 9
         },
@@ -202780,12 +202785,14 @@
           "params": [
             "has_negative"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "label",
           "params": [],
+          "returnType": "&'static str",
           "exported": true,
           "lineCount": 46
         },
@@ -202794,6 +202801,7 @@
           "params": [
             "path"
           ],
+          "returnType": "Option<(u32, u32)>",
           "exported": false,
           "lineCount": 15
         },
@@ -202802,18 +202810,21 @@
           "params": [
             "text"
           ],
+          "returnType": "Option<(u32, u32)>",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "label",
           "params": [],
+          "returnType": "&'static str",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "next",
           "params": [],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -202822,6 +202833,7 @@
           "params": [
             "current"
           ],
+          "returnType": "u64",
           "exported": true,
           "lineCount": 9
         },
@@ -202830,6 +202842,7 @@
           "params": [
             "used_seed"
           ],
+          "returnType": "Option<u64>",
           "exported": true,
           "lineCount": 7
         },
@@ -202840,18 +202853,21 @@
             "prompt",
             "negative_prompt"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "label",
           "params": [],
+          "returnType": "&'static str",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "next",
           "params": [],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -202861,6 +202877,7 @@
             "params",
             "config"
           ],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 6
         },
@@ -202869,6 +202886,7 @@
           "params": [
             "config"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 58
         },
@@ -202877,6 +202895,7 @@
           "params": [
             "field"
           ],
+          "returnType": "String",
           "exported": true,
           "lineCount": 179
         },
@@ -202885,6 +202904,7 @@
           "params": [
             "value"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 5
         },
@@ -202896,6 +202916,7 @@
             "step",
             "max"
           ],
+          "returnType": "Option<f64>",
           "exported": false,
           "lineCount": 15
         },
@@ -202906,6 +202927,7 @@
             "delta",
             "max"
           ],
+          "returnType": "Option<u32>",
           "exported": false,
           "lineCount": 15
         },
@@ -202914,6 +202936,7 @@
           "params": [
             "input"
           ],
+          "returnType": "std::result::Result<Option<Vec<u32>>, String>",
           "exported": false,
           "lineCount": 33
         },
@@ -202922,6 +202945,7 @@
           "params": [
             "target"
           ],
+          "returnType": "u32",
           "exported": false,
           "lineCount": 8
         },
@@ -202931,6 +202955,7 @@
             "grid",
             "fps"
           ],
+          "returnType": "u32",
           "exported": false,
           "lineCount": 13
         },
@@ -202950,6 +202975,7 @@
             "negative_cleared",
             "advertised_default"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 13
         },
@@ -202958,6 +202984,7 @@
           "params": [
             "text"
           ],
+          "returnType": "TextArea<'static>",
           "exported": false,
           "lineCount": 10
         },
@@ -202968,6 +202995,7 @@
             "submission",
             "outcomes"
           ],
+          "returnType": "Option<Self>",
           "exported": true,
           "lineCount": 20
         },
@@ -202980,18 +203008,21 @@
         {
           "name": "guidance_adjustable",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "negative_visible",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 5
         },
         {
           "name": "default",
           "params": [],
+          "returnType": "Self",
           "exported": false,
           "lineCount": 27
         },
@@ -203004,12 +203035,14 @@
         {
           "name": "selected_pos",
           "params": [],
+          "returnType": "Option<usize>",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "rescan_due",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203019,12 +203052,14 @@
             "code",
             "modifiers"
           ],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 27
         },
         {
           "name": "local",
           "params": [],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -203033,6 +203068,7 @@
           "params": [
             "entry"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -203041,42 +203077,49 @@
           "params": [
             "url"
           ],
+          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "is_local",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "is_this_machine",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "filename",
           "params": [],
+          "returnType": "String",
           "exported": true,
           "lineCount": 6
         },
         {
           "name": "owning_origins",
           "params": [],
+          "returnType": "Vec<GalleryOrigin>",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "primary_origin",
           "params": [],
+          "returnType": "GalleryOrigin",
           "exported": true,
           "lineCount": 6
         },
         {
           "name": "machine_label",
           "params": [],
+          "returnType": "String",
           "exported": true,
           "lineCount": 8
         },
@@ -203085,12 +203128,14 @@
           "params": [
             "days"
           ],
+          "returnType": "String",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "hint_label",
           "params": [],
+          "returnType": "&'static str",
           "exported": true,
           "lineCount": 6
         },
@@ -203101,6 +203146,7 @@
             "machines",
             "kind"
           ],
+          "returnType": "String",
           "exported": true,
           "lineCount": 12
         },
@@ -203109,6 +203155,7 @@
           "params": [
             "model"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 6
         },
@@ -203118,18 +203165,21 @@
             "catalog",
             "query"
           ],
+          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 12
         },
         {
           "name": "is_field",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "is_read_only",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203138,6 +203188,17 @@
           "params": [
             "url"
           ],
+          "returnType": "bool",
+          "exported": false,
+          "lineCount": 8
+        },
+        {
+          "name": "check_gallery_access",
+          "params": [
+            "url",
+            "api_key"
+          ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 8
         },
@@ -203146,6 +203207,7 @@
           "params": [
             "port"
           ],
+          "returnType": "Option<std::process::Child>",
           "exported": false,
           "lineCount": 6
         },
@@ -203155,6 +203217,7 @@
             "col",
             "tab_bar_x"
           ],
+          "returnType": "Option<View>",
           "exported": true,
           "lineCount": 5
         },
@@ -203173,6 +203236,7 @@
             "url",
             "timeout_secs"
           ],
+          "returnType": "bool",
           "exported": false,
           "lineCount": 10
         },
@@ -203183,8 +203247,9 @@
             "local",
             "picker"
           ],
+          "returnType": "Result<Self>",
           "exported": true,
-          "lineCount": 3
+          "lineCount": 9
         },
         {
           "name": "new_with_launch_policy",
@@ -203192,26 +203257,30 @@
             "host",
             "local",
             "picker",
+            "api_key",
             "strict_host"
           ],
+          "returnType": "Result<Self>",
           "exported": true,
-          "lineCount": 320
+          "lineCount": 354
         },
         {
           "name": "spawn_gallery_scan",
           "params": [],
           "exported": true,
-          "lineCount": 9
+          "lineCount": 10
         },
         {
           "name": "should_poll_remote",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "should_save_output_locally",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 6
         },
@@ -203220,6 +203289,7 @@
           "params": [
             "from_local"
           ],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203263,18 +203333,21 @@
           "params": [
             "model"
           ],
+          "returnType": "Option<mold_core::SourceImageCapability>",
           "exported": false,
           "lineCount": 11
         },
         {
           "name": "identity_gate_error",
           "params": [],
+          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 27
         },
         {
           "name": "identity_dispatch_error",
           "params": [],
+          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 7
         },
@@ -203310,6 +203383,12 @@
           "name": "shutdown",
           "params": [],
           "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "cleanup_runtime_authority",
+          "params": [],
+          "exported": false,
           "lineCount": 11
         },
         {
@@ -203367,12 +203446,14 @@
         {
           "name": "model_default_size",
           "params": [],
+          "returnType": "(u32, u32)",
           "exported": false,
           "lineCount": 19
         },
         {
           "name": "active_generation_recipe",
           "params": [],
+          "returnType": "Option<mold_core::GenerationRecipeProfile>",
           "exported": false,
           "lineCount": 10
         },
@@ -203415,6 +203496,7 @@
         {
           "name": "available_upscaler_models",
           "params": [],
+          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 20
         },
@@ -203480,6 +203562,7 @@
           "params": [
             "path"
           ],
+          "returnType": "bool",
           "exported": false,
           "lineCount": 16
         },
@@ -203516,6 +203599,7 @@
           "params": [
             "origin"
           ],
+          "returnType": "Option<&mold_core::ServerCapabilities>",
           "exported": true,
           "lineCount": 12
         },
@@ -203524,6 +203608,7 @@
           "params": [
             "origin"
           ],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203532,12 +203617,14 @@
           "params": [
             "entry"
           ],
+          "returnType": "RemovalKind",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "selected_removal_kind",
           "params": [],
+          "returnType": "RemovalKind",
           "exported": true,
           "lineCount": 7
         },
@@ -203558,12 +203645,14 @@
           "params": [
             "model_name"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 49
         },
         {
           "name": "needs_confirm",
           "params": [],
+          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
@@ -203615,6 +203704,7 @@
           "params": [
             "field"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 10
         },
@@ -203643,6 +203733,7 @@
         {
           "name": "build_settings_rows",
           "params": [],
+          "returnType": "Vec<SettingsRow>",
           "exported": true,
           "lineCount": 323
         },
@@ -203651,6 +203742,7 @@
           "params": [
             "key"
           ],
+          "returnType": "String",
           "exported": true,
           "lineCount": 139
         },
@@ -203667,6 +203759,7 @@
           "params": [
             "key"
           ],
+          "returnType": "Option<&'static str>",
           "exported": true,
           "lineCount": 24
         },
@@ -203789,6 +203882,7 @@
         {
           "name": "prompt_transform_task",
           "params": [],
+          "returnType": "mold_core::ExpandTask",
           "exported": false,
           "lineCount": 18
         },
@@ -203797,6 +203891,7 @@
           "params": [
             "target"
           ],
+          "returnType": "std::result::Result<String, String>",
           "exported": false,
           "lineCount": 37
         },
@@ -203824,6 +203919,7 @@
             "snapshot",
             "dimensions"
           ],
+          "returnType": "mold_core::PromptTransformProvenance",
           "exported": false,
           "lineCount": 13
         },
@@ -203832,6 +203928,7 @@
           "params": [
             "snapshot"
           ],
+          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 32
         },
@@ -203840,6 +203937,7 @@
           "params": [
             "snapshot"
           ],
+          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 31
         },
@@ -203849,6 +203947,7 @@
             "snapshot",
             "response"
           ],
+          "returnType": "bool",
           "exported": false,
           "lineCount": 9
         },
@@ -203889,6 +203988,7 @@
           "params": [
             "config"
           ],
+          "returnType": "Vec<mold_core::ModelInfoExtended>",
           "exported": false,
           "lineCount": 19
         },
@@ -203897,6 +203997,7 @@
           "params": [
             "encoded"
           ],
+          "returnType": "Option<image::DynamicImage>",
           "exported": false,
           "lineCount": 18
         },
@@ -203905,6 +204006,7 @@
           "params": [
             "position"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 7
         },
@@ -203914,8 +204016,15 @@
             "progress",
             "event"
           ],
+          "returnType": "bool",
           "exported": false,
           "lineCount": 161
+        },
+        {
+          "name": "drop",
+          "params": [],
+          "exported": false,
+          "lineCount": 6
         }
       ],
       "classes": [
@@ -204621,6 +204730,7 @@
             "sync_pipeline_guidance",
             "spawn_upscale",
             "shutdown",
+            "cleanup_runtime_authority",
             "save_session",
             "apply_theme_preset",
             "update_model",
@@ -204697,7 +204807,8 @@
             "apply_prompt_variant",
             "prepare_prompt_variants",
             "process_background_events",
-            "handle_progress"
+            "handle_progress",
+            "drop"
           ],
           "properties": [
             "active_view",
@@ -204725,6 +204836,8 @@
             "history",
             "layout",
             "server_process",
+            "session_api_key_host_id",
+            "strict_gallery_authority",
             "upscale_in_progress",
             "upscale_task",
             "upscale_tile_progress",
@@ -204733,7 +204846,7 @@
             "show_timeline"
           ],
           "exported": true,
-          "lineCount": 52
+          "lineCount": 58
         },
         {
           "name": "LayoutAreas",
@@ -204756,20 +204869,106 @@
       ],
       "imports": [
         {
-          "source": "crates/mold-tui/src/action.rs",
-          "specifiers": []
+          "source": "anyhow",
+          "specifiers": [
+            "Context",
+            "Result"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/event.rs",
-          "specifiers": []
+          "source": "crossterm::event",
+          "specifiers": [
+            "KeyCode",
+            "KeyModifiers"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/model_info.rs",
-          "specifiers": []
+          "source": "mold_core",
+          "specifiers": [
+            "Config",
+            "GenerateResponse",
+            "Ltx2GuidanceOverrides",
+            "Ltx2PipelineMode",
+            "Ltx2SpatialUpscale",
+            "Ltx2TemporalUpscale",
+            "ModelInfoExtended",
+            "OutputFormat",
+            "PromptTransformOperation",
+            "RemixResponse",
+            "Scheduler",
+            "ServerStatus",
+            "SseProgressEvent"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/ui/theme.rs",
-          "specifiers": []
+          "source": "rand",
+          "specifiers": [
+            "Rng"
+          ]
+        },
+        {
+          "source": "ratatui_image::picker",
+          "specifiers": [
+            "Picker"
+          ]
+        },
+        {
+          "source": "ratatui_image::protocol",
+          "specifiers": [
+            "Protocol",
+            "StatefulProtocol"
+          ]
+        },
+        {
+          "source": "std::collections",
+          "specifiers": [
+            "VecDeque"
+          ]
+        },
+        {
+          "source": "tokio::sync",
+          "specifiers": [
+            "mpsc"
+          ]
+        },
+        {
+          "source": "tui_textarea",
+          "specifiers": [
+            "TextArea"
+          ]
+        },
+        {
+          "source": "crate::action",
+          "specifiers": [
+            "Action",
+            "View"
+          ]
+        },
+        {
+          "source": "crate::event",
+          "specifiers": [
+            "map_event"
+          ]
+        },
+        {
+          "source": "crate::model_info",
+          "specifiers": [
+            "capabilities_for_family"
+          ]
+        },
+        {
+          "source": "crate::model_info",
+          "specifiers": [
+            "capabilities_for_model",
+            "family_for_model",
+            "ModelCapabilities"
+          ]
+        },
+        {
+          "source": "crate::ui::theme",
+          "specifiers": [
+            "Theme"
+          ]
         }
       ],
       "exports": [
@@ -204882,7 +205081,7 @@
         "settings_env_override",
         "process_background_events"
       ],
-      "totalLines": 18675,
+      "totalLines": 18774,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/backend.rs": {
@@ -205484,7 +205683,7 @@
     },
     "crates/mold-tui/src/gallery_scan.rs": {
       "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "contentHash": "b8db22152591e1f9aa14a3ab98ce50ace2e2d73cde3b49442399d87d799c160c",
+      "contentHash": "cc7e6d2bf16e865e8d28a07ac7862bda6df27c33fe5948ae591885a0dff7a06d",
       "functions": [
         {
           "name": "default_gallery_dir",
@@ -205615,11 +205814,12 @@
         {
           "name": "scan_all_hosts",
           "params": [
-            "sources"
+            "sources",
+            "allow_local_fallback"
           ],
           "returnType": "MergedScan",
           "exported": true,
-          "lineCount": 41
+          "lineCount": 48
         },
         {
           "name": "merge_scans",
@@ -205737,7 +205937,7 @@
         "filter_entries",
         "library_hint"
       ],
-      "totalLines": 1144,
+      "totalLines": 1165,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/gallery_trash.rs": {
@@ -206257,7 +206457,7 @@
     },
     "crates/mold-tui/src/hosts.rs": {
       "filePath": "crates/mold-tui/src/hosts.rs",
-      "contentHash": "162fd4c9a45e875689a8c6dac547c28920569ae44f6cbad4354f6d5672e492b5",
+      "contentHash": "f4ac58abcafc451d9ffed32dc85d629f165cacc9623fd5c29580843409221168",
       "functions": [
         {
           "name": "local_display_name",
@@ -206371,13 +206571,30 @@
           "lineCount": 3
         },
         {
+          "name": "set_session_api_key",
+          "params": [
+            "id",
+            "key"
+          ],
+          "exported": true,
+          "lineCount": 9
+        },
+        {
+          "name": "clear_session_api_key",
+          "params": [
+            "id"
+          ],
+          "exported": true,
+          "lineCount": 6
+        },
+        {
           "name": "api_key_for",
           "params": [
             "id"
           ],
           "returnType": "Option<String>",
           "exported": true,
-          "lineCount": 7
+          "lineCount": 15
         },
         {
           "name": "save_api_key",
@@ -207035,6 +207252,13 @@
           ]
         },
         {
+          "source": "std::sync",
+          "specifiers": [
+            "LazyLock",
+            "RwLock"
+          ]
+        },
+        {
           "source": "tokio::sync",
           "specifiers": [
             "mpsc"
@@ -207085,6 +207309,8 @@
         "all",
         "host_id_from_url",
         "host_port_label",
+        "set_session_api_key",
+        "clear_session_api_key",
         "api_key_for",
         "save_api_key",
         "delete_api_key",
@@ -207145,7 +207371,7 @@
         "test_connection",
         "cancel_host_job"
       ],
-      "totalLines": 2278,
+      "totalLines": 2310,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/identity.rs": {
@@ -207227,14 +207453,34 @@
     },
     "crates/mold-tui/src/lib.rs": {
       "filePath": "crates/mold-tui/src/lib.rs",
-      "contentHash": "3e922090b8730e8b996876a58e88ec963dda1e19fc04d6b28497fe2e0ebe80d4",
+      "contentHash": "6c32ca2e3be0cdc54ad12a31d66ec29f8fa66956414ac406b8f1379949da3aed",
       "functions": [
+        {
+          "name": "arm",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
+        {
+          "name": "restore",
+          "params": [],
+          "returnType": "io::Result<()>",
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "drop",
+          "params": [],
+          "exported": false,
+          "lineCount": 3
+        },
         {
           "name": "run_tui",
           "params": [
             "host",
             "local"
           ],
+          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 8
         },
@@ -207243,8 +207489,9 @@
           "params": [
             "options"
           ],
+          "returnType": "Result<()>",
           "exported": true,
-          "lineCount": 48
+          "lineCount": 53
         },
         {
           "name": "run_event_loop",
@@ -207252,11 +207499,25 @@
             "terminal",
             "app"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 46
         }
       ],
       "classes": [
+        {
+          "name": "TerminalRestoreGuard",
+          "methods": [
+            "arm",
+            "restore",
+            "drop"
+          ],
+          "properties": [
+            "active"
+          ],
+          "exported": false,
+          "lineCount": 3
+        },
         {
           "name": "TuiInitialWorkspace",
           "methods": [],
@@ -207273,89 +207534,50 @@
           "properties": [
             "host",
             "local",
+            "api_key",
             "initial_workspace",
             "strict_host"
           ],
           "exported": true,
-          "lineCount": 8
+          "lineCount": 11
         }
       ],
       "imports": [
         {
-          "source": "crates/mold-tui/src/action.rs",
-          "specifiers": []
+          "source": "std",
+          "specifiers": [
+            "io"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/animation.rs",
-          "specifiers": []
+          "source": "std",
+          "specifiers": [
+            "panic"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/app.rs",
-          "specifiers": []
+          "source": "anyhow",
+          "specifiers": [
+            "Result"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/backend.rs",
-          "specifiers": []
+          "source": "crossterm",
+          "specifiers": [
+            "execute"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/event.rs",
-          "specifiers": []
+          "source": "ratatui::prelude",
+          "specifiers": [
+            "*"
+          ]
         },
         {
-          "source": "crates/mold-tui/src/gallery_scan.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/gallery_trash.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/h3_references.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/history.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/hosts.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/identity.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/model_info.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/motion.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/palette.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/prefs.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/session.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/test_env.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/thumbnails.rs",
-          "specifiers": []
-        },
-        {
-          "source": "crates/mold-tui/src/ui/mod.rs",
-          "specifiers": []
+          "source": "app",
+          "specifiers": [
+            "App"
+          ]
         }
       ],
       "exports": [
@@ -207364,7 +207586,7 @@
         "run_tui",
         "run_tui_with_options"
       ],
-      "totalLines": 188,
+      "totalLines": 271,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/model_info.rs": {
@@ -210007,7 +210229,7 @@
     },
     "crates/mold-tui/src/ui/popup.rs": {
       "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "contentHash": "61a2bed0d8af64f8de1750f4c0beb14b539d32ab0fa031853d15cd275bafaaa1",
+      "contentHash": "f108eee7734ff57bbffd147a23219e667d6632788389f1b2f333b24768dc0288",
       "functions": [
         {
           "name": "render",
@@ -210283,7 +210505,7 @@
       "exports": [
         "render"
       ],
-      "totalLines": 1671,
+      "totalLines": 1673,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/ui/preview.rs": {
@@ -283080,13 +283302,14 @@
     },
     "crates/mold-cli/src/commands/library.rs": {
       "filePath": "crates/mold-cli/src/commands/library.rs",
-      "contentHash": "8508ee1e033f01a49b38500079f8bcebb098a0c4dfce4a5c6f37b276e8745b72",
+      "contentHash": "619f32df40276dcc474cff0a20b1d430450c1a71940f53cbcb4002084523ec75",
       "functions": [
         {
           "name": "run",
           "params": [
             "action"
           ],
+          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 6
         },
@@ -283096,6 +283319,7 @@
             "action",
             "client"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 49
         },
@@ -283105,6 +283329,7 @@
             "client",
             "options"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 49
         },
@@ -283116,6 +283341,7 @@
             "json",
             "preview"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 22
         },
@@ -283125,6 +283351,7 @@
             "client",
             "image"
           ],
+          "returnType": "Result<Vec<u8>>",
           "exported": false,
           "lineCount": 13
         },
@@ -283136,6 +283363,7 @@
             "title",
             "clear"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 20
         },
@@ -283145,6 +283373,7 @@
             "client",
             "action"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 39
         },
@@ -283157,6 +283386,7 @@
             "add_tags",
             "remove_tags"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 33
         },
@@ -283166,6 +283396,7 @@
             "client",
             "action"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 118
         },
@@ -283177,6 +283408,7 @@
             "filenames",
             "add"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 26
         },
@@ -283186,6 +283418,7 @@
             "client",
             "filenames"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 24
         },
@@ -283194,6 +283427,7 @@
           "params": [
             "client"
           ],
+          "returnType": "Result<ServerCapabilities>",
           "exported": false,
           "lineCount": 13
         },
@@ -283203,6 +283437,7 @@
             "collections",
             "value"
           ],
+          "returnType": "Result<&'a Collection>",
           "exported": false,
           "lineCount": 31
         },
@@ -283224,6 +283459,7 @@
           "params": [
             "row"
           ],
+          "returnType": "Option<OutputFormat>",
           "exported": false,
           "lineCount": 7
         },
@@ -283232,6 +283468,7 @@
           "params": [
             "row"
           ],
+          "returnType": "&str",
           "exported": false,
           "lineCount": 7
         },
@@ -283243,6 +283480,7 @@
             "offset",
             "collections"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 53
         },
@@ -283251,6 +283489,7 @@
           "params": [
             "row"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 30
         },
@@ -283259,6 +283498,7 @@
           "params": [
             "rows"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 23
         },
@@ -283268,6 +283508,7 @@
             "value",
             "max"
           ],
+          "returnType": "String",
           "exported": false,
           "lineCount": 12
         },
@@ -283276,6 +283517,7 @@
           "params": [
             "prompt"
           ],
+          "returnType": "Result<bool>",
           "exported": false,
           "lineCount": 13
         },
@@ -283285,8 +283527,9 @@
             "host",
             "local"
           ],
+          "returnType": "Result<()>",
           "exported": false,
-          "lineCount": 9
+          "lineCount": 10
         },
         {
           "name": "library_grid",
@@ -283294,6 +283537,7 @@
             "_host",
             "_local"
           ],
+          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 3
         }
@@ -283316,11 +283560,64 @@
           "lineCount": 10
         }
       ],
-      "imports": [],
+      "imports": [
+        {
+          "source": "std::collections",
+          "specifiers": [
+            "HashMap"
+          ]
+        },
+        {
+          "source": "std::io",
+          "specifiers": [
+            "self",
+            "IsTerminal",
+            "Write"
+          ]
+        },
+        {
+          "source": "anyhow",
+          "specifiers": [
+            "bail",
+            "Context",
+            "Result"
+          ]
+        },
+        {
+          "source": "colored",
+          "specifiers": [
+            "Colorize"
+          ]
+        },
+        {
+          "source": "mold_core",
+          "specifiers": [
+            "Collection",
+            "CollectionCreateRequest",
+            "CollectionItemsRequest",
+            "CollectionUpdateRequest",
+            "GalleryBulkMutationRequest",
+            "GalleryImage",
+            "GalleryOrganizeRequest",
+            "GalleryPatchRequest",
+            "MoldClient",
+            "OutputFormat",
+            "ServerCapabilities"
+          ]
+        },
+        {
+          "source": "crate",
+          "specifiers": [
+            "LibraryAction",
+            "LibraryCollectionAction",
+            "LibraryTagAction"
+          ]
+        }
+      ],
       "exports": [
         "run"
       ],
-      "totalLines": 773,
+      "totalLines": 774,
       "hasStructuralAnalysis": true
     }
   }

--- a/.ua/fingerprints.json
+++ b/.ua/fingerprints.json
@@ -1,7 +1,7 @@
 {
   "version": "1.0.0",
-  "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3",
-  "generatedAt": "2026-08-28T14:10:09.351Z",
+  "gitCommitHash": "6a18814b6081fd954d1c7471565d741594b19ad5",
+  "generatedAt": "2026-08-28T15:45:52.694Z",
   "files": {
     "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt": {
       "filePath": "apps/mobile/plugins/android/src/androidTest/java/AndroidDiscoveryInstrumentedTest.kt",
@@ -36524,14 +36524,13 @@
     },
     "crates/mold-cli/src/main.rs": {
       "filePath": "crates/mold-cli/src/main.rs",
-      "contentHash": "38024ac2d6ec2b046011f7d8d3fb788f22b4dac84ded0cec274a55c721b8c113",
+      "contentHash": "5b7e10f51dae246552e418e48ba0cb11b379234cba5f42d95bdda2b0d12dc1db",
       "functions": [
         {
           "name": "output_format_parser",
           "params": [
             "formats"
           ],
-          "returnType": "clap::builder::ValueParser",
           "exported": false,
           "lineCount": 7
         },
@@ -36540,7 +36539,6 @@
           "params": [
             "raw"
           ],
-          "returnType": "Result<String, String>",
           "exported": false,
           "lineCount": 7
         },
@@ -36549,7 +36547,6 @@
           "params": [
             "raw"
           ],
-          "returnType": "Result<String, String>",
           "exported": false,
           "lineCount": 7
         },
@@ -36558,23 +36555,28 @@
           "params": [
             "raw"
           ],
-          "returnType": "Result<String, String>",
           "exported": false,
           "lineCount": 3
+        },
+        {
+          "name": "library_limit_parser",
+          "params": [
+            "raw"
+          ],
+          "exported": false,
+          "lineCount": 9
         },
         {
           "name": "fmt",
           "params": [
             "_f"
           ],
-          "returnType": "std::fmt::Result",
           "exported": false,
           "lineCount": 3
         },
         {
           "name": "complete_shell",
           "params": [],
-          "returnType": "Vec<CompletionCandidate>",
           "exported": false,
           "lineCount": 6
         },
@@ -36595,16 +36597,14 @@
         {
           "name": "run",
           "params": [],
-          "returnType": "anyhow::Result<()>",
           "exported": false,
-          "lineCount": 774
+          "lineCount": 777
         },
         {
           "name": "generate_completions",
           "params": [
             "shell"
           ],
-          "returnType": "anyhow::Result<()>",
           "exported": false,
           "lineCount": 86
         },
@@ -36613,7 +36613,6 @@
           "params": [
             "id"
           ],
-          "returnType": "anyhow::Result<CatalogIdResolution>",
           "exported": true,
           "lineCount": 20
         }
@@ -36838,6 +36837,51 @@
           "lineCount": 30
         },
         {
+          "name": "LibraryTagAction",
+          "methods": [],
+          "properties": [
+            "List",
+            "Add",
+            "Remove",
+            "Rename",
+            "Delete"
+          ],
+          "exported": true,
+          "lineCount": 35
+        },
+        {
+          "name": "LibraryCollectionAction",
+          "methods": [],
+          "properties": [
+            "List",
+            "Show",
+            "Create",
+            "Update",
+            "Delete",
+            "Add",
+            "Remove"
+          ],
+          "exported": true,
+          "lineCount": 61
+        },
+        {
+          "name": "LibraryAction",
+          "methods": [],
+          "properties": [
+            "List",
+            "Show",
+            "Grid",
+            "Title",
+            "Favorite",
+            "Unfavorite",
+            "Tag",
+            "Collection",
+            "Trash"
+          ],
+          "exported": true,
+          "lineCount": 71
+        },
+        {
           "name": "Commands",
           "methods": [],
           "properties": [
@@ -36849,6 +36893,7 @@
             "Chain",
             "Jobs",
             "Queue",
+            "Library",
             "Trash",
             "Pull",
             "Licenses",
@@ -36874,7 +36919,7 @@
             "Completions"
           ],
           "exported": false,
-          "lineCount": 1101
+          "lineCount": 1120
         },
         {
           "name": "CatalogIdResolution",
@@ -36889,27 +36934,52 @@
       ],
       "imports": [
         {
-          "source": "clap",
-          "specifiers": [
-            "builder::ValueHint",
-            "CommandFactory",
-            "Parser",
-            "Subcommand"
-          ]
+          "source": "crates/mold-cli/src/catalog_bridge.rs",
+          "specifiers": []
         },
         {
-          "source": "clap_complete::engine",
-          "specifiers": [
-            "ArgValueCandidates",
-            "CompletionCandidate"
-          ]
+          "source": "crates/mold-cli/src/commands/mod.rs",
+          "specifiers": []
         },
         {
-          "source": "mold_core",
-          "specifiers": [
-            "OutputFormat",
-            "Scheduler"
-          ]
+          "source": "crates/mold-cli/src/control.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/errors.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/fs_util.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/metadata_db.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/output.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/procinfo.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/skill/mod.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/test_support.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/theme.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-cli/src/ui.rs",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -36920,10 +36990,13 @@
         "RetakeModeArg",
         "QueueAction",
         "TrashAction",
+        "LibraryTagAction",
+        "LibraryCollectionAction",
+        "LibraryAction",
         "CatalogIdResolution",
         "resolve_catalog_id"
       ],
-      "totalLines": 4200,
+      "totalLines": 4522,
       "hasStructuralAnalysis": true
     },
     "crates/mold-cli/src/metadata_db.rs": {
@@ -37958,7 +38031,7 @@
     },
     "crates/mold-cli/tests/cli_integration.rs": {
       "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "contentHash": "917c36fb6d4a44c9b4cee4723e1e12d422db15075ce3f0d8d2641fe9fb8e0968",
+      "contentHash": "aa8dc5e6319a8c51a3c74bb121e0fdc6698e8c5851a77ba60846abfca4c052bb",
       "functions": [
         {
           "name": "loopback_admin_commands_do_not_hide_live_server_http_errors",
@@ -37989,6 +38062,68 @@
           "params": [],
           "exported": false,
           "lineCount": 4
+        },
+        {
+          "name": "library_capabilities",
+          "params": [
+            "organize",
+            "bulk_mutations",
+            "trash"
+          ],
+          "exported": false,
+          "lineCount": 14
+        },
+        {
+          "name": "library_row",
+          "params": [
+            "filename",
+            "timestamp",
+            "tags"
+          ],
+          "exported": false,
+          "lineCount": 21
+        },
+        {
+          "name": "library_list_json_is_pure_and_uses_the_same_filtered_page",
+          "params": [],
+          "exported": false,
+          "lineCount": 36
+        },
+        {
+          "name": "library_tag_add_uses_replay_safe_bulk_mutation_when_advertised",
+          "params": [],
+          "exported": false,
+          "lineCount": 47
+        },
+        {
+          "name": "library_tag_add_falls_back_to_legacy_organize_route",
+          "params": [],
+          "exported": false,
+          "lineCount": 29
+        },
+        {
+          "name": "library_trash_refuses_a_host_without_recoverable_trash",
+          "params": [],
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "library_collection_remove_resolves_slug_and_sends_membership_change",
+          "params": [],
+          "exported": false,
+          "lineCount": 58
+        },
+        {
+          "name": "library_show_video_uses_thumbnail_when_animated_preview_is_missing",
+          "params": [],
+          "exported": false,
+          "lineCount": 35
+        },
+        {
+          "name": "library_global_tag_delete_requires_yes_without_a_tty",
+          "params": [],
+          "exported": false,
+          "lineCount": 23
         },
         {
           "name": "default_shows_fallback_model",
@@ -38288,20 +38423,12 @@
       "classes": [],
       "imports": [
         {
-          "source": "common",
-          "specifiers": [
-            "TestEnv"
-          ]
-        },
-        {
-          "source": "predicates::prelude",
-          "specifiers": [
-            "*"
-          ]
+          "source": "crates/mold-cli/tests/common/mod.rs",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 951,
+      "totalLines": 1254,
       "hasStructuralAnalysis": true
     },
     "crates/mold-cli/tests/common/mod.rs": {
@@ -40283,7 +40410,7 @@
     },
     "crates/mold-core/src/client.rs": {
       "filePath": "crates/mold-core/src/client.rs",
-      "contentHash": "6a9f1206799d1f2f7eb59a823fc2c8bb9d93700455e8fab3894a8dee17afdfc7",
+      "contentHash": "9b22a914a0ddc106c2e3b8ba59a3bec519bfd311363f212f8f4adb04688b0db1",
       "functions": [
         {
           "name": "pull_body",
@@ -40291,7 +40418,6 @@
             "model",
             "accept_licenses"
           ],
-          "returnType": "serde_json::Value",
           "exported": false,
           "lineCount": 10
         },
@@ -40300,7 +40426,6 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 10
         },
@@ -40311,7 +40436,6 @@
             "job_id",
             "host"
           ],
-          "returnType": "anyhow::Error",
           "exported": false,
           "lineCount": 10
         },
@@ -40322,7 +40446,6 @@
             "job_id",
             "host"
           ],
-          "returnType": "anyhow::Error",
           "exported": false,
           "lineCount": 8
         },
@@ -40331,7 +40454,6 @@
           "params": [
             "base_url"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 8
         },
@@ -40341,21 +40463,18 @@
             "base_url",
             "api_key"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 8
         },
         {
           "name": "from_env",
           "params": [],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "has_api_key",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
@@ -40364,7 +40483,6 @@
           "params": [
             "request"
           ],
-          "returnType": "Result<ReferenceUploadSessionResponse>",
           "exported": true,
           "lineCount": 21
         },
@@ -40375,7 +40493,6 @@
             "path",
             "mime_type"
           ],
-          "returnType": "Result<ReferenceUploadCompleteResponse>",
           "exported": true,
           "lineCount": 26
         },
@@ -40386,7 +40503,6 @@
             "file",
             "mime_type"
           ],
-          "returnType": "Result<ReferenceUploadCompleteResponse>",
           "exported": true,
           "lineCount": 22
         },
@@ -40397,7 +40513,6 @@
             "bytes",
             "mime_type"
           ],
-          "returnType": "Result<ReferenceUploadCompleteResponse>",
           "exported": true,
           "lineCount": 11
         },
@@ -40409,7 +40524,6 @@
             "content_length",
             "body"
           ],
-          "returnType": "Result<ReferenceUploadCompleteResponse>",
           "exported": false,
           "lineCount": 21
         },
@@ -40418,7 +40532,6 @@
           "params": [
             "handle"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
@@ -40427,7 +40540,6 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<Vec<u8>>",
           "exported": true,
           "lineCount": 16
         },
@@ -40436,21 +40548,18 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<GenerateResponse>",
           "exported": true,
           "lineCount": 118
         },
         {
           "name": "list_models",
           "params": [],
-          "returnType": "Result<Vec<ModelInfo>>",
           "exported": true,
           "lineCount": 4
         },
         {
           "name": "list_models_extended",
           "params": [],
-          "returnType": "Result<Vec<ModelInfoExtended>>",
           "exported": true,
           "lineCount": 11
         },
@@ -40459,7 +40568,6 @@
           "params": [
             "model"
           ],
-          "returnType": "Result<Vec<LoraInfo>>",
           "exported": true,
           "lineCount": 14
         },
@@ -40468,7 +40576,6 @@
           "params": [
             "model"
           ],
-          "returnType": "Result<Vec<LoraInfo>>",
           "exported": false,
           "lineCount": 15
         },
@@ -40477,7 +40584,6 @@
           "params": [
             "model"
           ],
-          "returnType": "Result<Vec<LoraInfo>>",
           "exported": false,
           "lineCount": 34
         },
@@ -40486,7 +40592,6 @@
           "params": [
             "err"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 12
         },
@@ -40495,7 +40600,6 @@
           "params": [
             "err"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 13
         },
@@ -40505,7 +40609,6 @@
             "req",
             "progress_tx"
           ],
-          "returnType": "Result<GenerateResponse>",
           "exported": true,
           "lineCount": 222
         },
@@ -40515,7 +40618,6 @@
             "job_id",
             "progress_tx"
           ],
-          "returnType": "Result<ChainJobOutcome>",
           "exported": true,
           "lineCount": 109
         },
@@ -40524,14 +40626,12 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<CreateChainJobResponse>",
           "exported": true,
           "lineCount": 13
         },
         {
           "name": "list_chain_jobs",
           "params": [],
-          "returnType": "Result<ChainJobListing>",
           "exported": true,
           "lineCount": 16
         },
@@ -40540,7 +40640,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<ChainJobDetail>",
           "exported": true,
           "lineCount": 15
         },
@@ -40549,7 +40648,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<ChainJobSummary>",
           "exported": true,
           "lineCount": 15
         },
@@ -40559,7 +40657,6 @@
             "id",
             "req"
           ],
-          "returnType": "Result<ChainJobSummary>",
           "exported": true,
           "lineCount": 17
         },
@@ -40568,7 +40665,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<ChainJobSummary>",
           "exported": true,
           "lineCount": 15
         },
@@ -40577,14 +40673,12 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
         {
           "name": "gc_chain_jobs",
           "params": [],
-          "returnType": "Result<GcOutcome>",
           "exported": true,
           "lineCount": 11
         },
@@ -40593,7 +40687,6 @@
           "params": [
             "model"
           ],
-          "returnType": "Result<String>",
           "exported": true,
           "lineCount": 3
         },
@@ -40603,14 +40696,12 @@
             "model",
             "accept_licenses"
           ],
-          "returnType": "Result<String>",
           "exported": true,
           "lineCount": 16
         },
         {
           "name": "list_licenses",
           "params": [],
-          "returnType": "Result<Vec<crate::types::ThirdPartyLicenseStatus>>",
           "exported": true,
           "lineCount": 11
         },
@@ -40620,14 +40711,12 @@
             "request",
             "copies"
           ],
-          "returnType": "Result<crate::types::GenerationPlacementPreview>",
           "exported": true,
           "lineCount": 17
         },
         {
           "name": "shutdown_server",
           "params": [],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 8
         },
@@ -40637,7 +40726,6 @@
             "model",
             "progress_tx"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 8
         },
@@ -40648,21 +40736,18 @@
             "accept_licenses",
             "progress_tx"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 64
         },
         {
           "name": "host",
           "params": [],
-          "returnType": "&str",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "unload_model",
           "params": [],
-          "returnType": "Result<String>",
           "exported": true,
           "lineCount": 3
         },
@@ -40672,35 +40757,30 @@
             "model",
             "gpu"
           ],
-          "returnType": "Result<String>",
           "exported": true,
           "lineCount": 20
         },
         {
           "name": "server_status",
           "params": [],
-          "returnType": "Result<ServerStatus>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "server_capabilities",
           "params": [],
-          "returnType": "Result<crate::ServerCapabilities>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "devices",
           "params": [],
-          "returnType": "Result<DeviceState>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "capabilities",
           "params": [],
-          "returnType": "Result<crate::ServerCapabilities>",
           "exported": true,
           "lineCount": 3
         },
@@ -40709,7 +40789,6 @@
           "params": [
             "request"
           ],
-          "returnType": "Result<GenerationBatchStatus>",
           "exported": true,
           "lineCount": 15
         },
@@ -40718,7 +40797,6 @@
           "params": [
             "client_batch_id"
           ],
-          "returnType": "Result<Option<GenerationBatchStatus>>",
           "exported": true,
           "lineCount": 23
         },
@@ -40727,7 +40805,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<Option<GenerationBatchStatus>>",
           "exported": true,
           "lineCount": 20
         },
@@ -40736,7 +40813,6 @@
           "params": [
             "request"
           ],
-          "returnType": "Result<GenerationBatchStatusResponse>",
           "exported": true,
           "lineCount": 15
         },
@@ -40745,7 +40821,6 @@
           "params": [
             "request"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 14
         },
@@ -40755,14 +40830,12 @@
             "device_id",
             "enabled"
           ],
-          "returnType": "Result<crate::DeviceInfo>",
           "exported": true,
           "lineCount": 21
         },
         {
           "name": "list_queue",
           "params": [],
-          "returnType": "Result<QueueListingWire>",
           "exported": true,
           "lineCount": 4
         },
@@ -40771,7 +40844,6 @@
           "params": [
             "queue_capacity"
           ],
-          "returnType": "Result<QueueListingWire>",
           "exported": true,
           "lineCount": 10
         },
@@ -40781,14 +40853,12 @@
             "limit",
             "cursor"
           ],
-          "returnType": "Result<QueueListingWire>",
           "exported": true,
           "lineCount": 10
         },
         {
           "name": "list_queue_all",
           "params": [],
-          "returnType": "Result<QueueListingWire>",
           "exported": true,
           "lineCount": 36
         },
@@ -40797,7 +40867,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<Option<crate::QueueJobEntryWire>>",
           "exported": true,
           "lineCount": 19
         },
@@ -40807,7 +40876,6 @@
             "limit",
             "cursor"
           ],
-          "returnType": "Result<QueueListingWire>",
           "exported": false,
           "lineCount": 21
         },
@@ -40816,7 +40884,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<Option<QueueJobProgress>>",
           "exported": true,
           "lineCount": 18
         },
@@ -40825,7 +40892,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
@@ -40834,7 +40900,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<Option<crate::QueueJobDetailWire>>",
           "exported": true,
           "lineCount": 20
         },
@@ -40844,14 +40909,12 @@
             "id",
             "position"
           ],
-          "returnType": "Result<crate::QueueJobEntryWire>",
           "exported": true,
           "lineCount": 20
         },
         {
           "name": "cancel_all_queue_jobs",
           "params": [],
-          "returnType": "Result<usize>",
           "exported": true,
           "lineCount": 12
         },
@@ -40860,21 +40923,18 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<GenerationBatchStatus>",
           "exported": true,
           "lineCount": 15
         },
         {
           "name": "pause_queue",
           "params": [],
-          "returnType": "Result<bool>",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "resume_queue",
           "params": [],
-          "returnType": "Result<bool>",
           "exported": true,
           "lineCount": 3
         },
@@ -40883,28 +40943,24 @@
           "params": [
             "action"
           ],
-          "returnType": "Result<bool>",
           "exported": false,
           "lineCount": 12
         },
         {
           "name": "sweep_held_queue",
           "params": [],
-          "returnType": "Result<crate::HeldSweepResult>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "sweep_settled_batches",
           "params": [],
-          "returnType": "Result<crate::SettledBatchSweepResult>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "list_gallery",
           "params": [],
-          "returnType": "Result<Vec<GalleryImage>>",
           "exported": true,
           "lineCount": 11
         },
@@ -40913,7 +40969,6 @@
           "params": [
             "filename"
           ],
-          "returnType": "Result<Option<GalleryImage>>",
           "exported": true,
           "lineCount": 12
         },
@@ -40922,25 +40977,22 @@
           "params": [
             "filename"
           ],
-          "returnType": "Result<Vec<u8>>",
           "exported": true,
-          "lineCount": 11
+          "lineCount": 15
         },
         {
           "name": "delete_gallery_image",
           "params": [
             "filename"
           ],
-          "returnType": "Result<()>",
           "exported": true,
-          "lineCount": 8
+          "lineCount": 12
         },
         {
           "name": "list_gallery_view",
           "params": [
             "view"
           ],
-          "returnType": "Result<Vec<GalleryImage>>",
           "exported": true,
           "lineCount": 12
         },
@@ -40949,7 +41001,6 @@
           "params": [
             "filename"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
@@ -40958,7 +41009,6 @@
           "params": [
             "filename"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 14
         },
@@ -40967,7 +41017,6 @@
           "params": [
             "filenames"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 12
         },
@@ -40976,21 +41025,18 @@
           "params": [
             "filenames"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 12
         },
         {
           "name": "empty_trash",
           "params": [],
-          "returnType": "Result<EmptyTrashResult>",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "sweep_trash",
           "params": [],
-          "returnType": "Result<TrashSweepResult>",
           "exported": true,
           "lineCount": 11
         },
@@ -41000,7 +41046,6 @@
             "filename",
             "patch"
           ],
-          "returnType": "Result<GalleryImage>",
           "exported": true,
           "lineCount": 20
         },
@@ -41009,23 +41054,36 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 10
         },
         {
+          "name": "mutate_gallery_bulk",
+          "params": [
+            "req"
+          ],
+          "exported": true,
+          "lineCount": 15
+        },
+        {
           "name": "list_collections",
           "params": [],
-          "returnType": "Result<Vec<Collection>>",
           "exported": true,
           "lineCount": 11
+        },
+        {
+          "name": "get_collection",
+          "params": [
+            "id"
+          ],
+          "exported": true,
+          "lineCount": 15
         },
         {
           "name": "create_collection",
           "params": [
             "req"
           ],
-          "returnType": "Result<Collection>",
           "exported": true,
           "lineCount": 12
         },
@@ -41035,7 +41093,6 @@
             "id",
             "req"
           ],
-          "returnType": "Result<Collection>",
           "exported": true,
           "lineCount": 20
         },
@@ -41044,7 +41101,6 @@
           "params": [
             "id"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
@@ -41054,14 +41110,12 @@
             "id",
             "req"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 14
         },
         {
           "name": "list_tags",
           "params": [],
-          "returnType": "Result<Vec<TagCount>>",
           "exported": true,
           "lineCount": 11
         },
@@ -41071,7 +41125,6 @@
             "name",
             "new_name"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 16
         },
@@ -41080,7 +41133,6 @@
           "params": [
             "name"
           ],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 13
         },
@@ -41089,25 +41141,22 @@
           "params": [
             "filename"
           ],
-          "returnType": "Result<Option<Vec<u8>>>",
           "exported": true,
-          "lineCount": 12
+          "lineCount": 16
         },
         {
           "name": "get_gallery_thumbnail",
           "params": [
             "filename"
           ],
-          "returnType": "Result<Vec<u8>>",
           "exported": true,
-          "lineCount": 14
+          "lineCount": 15
         },
         {
           "name": "expand_prompt",
           "params": [
             "req"
           ],
-          "returnType": "Result<ExpandResponse>",
           "exported": true,
           "lineCount": 13
         },
@@ -41116,7 +41165,6 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<crate::RemixResponse>",
           "exported": true,
           "lineCount": 13
         },
@@ -41125,7 +41173,6 @@
           "params": [
             "req"
           ],
-          "returnType": "Result<crate::UpscaleResponse>",
           "exported": true,
           "lineCount": 12
         },
@@ -41135,7 +41182,6 @@
             "req",
             "progress_tx"
           ],
-          "returnType": "Result<Option<crate::UpscaleResponse>>",
           "exported": true,
           "lineCount": 73
         },
@@ -41144,7 +41190,6 @@
           "params": [
             "entry"
           ],
-          "returnType": "Option<LoraInfo>",
           "exported": false,
           "lineCount": 18
         },
@@ -41153,7 +41198,6 @@
           "params": [
             "err"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 12
         },
@@ -41162,7 +41206,6 @@
           "params": [
             "err"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 14
         },
@@ -41171,7 +41214,6 @@
           "params": [
             "err"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 20
         },
@@ -41180,7 +41222,6 @@
           "params": [
             "formatter"
           ],
-          "returnType": "std::fmt::Result",
           "exported": false,
           "lineCount": 3
         },
@@ -41189,7 +41230,6 @@
           "params": [
             "resp"
           ],
-          "returnType": "Result<reqwest::Response>",
           "exported": false,
           "lineCount": 8
         },
@@ -41198,7 +41238,6 @@
           "params": [
             "resp"
           ],
-          "returnType": "Result<reqwest::Response>",
           "exported": false,
           "lineCount": 40
         },
@@ -41207,7 +41246,6 @@
           "params": [
             "resp"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 6
         },
@@ -41216,7 +41254,6 @@
           "params": [
             "body"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 14
         },
@@ -41225,7 +41262,6 @@
           "params": [
             "model"
           ],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 18
         },
@@ -41234,7 +41270,6 @@
           "params": [
             "family"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 6
         },
@@ -41243,7 +41278,6 @@
           "params": [
             "headers"
           ],
-          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 10
         },
@@ -41253,7 +41287,6 @@
             "from_headers",
             "from_completion"
           ],
-          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 11
         },
@@ -41262,7 +41295,6 @@
           "params": [
             "headers"
           ],
-          "returnType": "Option<VideoMeta>",
           "exported": false,
           "lineCount": 62
         },
@@ -41271,7 +41303,6 @@
           "params": [
             "headers"
           ],
-          "returnType": "Option<AudioMeta>",
           "exported": false,
           "lineCount": 23
         },
@@ -41280,7 +41311,6 @@
           "params": [
             "buffer"
           ],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 10
         },
@@ -41289,7 +41319,6 @@
           "params": [
             "event_text"
           ],
-          "returnType": "(String, String)",
           "exported": false,
           "lineCount": 15
         },
@@ -41298,7 +41327,6 @@
           "params": [
             "api_key"
           ],
-          "returnType": "(Client, bool)",
           "exported": false,
           "lineCount": 24
         },
@@ -41307,7 +41335,6 @@
           "params": [
             "input"
           ],
-          "returnType": "String",
           "exported": true,
           "lineCount": 10
         },
@@ -41316,7 +41343,6 @@
           "params": [
             "raw"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 12
         },
@@ -41325,7 +41351,6 @@
           "params": [
             "f"
           ],
-          "returnType": "std::fmt::Result",
           "exported": false,
           "lineCount": 3
         }
@@ -41413,7 +41438,9 @@
             "sweep_trash",
             "patch_gallery_image",
             "organize_gallery",
+            "mutate_gallery_bulk",
             "list_collections",
+            "get_collection",
             "create_collection",
             "update_collection",
             "delete_collection",
@@ -41504,115 +41531,24 @@
       ],
       "imports": [
         {
-          "source": "crate::chain",
-          "specifiers": [
-            "ChainProgressEvent",
-            "ChainRequest"
-          ]
+          "source": "crates/mold-core/src/chain.rs",
+          "specifiers": []
         },
         {
-          "source": "crate::chain_job",
-          "specifiers": [
-            "ChainJobDetail",
-            "ChainJobListing",
-            "ChainJobSummary",
-            "CreateChainJobResponse",
-            "GcOutcome",
-            "RetakeRequest"
-          ]
+          "source": "crates/mold-core/src/chain_job.rs",
+          "specifiers": []
         },
         {
-          "source": "crate::error",
-          "specifiers": [
-            "MoldError"
-          ]
+          "source": "crates/mold-core/src/error.rs",
+          "specifiers": []
         },
         {
-          "source": "crate::queue_progress",
-          "specifiers": [
-            "QueueJobProgress"
-          ]
+          "source": "crates/mold-core/src/queue_progress.rs",
+          "specifiers": []
         },
         {
-          "source": "crate::types",
-          "specifiers": [
-            "AudioData",
-            "Collection",
-            "CollectionCreateRequest",
-            "CollectionItemsRequest",
-            "CollectionUpdateRequest",
-            "DeviceState",
-            "EmptyTrashResult",
-            "ExpandRequest",
-            "ExpandResponse",
-            "GalleryImage",
-            "GalleryOrganizeRequest",
-            "GalleryPatchRequest",
-            "GenerateRequest",
-            "GenerateResponse",
-            "GenerationBatchAdmissionRequest",
-            "GenerationBatchStatus",
-            "GenerationBatchStatusRequest",
-            "GenerationBatchStatusResponse",
-            "GenerationRetryRequest",
-            "ImageData",
-            "LoraInfo",
-            "ModelInfo",
-            "ModelInfoExtended",
-            "OutputFormat",
-            "QueueListingWire",
-            "ReferenceUploadCompleteResponse",
-            "ReferenceUploadSessionRequest",
-            "ReferenceUploadSessionResponse",
-            "ServerStatus",
-            "SseCompleteEvent",
-            "SseErrorEvent",
-            "SseProgressEvent",
-            "TagCount",
-            "TagRenameRequest",
-            "TrashFilenamesRequest",
-            "TrashSweepResult",
-            "VideoData"
-          ]
-        },
-        {
-          "source": "anyhow",
-          "specifiers": [
-            "Context",
-            "Result"
-          ]
-        },
-        {
-          "source": "base64::Engine as _",
-          "specifiers": [
-            "base64::Engine as _"
-          ]
-        },
-        {
-          "source": "reqwest",
-          "specifiers": [
-            "Client",
-            "StatusCode"
-          ]
-        },
-        {
-          "source": "std::io",
-          "specifiers": [
-            "Seek",
-            "SeekFrom"
-          ]
-        },
-        {
-          "source": "std::path",
-          "specifiers": [
-            "Path"
-          ]
-        },
-        {
-          "source": "tokio_util::io",
-          "specifiers": [
-            "ReaderStream"
-          ]
+          "source": "crates/mold-core/src/types.rs",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -41692,7 +41628,9 @@
         "sweep_trash",
         "patch_gallery_image",
         "organize_gallery",
+        "mutate_gallery_bulk",
         "list_collections",
+        "get_collection",
         "create_collection",
         "update_collection",
         "delete_collection",
@@ -41711,7 +41649,7 @@
         "normalize_host",
         "ModelNotFoundError"
       ],
-      "totalLines": 4926,
+      "totalLines": 5016,
       "hasStructuralAnalysis": true
     },
     "crates/mold-core/src/config.rs": {
@@ -82640,12 +82578,11 @@
     },
     "crates/mold-inference/src/expand.rs": {
       "filePath": "crates/mold-inference/src/expand.rs",
-      "contentHash": "42ae2ef6a540d2be67cd74f42a2f7b6f87c41208c5daf3d4521cc8293d497d23",
+      "contentHash": "9c7ebb1e19a722934f2d6d0645eceae706c497f03801cfacc1874d3e2c19c774",
       "functions": [
         {
           "name": "validate",
           "params": [],
-          "returnType": "Result<()>",
           "exported": true,
           "lineCount": 19
         },
@@ -82655,7 +82592,6 @@
             "progress",
             "_safe_point"
           ],
-          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 3
         },
@@ -82665,7 +82601,6 @@
             "path",
             "size_bytes"
           ],
-          "returnType": "Result<String>",
           "exported": false,
           "lineCount": 31
         },
@@ -82674,7 +82609,6 @@
           "params": [
             "path"
           ],
-          "returnType": "Result<ResolvedExpandArtifact>",
           "exported": false,
           "lineCount": 11
         },
@@ -82684,7 +82618,6 @@
             "label",
             "frozen"
           ],
-          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 15
         },
@@ -82693,7 +82626,6 @@
           "params": [
             "expand_model"
           ],
-          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 16
         },
@@ -82703,7 +82635,6 @@
             "artifacts",
             "placement"
           ],
-          "returnType": "(u64, u64)",
           "exported": false,
           "lineCount": 28
         },
@@ -82715,7 +82646,6 @@
             "predicted_vram_peak_bytes",
             "predicted_host_increment_bytes"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 28
         },
@@ -82725,7 +82655,6 @@
             "config",
             "expand_model"
           ],
-          "returnType": "Result<ResolvedExpandArtifacts>",
           "exported": true,
           "lineCount": 35
         },
@@ -82736,7 +82665,6 @@
             "expand_model",
             "placement"
           ],
-          "returnType": "Result<ResolvedExpandExecutionPlan>",
           "exported": true,
           "lineCount": 10
         },
@@ -82746,7 +82674,6 @@
             "artifacts",
             "placement"
           ],
-          "returnType": "ResolvedExpandExecutionPlan",
           "exported": true,
           "lineCount": 20
         },
@@ -82757,7 +82684,6 @@
             "progress",
             "gpu_factory"
           ],
-          "returnType": "Result<Device>",
           "exported": false,
           "lineCount": 38
         },
@@ -82770,7 +82696,6 @@
             "preferred_gpu",
             "progress"
           ],
-          "returnType": "Result<Device>",
           "exported": false,
           "lineCount": 41
         },
@@ -82790,7 +82715,6 @@
             "model_path",
             "tokenizer_path"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 10
         },
@@ -82799,7 +82723,6 @@
           "params": [
             "plan"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 10
         },
@@ -82832,7 +82755,6 @@
             "config",
             "token"
           ],
-          "returnType": "Result<ExpandResult>",
           "exported": true,
           "lineCount": 16
         },
@@ -82841,7 +82763,6 @@
           "params": [
             "gpu_selection"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 4
         },
@@ -82850,7 +82771,6 @@
           "params": [
             "preferred_gpu"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 4
         },
@@ -82860,7 +82780,6 @@
             "config",
             "expand_model"
           ],
-          "returnType": "Option<Self>",
           "exported": true,
           "lineCount": 3
         },
@@ -82870,7 +82789,6 @@
             "config",
             "expand_model"
           ],
-          "returnType": "Option<Self>",
           "exported": true,
           "lineCount": 7
         },
@@ -82880,7 +82798,6 @@
             "prompt_text",
             "config"
           ],
-          "returnType": "Result<String>",
           "exported": false,
           "lineCount": 163
         },
@@ -82890,9 +82807,16 @@
             "prompt",
             "config"
           ],
-          "returnType": "Result<ExpandResult>",
           "exported": false,
-          "lineCount": 67
+          "lineCount": 59
+        },
+        {
+          "name": "local_expand_error_with_recovery",
+          "params": [
+            "error"
+          ],
+          "exported": false,
+          "lineCount": 7
         },
         {
           "name": "sample_token",
@@ -82901,7 +82825,6 @@
             "temperature",
             "top_p"
           ],
-          "returnType": "Result<u32>",
           "exported": false,
           "lineCount": 53
         },
@@ -82911,7 +82834,6 @@
             "dir",
             "model_spec"
           ],
-          "returnType": "Option<PathBuf>",
           "exported": false,
           "lineCount": 27
         },
@@ -82920,7 +82842,6 @@
           "params": [
             "dir"
           ],
-          "returnType": "Option<PathBuf>",
           "exported": false,
           "lineCount": 25
         }
@@ -83017,94 +82938,12 @@
       ],
       "imports": [
         {
-          "source": "anyhow",
-          "specifiers": [
-            "bail",
-            "Result"
-          ]
+          "source": "crates/mold-inference/src/device.rs",
+          "specifiers": []
         },
         {
-          "source": "candle_core",
-          "specifiers": [
-            "DType",
-            "Device",
-            "Tensor"
-          ]
-        },
-        {
-          "source": "candle_transformers::models::quantized_qwen3",
-          "specifiers": [
-            "ModelWeights"
-          ]
-        },
-        {
-          "source": "sha2",
-          "specifiers": [
-            "Digest",
-            "Sha256"
-          ]
-        },
-        {
-          "source": "std::io",
-          "specifiers": [
-            "Seek"
-          ]
-        },
-        {
-          "source": "std::path",
-          "specifiers": [
-            "Path",
-            "PathBuf"
-          ]
-        },
-        {
-          "source": "tokenizers",
-          "specifiers": [
-            "Tokenizer"
-          ]
-        },
-        {
-          "source": "mold_core::expand",
-          "specifiers": [
-            "ExpandConfig",
-            "ExpandResult",
-            "PromptExpander"
-          ]
-        },
-        {
-          "source": "mold_core::expand_prompts",
-          "specifiers": [
-            "build_batch_messages_with_context_for_task",
-            "build_remix_messages_with_context_for_task",
-            "build_single_messages_for_task",
-            "format_chatml"
-          ]
-        },
-        {
-          "source": "crate::device",
-          "specifiers": [
-            "discover_gpus",
-            "expand_vram_threshold",
-            "memory_status_string",
-            "preflight_memory_check",
-            "resolve_gpu_selection",
-            "select_expand_device_with_preference",
-            "ExpandPlacement"
-          ]
-        },
-        {
-          "source": "crate::progress",
-          "specifiers": [
-            "InferenceCancellationToken",
-            "ProgressCallback",
-            "ProgressReporter"
-          ]
-        },
-        {
-          "source": "mold_core::types",
-          "specifiers": [
-            "GpuSelection"
-          ]
+          "source": "crates/mold-inference/src/progress.rs",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -83128,7 +82967,7 @@
         "from_config",
         "from_config_legacy_dynamic"
       ],
-      "totalLines": 1157,
+      "totalLines": 1168,
       "hasStructuralAnalysis": true
     },
     "crates/mold-inference/src/factory.rs": {
@@ -202861,7 +202700,7 @@
     },
     "crates/mold-tui/src/app.rs": {
       "filePath": "crates/mold-tui/src/app.rs",
-      "contentHash": "a2001ec755f3ffdb598c30906cf23a133c2471870074ccc1dba3d23870d4a03b",
+      "contentHash": "3cb2eba8782e2a6f970e1e4993ea930cc3ea209f4c3a15637ee54427e5936b47",
       "functions": [
         {
           "name": "clear",
@@ -202878,14 +202717,12 @@
         {
           "name": "generation_elapsed",
           "params": [],
-          "returnType": "Option<std::time::Duration>",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "stage_elapsed",
           "params": [],
-          "returnType": "Option<std::time::Duration>",
           "exported": true,
           "lineCount": 3
         },
@@ -202906,14 +202743,12 @@
         {
           "name": "is_downloading",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "download_status_text",
           "params": [],
-          "returnType": "&str",
           "exported": true,
           "lineCount": 15
         },
@@ -202937,7 +202772,6 @@
           "params": [
             "has_negative"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 9
         },
@@ -202946,14 +202780,12 @@
           "params": [
             "has_negative"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "label",
           "params": [],
-          "returnType": "&'static str",
           "exported": true,
           "lineCount": 46
         },
@@ -202962,7 +202794,6 @@
           "params": [
             "path"
           ],
-          "returnType": "Option<(u32, u32)>",
           "exported": false,
           "lineCount": 15
         },
@@ -202971,21 +202802,18 @@
           "params": [
             "text"
           ],
-          "returnType": "Option<(u32, u32)>",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "label",
           "params": [],
-          "returnType": "&'static str",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "next",
           "params": [],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -202994,7 +202822,6 @@
           "params": [
             "current"
           ],
-          "returnType": "u64",
           "exported": true,
           "lineCount": 9
         },
@@ -203003,7 +202830,6 @@
           "params": [
             "used_seed"
           ],
-          "returnType": "Option<u64>",
           "exported": true,
           "lineCount": 7
         },
@@ -203014,21 +202840,18 @@
             "prompt",
             "negative_prompt"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "label",
           "params": [],
-          "returnType": "&'static str",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "next",
           "params": [],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -203038,7 +202861,6 @@
             "params",
             "config"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 6
         },
@@ -203047,7 +202869,6 @@
           "params": [
             "config"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 58
         },
@@ -203056,7 +202877,6 @@
           "params": [
             "field"
           ],
-          "returnType": "String",
           "exported": true,
           "lineCount": 179
         },
@@ -203065,7 +202885,6 @@
           "params": [
             "value"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 5
         },
@@ -203077,7 +202896,6 @@
             "step",
             "max"
           ],
-          "returnType": "Option<f64>",
           "exported": false,
           "lineCount": 15
         },
@@ -203088,7 +202906,6 @@
             "delta",
             "max"
           ],
-          "returnType": "Option<u32>",
           "exported": false,
           "lineCount": 15
         },
@@ -203097,7 +202914,6 @@
           "params": [
             "input"
           ],
-          "returnType": "std::result::Result<Option<Vec<u32>>, String>",
           "exported": false,
           "lineCount": 33
         },
@@ -203106,7 +202922,6 @@
           "params": [
             "target"
           ],
-          "returnType": "u32",
           "exported": false,
           "lineCount": 8
         },
@@ -203116,7 +202931,6 @@
             "grid",
             "fps"
           ],
-          "returnType": "u32",
           "exported": false,
           "lineCount": 13
         },
@@ -203136,7 +202950,6 @@
             "negative_cleared",
             "advertised_default"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 13
         },
@@ -203145,7 +202958,6 @@
           "params": [
             "text"
           ],
-          "returnType": "TextArea<'static>",
           "exported": false,
           "lineCount": 10
         },
@@ -203156,7 +202968,6 @@
             "submission",
             "outcomes"
           ],
-          "returnType": "Option<Self>",
           "exported": true,
           "lineCount": 20
         },
@@ -203169,21 +202980,18 @@
         {
           "name": "guidance_adjustable",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "negative_visible",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 5
         },
         {
           "name": "default",
           "params": [],
-          "returnType": "Self",
           "exported": false,
           "lineCount": 27
         },
@@ -203196,14 +203004,12 @@
         {
           "name": "selected_pos",
           "params": [],
-          "returnType": "Option<usize>",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "rescan_due",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203213,14 +203019,12 @@
             "code",
             "modifiers"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 27
         },
         {
           "name": "local",
           "params": [],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -203229,7 +203033,6 @@
           "params": [
             "entry"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
@@ -203238,49 +203041,42 @@
           "params": [
             "url"
           ],
-          "returnType": "Self",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "is_local",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "is_this_machine",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "filename",
           "params": [],
-          "returnType": "String",
           "exported": true,
           "lineCount": 6
         },
         {
           "name": "owning_origins",
           "params": [],
-          "returnType": "Vec<GalleryOrigin>",
           "exported": true,
           "lineCount": 9
         },
         {
           "name": "primary_origin",
           "params": [],
-          "returnType": "GalleryOrigin",
           "exported": true,
           "lineCount": 6
         },
         {
           "name": "machine_label",
           "params": [],
-          "returnType": "String",
           "exported": true,
           "lineCount": 8
         },
@@ -203289,14 +203085,12 @@
           "params": [
             "days"
           ],
-          "returnType": "String",
           "exported": true,
           "lineCount": 7
         },
         {
           "name": "hint_label",
           "params": [],
-          "returnType": "&'static str",
           "exported": true,
           "lineCount": 6
         },
@@ -203307,7 +203101,6 @@
             "machines",
             "kind"
           ],
-          "returnType": "String",
           "exported": true,
           "lineCount": 12
         },
@@ -203316,7 +203109,6 @@
           "params": [
             "model"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 6
         },
@@ -203326,21 +203118,18 @@
             "catalog",
             "query"
           ],
-          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 12
         },
         {
           "name": "is_field",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "is_read_only",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203349,7 +203138,6 @@
           "params": [
             "url"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 8
         },
@@ -203358,7 +203146,6 @@
           "params": [
             "port"
           ],
-          "returnType": "Option<std::process::Child>",
           "exported": false,
           "lineCount": 6
         },
@@ -203368,7 +203155,6 @@
             "col",
             "tab_bar_x"
           ],
-          "returnType": "Option<View>",
           "exported": true,
           "lineCount": 5
         },
@@ -203387,7 +203173,6 @@
             "url",
             "timeout_secs"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 10
         },
@@ -203398,9 +203183,19 @@
             "local",
             "picker"
           ],
-          "returnType": "Result<Self>",
           "exported": true,
-          "lineCount": 307
+          "lineCount": 3
+        },
+        {
+          "name": "new_with_launch_policy",
+          "params": [
+            "host",
+            "local",
+            "picker",
+            "strict_host"
+          ],
+          "exported": true,
+          "lineCount": 320
         },
         {
           "name": "spawn_gallery_scan",
@@ -203411,14 +203206,12 @@
         {
           "name": "should_poll_remote",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "should_save_output_locally",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 6
         },
@@ -203427,7 +203220,6 @@
           "params": [
             "from_local"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203471,21 +203263,18 @@
           "params": [
             "model"
           ],
-          "returnType": "Option<mold_core::SourceImageCapability>",
           "exported": false,
           "lineCount": 11
         },
         {
           "name": "identity_gate_error",
           "params": [],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 27
         },
         {
           "name": "identity_dispatch_error",
           "params": [],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 7
         },
@@ -203578,14 +203367,12 @@
         {
           "name": "model_default_size",
           "params": [],
-          "returnType": "(u32, u32)",
           "exported": false,
           "lineCount": 19
         },
         {
           "name": "active_generation_recipe",
           "params": [],
-          "returnType": "Option<mold_core::GenerationRecipeProfile>",
           "exported": false,
           "lineCount": 10
         },
@@ -203628,7 +203415,6 @@
         {
           "name": "available_upscaler_models",
           "params": [],
-          "returnType": "Vec<String>",
           "exported": false,
           "lineCount": 20
         },
@@ -203651,6 +203437,12 @@
           ],
           "exported": false,
           "lineCount": 20
+        },
+        {
+          "name": "open_library",
+          "params": [],
+          "exported": true,
+          "lineCount": 3
         },
         {
           "name": "dispatch_action",
@@ -203688,7 +203480,6 @@
           "params": [
             "path"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 16
         },
@@ -203725,7 +203516,6 @@
           "params": [
             "origin"
           ],
-          "returnType": "Option<&mold_core::ServerCapabilities>",
           "exported": true,
           "lineCount": 12
         },
@@ -203734,7 +203524,6 @@
           "params": [
             "origin"
           ],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 9
         },
@@ -203743,14 +203532,12 @@
           "params": [
             "entry"
           ],
-          "returnType": "RemovalKind",
           "exported": true,
           "lineCount": 11
         },
         {
           "name": "selected_removal_kind",
           "params": [],
-          "returnType": "RemovalKind",
           "exported": true,
           "lineCount": 7
         },
@@ -203771,14 +203558,12 @@
           "params": [
             "model_name"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 49
         },
         {
           "name": "needs_confirm",
           "params": [],
-          "returnType": "bool",
           "exported": true,
           "lineCount": 3
         },
@@ -203830,7 +203615,6 @@
           "params": [
             "field"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 10
         },
@@ -203859,7 +203643,6 @@
         {
           "name": "build_settings_rows",
           "params": [],
-          "returnType": "Vec<SettingsRow>",
           "exported": true,
           "lineCount": 323
         },
@@ -203868,7 +203651,6 @@
           "params": [
             "key"
           ],
-          "returnType": "String",
           "exported": true,
           "lineCount": 139
         },
@@ -203885,7 +203667,6 @@
           "params": [
             "key"
           ],
-          "returnType": "Option<&'static str>",
           "exported": true,
           "lineCount": 24
         },
@@ -204008,7 +203789,6 @@
         {
           "name": "prompt_transform_task",
           "params": [],
-          "returnType": "mold_core::ExpandTask",
           "exported": false,
           "lineCount": 18
         },
@@ -204017,7 +203797,6 @@
           "params": [
             "target"
           ],
-          "returnType": "std::result::Result<String, String>",
           "exported": false,
           "lineCount": 37
         },
@@ -204045,7 +203824,6 @@
             "snapshot",
             "dimensions"
           ],
-          "returnType": "mold_core::PromptTransformProvenance",
           "exported": false,
           "lineCount": 13
         },
@@ -204054,7 +203832,6 @@
           "params": [
             "snapshot"
           ],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 32
         },
@@ -204063,7 +203840,6 @@
           "params": [
             "snapshot"
           ],
-          "returnType": "Option<String>",
           "exported": false,
           "lineCount": 31
         },
@@ -204073,7 +203849,6 @@
             "snapshot",
             "response"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 9
         },
@@ -204114,7 +203889,6 @@
           "params": [
             "config"
           ],
-          "returnType": "Vec<mold_core::ModelInfoExtended>",
           "exported": false,
           "lineCount": 19
         },
@@ -204123,7 +203897,6 @@
           "params": [
             "encoded"
           ],
-          "returnType": "Option<image::DynamicImage>",
           "exported": false,
           "lineCount": 18
         },
@@ -204132,7 +203905,6 @@
           "params": [
             "position"
           ],
-          "returnType": "String",
           "exported": false,
           "lineCount": 7
         },
@@ -204142,7 +203914,6 @@
             "progress",
             "event"
           ],
-          "returnType": "bool",
           "exported": false,
           "lineCount": 161
         }
@@ -204832,6 +204603,7 @@
           "name": "App",
           "methods": [
             "new",
+            "new_with_launch_policy",
             "spawn_gallery_scan",
             "should_poll_remote",
             "should_save_output_locally",
@@ -204867,6 +204639,7 @@
             "update_upscale_model_filter",
             "update_model_selector_filter",
             "set_active_view",
+            "open_library",
             "dispatch_action",
             "increment_param",
             "adjust_field",
@@ -204983,105 +204756,20 @@
       ],
       "imports": [
         {
-          "source": "anyhow",
-          "specifiers": [
-            "Result"
-          ]
+          "source": "crates/mold-tui/src/action.rs",
+          "specifiers": []
         },
         {
-          "source": "crossterm::event",
-          "specifiers": [
-            "KeyCode",
-            "KeyModifiers"
-          ]
+          "source": "crates/mold-tui/src/event.rs",
+          "specifiers": []
         },
         {
-          "source": "mold_core",
-          "specifiers": [
-            "Config",
-            "GenerateResponse",
-            "Ltx2GuidanceOverrides",
-            "Ltx2PipelineMode",
-            "Ltx2SpatialUpscale",
-            "Ltx2TemporalUpscale",
-            "ModelInfoExtended",
-            "OutputFormat",
-            "PromptTransformOperation",
-            "RemixResponse",
-            "Scheduler",
-            "ServerStatus",
-            "SseProgressEvent"
-          ]
+          "source": "crates/mold-tui/src/model_info.rs",
+          "specifiers": []
         },
         {
-          "source": "rand",
-          "specifiers": [
-            "Rng"
-          ]
-        },
-        {
-          "source": "ratatui_image::picker",
-          "specifiers": [
-            "Picker"
-          ]
-        },
-        {
-          "source": "ratatui_image::protocol",
-          "specifiers": [
-            "Protocol",
-            "StatefulProtocol"
-          ]
-        },
-        {
-          "source": "std::collections",
-          "specifiers": [
-            "VecDeque"
-          ]
-        },
-        {
-          "source": "tokio::sync",
-          "specifiers": [
-            "mpsc"
-          ]
-        },
-        {
-          "source": "tui_textarea",
-          "specifiers": [
-            "TextArea"
-          ]
-        },
-        {
-          "source": "crate::action",
-          "specifiers": [
-            "Action",
-            "View"
-          ]
-        },
-        {
-          "source": "crate::event",
-          "specifiers": [
-            "map_event"
-          ]
-        },
-        {
-          "source": "crate::model_info",
-          "specifiers": [
-            "capabilities_for_family"
-          ]
-        },
-        {
-          "source": "crate::model_info",
-          "specifiers": [
-            "capabilities_for_model",
-            "family_for_model",
-            "ModelCapabilities"
-          ]
-        },
-        {
-          "source": "crate::ui::theme",
-          "specifiers": [
-            "Theme"
-          ]
+          "source": "crates/mold-tui/src/ui/theme.rs",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -205165,6 +204853,7 @@
         "tab_at_column",
         "configure_background_server_command",
         "new",
+        "new_with_launch_policy",
         "spawn_gallery_scan",
         "should_poll_remote",
         "should_save_output_locally",
@@ -205177,6 +204866,7 @@
         "update_model",
         "refresh_create_rows",
         "handle_crossterm_event",
+        "open_library",
         "dispatch_action",
         "tick_animations",
         "apply_gallery_scan",
@@ -205192,7 +204882,7 @@
         "settings_env_override",
         "process_background_events"
       ],
-      "totalLines": 18654,
+      "totalLines": 18675,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/backend.rs": {
@@ -207537,7 +207227,7 @@
     },
     "crates/mold-tui/src/lib.rs": {
       "filePath": "crates/mold-tui/src/lib.rs",
-      "contentHash": "d5f33d0073245a649d1d0f891a2e189ff50492ff1bc56002489829af095996d2",
+      "contentHash": "3e922090b8730e8b996876a58e88ec963dda1e19fc04d6b28497fe2e0ebe80d4",
       "functions": [
         {
           "name": "run_tui",
@@ -207545,9 +207235,16 @@
             "host",
             "local"
           ],
-          "returnType": "Result<()>",
           "exported": true,
-          "lineCount": 41
+          "lineCount": 8
+        },
+        {
+          "name": "run_tui_with_options",
+          "params": [
+            "options"
+          ],
+          "exported": true,
+          "lineCount": 48
         },
         {
           "name": "run_event_loop",
@@ -207555,54 +207252,119 @@
             "terminal",
             "app"
           ],
-          "returnType": "Result<()>",
           "exported": false,
           "lineCount": 46
         }
       ],
-      "classes": [],
+      "classes": [
+        {
+          "name": "TuiInitialWorkspace",
+          "methods": [],
+          "properties": [
+            "Create",
+            "Library"
+          ],
+          "exported": true,
+          "lineCount": 5
+        },
+        {
+          "name": "TuiLaunchOptions",
+          "methods": [],
+          "properties": [
+            "host",
+            "local",
+            "initial_workspace",
+            "strict_host"
+          ],
+          "exported": true,
+          "lineCount": 8
+        }
+      ],
       "imports": [
         {
-          "source": "std",
-          "specifiers": [
-            "io"
-          ]
+          "source": "crates/mold-tui/src/action.rs",
+          "specifiers": []
         },
         {
-          "source": "std",
-          "specifiers": [
-            "panic"
-          ]
+          "source": "crates/mold-tui/src/animation.rs",
+          "specifiers": []
         },
         {
-          "source": "anyhow",
-          "specifiers": [
-            "Result"
-          ]
+          "source": "crates/mold-tui/src/app.rs",
+          "specifiers": []
         },
         {
-          "source": "crossterm",
-          "specifiers": [
-            "execute"
-          ]
+          "source": "crates/mold-tui/src/backend.rs",
+          "specifiers": []
         },
         {
-          "source": "ratatui::prelude",
-          "specifiers": [
-            "*"
-          ]
+          "source": "crates/mold-tui/src/event.rs",
+          "specifiers": []
         },
         {
-          "source": "app",
-          "specifiers": [
-            "App"
-          ]
+          "source": "crates/mold-tui/src/gallery_scan.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/gallery_trash.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/h3_references.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/history.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/hosts.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/identity.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/model_info.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/motion.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/palette.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/prefs.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/session.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/test_env.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/thumbnails.rs",
+          "specifiers": []
+        },
+        {
+          "source": "crates/mold-tui/src/ui/mod.rs",
+          "specifiers": []
         }
       ],
       "exports": [
-        "run_tui"
+        "TuiInitialWorkspace",
+        "TuiLaunchOptions",
+        "run_tui",
+        "run_tui_with_options"
       ],
-      "totalLines": 130,
+      "totalLines": 188,
       "hasStructuralAnalysis": true
     },
     "crates/mold-tui/src/model_info.rs": {
@@ -217289,14 +217051,13 @@
     },
     "desktop/src/components/generate/SourceImageWell.test.ts": {
       "filePath": "desktop/src/components/generate/SourceImageWell.test.ts",
-      "contentHash": "c48f5f5402e255842cdfd69de374a976fc3d204daa7e45744b717d542af57532",
+      "contentHash": "a90bb4284c853057c538ec5464c9d1e1d17f905fd6a9aa914254543f55ff0cfc",
       "functions": [
         {
           "name": "formFor",
           "params": [
             "family"
           ],
-          "returnType": "GenerateForm",
           "exported": false,
           "lineCount": 3
         }
@@ -217304,70 +217065,28 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/components/generate/ImagePickerModal.vue",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
+          "source": "desktop/src/components/generate/MaskEditorModal.vue",
+          "specifiers": []
         },
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "mount",
-            "flushPromises"
-          ]
+          "source": "desktop/src/components/generate/SourceImageWell.vue",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "reactive"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "./SourceImageWell.vue",
-          "specifiers": [
-            "SourceImageWell"
-          ]
-        },
-        {
-          "source": "./ImagePickerModal.vue",
-          "specifiers": [
-            "ImagePickerModal"
-          ]
-        },
-        {
-          "source": "./MaskEditorModal.vue",
-          "specifiers": [
-            "MaskEditorModal"
-          ]
-        },
-        {
-          "source": "@studio/components/ReferenceCropEditor.vue",
-          "specifiers": [
-            "ReferenceCropEditor"
-          ]
-        },
-        {
-          "source": "../../lib/generateForm",
-          "specifiers": [
-            "newGenerateForm",
-            "GenerateForm"
-          ]
+          "source": "studio/components/ReferenceCropEditor.vue",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 509,
+      "totalLines": 511,
       "hasStructuralAnalysis": true
     },
     "desktop/src/components/generate/StarterCards.test.ts": {
@@ -223312,7 +223031,7 @@
     },
     "desktop/src/lib/desktopImageDrop.ts": {
       "filePath": "desktop/src/lib/desktopImageDrop.ts",
-      "contentHash": "561dbc2d698168353ab6716d7f8e4b8639286fd00ffcfb36d606e6720ef0d235",
+      "contentHash": "cdd9b52cf089be574269c38813c12b34abd3d8f91ed6c98066d790434f753a32",
       "functions": [
         {
           "name": "applyDesktopImageDrop",
@@ -223321,7 +223040,6 @@
             "image",
             "models"
           ],
-          "returnType": "DesktopImageDropResult",
           "exported": true,
           "lineCount": 28
         }
@@ -223329,30 +223047,22 @@
       "classes": [],
       "imports": [
         {
-          "source": "./capabilities",
-          "specifiers": [
-            "generationCapabilitiesForFamily"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "./api/types",
-          "specifiers": [
-            "ModelEntry",
-            "OutputMetadata"
-          ]
+          "source": "desktop/src/lib/capabilities.ts",
+          "specifiers": []
         },
         {
-          "source": "./generateForm",
-          "specifiers": [
-            "applyMetadataToForm",
-            "GenerateForm"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         }
       ],
       "exports": [
         "applyDesktopImageDrop"
       ],
-      "totalLines": 54,
+      "totalLines": 55,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/discovery.test.ts": {
@@ -225014,19 +224724,17 @@
     },
     "desktop/src/lib/generateForm.test.ts": {
       "filePath": "desktop/src/lib/generateForm.test.ts",
-      "contentHash": "c67505e8b951413d04ffa8172eed80bac8c0ebc3112017bd8ec72dff32a30b23",
+      "contentHash": "d94cba23abe592795234d22053fae20edca4697b0e75a128d5d381678548fbe1",
       "functions": [
         {
           "name": "ltx2Model",
           "params": [],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 15
         },
         {
           "name": "profiledLtx2Model",
           "params": [],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 84
         },
@@ -225039,7 +224747,6 @@
         {
           "name": "qwenEditModel",
           "params": [],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 11
         },
@@ -225048,7 +224755,6 @@
           "params": [
             "name"
           ],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 11
         },
@@ -225063,14 +224769,12 @@
         {
           "name": "sd15Model",
           "params": [],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 11
         },
         {
           "name": "richImageMetadata",
           "params": [],
-          "returnType": "OutputMetadata",
           "exported": false,
           "lineCount": 27
         }
@@ -225078,95 +224782,53 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "describe",
-            "expect",
-            "it"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "./generateForm",
-          "specifiers": [
-            "applyMetadataToForm",
-            "applyModelDefaults",
-            "applyRecipeDefaults",
-            "applyPrefillToForm",
-            "applyRequestToForm",
-            "buildRequest",
-            "chainFilingFields",
-            "cloneGenerateForm",
-            "newGenerateForm",
-            "normalizeLegacyNegativeSnapshot",
-            "reconcileModelCapabilities",
-            "resetAdvancedToModelDefaults",
-            "resetFormToModelDefaults",
-            "seedMode",
-            "GenerateForm"
-          ]
+          "source": "desktop/src/lib/capabilities.ts",
+          "specifiers": []
         },
         {
-          "source": "./capabilities",
-          "specifiers": [
-            "MAX_LORA_STACK"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/negativePrompt",
-          "specifiers": [
-            "WAN_FAMILY_DEFAULT_NEGATIVE_PROMPT"
-          ]
+          "source": "studio/lib/extend.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/extend",
-          "specifiers": [
-            "DEFAULT_EXTEND_OVERLAP_FRAMES"
-          ]
+          "source": "studio/lib/fileUnder.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/fileUnder",
-          "specifiers": [
-            "addTag",
-            "emptyFileUnderState",
-            "pickCollection"
-          ]
+          "source": "studio/lib/generationProfile.ts",
+          "specifiers": []
         },
         {
-          "source": "./api/types",
-          "specifiers": [
-            "ModelEntry",
-            "OutputMetadata"
-          ]
-        },
-        {
-          "source": "@studio/lib/generationProfile",
-          "specifiers": [
-            "GenerationProfileSet",
-            "GenerationRecipeProfile"
-          ]
+          "source": "studio/lib/negativePrompt.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 3196,
+      "totalLines": 3197,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/generateForm.ts": {
       "filePath": "desktop/src/lib/generateForm.ts",
-      "contentHash": "56d798f112d8000c2e70feace9d274bc095fa2ba64e71fd8d2d2d1b5246e7852",
+      "contentHash": "bb724d9068e6c2d08cc0dc3f7aad34449ba2ddf592fc1929672b2ee0c4ef3fff",
       "functions": [
         {
           "name": "seedMode",
           "params": [
             "seed"
           ],
-          "returnType": "\"random\" | \"fixed\"",
           "exported": true,
           "lineCount": 3
         },
         {
           "name": "newGenerateForm",
           "params": [],
-          "returnType": "GenerateForm",
           "exported": true,
           "lineCount": 65
         },
@@ -225175,7 +224837,6 @@
           "params": [
             "form"
           ],
-          "returnType": "GenerateForm",
           "exported": true,
           "lineCount": 34
         },
@@ -225185,7 +224846,6 @@
             "form",
             "m"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 40
         },
@@ -225196,7 +224856,6 @@
             "m",
             "pipeline"
           ],
-          "returnType": "boolean",
           "exported": true,
           "lineCount": 55
         },
@@ -225206,7 +224865,6 @@
             "form",
             "m"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 205
         },
@@ -225216,7 +224874,6 @@
             "snapshot",
             "models"
           ],
-          "returnType": "GenerateForm",
           "exported": true,
           "lineCount": 21
         },
@@ -225226,7 +224883,6 @@
             "form",
             "rewrite"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 8
         },
@@ -225236,7 +224892,6 @@
             "form",
             "m"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 16
         },
@@ -225246,7 +224901,6 @@
             "form",
             "m"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 39
         },
@@ -225255,7 +224909,6 @@
           "params": [
             "form"
           ],
-          "returnType": "number",
           "exported": true,
           "lineCount": 6
         },
@@ -225264,7 +224917,6 @@
           "params": [
             "form"
           ],
-          "returnType": "GenerateRequest",
           "exported": true,
           "lineCount": 220
         },
@@ -225273,7 +224925,6 @@
           "params": [
             "form"
           ],
-          "returnType": "{\n  title?: string;\n  tags?: string[];\n  collection?: { name: string };\n}",
           "exported": true,
           "lineCount": 18
         },
@@ -225285,7 +224936,6 @@
             "tags",
             "collectionName"
           ],
-          "returnType": "FileUnderState",
           "exported": true,
           "lineCount": 24
         },
@@ -225294,7 +224944,6 @@
           "params": [
             "name"
           ],
-          "returnType": "string",
           "exported": false,
           "lineCount": 1
         },
@@ -225303,7 +224952,6 @@
           "params": [
             "s"
           ],
-          "returnType": "Scheduler",
           "exported": false,
           "lineCount": 5
         },
@@ -225312,7 +224960,6 @@
           "params": [
             "path"
           ],
-          "returnType": "string",
           "exported": false,
           "lineCount": 5
         },
@@ -225323,7 +224970,6 @@
             "metadata",
             "models"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 137
         },
@@ -225334,7 +224980,6 @@
             "request",
             "models"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 134
         },
@@ -225345,7 +224990,6 @@
             "prefill",
             "models"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 24
         }
@@ -225353,181 +224997,88 @@
       "classes": [],
       "imports": [
         {
-          "source": "./api/types",
-          "specifiers": [
-            "GenerateRequest",
-            "KeyframeConditionWire",
-            "LoraWeight",
-            "Ltx2PipelineMode",
-            "Ltx2SpatialUpscale",
-            "Ltx2TemporalUpscale",
-            "ModelEntry",
-            "OutputFormat",
-            "OutputMetadata",
-            "Scheduler",
-            "TimeRange"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "./capabilities",
-          "specifiers": [
-            "MAX_LORA_STACK",
-            "defaultOutputFormat",
-            "generationCapabilitiesForFamily",
-            "outputFormatsForFamily",
-            "pruneRequestForFamily"
-          ]
+          "source": "desktop/src/lib/capabilities.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sourceFit",
-          "specifiers": [
-            "coerceSourceFitForMaskless",
-            "parseSourceFitPolicy",
-            "SourceFitPolicy"
-          ]
+          "source": "desktop/src/lib/generateModels.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/fileUnder",
-          "specifiers": [
-            "addTag",
-            "buildFileUnderRequestFields",
-            "deriveGhostTag",
-            "emptyFileUnderState",
-            "pickCollection",
-            "requestTagKey",
-            "FileUnderCollectionLike",
-            "FileUnderState"
-          ]
+          "source": "studio/lib/cameraMotion.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sequence",
-          "specifiers": [
-            "defaultVideoFps"
-          ]
+          "source": "studio/lib/extend.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/videoDuration",
-          "specifiers": [
-            "videoFramesForModelSelection"
-          ]
+          "source": "studio/lib/fileUnder.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/outputReuse",
-          "specifiers": [
-            "pipelineForSettingsReuse"
-          ]
+          "source": "studio/lib/generationCapabilities.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/extend",
-          "specifiers": [
-            "familySupportsExtend",
-            "resolveExtendOverlapFrames"
-          ]
+          "source": "studio/lib/generationProfile.ts",
+          "specifiers": []
         },
         {
-          "source": "./generateModels",
-          "specifiers": [
-            "findInstalledModel"
-          ]
+          "source": "studio/lib/guidanceOverrides.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/cameraMotion",
-          "specifiers": [
-            "cameraMotionFromLoraPath",
-            "cameraMotionLoraLabel",
-            "syncCameraMotionLora"
-          ]
+          "source": "studio/lib/identityConditioning.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/guidanceOverrides",
-          "specifiers": [
-            "emptyGuidanceOverrides",
-            "guidanceOverridesFromWire",
-            "guidanceOverridesToWire",
-            "Ltx2GuidanceOverridesState"
-          ]
+          "source": "studio/lib/libraryOrganization.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/wanRecipe",
-          "specifiers": [
-            "emptyWanRecipe",
-            "wanRecipeFromWire",
-            "wanRecipeToWire",
-            "WanRecipeState"
-          ]
+          "source": "studio/lib/ltx2Control.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/negativePrompt",
-          "specifiers": [
-            "effectiveNegativeDefault",
-            "negativePromptOnDefaultChange",
-            "negativePromptWireValue",
-            "restoredNegativeExplicitClear",
-            "restoredNegativePrompt"
-          ]
+          "source": "studio/lib/ltx2Pipeline.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/ltx2Control",
-          "specifiers": [
-            "pipelineForControlId"
-          ]
+          "source": "studio/lib/minimaxH3Authoring.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/identityConditioning",
-          "specifiers": [
-            "identityRequestFields",
-            "identityReuse",
-            "supportsIdentity"
-          ]
+          "source": "studio/lib/negativePrompt.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/libraryOrganization",
-          "specifiers": [
-            "validatePrintTitle"
-          ]
+          "source": "studio/lib/outputReuse.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sourceImageCapability",
-          "specifiers": [
-            "firstLastFrameKeyframes"
-          ]
+          "source": "studio/lib/sequence.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/generationCapabilities",
-          "specifiers": [
-            "effectiveGenerationGuidance",
-            "isWanFamily"
-          ]
+          "source": "studio/lib/sourceFit.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/ltx2Pipeline",
-          "specifiers": [
-            "stripAudioOnlyIncompatibleFields"
-          ]
+          "source": "studio/lib/sourceImageCapability.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/generationProfile",
-          "specifiers": [
-            "effectiveGenerationRecipe",
-            "fixedRecipeControlOverrides"
-          ]
+          "source": "studio/lib/videoDuration.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/minimaxH3Authoring",
-          "specifiers": [
-            "MINIMAX_H3_REVIEWED_COMPACT_FRAMES",
-            "cloneMinimaxH3AuthoringState",
-            "emptyMinimaxH3AuthoringState",
-            "isMinimaxH3Family",
-            "minimaxH3BoundaryFromSourceMetadata",
-            "minimaxH3BoundaryFromStagedImage",
-            "minimaxH3ClosingBoundaryFromMetadata",
-            "minimaxH3ReferenceDraftsFromMetadata",
-            "minimaxH3TaskForModel",
-            "serializeMinimaxH3Authoring",
-            "stagedImageFromMinimaxH3Boundary",
-            "MinimaxH3AuthoringState"
-          ]
+          "source": "studio/lib/wanRecipe.ts",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -225549,7 +225100,7 @@
         "applyRequestToForm",
         "applyPrefillToForm"
       ],
-      "totalLines": 1524,
+      "totalLines": 1525,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/generateModels.test.ts": {
@@ -229877,7 +229428,7 @@
     },
     "desktop/src/lib/sourceAttachment.ts": {
       "filePath": "desktop/src/lib/sourceAttachment.ts",
-      "contentHash": "b3ff04a9697664c5d56a069345e815dd092b5fd220bb6464e35ac31464d45c43",
+      "contentHash": "37574f05f373e3bbe07e09c10eb3f4ec21deaa4cdce298bcdf9494f14ecf39bf",
       "functions": [
         {
           "name": "attachPickedImage",
@@ -229885,7 +229436,6 @@
             "form",
             "picked"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 5
         },
@@ -229895,7 +229445,6 @@
             "form",
             "picked"
           ],
-          "returnType": "void",
           "exported": true,
           "lineCount": 3
         }
@@ -229903,30 +229452,26 @@
       "classes": [],
       "imports": [
         {
-          "source": "./generateForm",
-          "specifiers": [
-            "GenerateForm",
-            "PickedImage"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         }
       ],
       "exports": [
         "attachPickedImage",
         "attachPickedVideo"
       ],
-      "totalLines": 14,
+      "totalLines": 15,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/sourceFitPreprocess.test.ts": {
       "filePath": "desktop/src/lib/sourceFitPreprocess.test.ts",
-      "contentHash": "e7fa01177f04f2d8d2bae0e3f4de4b84e92959a81bb263c6ddcc797c222d65f7",
+      "contentHash": "816da0e017e166e631680f03cba3893aafa7a9664aabbf957d1ee2fdd1a52bd4",
       "functions": [
         {
           "name": "fakeOps",
           "params": [
             "size"
           ],
-          "returnType": "SourceFitCanvasOps & {\n  fitCalls: Array<{ base64: string; transform: SourceFitTransform }>;\n  maskCalls: Array<{ existing: string | null; padRects: Rect[] }>;\n}",
           "exported": false,
           "lineCount": 20
         }
@@ -229934,53 +229479,31 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/lib/sourceFitPreprocess.ts",
+          "specifiers": []
         },
         {
-          "source": "@ui/lib/sourceFitPreprocessCache",
-          "specifiers": [
-            "SourceFitPreprocessCache"
-          ]
+          "source": "studio/lib/sourceFit.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sourceFit",
-          "specifiers": [
-            "Rect",
-            "SourceFitPolicy",
-            "SourceFitTransform"
-          ]
-        },
-        {
-          "source": "./sourceFitPreprocess",
-          "specifiers": [
-            "applyH3BoundaryFit",
-            "applySourceFitPreprocess",
-            "drawableFitPolicy",
-            "SourceFitCanvasOps",
-            "SourceFitInput"
-          ]
+          "source": "ui/lib/sourceFitPreprocessCache.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 388,
+      "totalLines": 387,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/sourceFitPreprocess.ts": {
       "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
-      "contentHash": "3723e9e0157a6b8daa938a1e96d4340945f22cb8d781c22f043dd6755fef3c25",
+      "contentHash": "b5f4b26e50dc9d0ce3ef02afcce05bcf04cdf84a0f2ca8859e8fafceb130598a",
       "functions": [
         {
           "name": "drawableFitPolicy",
           "params": [
             "policy"
           ],
-          "returnType": "SourceFitPolicy",
           "exported": true,
           "lineCount": 5
         },
@@ -229990,7 +229513,6 @@
             "input",
             "deps"
           ],
-          "returnType": "Promise<SourceFitResult>",
           "exported": true,
           "lineCount": 51
         },
@@ -230002,7 +229524,6 @@
             "target",
             "deps"
           ],
-          "returnType": "Promise<MinimaxH3AuthoringState | null>",
           "exported": true,
           "lineCount": 30
         }
@@ -230010,32 +229531,20 @@
       "classes": [],
       "imports": [
         {
-          "source": "@ui/lib/sourceFitPreprocessCache",
-          "specifiers": [
-            "SourceFitPreprocessCache"
-          ]
+          "source": "studio/lib/minimaxH3Authoring.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sourceFit",
-          "specifiers": [
-            "coerceSourceFitForMaskless",
-            "maskPaddingRectangles",
-            "resolveSourceFitTransform",
-            "Size",
-            "SourceFitPolicy"
-          ]
+          "source": "studio/lib/sourceFit.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/sourceFitCanvas",
-          "specifiers": [
-            "SourceFitCanvasOps"
-          ]
+          "source": "studio/lib/sourceFitCanvas.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/minimaxH3Authoring",
-          "specifiers": [
-            "MinimaxH3AuthoringState"
-          ]
+          "source": "ui/lib/sourceFitPreprocessCache.ts",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -230044,7 +229553,7 @@
         "applySourceFitPreprocess",
         "applyH3BoundaryFit"
       ],
-      "totalLines": 155,
+      "totalLines": 153,
       "hasStructuralAnalysis": true
     },
     "desktop/src/lib/sourceRestore.test.ts": {
@@ -230596,7 +230105,7 @@
     },
     "desktop/src/mobile/MobileApp.test.ts": {
       "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "contentHash": "c82c010ef4ada2f4f6ad7b0e281421c39f427921d3171983433bd2fd41453095",
+      "contentHash": "b571e2186f26033b1eab19d0bd5fa7127af4156f946e64986a85c65b5fee2ba5",
       "functions": [
         {
           "name": "plannedPlacement",
@@ -230610,7 +230119,6 @@
             "init",
             "overrides"
           ],
-          "returnType": "Record<string, unknown>",
           "exported": false,
           "lineCount": 31
         },
@@ -230621,7 +230129,6 @@
             "init",
             "callTarget"
           ],
-          "returnType": "Promise<unknown>",
           "exported": false,
           "lineCount": 30
         },
@@ -230630,49 +230137,42 @@
           "params": [
             "...filenames"
           ],
-          "returnType": "void",
           "exported": false,
           "lineCount": 3
         },
         {
           "name": "admittedRequests",
           "params": [],
-          "returnType": "Array<Record<string, unknown>>",
           "exported": false,
           "lineCount": 3
         },
         {
           "name": "admissionTargets",
           "params": [],
-          "returnType": "unknown[]",
           "exported": false,
           "lineCount": 3
         },
         {
           "name": "admittedBatches",
           "params": [],
-          "returnType": "Array<{ client_batch_id: string; requests: unknown[] }>",
           "exported": false,
           "lineCount": 3
         },
         {
           "name": "admissionCalls",
           "params": [],
-          "returnType": "unknown[][]",
           "exported": false,
           "lineCount": 7
         },
         {
           "name": "heldAdmissions",
           "params": [],
-          "returnType": "{\n  count: () => number;\n  settleAt: (\n    index: number,\n    options?: {\n      state?: string;\n      filename?: string | null;\n      error?: string;\n      children?: ReadonlyArray<{ state?: string; filename?: string | null; error?: string }>;\n    },\n  ) => void;\n  settle: (state?: string, filenames?: readonly string[]) => void;\n}",
           "exported": false,
           "lineCount": 83
         },
         {
           "name": "serveStillModel",
           "params": [],
-          "returnType": "void",
           "exported": false,
           "lineCount": 7
         },
@@ -230681,7 +230181,6 @@
           "params": [
             "pinia"
           ],
-          "returnType": "VueWrapper",
           "exported": false,
           "lineCount": 7
         },
@@ -230690,7 +230189,6 @@
           "params": [
             "label"
           ],
-          "returnType": "DOMWrapper<Element>",
           "exported": false,
           "lineCount": 7
         },
@@ -230720,153 +230218,76 @@
       ],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "flushPromises",
-            "mount",
-            "DOMWrapper",
-            "VueWrapper"
-          ]
+          "source": "desktop/src/lib/api/client.ts",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "Pinia"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "fake-indexeddb",
-          "specifiers": [
-            "IDBFactory"
-          ]
+          "source": "desktop/src/lib/generationTemplates.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/testSupport/memoryLocalStorage",
-          "specifiers": [
-            "installMemoryLocalStorage"
-          ]
+          "source": "desktop/src/lib/testSupport/memoryLocalStorage.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/api/types",
-          "specifiers": [
-            "GalleryImage",
-            "ModelEntry",
-            "ServerStatus"
-          ]
+          "source": "desktop/src/mobile/MobileApp.vue",
+          "specifiers": []
         },
         {
-          "source": "../lib/generateForm",
-          "specifiers": [
-            "applyModelDefaults",
-            "newGenerateForm",
-            "GenerateForm"
-          ]
+          "source": "desktop/src/mobile/MobileImagePickerSheet.vue",
+          "specifiers": []
         },
         {
-          "source": "../lib/generationTemplates",
-          "specifiers": [
-            "saveGenerationTemplate"
-          ]
+          "source": "desktop/src/mobile/MobileLoraControls.vue",
+          "specifiers": []
         },
         {
-          "source": "./mobileTemplateStorage",
-          "specifiers": [
-            "MOBILE_GENERATION_TEMPLATES_STORAGE_KEY"
-          ]
+          "source": "desktop/src/mobile/MobileSourceControls.vue",
+          "specifiers": []
         },
         {
-          "source": "./mobileGenerationRecovery",
-          "specifiers": [
-            "MOBILE_DURABLE_GENERATIONS_KEY",
-            "createMobileDurableGenerationRecovery",
-            "reduceMobileDurableGenerationRecovery"
-          ]
+          "source": "desktop/src/mobile/MobileTemplates.vue",
+          "specifiers": []
         },
         {
-          "source": "./galleryCache",
-          "specifiers": [
-            "loadCachedGallery",
-            "storeCachedGallery",
-            "storeCachedGalleryMedia",
-            "storeCachedHostPresentation"
-          ]
+          "source": "desktop/src/mobile/galleryCache.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/libraryOrganization",
-          "specifiers": [
-            "clearSessionScrollForTests",
-            "sessionScrollPosition"
-          ]
+          "source": "desktop/src/mobile/mobileDownloads.ts",
+          "specifiers": []
         },
         {
-          "source": "./MobileApp.vue",
-          "specifiers": [
-            "MobileApp"
-          ]
+          "source": "desktop/src/mobile/mobileGenerationRecovery.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/components/IdentityPhotoWell.vue",
-          "specifiers": [
-            "IdentityPhotoWell"
-          ]
+          "source": "desktop/src/mobile/mobileTemplateStorage.ts",
+          "specifiers": []
         },
         {
-          "source": "./MobileImagePickerSheet.vue",
-          "specifiers": [
-            "MobileImagePickerSheet"
-          ]
+          "source": "studio/components/IdentityPhotoWell.vue",
+          "specifiers": []
         },
         {
-          "source": "./MobileLoraControls.vue",
-          "specifiers": [
-            "MobileLoraControls"
-          ]
+          "source": "studio/lib/libraryOrganization.ts",
+          "specifiers": []
         },
         {
-          "source": "./MobileSourceControls.vue",
-          "specifiers": [
-            "MobileSourceControls"
-          ]
-        },
-        {
-          "source": "./MobileTemplates.vue",
-          "specifiers": [
-            "MobileTemplates"
-          ]
-        },
-        {
-          "source": "./mobileDownloads",
-          "specifiers": [
-            "useMobileDownloadsStore"
-          ]
-        },
-        {
-          "source": "../lib/api/client",
-          "specifiers": [
-            "ApiError"
-          ]
-        },
-        {
-          "source": "@studio/stores/sequenceDraft",
-          "specifiers": [
-            "useSequenceDraftStore"
-          ]
+          "source": "studio/stores/sequenceDraft.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 13212,
+      "totalLines": 13235,
       "hasStructuralAnalysis": true
     },
     "desktop/src/mobile/MobileBatchControl.test.ts": {
@@ -232240,14 +231661,13 @@
     },
     "desktop/src/mobile/MobileSourceControls.test.ts": {
       "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
-      "contentHash": "e8892a38f8558f6185487ff6ddaf6381aadbd7e66afc2f89532d971e3f2b700f",
+      "contentHash": "c2f239bfba2ba5f167bb8c0079a3867cd99c5a51542e6bf292f6426bbfb76e33",
       "functions": [
         {
           "name": "formFor",
           "params": [
             "family"
           ],
-          "returnType": "GenerateForm",
           "exported": false,
           "lineCount": 3
         },
@@ -232258,7 +231678,6 @@
             "family",
             "downloaded"
           ],
-          "returnType": "ModelEntry",
           "exported": false,
           "lineCount": 15
         },
@@ -232269,7 +231688,6 @@
             "selector",
             "files"
           ],
-          "returnType": "Promise<void>",
           "exported": false,
           "lineCount": 14
         }
@@ -232277,81 +231695,40 @@
       "classes": [],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "flushPromises",
-            "mount"
-          ]
+          "source": "desktop/src/components/generate/MaskEditorModal.vue",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "reactive"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/lib/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/api/types",
-          "specifiers": [
-            "ModelEntry"
-          ]
+          "source": "desktop/src/lib/generateValidation.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/generateValidation",
-          "specifiers": [
-            "MAX_MOBILE_GENERATION_REQUEST_MEDIA_BYTES"
-          ]
+          "source": "desktop/src/mobile/MobileImagePickerSheet.vue",
+          "specifiers": []
         },
         {
-          "source": "../lib/generateForm",
-          "specifiers": [
-            "newGenerateForm",
-            "GenerateForm"
-          ]
+          "source": "desktop/src/mobile/MobileReferenceCropSheet.vue",
+          "specifiers": []
         },
         {
-          "source": "../components/generate/MaskEditorModal.vue",
-          "specifiers": [
-            "MaskEditorModal"
-          ]
+          "source": "desktop/src/mobile/MobileSourceControls.vue",
+          "specifiers": []
         },
         {
-          "source": "./MobileImagePickerSheet.vue",
-          "specifiers": [
-            "MobileImagePickerSheet"
-          ]
-        },
-        {
-          "source": "./MobileReferenceCropSheet.vue",
-          "specifiers": [
-            "MobileReferenceCropSheet"
-          ]
-        },
-        {
-          "source": "@studio/components/ReferenceCropEditor.vue",
-          "specifiers": [
-            "ReferenceCropEditor"
-          ]
-        },
-        {
-          "source": "./MobileSourceControls.vue",
-          "specifiers": [
-            "MobileSourceControls"
-          ]
+          "source": "studio/components/ReferenceCropEditor.vue",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 704,
+      "totalLines": 717,
       "hasStructuralAnalysis": true
     },
     "desktop/src/mobile/MobileStyleChips.test.ts": {
@@ -241117,7 +240494,7 @@
     },
     "desktop/src/views/GenerateView.prepared.test.ts": {
       "filePath": "desktop/src/views/GenerateView.prepared.test.ts",
-      "contentHash": "fb866886a6a7cb87117702bcf55fedc3cc564cbee95777a9ebde6c37aa3a572b",
+      "contentHash": "181744833c3033f0a0990224f2f4c6e9fb4cfff73e17c18fceab33c2422de0ac",
       "functions": [
         {
           "name": "deferred",
@@ -241135,174 +240512,92 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/components/generate/ExpandControl.vue",
+          "specifiers": []
         },
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "enableAutoUnmount",
-            "flushPromises",
-            "mount"
-          ]
+          "source": "desktop/src/components/generate/ExpansionPullStatus.vue",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
+          "source": "desktop/src/components/generate/MissingModelDialog.vue",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "nextTick"
-          ]
+          "source": "desktop/src/components/generate/PreparedExpansionBatch.vue",
+          "specifiers": []
         },
         {
-          "source": "./GenerateView.vue",
-          "specifiers": [
-            "GenerateView"
-          ]
+          "source": "desktop/src/lib/api/catalog.ts",
+          "specifiers": []
         },
         {
-          "source": "../components/generate/ExpandControl.vue",
-          "specifiers": [
-            "ExpandControl"
-          ]
+          "source": "desktop/src/lib/api/client.ts",
+          "specifiers": []
         },
         {
-          "source": "../components/generate/PreparedExpansionBatch.vue",
-          "specifiers": [
-            "PreparedExpansionBatch"
-          ]
+          "source": "desktop/src/lib/api/expand.ts",
+          "specifiers": []
         },
         {
-          "source": "../components/generate/ExpansionPullStatus.vue",
-          "specifiers": [
-            "ExpansionPullStatus"
-          ]
+          "source": "desktop/src/lib/api/remix.ts",
+          "specifiers": []
         },
         {
-          "source": "../components/generate/MissingModelDialog.vue",
-          "specifiers": [
-            "MissingModelDialog"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/connection",
-          "specifiers": [
-            "useConnectionStore"
-          ]
+          "source": "desktop/src/lib/sourceFitPreprocess.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/generateForm",
-          "specifiers": [
-            "useGenerateFormStore"
-          ]
+          "source": "desktop/src/stores/appPrefs.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/generation",
-          "specifiers": [
-            "newJob",
-            "useGenerationStore"
-          ]
+          "source": "desktop/src/stores/composer.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/hosts",
-          "specifiers": [
-            "useHostsStore",
-            "FeasibleRouteResult"
-          ]
+          "source": "desktop/src/stores/connection.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/hostModels",
-          "specifiers": [
-            "useHostModelsStore"
-          ]
+          "source": "desktop/src/stores/downloads.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/models",
-          "specifiers": [
-            "useModelStore"
-          ]
+          "source": "desktop/src/stores/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/toasts",
-          "specifiers": [
-            "useToastStore"
-          ]
+          "source": "desktop/src/stores/hostModels.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/downloads",
-          "specifiers": [
-            "useDownloadsStore"
-          ]
+          "source": "desktop/src/stores/hosts.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/ui",
-          "specifiers": [
-            "useUiStore"
-          ]
+          "source": "desktop/src/stores/models.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/appPrefs",
-          "specifiers": [
-            "useAppPrefsStore"
-          ]
+          "source": "desktop/src/stores/toasts.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/composer",
-          "specifiers": [
-            "useComposerStore"
-          ]
+          "source": "desktop/src/stores/ui.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/api/expand",
-          "specifiers": [
-            "expandPrompt"
-          ]
-        },
-        {
-          "source": "../lib/api/remix",
-          "specifiers": [
-            "remixPrompt"
-          ]
-        },
-        {
-          "source": "../lib/api/catalog",
-          "specifiers": [
-            "startCatalogDownload"
-          ]
-        },
-        {
-          "source": "../lib/api/client",
-          "specifiers": [
-            "ApiError"
-          ]
-        },
-        {
-          "source": "../lib/sourceFitPreprocess",
-          "specifiers": [
-            "applySourceFitPreprocess"
-          ]
-        },
-        {
-          "source": "../lib/api/types",
-          "specifiers": [
-            "ModelEntry"
-          ]
+          "source": "desktop/src/views/GenerateView.vue",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 1593,
+      "totalLines": 1611,
       "hasStructuralAnalysis": true
     },
     "desktop/src/views/GenerateView.printIdentity.test.ts": {
@@ -241424,7 +240719,7 @@
     },
     "desktop/src/views/GenerateView.sequence.test.ts": {
       "filePath": "desktop/src/views/GenerateView.sequence.test.ts",
-      "contentHash": "1f6cf9b2f7653bb85127548e515ffa7abbb65ef684454edc583f41024620229e",
+      "contentHash": "1aed70f9e54589ffb23c45fbea06004b972fba1b11ac0f0fa912b62de0e6447d",
       "functions": [
         {
           "name": "readyLocal",
@@ -241442,128 +240737,64 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "desktop/src/lib/api/types.ts",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
+          "source": "desktop/src/stores/appPrefs.ts",
+          "specifiers": []
         },
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "enableAutoUnmount",
-            "flushPromises",
-            "mount"
-          ]
+          "source": "desktop/src/stores/chainJobs.ts",
+          "specifiers": []
         },
         {
-          "source": "./GenerateView.vue",
-          "specifiers": [
-            "GenerateView"
-          ]
+          "source": "desktop/src/stores/composer.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/stores/sequenceDraft",
-          "specifiers": [
-            "useSequenceDraftStore"
-          ]
+          "source": "desktop/src/stores/connection.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/lib/fileUnder",
-          "specifiers": [
-            "addTag"
-          ]
+          "source": "desktop/src/stores/contextMenu.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/generateForm",
-          "specifiers": [
-            "useGenerateFormStore"
-          ]
+          "source": "desktop/src/stores/generateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/chainJobs",
-          "specifiers": [
-            "useChainJobsStore"
-          ]
+          "source": "desktop/src/stores/hosts.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/composer",
-          "specifiers": [
-            "useComposerStore"
-          ]
+          "source": "desktop/src/stores/models.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/connection",
-          "specifiers": [
-            "useConnectionStore"
-          ]
+          "source": "desktop/src/stores/toasts.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/hosts",
-          "specifiers": [
-            "useHostsStore"
-          ]
+          "source": "desktop/src/stores/ui.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/appPrefs",
-          "specifiers": [
-            "useAppPrefsStore"
-          ]
+          "source": "desktop/src/views/GenerateView.vue",
+          "specifiers": []
         },
         {
-          "source": "../stores/models",
-          "specifiers": [
-            "useModelStore"
-          ]
+          "source": "studio/lib/api/chainTypes.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/toasts",
-          "specifiers": [
-            "useToastStore"
-          ]
+          "source": "studio/lib/fileUnder.ts",
+          "specifiers": []
         },
         {
-          "source": "../stores/ui",
-          "specifiers": [
-            "useUiStore"
-          ]
-        },
-        {
-          "source": "../stores/contextMenu",
-          "specifiers": [
-            "useContextMenuStore"
-          ]
-        },
-        {
-          "source": "../stores/generation",
-          "specifiers": [
-            "newJob",
-            "useGenerationStore"
-          ]
-        },
-        {
-          "source": "../lib/api/types",
-          "specifiers": [
-            "ModelEntry",
-            "OutputMetadata"
-          ]
-        },
-        {
-          "source": "@studio/lib/api/chainTypes",
-          "specifiers": [
-            "ChainJobDetail"
-          ]
+          "source": "studio/stores/sequenceDraft.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
@@ -256295,7 +255526,7 @@
     },
     "studio/lib/expansionRouting.test.ts": {
       "filePath": "studio/lib/expansionRouting.test.ts",
-      "contentHash": "ef282dad8691daf81a009932a492eb8d2b8d028f014eba11b3689957a49563f3",
+      "contentHash": "d991992210331e9e27ad12061a124206d591237fa711766b5f2047f19520e5a3",
       "functions": [
         {
           "name": "candidate",
@@ -256303,7 +255534,6 @@
             "hostId",
             "overrides"
           ],
-          "returnType": "ExpansionCandidate",
           "exported": false,
           "lineCount": 6
         },
@@ -256319,32 +255549,17 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
-        },
-        {
-          "source": "./expansionRouting",
-          "specifiers": [
-            "DEFAULT_EXPAND_MODEL",
-            "expandModelId",
-            "expansionPolicyForSelection",
-            "resolveExpansionRoute",
-            "ExpansionCandidate"
-          ]
+          "source": "studio/lib/expansionRouting.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 195,
+      "totalLines": 220,
       "hasStructuralAnalysis": true
     },
     "studio/lib/expansionRouting.ts": {
       "filePath": "studio/lib/expansionRouting.ts",
-      "contentHash": "fad1547c296268369e8118ced7bca53238091ade1b668834d9024c5c98a40742",
+      "contentHash": "63282377680ac424fa31fa41948870f53c5572f3dfc1ce3d9b686c80b9458062",
       "functions": [
         {
           "name": "candidateFor",
@@ -256352,7 +255567,6 @@
             "candidates",
             "hostId"
           ],
-          "returnType": "ExpansionCandidate | null",
           "exported": false,
           "lineCount": 7
         },
@@ -256361,7 +255575,6 @@
           "params": [
             "candidate"
           ],
-          "returnType": "boolean",
           "exported": false,
           "lineCount": 3
         },
@@ -256373,7 +255586,6 @@
             "candidates",
             "rank"
           ],
-          "returnType": "ExpansionRouteDecision",
           "exported": true,
           "lineCount": 27
         },
@@ -256383,7 +255595,6 @@
             "selection",
             "sentinels"
           ],
-          "returnType": "ExpansionPolicy",
           "exported": true,
           "lineCount": 10
         },
@@ -256392,16 +255603,14 @@
           "params": [
             "message"
           ],
-          "returnType": "string | null",
           "exported": true,
-          "lineCount": 4
+          "lineCount": 7
         },
         {
           "name": "expandModelId",
           "params": [
             "capability"
           ],
-          "returnType": "string",
           "exported": true,
           "lineCount": 6
         }
@@ -256415,7 +255624,7 @@
         "parseMissingExpandModel",
         "expandModelId"
       ],
-      "totalLines": 142,
+      "totalLines": 146,
       "hasStructuralAnalysis": true
     },
     "studio/lib/extend.test.ts": {
@@ -265792,44 +265001,34 @@
     },
     "studio/lib/sourceFit.test.ts": {
       "filePath": "studio/lib/sourceFit.test.ts",
-      "contentHash": "84a9a1a2c0efd5cd1e55fa7df12940f74ef94d0d8b2fa6b3ed231b7fd3c784aa",
+      "contentHash": "87a1fa87b4a7cc9e572cd5e8823ade1948df09c01af8ccac2a414f3c898303f8",
       "functions": [],
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "describe",
-            "expect",
-            "it"
-          ]
-        },
-        {
-          "source": "./sourceFit",
-          "specifiers": [
-            "coerceSourceFitForMaskless",
-            "describeSourceFit",
-            "maskPaddingRectangles",
-            "parseSourceFitPolicy",
-            "resolveSourceFitTransform",
-            "sourceFitPolicyForMode"
-          ]
+          "source": "studio/lib/sourceFit.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 254,
+      "totalLines": 272,
       "hasStructuralAnalysis": true
     },
     "studio/lib/sourceFit.ts": {
       "filePath": "studio/lib/sourceFit.ts",
-      "contentHash": "16b98db8c51e699e51a58f35f2b2f6c86e3641314a52474c160bc6cf86f2c3a5",
+      "contentHash": "bf66c4342906c07239e7709c092f60b2a36e6e1a59d3489e03174ca4b97013cf",
       "functions": [
+        {
+          "name": "defaultSourceFitPolicy",
+          "params": [],
+          "exported": true,
+          "lineCount": 3
+        },
         {
           "name": "sourceFitHelp",
           "params": [
             "mode"
           ],
-          "returnType": "string",
           "exported": true,
           "lineCount": 3
         },
@@ -265838,7 +265037,6 @@
           "params": [
             "value"
           ],
-          "returnType": "SourceFitPolicy | null",
           "exported": true,
           "lineCount": 37
         },
@@ -265848,9 +265046,8 @@
             "mode",
             "options"
           ],
-          "returnType": "SourceFitPolicy",
           "exported": true,
-          "lineCount": 21
+          "lineCount": 19
         },
         {
           "name": "alignOffset",
@@ -265858,7 +265055,6 @@
             "available",
             "align"
           ],
-          "returnType": "number",
           "exported": false,
           "lineCount": 8
         },
@@ -265869,7 +265065,6 @@
             "target",
             "policy"
           ],
-          "returnType": "SourceFitTransform",
           "exported": true,
           "lineCount": 53
         },
@@ -265878,7 +265073,6 @@
           "params": [
             "t"
           ],
-          "returnType": "Rect[]",
           "exported": true,
           "lineCount": 31
         },
@@ -265887,7 +265081,6 @@
           "params": [
             "policy"
           ],
-          "returnType": "SourceFitPolicy",
           "exported": true,
           "lineCount": 14
         },
@@ -265896,7 +265089,6 @@
           "params": [
             "policy"
           ],
-          "returnType": "string",
           "exported": true,
           "lineCount": 14
         }
@@ -265904,6 +265096,7 @@
       "classes": [],
       "imports": [],
       "exports": [
+        "defaultSourceFitPolicy",
         "SOURCE_FIT_OPTIONS",
         "MASKLESS_SOURCE_FIT_OPTIONS",
         "sourceFitHelp",
@@ -265914,7 +265107,7 @@
         "coerceSourceFitForMaskless",
         "describeSourceFit"
       ],
-      "totalLines": 293,
+      "totalLines": 296,
       "hasStructuralAnalysis": true
     },
     "studio/lib/sourceFitCanvas.ts": {
@@ -272645,14 +271838,13 @@
     },
     "web/src/components/create/SequenceOpeningImagePanel.test.ts": {
       "filePath": "web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "contentHash": "8b6d8dc99255a1ecacbe7a75f00af12536b75549bf24e60bd7c538fa71aea914",
+      "contentHash": "0eded01ae5a33c3c8f9d0d7f6d5bf08ce2fcc4f43654cda73a254ff138baac82",
       "functions": [
         {
           "name": "baseForm",
           "params": [
             "overrides"
           ],
-          "returnType": "GenerateFormState",
           "exported": false,
           "lineCount": 7
         },
@@ -272676,53 +271868,16 @@
       "classes": [],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "flushPromises",
-            "mount"
-          ]
+          "source": "web/src/components/create/SequenceOpeningImagePanel.vue",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it"
-          ]
+          "source": "web/src/composables/useGenerateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
-        },
-        {
-          "source": "./SequenceOpeningImagePanel.vue",
-          "specifiers": [
-            "SequenceOpeningImagePanel"
-          ]
-        },
-        {
-          "source": "../../composables/useGenerateForm",
-          "specifiers": [
-            "useGenerateForm",
-            "__testing__"
-          ]
-        },
-        {
-          "source": "@studio/stores/sequenceDraft",
-          "specifiers": [
-            "useSequenceDraftStore"
-          ]
-        },
-        {
-          "source": "../../types",
-          "specifiers": [
-            "GenerateFormState"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
@@ -272731,14 +271886,13 @@
     },
     "web/src/components/create/SourceMediaPanel.test.ts": {
       "filePath": "web/src/components/create/SourceMediaPanel.test.ts",
-      "contentHash": "1dce8a58936e670361680f0a4b7cf77e1ac772ec729fa5feff737baf254be54c",
+      "contentHash": "780801cb6fab6e0936fd815144127edd228b569ee2e1202e6220ae2f40e4938c",
       "functions": [
         {
           "name": "baseForm",
           "params": [
             "overrides"
           ],
-          "returnType": "GenerateFormState",
           "exported": false,
           "lineCount": 7
         },
@@ -272756,44 +271910,20 @@
       "classes": [],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "mount"
-          ]
+          "source": "web/src/components/create/SourceMediaPanel.vue",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it"
-          ]
+          "source": "web/src/composables/useGenerateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "./SourceMediaPanel.vue",
-          "specifiers": [
-            "SourceMediaPanel"
-          ]
-        },
-        {
-          "source": "../../composables/useGenerateForm",
-          "specifiers": [
-            "useGenerateForm",
-            "__testing__"
-          ]
-        },
-        {
-          "source": "../../types",
-          "specifiers": [
-            "GenerateFormState",
-            "ModelInfoExtended"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 447,
+      "totalLines": 448,
       "hasStructuralAnalysis": true
     },
     "web/src/components/create/advanced/ExtendVideoControls.test.ts": {
@@ -275657,14 +274787,13 @@
     },
     "web/src/composables/useGenerateForm.test.ts": {
       "filePath": "web/src/composables/useGenerateForm.test.ts",
-      "contentHash": "12159d0ccb21ed80c3c219c35a739765a44e3ed4fb92930f853e8232df07b6a0",
+      "contentHash": "1e8df2d9164f78def7f7e654ca40ed05a5fc000e1560498da0a5c4f577885faa",
       "functions": [
         {
           "name": "makeModel",
           "params": [
             "overrides"
           ],
-          "returnType": "ModelInfoExtended",
           "exported": false,
           "lineCount": 19
         },
@@ -275684,53 +274813,12 @@
       "classes": [],
       "imports": [
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "web/src/composables/useGenerateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "nextTick"
-          ]
-        },
-        {
-          "source": "fake-indexeddb",
-          "specifiers": [
-            "IDBFactory"
-          ]
-        },
-        {
-          "source": "./useGenerateForm",
-          "specifiers": [
-            "applyMetadataToForm",
-            "normalizeLegacyNegativeFormState",
-            "cloneTemplateForm",
-            "promptWithStyle",
-            "sanitizePersistedForm",
-            "useGenerateForm",
-            "__testing__"
-          ]
-        },
-        {
-          "source": "../types",
-          "specifiers": [
-            "GenerateFormState",
-            "ModelInfoExtended",
-            "OutputMetadata"
-          ]
-        },
-        {
-          "source": "@studio/lib/negativePrompt",
-          "specifiers": [
-            "WAN_FAMILY_DEFAULT_NEGATIVE_PROMPT"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
@@ -275739,14 +274827,13 @@
     },
     "web/src/composables/useGenerateForm.ts": {
       "filePath": "web/src/composables/useGenerateForm.ts",
-      "contentHash": "ba672788645b6ceedcdd3f8e81c6e9148a192e8794890c43eacd45e569ac6419",
+      "contentHash": "6452c72b476311aad82e3d9dc3a2cb372fe0b25ebb6a12e97ea6a544e52aa3d4",
       "functions": [
         {
           "name": "promptWithStyle",
           "params": [
             "state"
           ],
-          "returnType": "string",
           "exported": true,
           "lineCount": 5
         },
@@ -275755,14 +274842,12 @@
           "params": [
             "s"
           ],
-          "returnType": "string",
           "exported": false,
           "lineCount": 27
         },
         {
           "name": "defaultForm",
           "params": [],
-          "returnType": "GenerateFormState",
           "exported": false,
           "lineCount": 64
         },
@@ -275771,7 +274856,6 @@
           "params": [
             "state"
           ],
-          "returnType": "T",
           "exported": false,
           "lineCount": 3
         },
@@ -275780,7 +274864,6 @@
           "params": [
             "state"
           ],
-          "returnType": "GenerateFormState",
           "exported": true,
           "lineCount": 40
         },
@@ -275789,7 +274872,6 @@
           "params": [
             "state"
           ],
-          "returnType": "GenerateFormState",
           "exported": true,
           "lineCount": 3
         },
@@ -275799,7 +274881,6 @@
             "current",
             "model"
           ],
-          "returnType": "GenerateFormState",
           "exported": false,
           "lineCount": 262
         },
@@ -275809,7 +274890,6 @@
             "current",
             "model"
           ],
-          "returnType": "GenerateFormState",
           "exported": true,
           "lineCount": 17
         },
@@ -275819,7 +274899,6 @@
             "state",
             "models"
           ],
-          "returnType": "GenerateFormState",
           "exported": true,
           "lineCount": 22
         },
@@ -275830,7 +274909,6 @@
             "metadata",
             "options"
           ],
-          "returnType": "GenerateFormState",
           "exported": true,
           "lineCount": 145
         },
@@ -275839,7 +274917,6 @@
           "params": [
             "media"
           ],
-          "returnType": "T",
           "exported": false,
           "lineCount": 5
         },
@@ -275848,7 +274925,6 @@
           "params": [
             "state"
           ],
-          "returnType": "MinimaxH3AuthoringState",
           "exported": false,
           "lineCount": 26
         },
@@ -275865,7 +274941,6 @@
           "params": [
             "state"
           ],
-          "returnType": "DraftMediaRecord[]",
           "exported": false,
           "lineCount": 17
         },
@@ -275874,7 +274949,6 @@
           "params": [
             "state"
           ],
-          "returnType": "DraftMediaRecord[]",
           "exported": false,
           "lineCount": 14
         },
@@ -275897,7 +274971,6 @@
         {
           "name": "load",
           "params": [],
-          "returnType": "GenerateFormState",
           "exported": false,
           "lineCount": 26
         },
@@ -275912,7 +274985,6 @@
         {
           "name": "useGenerateForm",
           "params": [],
-          "returnType": "UseGenerateForm",
           "exported": true,
           "lineCount": 375
         }
@@ -275920,191 +274992,20 @@
       "classes": [],
       "imports": [
         {
-          "source": "vue",
-          "specifiers": [
-            "ref",
-            "watch",
-            "Ref",
-            "WatchStopHandle"
-          ]
+          "source": "web/src/lib/draftMediaStore.ts",
+          "specifiers": []
         },
         {
-          "source": "../types",
-          "specifiers": [
-            "GenerateFormState",
-            "GenerateRequestWire",
-            "LoraSelection",
-            "ModelInfoExtended",
-            "OutputMetadata",
-            "OutputFormat",
-            "Scheduler"
-          ]
+          "source": "web/src/lib/generateCapabilities.ts",
+          "specifiers": []
         },
         {
-          "source": "../types",
-          "specifiers": [
-            "MAX_LORA_STACK"
-          ]
+          "source": "web/src/lib/stylePresets.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/draftMediaStore",
-          "specifiers": [
-            "clearMemoryDraftsForTest",
-            "getDraftMedia",
-            "newDraftId"
-          ]
-        },
-        {
-          "source": "@studio/lib/draftMediaStore",
-          "specifiers": [
-            "putDurableMediaBatch",
-            "DraftMediaRecord"
-          ]
-        },
-        {
-          "source": "../lib/generateCapabilities",
-          "specifiers": [
-            "generationCapabilitiesForFamily",
-            "isQwenImageEditFamily",
-            "isVideoFamily",
-            "supportsLora",
-            "supportsNegativePrompt",
-            "supportsScheduler"
-          ]
-        },
-        {
-          "source": "../lib/stylePresets",
-          "specifiers": [
-            "composeStyle"
-          ]
-        },
-        {
-          "source": "@studio/lib/sourceFit",
-          "specifiers": [
-            "parseSourceFitPolicy"
-          ]
-        },
-        {
-          "source": "@studio/lib/negativePrompt",
-          "specifiers": [
-            "effectiveNegativeDefault",
-            "negativePromptOnDefaultChange",
-            "negativePromptWireValue",
-            "restoredNegativeExplicitClear",
-            "restoredNegativePrompt"
-          ]
-        },
-        {
-          "source": "@studio/lib/sequence",
-          "specifiers": [
-            "defaultVideoFps"
-          ]
-        },
-        {
-          "source": "@studio/lib/videoDuration",
-          "specifiers": [
-            "videoFramesForModelSelection"
-          ]
-        },
-        {
-          "source": "@studio/lib/outputReuse",
-          "specifiers": [
-            "pipelineForSettingsReuse"
-          ]
-        },
-        {
-          "source": "@studio/lib/extend",
-          "specifiers": [
-            "familySupportsExtend",
-            "resolveExtendOverlapFrames"
-          ]
-        },
-        {
-          "source": "@studio/lib/generationProfile",
-          "specifiers": [
-            "effectiveGenerationRecipe",
-            "fixedRecipeControlOverrides"
-          ]
-        },
-        {
-          "source": "@studio/lib/generationCapabilities",
-          "specifiers": [
-            "effectiveGenerationGuidance"
-          ]
-        },
-        {
-          "source": "@studio/lib/cameraMotion",
-          "specifiers": [
-            "cameraMotionLoraPath",
-            "normalizeCameraMotionLoraState",
-            "syncCameraMotionLora"
-          ]
-        },
-        {
-          "source": "@studio/lib/ltx2Control",
-          "specifiers": [
-            "pipelineForControlId"
-          ]
-        },
-        {
-          "source": "@studio/lib/identityConditioning",
-          "specifiers": [
-            "identityRequestFields",
-            "identityReuse",
-            "supportsIdentity"
-          ]
-        },
-        {
-          "source": "@studio/lib/libraryOrganization",
-          "specifiers": [
-            "validatePrintTitle"
-          ]
-        },
-        {
-          "source": "@studio/lib/sourceImageCapability",
-          "specifiers": [
-            "firstLastFrameKeyframes"
-          ]
-        },
-        {
-          "source": "@studio/lib/ltx2Pipeline",
-          "specifiers": [
-            "stripAudioOnlyIncompatibleFields"
-          ]
-        },
-        {
-          "source": "@studio/lib/guidanceOverrides",
-          "specifiers": [
-            "emptyGuidanceOverrides",
-            "guidanceOverridesFromWire",
-            "guidanceOverridesToWire"
-          ]
-        },
-        {
-          "source": "@studio/lib/wanRecipe",
-          "specifiers": [
-            "emptyWanRecipe",
-            "wanRecipeFromWire",
-            "wanRecipeToWire"
-          ]
-        },
-        {
-          "source": "@studio/lib/minimaxH3Authoring",
-          "specifiers": [
-            "MINIMAX_H3_REVIEWED_COMPACT_FRAMES",
-            "emptyMinimaxH3AuthoringState",
-            "isMinimaxH3Family",
-            "minimaxH3BoundaryFromSourceMetadata",
-            "minimaxH3BoundaryFromStagedImage",
-            "minimaxH3ClosingBoundaryFromMetadata",
-            "minimaxH3ReferenceDraftsFromMetadata",
-            "minimaxH3TaskForModel",
-            "serializeMinimaxH3Authoring",
-            "stagedImageFromMinimaxH3Boundary",
-            "MinimaxH3AuthoringState",
-            "MinimaxH3BoundaryImage",
-            "MinimaxH3ReferenceDraft"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [
@@ -276119,7 +275020,7 @@
         "isQwenImageEditFamily",
         "__testing__"
       ],
-      "totalLines": 1465,
+      "totalLines": 1468,
       "hasStructuralAnalysis": true
     },
     "web/src/composables/useGenerateStream.test.ts": {
@@ -282922,7 +281823,7 @@
     },
     "web/src/pages/CreatePage.test.ts": {
       "filePath": "web/src/pages/CreatePage.test.ts",
-      "contentHash": "67d1f681189a4ceaa5c33f83f73935e746b56451192f69f08695e50439fbf11c",
+      "contentHash": "925a5ee7853061f41e06f0b8ad6c67b7664127d2c5829d8c9f665b40fda7c58c",
       "functions": [
         {
           "name": "installedModelRow",
@@ -282955,171 +281856,68 @@
       "classes": [],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "flushPromises",
-            "mount"
-          ]
+          "source": "web/src/api.ts",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "web/src/composables/useChainJobs.ts",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "defineComponent",
-            "nextTick",
-            "Component"
-          ]
+          "source": "web/src/composables/useGenerateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
+          "source": "web/src/composables/useGenerateStream.ts",
+          "specifiers": []
         },
         {
-          "source": "./CreatePage.vue",
-          "specifiers": [
-            "CreatePage"
-          ]
+          "source": "web/src/composables/useGenerationHandoff.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/useGenerateForm",
-          "specifiers": [
-            "useGenerateForm",
-            "generateFormTesting"
-          ]
+          "source": "web/src/composables/useHostRouting.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/toasts",
-          "specifiers": [
-            "resetNotifications",
-            "runToastAction",
-            "settleConfirm",
-            "useNotifications"
-          ]
+          "source": "web/src/composables/usePullResume.ts",
+          "specifiers": []
         },
         {
-          "source": "../lib/stylePresets",
-          "specifiers": [
-            "styleHint"
-          ]
+          "source": "web/src/composables/useSequenceHandoff.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/useHostRouting",
-          "specifiers": [
-            "hostRoutingTesting"
-          ]
+          "source": "web/src/lib/fileUnder.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/useHostRouting",
-          "specifiers": [
-            "useHostRouting"
-          ]
+          "source": "web/src/lib/hostRegistry.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/usePullResume",
-          "specifiers": [
-            "usePullResume"
-          ]
+          "source": "web/src/lib/hostRouting.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/useChainJobs",
-          "specifiers": [
-            "chainJobsTesting",
-            "useChainJobs"
-          ]
+          "source": "web/src/lib/stylePresets.ts",
+          "specifiers": []
         },
         {
-          "source": "@studio/stores/sequenceDraft",
-          "specifiers": [
-            "useSequenceDraftStore"
-          ]
+          "source": "web/src/lib/toasts.ts",
+          "specifiers": []
         },
         {
-          "source": "../composables/useSequenceHandoff",
-          "specifiers": [
-            "pendingSequenceHandoff",
-            "setSequenceHandoff",
-            "takeSequenceHandoff"
-          ]
+          "source": "web/src/pages/CreatePage.vue",
+          "specifiers": []
         },
         {
-          "source": "../composables/useGenerationHandoff",
-          "specifiers": [
-            "setGenerationHandoff",
-            "takeGenerationHandoff"
-          ]
-        },
-        {
-          "source": "../api",
-          "specifiers": [
-            "ApiHttpError"
-          ]
-        },
-        {
-          "source": "../lib/hostRegistry",
-          "specifiers": [
-            "addHost",
-            "ORIGIN_HOST_ID"
-          ]
-        },
-        {
-          "source": "../lib/fileUnder",
-          "specifiers": [
-            "autoTagTitle",
-            "reloadAutoTagTitle"
-          ]
-        },
-        {
-          "source": "../lib/hostRouting",
-          "specifiers": [
-            "AUTO_TARGET_ID",
-            "CAPABLE_TARGET_ID"
-          ]
-        },
-        {
-          "source": "../types",
-          "specifiers": [
-            "GalleryImage",
-            "GenerateFormState",
-            "GenerateRequestWire",
-            "ModelInfoExtended",
-            "OutputMetadata"
-          ]
-        },
-        {
-          "source": "../composables/useGenerateStream",
-          "specifiers": [
-            "Job"
-          ]
-        },
-        {
-          "source": "@studio/lib/api/chainTypes",
-          "specifiers": [
-            "ChainJobDetail",
-            "ChainRequestWire",
-            "CreateChainJobResponse"
-          ]
-        },
-        {
-          "source": "../api",
-          "specifiers": [
-            "StreamTarget"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 5004,
+      "totalLines": 5080,
       "hasStructuralAnalysis": true
     },
     "web/src/pages/HostDetailPage.test.ts": {
@@ -283467,7 +282265,7 @@
     },
     "web/src/pages/LibraryPage.test.ts": {
       "filePath": "web/src/pages/LibraryPage.test.ts",
-      "contentHash": "66f2e26a95640200c2d948a5f793de4999c9eea5c7334d190cbf06ed14f09486",
+      "contentHash": "3691106850a6a7f1f5488fdc2f459e9baa3820f1064829ba7e2d33668e14b131",
       "functions": [
         {
           "name": "makeEntry",
@@ -283477,7 +282275,6 @@
             "model",
             "seed"
           ],
-          "returnType": "GalleryImage",
           "exported": false,
           "lineCount": 22
         },
@@ -283497,73 +282294,24 @@
       "classes": [],
       "imports": [
         {
-          "source": "@vue/test-utils",
-          "specifiers": [
-            "flushPromises",
-            "mount"
-          ]
+          "source": "web/src/composables/useGenerateForm.ts",
+          "specifiers": []
         },
         {
-          "source": "vitest",
-          "specifiers": [
-            "afterEach",
-            "beforeEach",
-            "describe",
-            "expect",
-            "it",
-            "vi"
-          ]
+          "source": "web/src/lib/toasts.ts",
+          "specifiers": []
         },
         {
-          "source": "vue",
-          "specifiers": [
-            "defineComponent"
-          ]
+          "source": "web/src/pages/LibraryPage.vue",
+          "specifiers": []
         },
         {
-          "source": "pinia",
-          "specifiers": [
-            "createPinia",
-            "setActivePinia"
-          ]
-        },
-        {
-          "source": "./LibraryPage.vue",
-          "specifiers": [
-            "LibraryPage"
-          ]
-        },
-        {
-          "source": "../lib/toasts",
-          "specifiers": [
-            "requestConfirm",
-            "resetNotifications",
-            "runToastAction",
-            "useNotifications"
-          ]
-        },
-        {
-          "source": "../composables/useGenerateForm",
-          "specifiers": [
-            "formTesting",
-            "useGenerateForm"
-          ]
-        },
-        {
-          "source": "../types",
-          "specifiers": [
-            "GalleryImage"
-          ]
-        },
-        {
-          "source": "@studio/lib/libraryOrganization",
-          "specifiers": [
-            "clearSessionScrollForTests"
-          ]
+          "source": "web/src/types.ts",
+          "specifiers": []
         }
       ],
       "exports": [],
-      "totalLines": 854,
+      "totalLines": 858,
       "hasStructuralAnalysis": true
     },
     "web/src/pages/MachinesPage.test.ts": {
@@ -284328,6 +283076,251 @@
       ],
       "exports": [],
       "totalLines": 14,
+      "hasStructuralAnalysis": true
+    },
+    "crates/mold-cli/src/commands/library.rs": {
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "contentHash": "8508ee1e033f01a49b38500079f8bcebb098a0c4dfce4a5c6f37b276e8745b72",
+      "functions": [
+        {
+          "name": "run",
+          "params": [
+            "action"
+          ],
+          "exported": true,
+          "lineCount": 6
+        },
+        {
+          "name": "run_remote",
+          "params": [
+            "action",
+            "client"
+          ],
+          "exported": false,
+          "lineCount": 49
+        },
+        {
+          "name": "library_list",
+          "params": [
+            "client",
+            "options"
+          ],
+          "exported": false,
+          "lineCount": 49
+        },
+        {
+          "name": "library_show",
+          "params": [
+            "client",
+            "filename",
+            "json",
+            "preview"
+          ],
+          "exported": false,
+          "lineCount": 22
+        },
+        {
+          "name": "preview_bytes",
+          "params": [
+            "client",
+            "image"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "library_title",
+          "params": [
+            "client",
+            "filename",
+            "title",
+            "clear"
+          ],
+          "exported": false,
+          "lineCount": 20
+        },
+        {
+          "name": "library_tag",
+          "params": [
+            "client",
+            "action"
+          ],
+          "exported": false,
+          "lineCount": 39
+        },
+        {
+          "name": "mutate_prints",
+          "params": [
+            "client",
+            "filenames",
+            "favorite",
+            "add_tags",
+            "remove_tags"
+          ],
+          "exported": false,
+          "lineCount": 33
+        },
+        {
+          "name": "library_collection",
+          "params": [
+            "client",
+            "action"
+          ],
+          "exported": false,
+          "lineCount": 118
+        },
+        {
+          "name": "collection_membership",
+          "params": [
+            "client",
+            "reference",
+            "filenames",
+            "add"
+          ],
+          "exported": false,
+          "lineCount": 26
+        },
+        {
+          "name": "library_trash",
+          "params": [
+            "client",
+            "filenames"
+          ],
+          "exported": false,
+          "lineCount": 24
+        },
+        {
+          "name": "require_organize",
+          "params": [
+            "client"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "resolve_collection",
+          "params": [
+            "collections",
+            "value"
+          ],
+          "exported": false,
+          "lineCount": 31
+        },
+        {
+          "name": "filter_and_sort",
+          "params": [
+            "rows",
+            "query",
+            "tags",
+            "collection_id",
+            "favorite",
+            "format"
+          ],
+          "exported": false,
+          "lineCount": 37
+        },
+        {
+          "name": "gallery_format",
+          "params": [
+            "row"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "display_title",
+          "params": [
+            "row"
+          ],
+          "exported": false,
+          "lineCount": 7
+        },
+        {
+          "name": "render_listing",
+          "params": [
+            "rows",
+            "total",
+            "offset",
+            "collections"
+          ],
+          "exported": false,
+          "lineCount": 53
+        },
+        {
+          "name": "render_detail",
+          "params": [
+            "row"
+          ],
+          "exported": false,
+          "lineCount": 30
+        },
+        {
+          "name": "render_collections",
+          "params": [
+            "rows"
+          ],
+          "exported": false,
+          "lineCount": 23
+        },
+        {
+          "name": "truncate",
+          "params": [
+            "value",
+            "max"
+          ],
+          "exported": false,
+          "lineCount": 12
+        },
+        {
+          "name": "confirm",
+          "params": [
+            "prompt"
+          ],
+          "exported": false,
+          "lineCount": 13
+        },
+        {
+          "name": "library_grid",
+          "params": [
+            "host",
+            "local"
+          ],
+          "exported": false,
+          "lineCount": 9
+        },
+        {
+          "name": "library_grid",
+          "params": [
+            "_host",
+            "_local"
+          ],
+          "exported": false,
+          "lineCount": 3
+        }
+      ],
+      "classes": [
+        {
+          "name": "ListOptions",
+          "methods": [],
+          "properties": [
+            "query",
+            "tags",
+            "collection",
+            "favorite",
+            "format",
+            "limit",
+            "offset",
+            "json"
+          ],
+          "exported": false,
+          "lineCount": 10
+        }
+      ],
+      "imports": [],
+      "exports": [
+        "run"
+      ],
+      "totalLines": 773,
       "hasStructuralAnalysis": true
     }
   }

--- a/.ua/knowledge-graph.json
+++ b/.ua/knowledge-graph.json
@@ -18939,19 +18939,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "type": "file",
-      "name": "GenerateView.sequence.test.ts",
-      "filePath": "desktop/src/views/GenerateView.sequence.test.ts",
-      "summary": "Exercises Generate View.sequence behavior with focused regression and integration coverage.",
-      "tags": [
-        "test",
-        "verification",
-        "regression"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "file:desktop/src/views/HostDetailView.vue",
       "type": "file",
       "name": "HostDetailView.vue",
@@ -22049,36 +22036,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:desktop/src/lib/desktopImageDrop.ts",
-      "type": "file",
-      "name": "desktopImageDrop.ts",
-      "filePath": "desktop/src/lib/desktopImageDrop.ts",
-      "summary": "Implements desktop Image Drop with 1 extracted structural definitions for the Mold codebase.",
-      "tags": [
-        "rust-module",
-        "implementation",
-        "tested"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
-      "type": "function",
-      "name": "applyDesktopImageDrop",
-      "filePath": "desktop/src/lib/desktopImageDrop.ts",
-      "lineRange": [
-        26,
-        53
-      ],
-      "summary": "Provides the applyDesktopImageDrop operation within desktopImageDrop.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:desktop/src/lib/generateModels.test.ts",
       "type": "file",
       "name": "generateModels.test.ts",
@@ -23002,83 +22959,6 @@
         "test",
         "verification",
         "regression"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:desktop/src/lib/sourceAttachment.ts",
-      "type": "file",
-      "name": "sourceAttachment.ts",
-      "filePath": "desktop/src/lib/sourceAttachment.ts",
-      "summary": "Implements source Attachment with 2 extracted structural definitions for the Mold codebase.",
-      "tags": [
-        "rust-module",
-        "implementation",
-        "tested"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
-      "type": "function",
-      "name": "attachPickedImage",
-      "filePath": "desktop/src/lib/sourceAttachment.ts",
-      "lineRange": [
-        4,
-        8
-      ],
-      "summary": "Provides the attachPickedImage operation within sourceAttachment.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
-      "type": "function",
-      "name": "attachPickedVideo",
-      "filePath": "desktop/src/lib/sourceAttachment.ts",
-      "lineRange": [
-        11,
-        13
-      ],
-      "summary": "Provides the attachPickedVideo operation within sourceAttachment.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "type": "file",
-      "name": "sourceFitPreprocess.test.ts",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.test.ts",
-      "summary": "Exercises source Fit Preprocess behavior with focused regression and integration coverage.",
-      "tags": [
-        "test",
-        "verification",
-        "regression"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceFitPreprocess.test.ts:fakeOps",
-      "type": "function",
-      "name": "fakeOps",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.test.ts",
-      "lineRange": [
-        13,
-        32
-      ],
-      "summary": "Provides the fakeOps operation within sourceFitPreprocess.test.ts.",
-      "tags": [
-        "test",
-        "verification",
-        "behavior"
       ],
       "complexity": "simple"
     },
@@ -32672,579 +32552,6 @@
         "implementation"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-inference/src/expand.rs",
-      "type": "file",
-      "name": "expand.rs",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "summary": "Implements expand with 35 extracted structural definitions for the Mold codebase.",
-      "tags": [
-        "rust-module",
-        "implementation"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:validate",
-      "type": "function",
-      "name": "validate",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        64,
-        82
-      ],
-      "summary": "Provides the validate operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
-      "type": "function",
-      "name": "artifact_identity_fingerprint",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        99,
-        129
-      ],
-      "summary": "Provides the artifact_identity_fingerprint operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
-      "type": "function",
-      "name": "freeze_artifact",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        131,
-        141
-      ],
-      "summary": "Provides the freeze_artifact operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
-      "type": "function",
-      "name": "validate_frozen_artifact",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        143,
-        157
-      ],
-      "summary": "Provides the validate_frozen_artifact operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:expand_candidate_dirs",
-      "type": "function",
-      "name": "expand_candidate_dirs",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        159,
-        174
-      ],
-      "summary": "Provides the expand_candidate_dirs operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
-      "type": "function",
-      "name": "expand_plan_memory_floors",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        176,
-        203
-      ],
-      "summary": "Provides the expand_plan_memory_floors operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
-      "type": "function",
-      "name": "expand_execution_fingerprint",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        205,
-        232
-      ],
-      "summary": "Provides the expand_execution_fingerprint operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "type": "function",
-      "name": "resolve_local_expand_artifacts",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        236,
-        270
-      ],
-      "summary": "Provides the resolve_local_expand_artifacts operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
-      "type": "function",
-      "name": "resolve_expand_execution_plan",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        277,
-        286
-      ],
-      "summary": "Provides the resolve_expand_execution_plan operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "type": "function",
-      "name": "resolve_expand_execution_plan_from_artifacts",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        292,
-        311
-      ],
-      "summary": "Provides the resolve_expand_execution_plan_from_artifacts operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
-      "type": "function",
-      "name": "create_exact_device_with",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        313,
-        350
-      ],
-      "summary": "Provides the create_exact_device_with operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:select_legacy_dynamic_expand_device",
-      "type": "function",
-      "name": "select_legacy_dynamic_expand_device",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        352,
-        392
-      ],
-      "summary": "Provides the select_legacy_dynamic_expand_device operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:report_expand_memory_status_with",
-      "type": "function",
-      "name": "report_expand_memory_status_with",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        394,
-        411
-      ],
-      "summary": "Provides the report_expand_memory_status_with operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "function",
-      "name": "new",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        425,
-        434
-      ],
-      "summary": "Provides the new operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
-      "type": "function",
-      "name": "from_resolved_plan",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        441,
-        450
-      ],
-      "summary": "Provides the from_resolved_plan operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:set_on_progress",
-      "type": "function",
-      "name": "set_on_progress",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        453,
-        455
-      ],
-      "summary": "Provides the set_on_progress operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
-      "type": "function",
-      "name": "set_cancellation_token",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        457,
-        459
-      ],
-      "summary": "Provides the set_cancellation_token operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
-      "type": "function",
-      "name": "clear_cancellation_token",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        461,
-        463
-      ],
-      "summary": "Provides the clear_cancellation_token operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "type": "function",
-      "name": "expand_with_cancellation",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        467,
-        482
-      ],
-      "summary": "Provides the expand_with_cancellation operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
-      "type": "function",
-      "name": "with_gpu_selection",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        485,
-        488
-      ],
-      "summary": "Provides the with_gpu_selection operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
-      "type": "function",
-      "name": "with_preferred_gpu",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        491,
-        494
-      ],
-      "summary": "Provides the with_preferred_gpu operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:from_config",
-      "type": "function",
-      "name": "from_config",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        507,
-        509
-      ],
-      "summary": "Provides the from_config operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "type": "function",
-      "name": "from_config_legacy_dynamic",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        514,
-        520
-      ],
-      "summary": "Provides the from_config_legacy_dynamic operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "type": "function",
-      "name": "generate_text",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        523,
-        685
-      ],
-      "summary": "Provides the generate_text operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:expand",
-      "type": "function",
-      "name": "expand",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        689,
-        755
-      ],
-      "summary": "Provides the expand operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:sample_token",
-      "type": "function",
-      "name": "sample_token",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        759,
-        811
-      ],
-      "summary": "Provides the sample_token operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:find_gguf_in_dir",
-      "type": "function",
-      "name": "find_gguf_in_dir",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        815,
-        841
-      ],
-      "summary": "Provides the find_gguf_in_dir operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-inference/src/expand.rs:find_tokenizer_in_dir",
-      "type": "function",
-      "name": "find_tokenizer_in_dir",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        844,
-        868
-      ],
-      "summary": "Provides the find_tokenizer_in_dir operation within expand.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
-      "type": "class",
-      "name": "ResolvedExpandArtifact",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        28,
-        34
-      ],
-      "summary": "Defines ResolvedExpandArtifact, a structured rust type used by expand.rs.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
-      "type": "class",
-      "name": "ResolvedExpandArtifacts",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        37,
-        41
-      ],
-      "summary": "Defines ResolvedExpandArtifacts, a structured rust type used by expand.rs.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
-      "type": "class",
-      "name": "ExactExpandPlacement",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        44,
-        50
-      ],
-      "summary": "Defines ExactExpandPlacement, a structured rust type used by expand.rs.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
-      "type": "class",
-      "name": "ResolvedExpandExecutionPlan",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        53,
-        59
-      ],
-      "summary": "Defines ResolvedExpandExecutionPlan, a structured rust type used by expand.rs.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-inference/src/expand.rs:LocalExpander",
-      "type": "class",
-      "name": "LocalExpander",
-      "filePath": "crates/mold-inference/src/expand.rs",
-      "lineRange": [
-        414,
-        421
-      ],
-      "summary": "Defines LocalExpander, a structured rust type used by expand.rs.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "implementation"
-      ],
-      "complexity": "moderate"
     },
     {
       "id": "file:crates/mold-inference/src/flux/identity.rs",
@@ -64714,19 +64021,6 @@
       "languageNotes": "TypeScript Vue single-file component using <script setup> with component styling."
     },
     {
-      "id": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "type": "file",
-      "name": "SequenceOpeningImagePanel.test.ts",
-      "filePath": "web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "summary": "Exercises Sequence Opening Image Panel behavior with focused regression and integration coverage.",
-      "tags": [
-        "test",
-        "verification",
-        "regression"
-      ],
-      "complexity": "moderate"
-    },
-    {
       "id": "file:web/src/components/create/SequenceOpeningImagePanel.vue",
       "type": "file",
       "name": "SequenceOpeningImagePanel.vue",
@@ -76504,151 +75798,6 @@
         245
       ],
       "summary": "Provides the isPrintOfChainJob operation within sequenceReuse.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:studio/lib/sourceFit.test.ts",
-      "type": "file",
-      "name": "sourceFit.test.ts",
-      "filePath": "studio/lib/sourceFit.test.ts",
-      "summary": "Exercises source Fit behavior with focused regression and integration coverage.",
-      "tags": [
-        "test",
-        "verification",
-        "regression"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "file:studio/lib/sourceFit.ts",
-      "type": "file",
-      "name": "sourceFit.ts",
-      "filePath": "studio/lib/sourceFit.ts",
-      "summary": "Implements source Fit with 8 extracted structural definitions for the Mold codebase.",
-      "tags": [
-        "rust-module",
-        "implementation",
-        "tested"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:sourceFitHelp",
-      "type": "function",
-      "name": "sourceFitHelp",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        67,
-        69
-      ],
-      "summary": "Provides the sourceFitHelp operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
-      "type": "function",
-      "name": "parseSourceFitPolicy",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        80,
-        116
-      ],
-      "summary": "Provides the parseSourceFitPolicy operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
-      "type": "function",
-      "name": "sourceFitPolicyForMode",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        119,
-        139
-      ],
-      "summary": "Provides the sourceFitPolicyForMode operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
-      "type": "function",
-      "name": "resolveSourceFitTransform",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        172,
-        224
-      ],
-      "summary": "Provides the resolveSourceFitTransform operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
-      "type": "function",
-      "name": "maskPaddingRectangles",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        226,
-        256
-      ],
-      "summary": "Provides the maskPaddingRectangles operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
-      "type": "function",
-      "name": "coerceSourceFitForMaskless",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        264,
-        277
-      ],
-      "summary": "Provides the coerceSourceFitForMaskless operation within sourceFit.ts.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/sourceFit.ts:describeSourceFit",
-      "type": "function",
-      "name": "describeSourceFit",
-      "filePath": "studio/lib/sourceFit.ts",
-      "lineRange": [
-        279,
-        292
-      ],
-      "summary": "Provides the describeSourceFit operation within sourceFit.ts.",
       "tags": [
         "function",
         "implementation",
@@ -102385,53 +101534,6 @@
         117
       ],
       "summary": "Provides the provenance_summary operation within identity.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-tui/src/lib.rs",
-      "type": "file",
-      "name": "lib.rs",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "summary": "Implements lib with 2 extracted structural definitions for the Mold codebase.",
-      "tags": [
-        "entry-point",
-        "rust-module",
-        "implementation"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "function",
-      "name": "run_tui",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        42,
-        82
-      ],
-      "summary": "Provides the run_tui operation within lib.rs.",
-      "tags": [
-        "function",
-        "implementation",
-        "rust"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/lib.rs:run_event_loop",
-      "type": "function",
-      "name": "run_event_loop",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        84,
-        129
-      ],
-      "summary": "Provides the run_event_loop operation within lib.rs.",
       "tags": [
         "function",
         "implementation",
@@ -163494,102 +162596,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:studio/lib/expansionRouting.test.ts",
-      "type": "file",
-      "name": "expansionRouting.test.ts",
-      "filePath": "studio/lib/expansionRouting.test.ts",
-      "summary": "Exercises expansion Routing.test behavior and regression contracts for the lib subsystem.",
-      "tags": [
-        "source-code",
-        "test",
-        "utility",
-        "typescript"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "file:studio/lib/expansionRouting.ts",
-      "type": "file",
-      "name": "expansionRouting.ts",
-      "filePath": "studio/lib/expansionRouting.ts",
-      "summary": "Implements expansion Routing logic for the lib subsystem.",
-      "tags": [
-        "source-code",
-        "utility",
-        "typescript",
-        "tested"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
-      "type": "function",
-      "name": "resolveExpansionRoute",
-      "filePath": "studio/lib/expansionRouting.ts",
-      "lineRange": [
-        79,
-        105
-      ],
-      "summary": "Implements the resolve Expansion Route routine within this source file.",
-      "tags": [
-        "function",
-        "source-code",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
-      "type": "function",
-      "name": "expansionPolicyForSelection",
-      "filePath": "studio/lib/expansionRouting.ts",
-      "lineRange": [
-        111,
-        120
-      ],
-      "summary": "Implements the expansion Policy For Selection routine within this source file.",
-      "tags": [
-        "function",
-        "source-code",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
-      "type": "function",
-      "name": "parseMissingExpandModel",
-      "filePath": "studio/lib/expansionRouting.ts",
-      "lineRange": [
-        127,
-        130
-      ],
-      "summary": "Implements the parse Missing Expand Model routine within this source file.",
-      "tags": [
-        "function",
-        "source-code",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:studio/lib/expansionRouting.ts:expandModelId",
-      "type": "function",
-      "name": "expandModelId",
-      "filePath": "studio/lib/expansionRouting.ts",
-      "lineRange": [
-        136,
-        141
-      ],
-      "summary": "Implements the expand Model Id routine within this source file.",
-      "tags": [
-        "function",
-        "source-code",
-        "implementation"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:studio/lib/galleryThumbnailSize.test.ts",
       "type": "file",
       "name": "galleryThumbnailSize.test.ts",
@@ -174098,37 +173104,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "type": "file",
-      "name": "GenerateView.prepared.test.ts",
-      "filePath": "desktop/src/views/GenerateView.prepared.test.ts",
-      "summary": "Test suite verifying generate view.prepared.test, including regression and edge-case contracts exercised by the surrounding surface.",
-      "tags": [
-        "test",
-        "regression",
-        "desktop"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/views/GenerateView.prepared.test.ts:mountView",
-      "type": "function",
-      "name": "mountView",
-      "filePath": "desktop/src/views/GenerateView.prepared.test.ts",
-      "lineRange": [
-        93,
-        114
-      ],
-      "summary": "Implements mount view for generate view.prepared.test.",
-      "tags": [
-        "function",
-        "presentation",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:desktop/src/views/GenerateView.sourceConditioning.test.ts",
       "type": "file",
       "name": "GenerateView.sourceConditioning.test.ts",
@@ -174270,7 +173245,8 @@
       "tags": [
         "component",
         "vue",
-        "desktop"
+        "desktop",
+        "tested"
       ],
       "complexity": "complex",
       "languageNotes": "Vue single-file component combines reactive orchestration with scoped presentation."
@@ -196260,21 +195236,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "type": "file",
-      "name": "SourceImageWell.test.ts",
-      "filePath": "desktop/src/components/generate/SourceImageWell.test.ts",
-      "summary": "Exercises source image well.test behavior and regression contracts with focused automated coverage.",
-      "tags": [
-        "code",
-        "test",
-        "desktop",
-        "generation",
-        "typescript"
-      ],
-      "complexity": "complex"
-    },
-    {
       "id": "file:desktop/src/components/generate/SourceImageWell.vue",
       "type": "file",
       "name": "SourceImageWell.vue",
@@ -196289,594 +195250,6 @@
         "tested"
       ],
       "complexity": "complex"
-    },
-    {
-      "id": "file:desktop/src/lib/generateForm.test.ts",
-      "type": "file",
-      "name": "generateForm.test.ts",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "summary": "Exercises generate form.test behavior and regression contracts with focused automated coverage.",
-      "tags": [
-        "code",
-        "test",
-        "desktop",
-        "generation",
-        "typescript"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:ltx2Model",
-      "type": "function",
-      "name": "ltx2Model",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        26,
-        40
-      ],
-      "summary": "ltx2 model performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:profiledLtx2Model",
-      "type": "function",
-      "name": "profiledLtx2Model",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        42,
-        125
-      ],
-      "summary": "profiled ltx2 model performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:qwenEditModel",
-      "type": "function",
-      "name": "qwenEditModel",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        1095,
-        1105
-      ],
-      "summary": "qwen edit model performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:wanModel",
-      "type": "function",
-      "name": "wanModel",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        1441,
-        1451
-      ],
-      "summary": "wan model performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:sd15Model",
-      "type": "function",
-      "name": "sd15Model",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        1681,
-        1691
-      ],
-      "summary": "sd15 model performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.test.ts:richImageMetadata",
-      "type": "function",
-      "name": "richImageMetadata",
-      "filePath": "desktop/src/lib/generateForm.test.ts",
-      "lineRange": [
-        1693,
-        1719
-      ],
-      "summary": "rich image metadata performs a significant part of generate form.test's test and desktop behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:desktop/src/lib/generateForm.ts",
-      "type": "file",
-      "name": "generateForm.ts",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "summary": "Implements generate form behavior within Mold's local AI generation system and multi-surface application.",
-      "tags": [
-        "code",
-        "desktop",
-        "generation",
-        "typescript",
-        "implementation",
-        "tested"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:seedMode",
-      "type": "function",
-      "name": "seedMode",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        124,
-        126
-      ],
-      "summary": "seed mode performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
-      "type": "function",
-      "name": "newGenerateForm",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        289,
-        353
-      ],
-      "summary": "new generate form performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "factory"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
-      "type": "function",
-      "name": "cloneGenerateForm",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        360,
-        393
-      ],
-      "summary": "clone generate form performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
-      "type": "function",
-      "name": "applyModelDefaults",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        400,
-        439
-      ],
-      "summary": "apply model defaults performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
-      "type": "function",
-      "name": "applyRecipeDefaults",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        446,
-        500
-      ],
-      "summary": "apply recipe defaults performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
-      "type": "function",
-      "name": "reconcileModelCapabilities",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        507,
-        711
-      ],
-      "summary": "reconcile model capabilities performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
-      "type": "function",
-      "name": "normalizeLegacyNegativeSnapshot",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        724,
-        744
-      ],
-      "summary": "normalize legacy negative snapshot performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
-      "type": "function",
-      "name": "keepingPrintIdentity",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        761,
-        768
-      ],
-      "summary": "keeping print identity performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
-      "type": "function",
-      "name": "resetFormToModelDefaults",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        782,
-        797
-      ],
-      "summary": "reset form to model defaults performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
-      "type": "function",
-      "name": "resetAdvancedToModelDefaults",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        806,
-        844
-      ],
-      "summary": "reset advanced to model defaults performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
-      "type": "function",
-      "name": "formExtendOverlapFrames",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        860,
-        865
-      ],
-      "summary": "form extend overlap frames performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:buildRequest",
-      "type": "function",
-      "name": "buildRequest",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        867,
-        1086
-      ],
-      "summary": "build request performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "factory"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
-      "type": "function",
-      "name": "chainFilingFields",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        1097,
-        1114
-      ],
-      "summary": "chain filing fields performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
-      "type": "function",
-      "name": "restoredFileUnderState",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        1128,
-        1151
-      ],
-      "summary": "restored file under state performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
-      "type": "function",
-      "name": "applyMetadataToForm",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        1194,
-        1330
-      ],
-      "summary": "apply metadata to form performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
-      "type": "function",
-      "name": "applyRequestToForm",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        1360,
-        1493
-      ],
-      "summary": "apply request to form performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
-      "type": "function",
-      "name": "applyPrefillToForm",
-      "filePath": "desktop/src/lib/generateForm.ts",
-      "lineRange": [
-        1500,
-        1523
-      ],
-      "summary": "apply prefill to form performs a significant part of generate form's desktop and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "type": "file",
-      "name": "sourceFitPreprocess.ts",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
-      "summary": "Implements source-image fitting, padding, masking, and browser preprocessing as part of Mold's local generation engine and multi-surface application.",
-      "tags": [
-        "desktop",
-        "typescript",
-        "application",
-        "tested"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
-      "type": "function",
-      "name": "drawableFitPolicy",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
-      "lineRange": [
-        60,
-        64
-      ],
-      "summary": "Implements drawable fit policy for source-image fitting, padding, masking, and browser preprocessing.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
-      "type": "function",
-      "name": "applySourceFitPreprocess",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
-      "lineRange": [
-        66,
-        116
-      ],
-      "summary": "Updates source fit preprocess while preserving the module's lifecycle invariants.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
-      "type": "function",
-      "name": "applyH3BoundaryFit",
-      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
-      "lineRange": [
-        125,
-        154
-      ],
-      "summary": "Updates h3 boundary fit while preserving the module's lifecycle invariants.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:desktop/src/mobile/MobileApp.test.ts",
-      "type": "file",
-      "name": "MobileApp.test.ts",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "summary": "Provides the comprehensive behavior suite for the remote-only mobile application, covering generation routing, durable recovery, sequences, hosts, models, library organization, media, identity, and native bridges.",
-      "tags": [
-        "test",
-        "mobile",
-        "generation",
-        "durable-recovery",
-        "multi-host"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileApp.test.ts:plannedPlacement",
-      "type": "function",
-      "name": "plannedPlacement",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "lineRange": [
-        127,
-        144
-      ],
-      "summary": "Creates a deterministic multi-host placement-plan fixture for mobile routing tests.",
-      "tags": [
-        "test",
-        "factory",
-        "routing"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileApp.test.ts:durableBatchResponse",
-      "type": "function",
-      "name": "durableBatchResponse",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "lineRange": [
-        226,
-        256
-      ],
-      "summary": "Builds a durable generation batch response with overridable child records and states.",
-      "tags": [
-        "test",
-        "factory",
-        "durable-recovery"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileApp.test.ts:durableApiFallback",
-      "type": "function",
-      "name": "durableApiFallback",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "lineRange": [
-        274,
-        303
-      ],
-      "summary": "Implements the test API fallback that simulates durable generation endpoints and records admissions.",
-      "tags": [
-        "test",
-        "api-handler",
-        "durable-recovery"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileApp.test.ts:heldAdmissions",
-      "type": "function",
-      "name": "heldAdmissions",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "lineRange": [
-        359,
-        441
-      ],
-      "summary": "Installs controllable deferred durable-admission responses so tests can exercise concurrency, cancellation, and ordering races.",
-      "tags": [
-        "test",
-        "factory",
-        "concurrency",
-        "durable-recovery"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:desktop/src/mobile/MobileApp.test.ts:FakeIntersectionObserver",
-      "type": "class",
-      "name": "FakeIntersectionObserver",
-      "filePath": "desktop/src/mobile/MobileApp.test.ts",
-      "lineRange": [
-        479,
-        501
-      ],
-      "summary": "Provides a controllable IntersectionObserver substitute for mobile component visibility tests.",
-      "tags": [
-        "test",
-        "mock",
-        "browser-api"
-      ],
-      "complexity": "simple"
     },
     {
       "id": "file:desktop/src/mobile/MobileApp.vue",
@@ -196951,54 +195324,6 @@
         "tested"
       ],
       "complexity": "complex"
-    },
-    {
-      "id": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "type": "file",
-      "name": "MobileSourceControls.test.ts",
-      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
-      "summary": "Test suite verifying mobile source, frame, reference, and identity media controls, including regression and edge-case contracts exercised by the surrounding surface.",
-      "tags": [
-        "test",
-        "regression",
-        "mobile",
-        "desktop"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileSourceControls.test.ts:model",
-      "type": "function",
-      "name": "model",
-      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
-      "lineRange": [
-        23,
-        37
-      ],
-      "summary": "Implements model for mobile source, frame, reference, and identity media controls.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:desktop/src/mobile/MobileSourceControls.test.ts:chooseFiles",
-      "type": "function",
-      "name": "chooseFiles",
-      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
-      "lineRange": [
-        39,
-        52
-      ],
-      "summary": "Implements choose files for mobile source, frame, reference, and identity media controls.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
     },
     {
       "id": "file:desktop/src/mobile/MobileSourceControls.vue",
@@ -199812,22 +198137,6 @@
       "complexity": "complex"
     },
     {
-      "id": "file:web/src/components/create/SourceMediaPanel.test.ts",
-      "type": "file",
-      "name": "SourceMediaPanel.test.ts",
-      "filePath": "web/src/components/create/SourceMediaPanel.test.ts",
-      "summary": "Exercises the source media panel behavior and its integration contracts with focused regression scenarios.",
-      "tags": [
-        "test",
-        "regression",
-        "typescript",
-        "utility",
-        "web"
-      ],
-      "complexity": "complex",
-      "languageNotes": "TypeScript contracts keep shared UI and API state structurally typed."
-    },
-    {
       "id": "file:web/src/components/create/SourceMediaPanel.vue",
       "type": "file",
       "name": "SourceMediaPanel.vue",
@@ -199955,343 +198264,6 @@
         "domain-logic"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "file:web/src/composables/useGenerateForm.test.ts",
-      "type": "file",
-      "name": "useGenerateForm.test.ts",
-      "filePath": "web/src/composables/useGenerateForm.test.ts",
-      "summary": "Exercises use generate form.test behavior and regression contracts with focused automated coverage.",
-      "tags": [
-        "code",
-        "test",
-        "web",
-        "generation",
-        "typescript"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.test.ts:makeModel",
-      "type": "function",
-      "name": "makeModel",
-      "filePath": "web/src/composables/useGenerateForm.test.ts",
-      "lineRange": [
-        22,
-        40
-      ],
-      "summary": "make model performs a significant part of use generate form.test's test and web behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:web/src/composables/useGenerateForm.ts",
-      "type": "file",
-      "name": "useGenerateForm.ts",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "summary": "Implements use generate form behavior within Mold's local AI generation system and multi-surface application.",
-      "tags": [
-        "code",
-        "web",
-        "generation",
-        "typescript",
-        "implementation",
-        "tested"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
-      "type": "function",
-      "name": "promptWithStyle",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        95,
-        99
-      ],
-      "summary": "prompt with style performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:selectedFamily",
-      "type": "function",
-      "name": "selectedFamily",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        105,
-        131
-      ],
-      "summary": "selected family performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:defaultForm",
-      "type": "function",
-      "name": "defaultForm",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        133,
-        196
-      ],
-      "summary": "default form performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
-      "type": "function",
-      "name": "sanitizePersistedForm",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        207,
-        246
-      ],
-      "summary": "sanitize persisted form performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
-      "type": "function",
-      "name": "cloneTemplateForm",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        253,
-        255
-      ],
-      "summary": "clone template form performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:modelDefaultsPatch",
-      "type": "function",
-      "name": "modelDefaultsPatch",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        257,
-        518
-      ],
-      "summary": "model defaults patch performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
-      "type": "function",
-      "name": "settingsResetPatch",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        531,
-        547
-      ],
-      "summary": "settings reset patch performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
-      "type": "function",
-      "name": "normalizeLegacyNegativeFormState",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        561,
-        582
-      ],
-      "summary": "normalize legacy negative form state performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
-      "type": "function",
-      "name": "applyMetadataToForm",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        593,
-        737
-      ],
-      "summary": "apply metadata to form performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:stripH3AuthoringMedia",
-      "type": "function",
-      "name": "stripH3AuthoringMedia",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        745,
-        770
-      ],
-      "summary": "strip h3 authoring media performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:ensureDraftIds",
-      "type": "function",
-      "name": "ensureDraftIds",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        772,
-        796
-      ],
-      "summary": "ensure draft ids performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:h3MediaFromState",
-      "type": "function",
-      "name": "h3MediaFromState",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        798,
-        814
-      ],
-      "summary": "h3 media from state performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:mediaFromState",
-      "type": "function",
-      "name": "mediaFromState",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        816,
-        829
-      ],
-      "summary": "media from state performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:hydrateDraftMedia",
-      "type": "function",
-      "name": "hydrateDraftMedia",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        842,
-        953
-      ],
-      "summary": "hydrate draft media performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:load",
-      "type": "function",
-      "name": "load",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        955,
-        980
-      ],
-      "summary": "load performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:persist",
-      "type": "function",
-      "name": "persist",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        982,
-        1007
-      ],
-      "summary": "persist performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
-      "type": "function",
-      "name": "useGenerateForm",
-      "filePath": "web/src/composables/useGenerateForm.ts",
-      "lineRange": [
-        1061,
-        1435
-      ],
-      "summary": "use generate form performs a significant part of use generate form's web and generation behavior.",
-      "tags": [
-        "function",
-        "typescript",
-        "domain-logic"
-      ],
-      "complexity": "complex"
     },
     {
       "id": "file:web/src/composables/useGenerateStream.test.ts",
@@ -204260,1978 +202232,6 @@
         630
       ],
       "summary": "ChainFailure encapsulates chain state and behavior.",
-      "tags": [
-        "class",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-core/src/client.rs",
-      "type": "file",
-      "name": "client.rs",
-      "filePath": "crates/mold-core/src/client.rs",
-      "summary": "Provides the typed HTTP client used by Mold commands and surfaces to communicate with a remote or embedded Mold server.",
-      "tags": [
-        "code",
-        "rust",
-        "implementation"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pull_body",
-      "type": "function",
-      "name": "pull_body",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        31,
-        40
-      ],
-      "summary": "pull body performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:require_direct_singleton",
-      "type": "function",
-      "name": "require_direct_singleton",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        52,
-        61
-      ],
-      "summary": "require direct singleton performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:retained_frame_error",
-      "type": "function",
-      "name": "retained_frame_error",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        70,
-        79
-      ],
-      "summary": "retained frame error performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:new",
-      "type": "function",
-      "name": "new",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        111,
-        118
-      ],
-      "summary": "new performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:with_api_key",
-      "type": "function",
-      "name": "with_api_key",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        121,
-        128
-      ],
-      "summary": "with api key performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:from_env",
-      "type": "function",
-      "name": "from_env",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        130,
-        140
-      ],
-      "summary": "from env performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:has_api_key",
-      "type": "function",
-      "name": "has_api_key",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        143,
-        145
-      ],
-      "summary": "has api key performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
-      "type": "function",
-      "name": "create_reference_upload_session",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        153,
-        173
-      ],
-      "summary": "create reference upload session performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upload_reference_file",
-      "type": "function",
-      "name": "upload_reference_file",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        181,
-        206
-      ],
-      "summary": "upload reference file performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
-      "type": "function",
-      "name": "upload_reference_open_file",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        214,
-        235
-      ],
-      "summary": "upload reference open file performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
-      "type": "function",
-      "name": "upload_reference_bytes",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        242,
-        252
-      ],
-      "summary": "upload reference bytes performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upload_reference_body",
-      "type": "function",
-      "name": "upload_reference_body",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        254,
-        274
-      ],
-      "summary": "upload reference body performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
-      "type": "function",
-      "name": "cancel_reference_upload_session",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        277,
-        289
-      ],
-      "summary": "cancel reference upload session performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generate_raw",
-      "type": "function",
-      "name": "generate_raw",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        294,
-        309
-      ],
-      "summary": "generate raw performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generate",
-      "type": "function",
-      "name": "generate",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        315,
-        432
-      ],
-      "summary": "generate performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_models",
-      "type": "function",
-      "name": "list_models",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        434,
-        437
-      ],
-      "summary": "list models performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_models_extended",
-      "type": "function",
-      "name": "list_models_extended",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        439,
-        449
-      ],
-      "summary": "list models extended performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_loras",
-      "type": "function",
-      "name": "list_loras",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        452,
-        465
-      ],
-      "summary": "list loras performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_loras_endpoint",
-      "type": "function",
-      "name": "list_loras_endpoint",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        467,
-        481
-      ],
-      "summary": "list loras endpoint performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_loras_from_installed_catalog",
-      "type": "function",
-      "name": "list_loras_from_installed_catalog",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        483,
-        516
-      ],
-      "summary": "list loras from installed catalog performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:is_connection_error",
-      "type": "function",
-      "name": "is_connection_error",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        520,
-        531
-      ],
-      "summary": "is connection error performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:is_model_not_found",
-      "type": "function",
-      "name": "is_model_not_found",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        535,
-        547
-      ],
-      "summary": "is model not found performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generate_stream",
-      "type": "function",
-      "name": "generate_stream",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        554,
-        775
-      ],
-      "summary": "generate stream performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
-      "type": "function",
-      "name": "stream_chain_job_events",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        784,
-        892
-      ],
-      "summary": "stream chain job events performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:create_chain_job",
-      "type": "function",
-      "name": "create_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        894,
-        906
-      ],
-      "summary": "create chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_chain_jobs",
-      "type": "function",
-      "name": "list_chain_jobs",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        908,
-        923
-      ],
-      "summary": "list chain jobs performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:get_chain_job",
-      "type": "function",
-      "name": "get_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        925,
-        939
-      ],
-      "summary": "get chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:resume_chain_job",
-      "type": "function",
-      "name": "resume_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        941,
-        955
-      ],
-      "summary": "resume chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:retake_chain_job",
-      "type": "function",
-      "name": "retake_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        957,
-        973
-      ],
-      "summary": "retake chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:cancel_chain_job",
-      "type": "function",
-      "name": "cancel_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        975,
-        989
-      ],
-      "summary": "cancel chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:delete_chain_job",
-      "type": "function",
-      "name": "delete_chain_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        991,
-        1003
-      ],
-      "summary": "delete chain job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
-      "type": "function",
-      "name": "gc_chain_jobs",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1005,
-        1015
-      ],
-      "summary": "gc chain jobs performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pull_model",
-      "type": "function",
-      "name": "pull_model",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1020,
-        1022
-      ],
-      "summary": "pull model performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pull_model_accepting",
-      "type": "function",
-      "name": "pull_model_accepting",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1030,
-        1045
-      ],
-      "summary": "pull model accepting performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_licenses",
-      "type": "function",
-      "name": "list_licenses",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1048,
-        1058
-      ],
-      "summary": "list licenses performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:preview_generation_placement",
-      "type": "function",
-      "name": "preview_generation_placement",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1063,
-        1079
-      ],
-      "summary": "preview generation placement performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "host-routing",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:shutdown_server",
-      "type": "function",
-      "name": "shutdown_server",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1082,
-        1089
-      ],
-      "summary": "shutdown server performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pull_model_stream",
-      "type": "function",
-      "name": "pull_model_stream",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1095,
-        1102
-      ],
-      "summary": "pull model stream performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
-      "type": "function",
-      "name": "pull_model_stream_accepting",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1106,
-        1169
-      ],
-      "summary": "pull model stream accepting performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:host",
-      "type": "function",
-      "name": "host",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1171,
-        1173
-      ],
-      "summary": "host performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "host-routing"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:unload_model",
-      "type": "function",
-      "name": "unload_model",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1175,
-        1177
-      ],
-      "summary": "unload model performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:unload_model_target",
-      "type": "function",
-      "name": "unload_model_target",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1179,
-        1198
-      ],
-      "summary": "unload model target performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading",
-        "host-routing"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:server_status",
-      "type": "function",
-      "name": "server_status",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1200,
-        1210
-      ],
-      "summary": "server status performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:server_capabilities",
-      "type": "function",
-      "name": "server_capabilities",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1213,
-        1223
-      ],
-      "summary": "server capabilities performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:devices",
-      "type": "function",
-      "name": "devices",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1226,
-        1236
-      ],
-      "summary": "devices performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:capabilities",
-      "type": "function",
-      "name": "capabilities",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1239,
-        1241
-      ],
-      "summary": "capabilities performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:admit_generation_batch",
-      "type": "function",
-      "name": "admit_generation_batch",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1245,
-        1259
-      ],
-      "summary": "admit generation batch performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
-      "type": "function",
-      "name": "generation_batch_by_client_id",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1263,
-        1285
-      ],
-      "summary": "generation batch by client id performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generation_batch",
-      "type": "function",
-      "name": "generation_batch",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1288,
-        1307
-      ],
-      "summary": "generation batch performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
-      "type": "function",
-      "name": "generation_batch_statuses",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1310,
-        1324
-      ],
-      "summary": "generation batch statuses performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:retry_queue_job",
-      "type": "function",
-      "name": "retry_queue_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1327,
-        1340
-      ],
-      "summary": "retry queue job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:set_device_enabled",
-      "type": "function",
-      "name": "set_device_enabled",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1344,
-        1364
-      ],
-      "summary": "set device enabled performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_queue",
-      "type": "function",
-      "name": "list_queue",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1373,
-        1376
-      ],
-      "summary": "list queue performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
-      "type": "function",
-      "name": "list_queue_for_capacity",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1381,
-        1390
-      ],
-      "summary": "list queue for capacity performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_queue_page",
-      "type": "function",
-      "name": "list_queue_page",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1394,
-        1403
-      ],
-      "summary": "list queue page performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_queue_all",
-      "type": "function",
-      "name": "list_queue_all",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1423,
-        1458
-      ],
-      "summary": "list queue all performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:find_queue_job",
-      "type": "function",
-      "name": "find_queue_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1463,
-        1481
-      ],
-      "summary": "find queue job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:fetch_queue_listing",
-      "type": "function",
-      "name": "fetch_queue_listing",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1483,
-        1503
-      ],
-      "summary": "fetch queue listing performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:queue_job_progress",
-      "type": "function",
-      "name": "queue_job_progress",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1511,
-        1528
-      ],
-      "summary": "queue job progress performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:cancel_queue_job",
-      "type": "function",
-      "name": "cancel_queue_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1537,
-        1549
-      ],
-      "summary": "cancel queue job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:queue_job",
-      "type": "function",
-      "name": "queue_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1560,
-        1579
-      ],
-      "summary": "queue job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:move_queue_job",
-      "type": "function",
-      "name": "move_queue_job",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1584,
-        1603
-      ],
-      "summary": "move queue job performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
-      "type": "function",
-      "name": "cancel_all_queue_jobs",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1609,
-        1620
-      ],
-      "summary": "cancel all queue jobs performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
-      "type": "function",
-      "name": "cancel_generation_batch",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1625,
-        1639
-      ],
-      "summary": "cancel generation batch performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:pause_queue",
-      "type": "function",
-      "name": "pause_queue",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1643,
-        1645
-      ],
-      "summary": "pause queue performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:resume_queue",
-      "type": "function",
-      "name": "resume_queue",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1650,
-        1652
-      ],
-      "summary": "resume queue performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:set_queue_paused",
-      "type": "function",
-      "name": "set_queue_paused",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1654,
-        1665
-      ],
-      "summary": "set queue paused performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:sweep_held_queue",
-      "type": "function",
-      "name": "sweep_held_queue",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1668,
-        1678
-      ],
-      "summary": "sweep held queue performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
-      "type": "function",
-      "name": "sweep_settled_batches",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1682,
-        1692
-      ],
-      "summary": "sweep settled batches performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "job-lifecycle"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_gallery",
-      "type": "function",
-      "name": "list_gallery",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1695,
-        1705
-      ],
-      "summary": "list gallery performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:gallery_item",
-      "type": "function",
-      "name": "gallery_item",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1713,
-        1724
-      ],
-      "summary": "gallery item performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:get_gallery_image",
-      "type": "function",
-      "name": "get_gallery_image",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1727,
-        1737
-      ],
-      "summary": "get gallery image performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:delete_gallery_image",
-      "type": "function",
-      "name": "delete_gallery_image",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1740,
-        1747
-      ],
-      "summary": "delete gallery image performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_gallery_view",
-      "type": "function",
-      "name": "list_gallery_view",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1753,
-        1764
-      ],
-      "summary": "list gallery view performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:trash_gallery_image",
-      "type": "function",
-      "name": "trash_gallery_image",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1769,
-        1781
-      ],
-      "summary": "trash gallery image performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
-      "type": "function",
-      "name": "delete_gallery_image_forever",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1786,
-        1799
-      ],
-      "summary": "delete gallery image forever performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:trash_gallery_images",
-      "type": "function",
-      "name": "trash_gallery_images",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1802,
-        1813
-      ],
-      "summary": "trash gallery images performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:restore_trashed",
-      "type": "function",
-      "name": "restore_trashed",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1818,
-        1829
-      ],
-      "summary": "restore trashed performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:empty_trash",
-      "type": "function",
-      "name": "empty_trash",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1832,
-        1842
-      ],
-      "summary": "empty trash performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:sweep_trash",
-      "type": "function",
-      "name": "sweep_trash",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1847,
-        1857
-      ],
-      "summary": "sweep trash performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:patch_gallery_image",
-      "type": "function",
-      "name": "patch_gallery_image",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1861,
-        1880
-      ],
-      "summary": "patch gallery image performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:organize_gallery",
-      "type": "function",
-      "name": "organize_gallery",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1883,
-        1892
-      ],
-      "summary": "organize gallery performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_collections",
-      "type": "function",
-      "name": "list_collections",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1895,
-        1905
-      ],
-      "summary": "list collections performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:create_collection",
-      "type": "function",
-      "name": "create_collection",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1908,
-        1919
-      ],
-      "summary": "create collection performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:update_collection",
-      "type": "function",
-      "name": "update_collection",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1923,
-        1942
-      ],
-      "summary": "update collection performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:delete_collection",
-      "type": "function",
-      "name": "delete_collection",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1946,
-        1958
-      ],
-      "summary": "delete collection performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:set_collection_items",
-      "type": "function",
-      "name": "set_collection_items",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1962,
-        1975
-      ],
-      "summary": "set collection items performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:list_tags",
-      "type": "function",
-      "name": "list_tags",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1978,
-        1988
-      ],
-      "summary": "list tags performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:rename_tag",
-      "type": "function",
-      "name": "rename_tag",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        1991,
-        2006
-      ],
-      "summary": "rename tag performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:delete_tag",
-      "type": "function",
-      "name": "delete_tag",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2009,
-        2021
-      ],
-      "summary": "delete tag performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:get_gallery_preview",
-      "type": "function",
-      "name": "get_gallery_preview",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2028,
-        2039
-      ],
-      "summary": "get gallery preview performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
-      "type": "function",
-      "name": "get_gallery_thumbnail",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2042,
-        2055
-      ],
-      "summary": "get gallery thumbnail performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:expand_prompt",
-      "type": "function",
-      "name": "expand_prompt",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2058,
-        2070
-      ],
-      "summary": "expand prompt performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:remix_prompt",
-      "type": "function",
-      "name": "remix_prompt",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2074,
-        2086
-      ],
-      "summary": "remix prompt performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upscale",
-      "type": "function",
-      "name": "upscale",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2089,
-        2100
-      ],
-      "summary": "upscale performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:upscale_stream",
-      "type": "function",
-      "name": "upscale_stream",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2104,
-        2176
-      ],
-      "summary": "upscale stream performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:installed_entry_into_lora_info",
-      "type": "function",
-      "name": "installed_entry_into_lora_info",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2180,
-        2197
-      ],
-      "summary": "installed entry into lora info performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:should_fallback_loras_endpoint",
-      "type": "function",
-      "name": "should_fallback_loras_endpoint",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2199,
-        2210
-      ],
-      "summary": "should fallback loras endpoint performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
-      "type": "function",
-      "name": "is_missing_endpoint_error",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2216,
-        2229
-      ],
-      "summary": "is missing endpoint error performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:is_transient_request_error",
-      "type": "function",
-      "name": "is_transient_request_error",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2235,
-        2254
-      ],
-      "summary": "is transient request error performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:require_direct_media_response",
-      "type": "function",
-      "name": "require_direct_media_response",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2290,
-        2329
-      ],
-      "summary": "require direct media response performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:api_error_detail",
-      "type": "function",
-      "name": "api_error_detail",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2338,
-        2351
-      ],
-      "summary": "api error detail performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:lora_family_for_model_filter",
-      "type": "function",
-      "name": "lora_family_for_model_filter",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2353,
-        2370
-      ],
-      "summary": "lora family for model filter performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:parse_request_warnings",
-      "type": "function",
-      "name": "parse_request_warnings",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2414,
-        2423
-      ],
-      "summary": "parse request warnings performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:merge_completion_warnings",
-      "type": "function",
-      "name": "merge_completion_warnings",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2441,
-        2451
-      ],
-      "summary": "merge completion warnings performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:parse_video_headers",
-      "type": "function",
-      "name": "parse_video_headers",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2455,
-        2516
-      ],
-      "summary": "parse video headers performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "serialization"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:parse_audio_headers",
-      "type": "function",
-      "name": "parse_audio_headers",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2534,
-        2556
-      ],
-      "summary": "parse audio headers performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:next_sse_event",
-      "type": "function",
-      "name": "next_sse_event",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2558,
-        2567
-      ],
-      "summary": "next sse event performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:parse_sse_event",
-      "type": "function",
-      "name": "parse_sse_event",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2569,
-        2583
-      ],
-      "summary": "parse sse event performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:build_client",
-      "type": "function",
-      "name": "build_client",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2586,
-        2609
-      ],
-      "summary": "build client performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:normalize_host",
-      "type": "function",
-      "name": "normalize_host",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2618,
-        2627
-      ],
-      "summary": "normalize host performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "host-routing"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-core/src/client.rs:encode_path_segment",
-      "type": "function",
-      "name": "encode_path_segment",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2629,
-        2640
-      ],
-      "summary": "encode path segment performs a significant part of client's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-core/src/client.rs:MoldClient",
-      "type": "class",
-      "name": "MoldClient",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        46,
-        50
-      ],
-      "summary": "MoldClient encapsulates client state and behavior across 93 extracted methods.",
-      "tags": [
-        "class",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
-      "type": "class",
-      "name": "ChainJobOutcome",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        103,
-        108
-      ],
-      "summary": "ChainJobOutcome encapsulates client state and behavior.",
-      "tags": [
-        "class",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
-      "type": "class",
-      "name": "ModelNotFoundError",
-      "filePath": "crates/mold-core/src/client.rs",
-      "lineRange": [
-        2645,
-        2645
-      ],
-      "summary": "ModelNotFoundError encapsulates client state and behavior across 1 extracted methods.",
       "tags": [
         "class",
         "rust",
@@ -210779,73 +206779,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:web/src/pages/CreatePage.test.ts",
-      "type": "file",
-      "name": "CreatePage.test.ts",
-      "filePath": "web/src/pages/CreatePage.test.ts",
-      "summary": "Exercises the create page behavior and its integration contracts with focused regression scenarios.",
-      "tags": [
-        "test",
-        "regression",
-        "typescript",
-        "utility",
-        "web"
-      ],
-      "complexity": "complex",
-      "languageNotes": "TypeScript contracts keep shared UI and API state structurally typed."
-    },
-    {
-      "id": "function:web/src/pages/CreatePage.test.ts:installedModelRow",
-      "type": "function",
-      "name": "installedModelRow",
-      "filePath": "web/src/pages/CreatePage.test.ts",
-      "lineRange": [
-        269,
-        283
-      ],
-      "summary": "Implements installed model row within the create page workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "test",
-        "regression",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/pages/CreatePage.test.ts:installedSequenceModel",
-      "type": "function",
-      "name": "installedSequenceModel",
-      "filePath": "web/src/pages/CreatePage.test.ts",
-      "lineRange": [
-        361,
-        372
-      ],
-      "summary": "Implements installed sequence model within the create page workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "test",
-        "regression",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/pages/CreatePage.test.ts:pageStubs",
-      "type": "function",
-      "name": "pageStubs",
-      "filePath": "web/src/pages/CreatePage.test.ts",
-      "lineRange": [
-        4900,
-        5003
-      ],
-      "summary": "Implements page stubs within the create page workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "test",
-        "regression",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
       "id": "file:web/src/pages/CreatePage.vue",
       "type": "file",
       "name": "CreatePage.vue",
@@ -210941,56 +206874,6 @@
       ],
       "complexity": "complex",
       "languageNotes": "Vue single-file component combines reactive orchestration with scoped presentation."
-    },
-    {
-      "id": "file:web/src/pages/LibraryPage.test.ts",
-      "type": "file",
-      "name": "LibraryPage.test.ts",
-      "filePath": "web/src/pages/LibraryPage.test.ts",
-      "summary": "Exercises the library page behavior and its integration contracts with focused regression scenarios.",
-      "tags": [
-        "test",
-        "regression",
-        "typescript",
-        "utility",
-        "web"
-      ],
-      "complexity": "complex",
-      "languageNotes": "TypeScript contracts keep shared UI and API state structurally typed."
-    },
-    {
-      "id": "function:web/src/pages/LibraryPage.test.ts:makeEntry",
-      "type": "function",
-      "name": "makeEntry",
-      "filePath": "web/src/pages/LibraryPage.test.ts",
-      "lineRange": [
-        131,
-        152
-      ],
-      "summary": "Implements make entry within the library page workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "test",
-        "regression",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:web/src/pages/LibraryPage.test.ts:mountPage",
-      "type": "function",
-      "name": "mountPage",
-      "filePath": "web/src/pages/LibraryPage.test.ts",
-      "lineRange": [
-        196,
-        207
-      ],
-      "summary": "Implements mount page within the library page workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "test",
-        "regression",
-        "business-logic"
-      ],
-      "complexity": "simple"
     },
     {
       "id": "file:web/src/pages/LibraryPage.vue",
@@ -264434,360 +260317,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:crates/mold-cli/src/main.rs",
-      "type": "file",
-      "name": "main.rs",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "summary": "Implements the Mold CLI entry point, command model, configuration, and dispatch as part of Mold's local generation engine and multi-surface application.",
-      "tags": [
-        "entry-point",
-        "rust",
-        "application"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-cli/src/main.rs:apply_spatial_tile_override",
-      "type": "function",
-      "name": "apply_spatial_tile_override",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        1858,
-        1868
-      ],
-      "summary": "Updates spatial tile override while preserving the module's lifecycle invariants.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/main.rs:main",
-      "type": "function",
-      "name": "main",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        1871,
-        1995
-      ],
-      "summary": "Implements main for the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-cli/src/main.rs:run",
-      "type": "function",
-      "name": "run",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        1997,
-        2770
-      ],
-      "summary": "Executes  for the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-cli/src/main.rs:generate_completions",
-      "type": "function",
-      "name": "generate_completions",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        2777,
-        2862
-      ],
-      "summary": "Implements generate completions for the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
-      "type": "function",
-      "name": "resolve_catalog_id",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        2881,
-        2900
-      ],
-      "summary": "Implements resolve catalog id for the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "function",
-        "business-logic",
-        "utility"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
-      "type": "class",
-      "name": "Ltx2SpatialUpscaleArg",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        68,
-        73
-      ],
-      "summary": "Defines ltx2 spatial upscale arg, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
-      "type": "class",
-      "name": "Ltx2TemporalUpscaleArg",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        76,
-        79
-      ],
-      "summary": "Defines ltx2 temporal upscale arg, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
-      "type": "class",
-      "name": "Ltx2PipelineArg",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        82,
-        107
-      ],
-      "summary": "Defines ltx2 pipeline arg, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:ConfigAction",
-      "type": "class",
-      "name": "ConfigAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        142,
-        195
-      ],
-      "summary": "Defines config action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "type-definition",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:GpuAction",
-      "type": "class",
-      "name": "GpuAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        198,
-        217
-      ],
-      "summary": "Defines gpu action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:RunpodAction",
-      "type": "class",
-      "name": "RunpodAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        220,
-        406
-      ],
-      "summary": "Defines runpod action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:RunpodNetworkVolumeAction",
-      "type": "class",
-      "name": "RunpodNetworkVolumeAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        409,
-        454
-      ],
-      "summary": "Defines runpod network volume action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:LambdaAction",
-      "type": "class",
-      "name": "LambdaAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        457,
-        528
-      ],
-      "summary": "Defines lambda action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:ServerAction",
-      "type": "class",
-      "name": "ServerAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        531,
-        581
-      ],
-      "summary": "Defines server action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "service",
-        "orchestration"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:JobsAction",
-      "type": "class",
-      "name": "JobsAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        597,
-        630
-      ],
-      "summary": "Defines jobs action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
-      "type": "class",
-      "name": "RetakeModeArg",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        633,
-        636
-      ],
-      "summary": "Defines retake mode arg, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:QueueAction",
-      "type": "class",
-      "name": "QueueAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        639,
-        706
-      ],
-      "summary": "Defines queue action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:TrashAction",
-      "type": "class",
-      "name": "TrashAction",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        709,
-        738
-      ],
-      "summary": "Defines trash action, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:Commands",
-      "type": "class",
-      "name": "Commands",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        742,
-        1842
-      ],
-      "summary": "Defines commands, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
-      "type": "class",
-      "name": "CatalogIdResolution",
-      "filePath": "crates/mold-cli/src/main.rs",
-      "lineRange": [
-        2869,
-        2875
-      ],
-      "summary": "Defines catalog id resolution, a core type used by the Mold CLI entry point, command model, configuration, and dispatch.",
-      "tags": [
-        "data-model",
-        "rust-type",
-        "domain-model"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:crates/mold-cli/src/ui.rs",
       "type": "file",
       "name": "ui.rs",
@@ -272210,2927 +267739,6 @@
         180
       ],
       "summary": "Encapsulates view state and behavior for the action subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-tui/src/app.rs",
-      "type": "file",
-      "name": "app.rs",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "summary": "Implements app behavior for the src area of Mold.",
-      "tags": [
-        "rust",
-        "service",
-        "mold-runtime"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Rust implementation uses explicit ownership and typed results to keep runtime boundaries fail-safe."
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "function",
-      "name": "clear",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        296,
-        320
-      ],
-      "summary": "Implements clear within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "function",
-      "name": "mark_generation_start",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        326,
-        330
-      ],
-      "summary": "Implements mark generation start within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "function",
-      "name": "generation_elapsed",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        334,
-        336
-      ],
-      "summary": "Implements generation elapsed within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "function",
-      "name": "stage_elapsed",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        339,
-        341
-      ],
-      "summary": "Implements stage elapsed within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "function",
-      "name": "push_log",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        346,
-        352
-      ],
-      "summary": "Implements push log within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:clear_download",
-      "type": "function",
-      "name": "clear_download",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        354,
-        367
-      ],
-      "summary": "Implements clear download within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "function",
-      "name": "is_downloading",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        370,
-        372
-      ],
-      "summary": "Implements is downloading within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "function",
-      "name": "download_status_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        375,
-        389
-      ],
-      "summary": "Implements download status text within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:record_download_sample",
-      "type": "function",
-      "name": "record_download_sample",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        397,
-        445
-      ],
-      "summary": "Implements record download sample within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:next",
-      "type": "function",
-      "name": "next",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        473,
-        481
-      ],
-      "summary": "Implements next within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "function",
-      "name": "prev",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        483,
-        491
-      ],
-      "summary": "Implements prev within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:label",
-      "type": "function",
-      "name": "label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        558,
-        603
-      ],
-      "summary": "Implements label within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
-      "type": "function",
-      "name": "qwen_image_edit_dimensions_for_path",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        606,
-        620
-      ],
-      "summary": "Implements qwen image edit dimensions for path within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "function",
-      "name": "parse_size_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        625,
-        633
-      ],
-      "summary": "Implements parse size input within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "function",
-      "name": "resolve",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        665,
-        673
-      ],
-      "summary": "Implements resolve within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "function",
-      "name": "advance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        676,
-        682
-      ],
-      "summary": "Implements advance within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:new",
-      "type": "function",
-      "name": "new",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2192,
-        2498
-      ],
-      "summary": "Implements new within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "function",
-      "name": "prompt_required_for_params",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        853,
-        858
-      ],
-      "summary": "Implements prompt required for params within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "function",
-      "name": "from_config",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        861,
-        918
-      ],
-      "summary": "Implements from config within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "function",
-      "name": "display_value",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        921,
-        1099
-      ],
-      "summary": "Implements display value within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
-      "type": "function",
-      "name": "adjust_optional_scale",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1108,
-        1122
-      ],
-      "summary": "Implements adjust optional scale within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
-      "type": "function",
-      "name": "adjust_optional_u32",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1124,
-        1138
-      ],
-      "summary": "Implements adjust optional u32 within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
-      "type": "function",
-      "name": "parse_stg_blocks_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1140,
-        1172
-      ],
-      "summary": "Implements parse stg blocks input within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
-      "type": "function",
-      "name": "tui_max_video_frames",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1197,
-        1209
-      ],
-      "summary": "Implements tui max video frames within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "function",
-      "name": "normalize_generate_params_for_family",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1217,
-        1246
-      ],
-      "summary": "Implements normalize generate params for family within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
-      "type": "function",
-      "name": "restored_negative_editor_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1260,
-        1272
-      ],
-      "summary": "Implements restored negative editor text within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
-      "type": "function",
-      "name": "negative_prompt_textarea",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1276,
-        1285
-      ],
-      "summary": "Implements negative prompt textarea within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "function",
-      "name": "from_outcomes",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1394,
-        1413
-      ],
-      "summary": "Implements from outcomes within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "function",
-      "name": "guidance_adjustable",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1424,
-        1426
-      ],
-      "summary": "Implements guidance adjustable within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "function",
-      "name": "negative_visible",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1434,
-        1438
-      ],
-      "summary": "Implements negative visible within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:default",
-      "type": "function",
-      "name": "default",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1505,
-        1531
-      ],
-      "summary": "Implements default within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "function",
-      "name": "refresh_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1537,
-        1544
-      ],
-      "summary": "Implements refresh filter within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "function",
-      "name": "selected_pos",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1547,
-        1549
-      ],
-      "summary": "Implements selected pos within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "function",
-      "name": "rescan_due",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1554,
-        1562
-      ],
-      "summary": "Implements rescan due within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "function",
-      "name": "handle_filter_key",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1568,
-        1594
-      ],
-      "summary": "Implements handle filter key within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:local",
-      "type": "function",
-      "name": "local",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1612,
-        1618
-      ],
-      "summary": "Implements local within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "function",
-      "name": "from_host_entry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1620,
-        1626
-      ],
-      "summary": "Implements from host entry within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "function",
-      "name": "remote_from_url",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1630,
-        1636
-      ],
-      "summary": "Implements remote from url within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "function",
-      "name": "is_local",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1638,
-        1640
-      ],
-      "summary": "Implements is local within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "function",
-      "name": "is_this_machine",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1645,
-        1647
-      ],
-      "summary": "Implements is this machine within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "function",
-      "name": "filename",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1670,
-        1675
-      ],
-      "summary": "Implements filename within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "function",
-      "name": "owning_origins",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1679,
-        1687
-      ],
-      "summary": "Implements owning origins within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "function",
-      "name": "primary_origin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1690,
-        1695
-      ],
-      "summary": "Implements primary origin within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "function",
-      "name": "machine_label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1699,
-        1706
-      ],
-      "summary": "Implements machine label within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "function",
-      "name": "trash_retention_display",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1711,
-        1717
-      ],
-      "summary": "Implements trash retention display within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "function",
-      "name": "hint_label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1734,
-        1739
-      ],
-      "summary": "Implements hint label within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "function",
-      "name": "delete_confirm_message",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1747,
-        1758
-      ],
-      "summary": "Implements delete confirm message within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:generation_model_names",
-      "type": "function",
-      "name": "generation_model_names",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1790,
-        1801
-      ],
-      "summary": "Implements generation model names within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "function",
-      "name": "is_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1888,
-        1890
-      ],
-      "summary": "Implements is field within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "function",
-      "name": "is_read_only",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1892,
-        1900
-      ],
-      "summary": "Implements is read only within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "function",
-      "name": "tab_at_column",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2165,
-        2169
-      ],
-      "summary": "Implements tab at column within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "function",
-      "name": "configure_background_server_command",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2173,
-        2177
-      ],
-      "summary": "Implements configure background server command within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
-      "type": "function",
-      "name": "wait_for_server_health",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2180,
-        2189
-      ],
-      "summary": "Implements wait for server health within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "function",
-      "name": "spawn_gallery_scan",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2504,
-        2512
-      ],
-      "summary": "Implements spawn gallery scan within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "function",
-      "name": "should_poll_remote",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2516,
-        2518
-      ],
-      "summary": "Implements should poll remote within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "function",
-      "name": "should_save_output_locally",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2526,
-        2531
-      ],
-      "summary": "Implements should save output locally within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "function",
-      "name": "should_persist_response_locally",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2543,
-        2551
-      ],
-      "summary": "Implements should persist response locally within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "function",
-      "name": "spawn_server_status_fetch",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2565,
-        2613
-      ],
-      "summary": "Implements spawn server status fetch within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "function",
-      "name": "tick_host_polling",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2618,
-        2629
-      ],
-      "summary": "Implements tick host polling within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
-      "type": "function",
-      "name": "apply_remote_model_defaults",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2643,
-        2661
-      ],
-      "summary": "Implements apply remote model defaults within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:source_image_contract",
-      "type": "function",
-      "name": "source_image_contract",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2669,
-        2679
-      ],
-      "summary": "Implements source image contract within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:identity_gate_error",
-      "type": "function",
-      "name": "identity_gate_error",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2695,
-        2721
-      ],
-      "summary": "Implements identity gate error within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
-      "type": "function",
-      "name": "sync_generate_capabilities",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2746,
-        2862
-      ],
-      "summary": "Implements sync generate capabilities within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
-      "type": "function",
-      "name": "normalize_fixed_guidance_for_submit",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2867,
-        2887
-      ],
-      "summary": "Implements normalize fixed guidance for submit within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
-      "type": "function",
-      "name": "sync_pipeline_guidance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2893,
-        2909
-      ],
-      "summary": "Implements sync pipeline guidance within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_upscale",
-      "type": "function",
-      "name": "spawn_upscale",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2912,
-        3164
-      ],
-      "summary": "Implements spawn upscale within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "function",
-      "name": "shutdown",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3167,
-        3177
-      ],
-      "summary": "Implements shutdown within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "function",
-      "name": "save_session",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3180,
-        3203
-      ],
-      "summary": "Implements save session within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "function",
-      "name": "apply_theme_preset",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3210,
-        3214
-      ],
-      "summary": "Implements apply theme preset within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "function",
-      "name": "update_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3216,
-        3303
-      ],
-      "summary": "Implements update model within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
-      "type": "function",
-      "name": "save_prefs_for_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3308,
-        3341
-      ],
-      "summary": "Implements save prefs for model within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
-      "type": "function",
-      "name": "apply_prefs_for_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3346,
-        3406
-      ],
-      "summary": "Implements apply prefs for model within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "function",
-      "name": "refresh_create_rows",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3410,
-        3418
-      ],
-      "summary": "Implements refresh create rows within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
-      "type": "function",
-      "name": "set_advanced_expanded",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3424,
-        3442
-      ],
-      "summary": "Implements set advanced expanded within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:model_default_size",
-      "type": "function",
-      "name": "model_default_size",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3447,
-        3465
-      ],
-      "summary": "Implements model default size within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
-      "type": "function",
-      "name": "active_generation_recipe",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3470,
-        3479
-      ],
-      "summary": "Implements active generation recipe within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "function",
-      "name": "handle_crossterm_event",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3482,
-        3684
-      ],
-      "summary": "Implements handle crossterm event within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_popup_event",
-      "type": "function",
-      "name": "handle_popup_event",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3709,
-        4253
-      ],
-      "summary": "Implements handle popup event within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_mouse",
-      "type": "function",
-      "name": "handle_mouse",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4255,
-        4413
-      ],
-      "summary": "Implements handle mouse within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
-      "type": "function",
-      "name": "available_upscaler_models",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4416,
-        4435
-      ],
-      "summary": "Implements available upscaler models within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
-      "type": "function",
-      "name": "update_upscale_model_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4437,
-        4464
-      ],
-      "summary": "Implements update upscale model filter within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
-      "type": "function",
-      "name": "update_model_selector_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4466,
-        4478
-      ],
-      "summary": "Implements update model selector filter within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:set_active_view",
-      "type": "function",
-      "name": "set_active_view",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4483,
-        4502
-      ],
-      "summary": "Implements set active view within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "function",
-      "name": "dispatch_action",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4505,
-        5207
-      ],
-      "summary": "Implements dispatch action within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:increment_param",
-      "type": "function",
-      "name": "increment_param",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5209,
-        5238
-      ],
-      "summary": "Implements increment param within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_field",
-      "type": "function",
-      "name": "adjust_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5241,
-        5592
-      ],
-      "summary": "Implements adjust field within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
-      "type": "function",
-      "name": "load_gallery_preview",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5595,
-        5700
-      ],
-      "summary": "Implements load gallery preview within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
-      "type": "function",
-      "name": "try_install_gallery_animation",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5704,
-        5719
-      ],
-      "summary": "Implements try install gallery animation within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "function",
-      "name": "tick_animations",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5724,
-        5739
-      ],
-      "summary": "Implements tick animations within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
-      "type": "function",
-      "name": "load_gallery_into_generate",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5742,
-        5806
-      ],
-      "summary": "Implements load gallery into generate within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "function",
-      "name": "apply_gallery_scan",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5815,
-        5848
-      ],
-      "summary": "Implements apply gallery scan within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "function",
-      "name": "apply_delete_failure",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5857,
-        5863
-      ],
-      "summary": "Implements apply delete failure within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "function",
-      "name": "capabilities_for_origin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5869,
-        5880
-      ],
-      "summary": "Implements capabilities for origin within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "function",
-      "name": "origin_can_trash",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5885,
-        5893
-      ],
-      "summary": "Implements origin can trash within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "function",
-      "name": "removal_kind_for",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5897,
-        5907
-      ],
-      "summary": "Implements removal kind for within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "function",
-      "name": "selected_removal_kind",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5910,
-        5916
-      ],
-      "summary": "Implements selected removal kind within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
-      "type": "function",
-      "name": "delete_selected_gallery_image",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5923,
-        6035
-      ],
-      "summary": "Implements delete selected gallery image within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:open_gallery_file",
-      "type": "function",
-      "name": "open_gallery_file",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6039,
-        6060
-      ],
-      "summary": "Implements open gallery file within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
-      "type": "function",
-      "name": "build_remove_model_message",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6064,
-        6112
-      ],
-      "summary": "Implements build remove model message within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "function",
-      "name": "needs_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6116,
-        6118
-      ],
-      "summary": "Implements needs confirm within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "function",
-      "name": "request_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6124,
-        6133
-      ],
-      "summary": "Implements request confirm within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
-      "type": "function",
-      "name": "handle_confirm_action",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6136,
-        6171
-      ],
-      "summary": "Implements handle confirm action within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:open_model_selector",
-      "type": "function",
-      "name": "open_model_selector",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6182,
-        6201
-      ],
-      "summary": "Implements open model selector within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:activate_current_param",
-      "type": "function",
-      "name": "activate_current_param",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6204,
-        6228
-      ],
-      "summary": "Implements activate current param within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
-      "type": "function",
-      "name": "surface_request_advisories",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6247,
-        6258
-      ],
-      "summary": "Implements surface request advisories within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:filing_editor_text",
-      "type": "function",
-      "name": "filing_editor_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6262,
-        6271
-      ],
-      "summary": "Implements filing editor text within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:activate_field",
-      "type": "function",
-      "name": "activate_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6284,
-        6385
-      ],
-      "summary": "Implements activate field within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
-      "type": "function",
-      "name": "reset_params_to_model_defaults",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6388,
-        6469
-      ],
-      "summary": "Implements reset params to model defaults within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "function",
-      "name": "build_settings_rows",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6475,
-        6797
-      ],
-      "summary": "Implements build settings rows within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "function",
-      "name": "settings_display_value",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6800,
-        6938
-      ],
-      "summary": "Implements settings display value within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "function",
-      "name": "settings_env_override",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6956,
-        6979
-      ],
-      "summary": "Implements settings env override within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_navigate",
-      "type": "function",
-      "name": "settings_navigate",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6989,
-        7033
-      ],
-      "summary": "Implements settings navigate within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
-      "type": "function",
-      "name": "settings_cycle_theme",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7036,
-        7046
-      ],
-      "summary": "Implements settings cycle theme within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_increment",
-      "type": "function",
-      "name": "settings_increment",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7049,
-        7085
-      ],
-      "summary": "Implements settings increment within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
-      "type": "function",
-      "name": "settings_adjust_number",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7087,
-        7184
-      ],
-      "summary": "Implements settings adjust number within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
-      "type": "function",
-      "name": "settings_cycle_toggle",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7186,
-        7228
-      ],
-      "summary": "Implements settings cycle toggle within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
-      "type": "function",
-      "name": "settings_toggle_bool",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7230,
-        7272
-      ],
-      "summary": "Implements settings toggle bool within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
-      "type": "function",
-      "name": "settings_cycle_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7274,
-        7287
-      ],
-      "summary": "Implements settings cycle model within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_confirm",
-      "type": "function",
-      "name": "settings_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7290,
-        7336
-      ],
-      "summary": "Implements settings confirm within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_apply_input",
-      "type": "function",
-      "name": "settings_apply_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7339,
-        7393
-      ],
-      "summary": "Implements settings apply input within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_config",
-      "type": "function",
-      "name": "save_config",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7396,
-        7406
-      ],
-      "summary": "Implements save config within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_generation",
-      "type": "function",
-      "name": "start_generation",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7408,
-        7648
-      ],
-      "summary": "Implements start generation within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:retry_held_prints",
-      "type": "function",
-      "name": "retry_held_prints",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7656,
-        7677
-      ],
-      "summary": "Implements retry held prints within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
-      "type": "function",
-      "name": "prompt_transform_task",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7701,
-        7718
-      ],
-      "summary": "Implements prompt transform task within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
-      "type": "function",
-      "name": "reference_fingerprint_for_target",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7724,
-        7760
-      ],
-      "summary": "Implements reference fingerprint for target within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
-      "type": "function",
-      "name": "start_prompt_transform",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7762,
-        7805
-      ],
-      "summary": "Implements start prompt transform within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
-      "type": "function",
-      "name": "start_prompt_transform_from",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7807,
-        7884
-      ],
-      "summary": "Implements start prompt transform from within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_provenance",
-      "type": "function",
-      "name": "prompt_provenance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7886,
-        7898
-      ],
-      "summary": "Implements prompt provenance within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
-      "type": "function",
-      "name": "prompt_transform_staleness",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7900,
-        7931
-      ],
-      "summary": "Implements prompt transform staleness within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
-      "type": "function",
-      "name": "quick_transform_staleness",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7936,
-        7966
-      ],
-      "summary": "Implements quick transform staleness within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
-      "type": "function",
-      "name": "apply_prompt_variant",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7978,
-        7998
-      ],
-      "summary": "Implements apply prompt variant within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
-      "type": "function",
-      "name": "prepare_prompt_variants",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        8000,
-        8025
-      ],
-      "summary": "Implements prepare prompt variants within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "function",
-      "name": "process_background_events",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        8028,
-        9170
-      ],
-      "summary": "Implements process background events within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_progress",
-      "type": "function",
-      "name": "handle_progress",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9172,
-        9189
-      ],
-      "summary": "Implements handle progress within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
-      "type": "function",
-      "name": "build_local_model_catalog",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9192,
-        9210
-      ],
-      "summary": "Implements build local model catalog within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:decode_live_preview",
-      "type": "function",
-      "name": "decode_live_preview",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9216,
-        9233
-      ],
-      "summary": "Implements decode live preview within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "serialization"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
-      "type": "function",
-      "name": "reduce_progress_state",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9250,
-        9410
-      ],
-      "summary": "Implements reduce progress state within the app workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "class",
-      "name": "PromptTransformSnapshot",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        27,
-        38
-      ],
-      "summary": "Encapsulates prompt transform snapshot state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "class",
-      "name": "LicenseDownloadRequirement",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        43,
-        46
-      ],
-      "summary": "Encapsulates license download requirement state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "class",
-      "name": "DurableGenerationChildOutcome",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        49,
-        70
-      ],
-      "summary": "Encapsulates durable generation child outcome state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "class",
-      "name": "BackgroundEvent",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        73,
-        234
-      ],
-      "summary": "Encapsulates background event state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "class",
-      "name": "ProgressLogEntry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        238,
-        241
-      ],
-      "summary": "Encapsulates progress log entry state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "class",
-      "name": "ProgressStyle",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        244,
-        249
-      ],
-      "summary": "Encapsulates progress style state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "class",
-      "name": "ProgressState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        259,
-        293
-      ],
-      "summary": "Encapsulates progress state state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "class",
-      "name": "CreateMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        456,
-        460
-      ],
-      "summary": "Encapsulates create mode state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "class",
-      "name": "GenerateFocus",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        464,
-        470
-      ],
-      "summary": "Encapsulates generate focus state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "class",
-      "name": "ParamField",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        502,
-        555
-      ],
-      "summary": "Encapsulates param field state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "class",
-      "name": "SeedMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        637,
-        645
-      ],
-      "summary": "Encapsulates seed mode state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "class",
-      "name": "GenerateParams",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        687,
-        790
-      ],
-      "summary": "Encapsulates generate params state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "class",
-      "name": "GenerationMetadataSnapshot",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        795,
-        799
-      ],
-      "summary": "Encapsulates generation metadata snapshot state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "class",
-      "name": "InferenceMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        817,
-        825
-      ],
-      "summary": "Encapsulates inference mode state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "class",
-      "name": "GenerateState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1288,
-        1363
-      ],
-      "summary": "Encapsulates generate state state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "class",
-      "name": "HeldPrintRetry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1367,
-        1371
-      ],
-      "summary": "Encapsulates held print retry state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "class",
-      "name": "HeldHost",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1375,
-        1378
-      ],
-      "summary": "Encapsulates held host state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "class",
-      "name": "HeldBatch",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1385,
-        1389
-      ],
-      "summary": "Encapsulates held batch state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "class",
-      "name": "GalleryViewMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1443,
-        1447
-      ],
-      "summary": "Encapsulates gallery view mode state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "class",
-      "name": "GalleryState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1454,
-        1502
-      ],
-      "summary": "Encapsulates gallery state state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "class",
-      "name": "GalleryOrigin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1601,
-        1609
-      ],
-      "summary": "Encapsulates gallery origin state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "class",
-      "name": "GalleryEntry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1652,
-        1667
-      ],
-      "summary": "Encapsulates gallery entry state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "class",
-      "name": "RemovalKind",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1721,
-        1730
-      ],
-      "summary": "Encapsulates removal kind state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "class",
-      "name": "ModelsState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1761,
-        1766
-      ],
-      "summary": "Encapsulates models state state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "class",
-      "name": "SettingsKey",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1807,
-        1855
-      ],
-      "summary": "Encapsulates settings key state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "class",
-      "name": "SettingsFieldType",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1859,
-        1872
-      ],
-      "summary": "Encapsulates settings field type state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "class",
-      "name": "SettingsRow",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1876,
-        1885
-      ],
-      "summary": "Encapsulates settings row state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "class",
-      "name": "SettingsFocus",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1909,
-        1913
-      ],
-      "summary": "Encapsulates settings focus state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "class",
-      "name": "SettingsState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1917,
-        1938
-      ],
-      "summary": "Encapsulates settings state state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "class",
-      "name": "Popup",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1941,
-        2033
-      ],
-      "summary": "Encapsulates popup state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "class",
-      "name": "UpscalePickerPurpose",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2037,
-        2043
-      ],
-      "summary": "Encapsulates upscale picker purpose state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "class",
-      "name": "ConfirmAction",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2054,
-        2067
-      ],
-      "summary": "Encapsulates confirm action state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:App",
-      "type": "class",
-      "name": "App",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2070,
-        2121
-      ],
-      "summary": "Encapsulates app state and behavior for the app subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "class",
-      "name": "LayoutAreas",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2125,
-        2138
-      ],
-      "summary": "Encapsulates layout areas state and behavior for the app subsystem.",
       "tags": [
         "data-model",
         "class",
@@ -284732,547 +277340,6 @@
       "complexity": "moderate"
     },
     {
-      "id": "file:crates/mold-cli/tests/cli_integration.rs",
-      "type": "file",
-      "name": "cli_integration.rs",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "summary": "Exercises cli integration behavior and regression contracts with focused automated coverage.",
-      "tags": [
-        "code",
-        "test",
-        "rust",
-        "implementation"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:loopback_admin_commands_do_not_hide_live_server_http_errors",
-      "type": "function",
-      "name": "loopback_admin_commands_do_not_hide_live_server_http_errors",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        16,
-        38
-      ],
-      "summary": "loopback admin commands do not hide live server http errors performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:version_flag_matches_subcommand",
-      "type": "function",
-      "name": "version_flag_matches_subcommand",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        63,
-        79
-      ],
-      "summary": "version flag matches subcommand performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:default_set_persists_to_config",
-      "type": "function",
-      "name": "default_set_persists_to_config",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        100,
-        114
-      ],
-      "summary": "default set persists to config performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_list_json_is_valid",
-      "type": "function",
-      "name": "config_list_json_is_valid",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        151,
-        164
-      ],
-      "summary": "config list json is valid performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_get_raw_outputs_bare_value",
-      "type": "function",
-      "name": "config_get_raw_outputs_bare_value",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        177,
-        187
-      ],
-      "summary": "config get raw outputs bare value performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_set_persists_value",
-      "type": "function",
-      "name": "config_set_persists_value",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        190,
-        203
-      ],
-      "summary": "config set persists value performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_json_is_valid",
-      "type": "function",
-      "name": "stats_json_is_valid",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        226,
-        235
-      ],
-      "summary": "stats json is valid performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_with_populated_model",
-      "type": "function",
-      "name": "stats_with_populated_model",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        238,
-        248
-      ],
-      "summary": "stats with populated model performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_does_not_double_count_hidden_companions",
-      "type": "function",
-      "name": "stats_does_not_double_count_hidden_companions",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        257,
-        268
-      ],
-      "summary": "stats does not double count hidden companions performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_shows_column_headers_when_models_installed",
-      "type": "function",
-      "name": "list_shows_column_headers_when_models_installed",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        283,
-        293
-      ],
-      "summary": "list shows column headers when models installed performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_with_populated_model_shows_installed",
-      "type": "function",
-      "name": "list_with_populated_model_shows_installed",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        296,
-        305
-      ],
-      "summary": "list with populated model shows installed performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_upscaler_models_shown_as_installed",
-      "type": "function",
-      "name": "list_upscaler_models_shown_as_installed",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        318,
-        338
-      ],
-      "summary": "list upscaler models shown as installed performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:info_known_model_shows_details",
-      "type": "function",
-      "name": "info_known_model_shows_details",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        363,
-        372
-      ],
-      "summary": "info known model shows details performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
-      "type": "function",
-      "name": "gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        377,
-        394
-      ],
-      "summary": "gpu list json falls back to local inventory when loopback server is stopped performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:rm_removes_manifest_model",
-      "type": "function",
-      "name": "rm_removes_manifest_model",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        420,
-        437
-      ],
-      "summary": "rm removes manifest model performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:rm_preserves_shared_files_when_sibling_exists",
-      "type": "function",
-      "name": "rm_preserves_shared_files_when_sibling_exists",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        440,
-        458
-      ],
-      "summary": "rm preserves shared files when sibling exists performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:clean_detects_stale_pulling_marker",
-      "type": "function",
-      "name": "clean_detects_stale_pulling_marker",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        473,
-        483
-      ],
-      "summary": "clean detects stale pulling marker performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "data-loading"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_mask_requires_image_flag",
-      "type": "function",
-      "name": "run_mask_requires_image_flag",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        519,
-        530
-      ],
-      "summary": "run mask requires image flag performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_qwen_image_edit_rejects_batch_before_remote_generation",
-      "type": "function",
-      "name": "run_qwen_image_edit_rejects_batch_before_remote_generation",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        533,
-        553
-      ],
-      "summary": "run qwen image edit rejects batch before remote generation performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
-      "type": "function",
-      "name": "run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        565,
-        601
-      ],
-      "summary": "run extend satisfies a wan i2v checkpoints source contract performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "validation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_on_a_family_without_a_continuation_path_names_extend",
-      "type": "function",
-      "name": "run_extend_on_a_family_without_a_continuation_path_names_extend",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        606,
-        626
-      ],
-      "summary": "run extend on a family without a continuation path names extend performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_sends_the_familys_own_carryover_overlap",
-      "type": "function",
-      "name": "run_extend_sends_the_familys_own_carryover_overlap",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        641,
-        699
-      ],
-      "summary": "run extend sends the familys own carryover overlap performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:update_help_text",
-      "type": "function",
-      "name": "update_help_text",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        716,
-        728
-      ],
-      "summary": "update help text performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:update_check_runs_without_panic",
-      "type": "function",
-      "name": "update_check_runs_without_panic",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        751,
-        774
-      ],
-      "summary": "update check runs without panic performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "validation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:dry_run_prints_stage_summary",
-      "type": "function",
-      "name": "dry_run_prints_stage_summary",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        779,
-        813
-      ],
-      "summary": "dry run prints stage summary performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:repeated_prompt_flag_yields_chain",
-      "type": "function",
-      "name": "repeated_prompt_flag_yields_chain",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        818,
-        838
-      ],
-      "summary": "repeated prompt flag yields chain performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_reports_ok_for_valid_script",
-      "type": "function",
-      "name": "chain_validate_reports_ok_for_valid_script",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        843,
-        872
-      ],
-      "summary": "chain validate reports ok for valid script performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "validation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_errors_on_bad_schema",
-      "type": "function",
-      "name": "chain_validate_errors_on_bad_schema",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        875,
-        903
-      ],
-      "summary": "chain validate errors on bad schema performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "validation"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:positional_plus_prompt_flag_errors",
-      "type": "function",
-      "name": "positional_plus_prompt_flag_errors",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        908,
-        922
-      ],
-      "summary": "positional plus prompt flag errors performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:positional_alone_still_works",
-      "type": "function",
-      "name": "positional_alone_still_works",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        925,
-        934
-      ],
-      "summary": "positional alone still works performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/tests/cli_integration.rs:prompt_flag_alone_still_works",
-      "type": "function",
-      "name": "prompt_flag_alone_still_works",
-      "filePath": "crates/mold-cli/tests/cli_integration.rs",
-      "lineRange": [
-        937,
-        950
-      ],
-      "summary": "prompt flag alone still works performs a significant part of cli integration's test and rust behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "pipeline:.github/workflows/android.yml",
       "type": "pipeline",
       "name": "android.yml",
@@ -289615,6 +281682,8684 @@
       "tags": [
         "function",
         "business-logic",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-cli/src/commands/library.rs",
+      "type": "file",
+      "name": "library.rs",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "summary": "Implements the `mold library` command family for querying existing prints, previewing media, editing titles and organization metadata, managing collections and tags, moving prints to recoverable trash, and opening the terminal Library grid.",
+      "tags": [
+        "cli",
+        "library-management",
+        "gallery",
+        "terminal-preview",
+        "validation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "function",
+      "name": "run",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        21,
+        26
+      ],
+      "summary": "Implements run for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:run_remote",
+      "type": "function",
+      "name": "run_remote",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        28,
+        76
+      ],
+      "summary": "Dispatches a parsed Library action against an authenticated remote Mold client while preserving machine-readable output behavior.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_list",
+      "type": "function",
+      "name": "library_list",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        90,
+        138
+      ],
+      "summary": "Fetches gallery rows, resolves optional collection filters, applies deterministic filtering and pagination, and renders either JSON or a terminal table.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_show",
+      "type": "function",
+      "name": "library_show",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        140,
+        161
+      ],
+      "summary": "Fetches one gallery item and renders metadata or an inline terminal preview with media-specific fallback behavior.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
+      "type": "function",
+      "name": "preview_bytes",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        163,
+        175
+      ],
+      "summary": "Implements preview bytes for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_title",
+      "type": "function",
+      "name": "library_title",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        177,
+        196
+      ],
+      "summary": "Implements library title for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_tag",
+      "type": "function",
+      "name": "library_tag",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        198,
+        236
+      ],
+      "summary": "Implements library tag for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
+      "type": "function",
+      "name": "mutate_prints",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        238,
+        270
+      ],
+      "summary": "Applies favorite and tag changes through replay-safe bulk mutations when advertised, falling back to the legacy organization endpoint.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_collection",
+      "type": "function",
+      "name": "library_collection",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        272,
+        389
+      ],
+      "summary": "Implements collection listing, inspection, creation, updates, deletion, and print membership actions.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
+      "type": "function",
+      "name": "collection_membership",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        391,
+        416
+      ],
+      "summary": "Resolves a collection reference and replaces its membership set to add or remove named prints.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_trash",
+      "type": "function",
+      "name": "library_trash",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        418,
+        441
+      ],
+      "summary": "Moves named prints to recoverable server trash only when the host explicitly advertises trash capability.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:require_organize",
+      "type": "function",
+      "name": "require_organize",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        443,
+        455
+      ],
+      "summary": "Checks server capabilities and fails clearly when Library organization is unsupported.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
+      "type": "function",
+      "name": "resolve_collection",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        457,
+        487
+      ],
+      "summary": "Resolves a collection by identifier, slug, or case-insensitive exact display name while rejecting ambiguity.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
+      "type": "function",
+      "name": "filter_and_sort",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        489,
+        525
+      ],
+      "summary": "Filters gallery rows by query, tags, collection, favorite state, and media format before deterministic newest-first sorting.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_listing",
+      "type": "function",
+      "name": "render_listing",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        543,
+        595
+      ],
+      "summary": "Prints a concise terminal table for a paginated Library result set without contaminating JSON output.",
+      "tags": [
+        "cli",
+        "library-management",
+        "terminal-output"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_detail",
+      "type": "function",
+      "name": "render_detail",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        597,
+        626
+      ],
+      "summary": "Implements render detail for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "terminal-output"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_collections",
+      "type": "function",
+      "name": "render_collections",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        628,
+        650
+      ],
+      "summary": "Implements render collections for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "terminal-output"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:truncate",
+      "type": "function",
+      "name": "truncate",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        652,
+        663
+      ],
+      "summary": "Implements truncate for existing Library items and their terminal representation.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:confirm",
+      "type": "function",
+      "name": "confirm",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        665,
+        677
+      ],
+      "summary": "Requires an interactive confirmation for destructive global metadata changes unless the caller supplied an explicit override.",
+      "tags": [
+        "cli",
+        "library-management",
+        "api-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-cli/src/main.rs",
+      "type": "file",
+      "name": "main.rs",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "summary": "Defines Mold's command-line grammar, validation, help text, completion generation, and top-level dispatch across generation, model, queue, server, and Library operations.",
+      "tags": [
+        "entry-point",
+        "cli",
+        "command-dispatch",
+        "validation",
+        "configuration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-cli/src/main.rs:apply_spatial_tile_override",
+      "type": "function",
+      "name": "apply_spatial_tile_override",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        2060,
+        2070
+      ],
+      "summary": "Implements apply spatial tile override for CLI parsing, validation, dispatch, or completion generation.",
+      "tags": [
+        "cli",
+        "command-dispatch",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/main.rs:main",
+      "type": "function",
+      "name": "main",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        2073,
+        2197
+      ],
+      "summary": "Implements main for CLI parsing, validation, dispatch, or completion generation.",
+      "tags": [
+        "cli",
+        "command-dispatch",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/main.rs:run",
+      "type": "function",
+      "name": "run",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        2199,
+        2975
+      ],
+      "summary": "Implements run for CLI parsing, validation, dispatch, or completion generation.",
+      "tags": [
+        "cli",
+        "command-dispatch",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-cli/src/main.rs:generate_completions",
+      "type": "function",
+      "name": "generate_completions",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        2982,
+        3067
+      ],
+      "summary": "Implements generate completions for CLI parsing, validation, dispatch, or completion generation.",
+      "tags": [
+        "cli",
+        "command-dispatch",
+        "validation"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
+      "type": "function",
+      "name": "resolve_catalog_id",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        3086,
+        3105
+      ],
+      "summary": "Implements resolve catalog id for CLI parsing, validation, dispatch, or completion generation.",
+      "tags": [
+        "cli",
+        "command-dispatch",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
+      "type": "class",
+      "name": "Ltx2SpatialUpscaleArg",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        78,
+        83
+      ],
+      "summary": "Defines ltx2spatial upscale arg state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
+      "type": "class",
+      "name": "Ltx2TemporalUpscaleArg",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        86,
+        89
+      ],
+      "summary": "Defines ltx2temporal upscale arg state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
+      "type": "class",
+      "name": "Ltx2PipelineArg",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        92,
+        117
+      ],
+      "summary": "Defines ltx2pipeline arg state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:ConfigAction",
+      "type": "class",
+      "name": "ConfigAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        152,
+        205
+      ],
+      "summary": "Defines config action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:GpuAction",
+      "type": "class",
+      "name": "GpuAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        208,
+        227
+      ],
+      "summary": "Defines gpu action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:RunpodAction",
+      "type": "class",
+      "name": "RunpodAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        230,
+        416
+      ],
+      "summary": "Defines runpod action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:RunpodNetworkVolumeAction",
+      "type": "class",
+      "name": "RunpodNetworkVolumeAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        419,
+        464
+      ],
+      "summary": "Defines runpod network volume action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:LambdaAction",
+      "type": "class",
+      "name": "LambdaAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        467,
+        538
+      ],
+      "summary": "Defines lambda action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:ServerAction",
+      "type": "class",
+      "name": "ServerAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        541,
+        591
+      ],
+      "summary": "Defines server action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:JobsAction",
+      "type": "class",
+      "name": "JobsAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        607,
+        640
+      ],
+      "summary": "Defines jobs action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
+      "type": "class",
+      "name": "RetakeModeArg",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        643,
+        646
+      ],
+      "summary": "Defines retake mode arg state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:QueueAction",
+      "type": "class",
+      "name": "QueueAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        649,
+        716
+      ],
+      "summary": "Defines queue action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:TrashAction",
+      "type": "class",
+      "name": "TrashAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        719,
+        748
+      ],
+      "summary": "Defines trash action state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:LibraryTagAction",
+      "type": "class",
+      "name": "LibraryTagAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        751,
+        785
+      ],
+      "summary": "CLI argument model for library tag action commands and their validated options.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:LibraryCollectionAction",
+      "type": "class",
+      "name": "LibraryCollectionAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        788,
+        848
+      ],
+      "summary": "CLI argument model for library collection action commands and their validated options.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:LibraryAction",
+      "type": "class",
+      "name": "LibraryAction",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        851,
+        921
+      ],
+      "summary": "CLI argument model for library action commands and their validated options.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:Commands",
+      "type": "class",
+      "name": "Commands",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        925,
+        2044
+      ],
+      "summary": "Defines commands state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
+      "type": "class",
+      "name": "CatalogIdResolution",
+      "filePath": "crates/mold-cli/src/main.rs",
+      "lineRange": [
+        3074,
+        3080
+      ],
+      "summary": "Defines catalog id resolution state or command data used by main.rs.",
+      "tags": [
+        "cli",
+        "type-definition",
+        "command-dispatch"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-cli/tests/cli_integration.rs",
+      "type": "file",
+      "name": "cli_integration.rs",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "summary": "Exercises the Mold binary end to end, including Library filtering and JSON output, organization capability fallback, recoverable trash safety, media preview fallback, and the established model and configuration commands.",
+      "tags": [
+        "test",
+        "cli",
+        "integration-test",
+        "library-management",
+        "http-contract"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:loopback_admin_commands_do_not_hide_live_server_http_errors",
+      "type": "function",
+      "name": "loopback_admin_commands_do_not_hide_live_server_http_errors",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        16,
+        38
+      ],
+      "summary": "Verifies loopback admin commands do not hide live server http errors behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:version_flag_matches_subcommand",
+      "type": "function",
+      "name": "version_flag_matches_subcommand",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        63,
+        79
+      ],
+      "summary": "Verifies version flag matches subcommand behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_capabilities",
+      "type": "function",
+      "name": "library_capabilities",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        87,
+        100
+      ],
+      "summary": "Verifies library capabilities behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_row",
+      "type": "function",
+      "name": "library_row",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        102,
+        122
+      ],
+      "summary": "Verifies library row behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_list_json_is_pure_and_uses_the_same_filtered_page",
+      "type": "function",
+      "name": "library_list_json_is_pure_and_uses_the_same_filtered_page",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        125,
+        160
+      ],
+      "summary": "Verifies library list json is pure and uses the same filtered page behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_tag_add_uses_replay_safe_bulk_mutation_when_advertised",
+      "type": "function",
+      "name": "library_tag_add_uses_replay_safe_bulk_mutation_when_advertised",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        163,
+        209
+      ],
+      "summary": "Verifies library tag add uses replay safe bulk mutation when advertised behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_tag_add_falls_back_to_legacy_organize_route",
+      "type": "function",
+      "name": "library_tag_add_falls_back_to_legacy_organize_route",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        212,
+        240
+      ],
+      "summary": "Verifies library tag add falls back to legacy organize route behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_trash_refuses_a_host_without_recoverable_trash",
+      "type": "function",
+      "name": "library_trash_refuses_a_host_without_recoverable_trash",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        243,
+        266
+      ],
+      "summary": "Verifies library trash refuses a host without recoverable trash behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_collection_remove_resolves_slug_and_sends_membership_change",
+      "type": "function",
+      "name": "library_collection_remove_resolves_slug_and_sends_membership_change",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        269,
+        326
+      ],
+      "summary": "Verifies library collection remove resolves slug and sends membership change behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_show_video_uses_thumbnail_when_animated_preview_is_missing",
+      "type": "function",
+      "name": "library_show_video_uses_thumbnail_when_animated_preview_is_missing",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        329,
+        363
+      ],
+      "summary": "Verifies library show video uses thumbnail when animated preview is missing behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:library_global_tag_delete_requires_yes_without_a_tty",
+      "type": "function",
+      "name": "library_global_tag_delete_requires_yes_without_a_tty",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        366,
+        388
+      ],
+      "summary": "Verifies library global tag delete requires yes without a tty behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:default_set_persists_to_config",
+      "type": "function",
+      "name": "default_set_persists_to_config",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        403,
+        417
+      ],
+      "summary": "Verifies default set persists to config behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_list_json_is_valid",
+      "type": "function",
+      "name": "config_list_json_is_valid",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        454,
+        467
+      ],
+      "summary": "Verifies config list json is valid behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_get_raw_outputs_bare_value",
+      "type": "function",
+      "name": "config_get_raw_outputs_bare_value",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        480,
+        490
+      ],
+      "summary": "Verifies config get raw outputs bare value behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:config_set_persists_value",
+      "type": "function",
+      "name": "config_set_persists_value",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        493,
+        506
+      ],
+      "summary": "Verifies config set persists value behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_json_is_valid",
+      "type": "function",
+      "name": "stats_json_is_valid",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        529,
+        538
+      ],
+      "summary": "Verifies stats json is valid behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_with_populated_model",
+      "type": "function",
+      "name": "stats_with_populated_model",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        541,
+        551
+      ],
+      "summary": "Verifies stats with populated model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:stats_does_not_double_count_hidden_companions",
+      "type": "function",
+      "name": "stats_does_not_double_count_hidden_companions",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        560,
+        571
+      ],
+      "summary": "Verifies stats does not double count hidden companions behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_shows_column_headers_when_models_installed",
+      "type": "function",
+      "name": "list_shows_column_headers_when_models_installed",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        586,
+        596
+      ],
+      "summary": "Verifies list shows column headers when models installed behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_with_populated_model_shows_installed",
+      "type": "function",
+      "name": "list_with_populated_model_shows_installed",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        599,
+        608
+      ],
+      "summary": "Verifies list with populated model shows installed behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:list_upscaler_models_shown_as_installed",
+      "type": "function",
+      "name": "list_upscaler_models_shown_as_installed",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        621,
+        641
+      ],
+      "summary": "Verifies list upscaler models shown as installed behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:info_known_model_shows_details",
+      "type": "function",
+      "name": "info_known_model_shows_details",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        666,
+        675
+      ],
+      "summary": "Verifies info known model shows details behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
+      "type": "function",
+      "name": "gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        680,
+        697
+      ],
+      "summary": "Verifies gpu list json falls back to local inventory when loopback server is stopped behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:rm_removes_manifest_model",
+      "type": "function",
+      "name": "rm_removes_manifest_model",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        723,
+        740
+      ],
+      "summary": "Verifies rm removes manifest model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:rm_preserves_shared_files_when_sibling_exists",
+      "type": "function",
+      "name": "rm_preserves_shared_files_when_sibling_exists",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        743,
+        761
+      ],
+      "summary": "Verifies rm preserves shared files when sibling exists behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:clean_detects_stale_pulling_marker",
+      "type": "function",
+      "name": "clean_detects_stale_pulling_marker",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        776,
+        786
+      ],
+      "summary": "Verifies clean detects stale pulling marker behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_mask_requires_image_flag",
+      "type": "function",
+      "name": "run_mask_requires_image_flag",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        822,
+        833
+      ],
+      "summary": "Verifies run mask requires image flag behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_qwen_image_edit_rejects_batch_before_remote_generation",
+      "type": "function",
+      "name": "run_qwen_image_edit_rejects_batch_before_remote_generation",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        836,
+        856
+      ],
+      "summary": "Verifies run qwen image edit rejects batch before remote generation behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
+      "type": "function",
+      "name": "run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        868,
+        904
+      ],
+      "summary": "Verifies run extend satisfies a wan i2v checkpoints source contract behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_on_a_family_without_a_continuation_path_names_extend",
+      "type": "function",
+      "name": "run_extend_on_a_family_without_a_continuation_path_names_extend",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        909,
+        929
+      ],
+      "summary": "Verifies run extend on a family without a continuation path names extend behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_sends_the_familys_own_carryover_overlap",
+      "type": "function",
+      "name": "run_extend_sends_the_familys_own_carryover_overlap",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        944,
+        1002
+      ],
+      "summary": "Verifies run extend sends the familys own carryover overlap behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:update_help_text",
+      "type": "function",
+      "name": "update_help_text",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1019,
+        1031
+      ],
+      "summary": "Verifies update help text behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:update_check_runs_without_panic",
+      "type": "function",
+      "name": "update_check_runs_without_panic",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1054,
+        1077
+      ],
+      "summary": "Verifies update check runs without panic behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:dry_run_prints_stage_summary",
+      "type": "function",
+      "name": "dry_run_prints_stage_summary",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1082,
+        1116
+      ],
+      "summary": "Verifies dry run prints stage summary behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:repeated_prompt_flag_yields_chain",
+      "type": "function",
+      "name": "repeated_prompt_flag_yields_chain",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1121,
+        1141
+      ],
+      "summary": "Verifies repeated prompt flag yields chain behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_reports_ok_for_valid_script",
+      "type": "function",
+      "name": "chain_validate_reports_ok_for_valid_script",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1146,
+        1175
+      ],
+      "summary": "Verifies chain validate reports ok for valid script behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_errors_on_bad_schema",
+      "type": "function",
+      "name": "chain_validate_errors_on_bad_schema",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1178,
+        1206
+      ],
+      "summary": "Verifies chain validate errors on bad schema behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:positional_plus_prompt_flag_errors",
+      "type": "function",
+      "name": "positional_plus_prompt_flag_errors",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1211,
+        1225
+      ],
+      "summary": "Verifies positional plus prompt flag errors behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:positional_alone_still_works",
+      "type": "function",
+      "name": "positional_alone_still_works",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1228,
+        1237
+      ],
+      "summary": "Verifies positional alone still works behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/tests/cli_integration.rs:prompt_flag_alone_still_works",
+      "type": "function",
+      "name": "prompt_flag_alone_still_works",
+      "filePath": "crates/mold-cli/tests/cli_integration.rs",
+      "lineRange": [
+        1240,
+        1253
+      ],
+      "summary": "Verifies prompt flag alone still works behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-core/src/client.rs",
+      "type": "file",
+      "name": "client.rs",
+      "filePath": "crates/mold-core/src/client.rs",
+      "summary": "Provides the authenticated asynchronous HTTP client for Mold servers, covering generation streams, queue and device control, gallery organization and trash, collections, tags, model downloads, prompt transforms, and media retrieval.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization",
+        "gallery",
+        "streaming"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pull_body",
+      "type": "function",
+      "name": "pull_body",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        32,
+        41
+      ],
+      "summary": "Implements the pull body operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:require_direct_singleton",
+      "type": "function",
+      "name": "require_direct_singleton",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        53,
+        62
+      ],
+      "summary": "Implements the require direct singleton operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:retained_frame_error",
+      "type": "function",
+      "name": "retained_frame_error",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        71,
+        80
+      ],
+      "summary": "Implements the retained frame error operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        112,
+        119
+      ],
+      "summary": "Implements the new operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:with_api_key",
+      "type": "function",
+      "name": "with_api_key",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        122,
+        129
+      ],
+      "summary": "Implements the with api key operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:from_env",
+      "type": "function",
+      "name": "from_env",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        131,
+        141
+      ],
+      "summary": "Implements the from env operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:has_api_key",
+      "type": "function",
+      "name": "has_api_key",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        144,
+        146
+      ],
+      "summary": "Implements the has api key operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
+      "type": "function",
+      "name": "create_reference_upload_session",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        154,
+        174
+      ],
+      "summary": "Implements the create reference upload session operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upload_reference_file",
+      "type": "function",
+      "name": "upload_reference_file",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        182,
+        207
+      ],
+      "summary": "Implements the upload reference file operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
+      "type": "function",
+      "name": "upload_reference_open_file",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        215,
+        236
+      ],
+      "summary": "Implements the upload reference open file operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
+      "type": "function",
+      "name": "upload_reference_bytes",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        243,
+        253
+      ],
+      "summary": "Implements the upload reference bytes operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upload_reference_body",
+      "type": "function",
+      "name": "upload_reference_body",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        255,
+        275
+      ],
+      "summary": "Implements the upload reference body operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
+      "type": "function",
+      "name": "cancel_reference_upload_session",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        278,
+        290
+      ],
+      "summary": "Implements the cancel reference upload session operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generate_raw",
+      "type": "function",
+      "name": "generate_raw",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        295,
+        310
+      ],
+      "summary": "Implements the generate raw operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generate",
+      "type": "function",
+      "name": "generate",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        316,
+        433
+      ],
+      "summary": "Implements the generate operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_models",
+      "type": "function",
+      "name": "list_models",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        435,
+        438
+      ],
+      "summary": "Implements the list models operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_models_extended",
+      "type": "function",
+      "name": "list_models_extended",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        440,
+        450
+      ],
+      "summary": "Implements the list models extended operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_loras",
+      "type": "function",
+      "name": "list_loras",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        453,
+        466
+      ],
+      "summary": "Implements the list loras operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_loras_endpoint",
+      "type": "function",
+      "name": "list_loras_endpoint",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        468,
+        482
+      ],
+      "summary": "Implements the list loras endpoint operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_loras_from_installed_catalog",
+      "type": "function",
+      "name": "list_loras_from_installed_catalog",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        484,
+        517
+      ],
+      "summary": "Implements the list loras from installed catalog operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:is_connection_error",
+      "type": "function",
+      "name": "is_connection_error",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        521,
+        532
+      ],
+      "summary": "Implements the is connection error operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:is_model_not_found",
+      "type": "function",
+      "name": "is_model_not_found",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        536,
+        548
+      ],
+      "summary": "Implements the is model not found operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generate_stream",
+      "type": "function",
+      "name": "generate_stream",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        555,
+        776
+      ],
+      "summary": "Implements the generate stream operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "streaming"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
+      "type": "function",
+      "name": "stream_chain_job_events",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        785,
+        893
+      ],
+      "summary": "Implements the stream chain job events operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "streaming"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:create_chain_job",
+      "type": "function",
+      "name": "create_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        895,
+        907
+      ],
+      "summary": "Implements the create chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_chain_jobs",
+      "type": "function",
+      "name": "list_chain_jobs",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        909,
+        924
+      ],
+      "summary": "Implements the list chain jobs operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:get_chain_job",
+      "type": "function",
+      "name": "get_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        926,
+        940
+      ],
+      "summary": "Implements the get chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:resume_chain_job",
+      "type": "function",
+      "name": "resume_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        942,
+        956
+      ],
+      "summary": "Implements the resume chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:retake_chain_job",
+      "type": "function",
+      "name": "retake_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        958,
+        974
+      ],
+      "summary": "Implements the retake chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:cancel_chain_job",
+      "type": "function",
+      "name": "cancel_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        976,
+        990
+      ],
+      "summary": "Implements the cancel chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:delete_chain_job",
+      "type": "function",
+      "name": "delete_chain_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        992,
+        1004
+      ],
+      "summary": "Implements the delete chain job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
+      "type": "function",
+      "name": "gc_chain_jobs",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1006,
+        1016
+      ],
+      "summary": "Implements the gc chain jobs operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pull_model",
+      "type": "function",
+      "name": "pull_model",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1021,
+        1023
+      ],
+      "summary": "Implements the pull model operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pull_model_accepting",
+      "type": "function",
+      "name": "pull_model_accepting",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1031,
+        1046
+      ],
+      "summary": "Implements the pull model accepting operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_licenses",
+      "type": "function",
+      "name": "list_licenses",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1049,
+        1059
+      ],
+      "summary": "Implements the list licenses operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:preview_generation_placement",
+      "type": "function",
+      "name": "preview_generation_placement",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1064,
+        1080
+      ],
+      "summary": "Implements the preview generation placement operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:shutdown_server",
+      "type": "function",
+      "name": "shutdown_server",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1083,
+        1090
+      ],
+      "summary": "Implements the shutdown server operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pull_model_stream",
+      "type": "function",
+      "name": "pull_model_stream",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1096,
+        1103
+      ],
+      "summary": "Implements the pull model stream operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "streaming"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
+      "type": "function",
+      "name": "pull_model_stream_accepting",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1107,
+        1170
+      ],
+      "summary": "Implements the pull model stream accepting operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "streaming"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:host",
+      "type": "function",
+      "name": "host",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1172,
+        1174
+      ],
+      "summary": "Implements the host operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:unload_model",
+      "type": "function",
+      "name": "unload_model",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1176,
+        1178
+      ],
+      "summary": "Implements the unload model operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:unload_model_target",
+      "type": "function",
+      "name": "unload_model_target",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1180,
+        1199
+      ],
+      "summary": "Implements the unload model target operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:server_status",
+      "type": "function",
+      "name": "server_status",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1201,
+        1211
+      ],
+      "summary": "Implements the server status operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:server_capabilities",
+      "type": "function",
+      "name": "server_capabilities",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1214,
+        1224
+      ],
+      "summary": "Implements the server capabilities operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:devices",
+      "type": "function",
+      "name": "devices",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1227,
+        1237
+      ],
+      "summary": "Implements the devices operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:capabilities",
+      "type": "function",
+      "name": "capabilities",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1240,
+        1242
+      ],
+      "summary": "Implements the capabilities operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:admit_generation_batch",
+      "type": "function",
+      "name": "admit_generation_batch",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1246,
+        1260
+      ],
+      "summary": "Implements the admit generation batch operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
+      "type": "function",
+      "name": "generation_batch_by_client_id",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1264,
+        1286
+      ],
+      "summary": "Implements the generation batch by client id operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generation_batch",
+      "type": "function",
+      "name": "generation_batch",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1289,
+        1308
+      ],
+      "summary": "Implements the generation batch operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
+      "type": "function",
+      "name": "generation_batch_statuses",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1311,
+        1325
+      ],
+      "summary": "Implements the generation batch statuses operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:retry_queue_job",
+      "type": "function",
+      "name": "retry_queue_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1328,
+        1341
+      ],
+      "summary": "Implements the retry queue job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:set_device_enabled",
+      "type": "function",
+      "name": "set_device_enabled",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1345,
+        1365
+      ],
+      "summary": "Implements the set device enabled operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_queue",
+      "type": "function",
+      "name": "list_queue",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1374,
+        1377
+      ],
+      "summary": "Implements the list queue operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
+      "type": "function",
+      "name": "list_queue_for_capacity",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1382,
+        1391
+      ],
+      "summary": "Implements the list queue for capacity operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_queue_page",
+      "type": "function",
+      "name": "list_queue_page",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1395,
+        1404
+      ],
+      "summary": "Implements the list queue page operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_queue_all",
+      "type": "function",
+      "name": "list_queue_all",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1424,
+        1459
+      ],
+      "summary": "Implements the list queue all operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:find_queue_job",
+      "type": "function",
+      "name": "find_queue_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1464,
+        1482
+      ],
+      "summary": "Implements the find queue job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:fetch_queue_listing",
+      "type": "function",
+      "name": "fetch_queue_listing",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1484,
+        1504
+      ],
+      "summary": "Implements the fetch queue listing operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:queue_job_progress",
+      "type": "function",
+      "name": "queue_job_progress",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1512,
+        1529
+      ],
+      "summary": "Implements the queue job progress operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:cancel_queue_job",
+      "type": "function",
+      "name": "cancel_queue_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1538,
+        1550
+      ],
+      "summary": "Implements the cancel queue job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:queue_job",
+      "type": "function",
+      "name": "queue_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1561,
+        1580
+      ],
+      "summary": "Implements the queue job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:move_queue_job",
+      "type": "function",
+      "name": "move_queue_job",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1585,
+        1604
+      ],
+      "summary": "Implements the move queue job operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
+      "type": "function",
+      "name": "cancel_all_queue_jobs",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1610,
+        1621
+      ],
+      "summary": "Implements the cancel all queue jobs operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
+      "type": "function",
+      "name": "cancel_generation_batch",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1626,
+        1640
+      ],
+      "summary": "Implements the cancel generation batch operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:pause_queue",
+      "type": "function",
+      "name": "pause_queue",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1644,
+        1646
+      ],
+      "summary": "Implements the pause queue operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:resume_queue",
+      "type": "function",
+      "name": "resume_queue",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1651,
+        1653
+      ],
+      "summary": "Implements the resume queue operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:set_queue_paused",
+      "type": "function",
+      "name": "set_queue_paused",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1655,
+        1666
+      ],
+      "summary": "Implements the set queue paused operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:sweep_held_queue",
+      "type": "function",
+      "name": "sweep_held_queue",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1669,
+        1679
+      ],
+      "summary": "Implements the sweep held queue operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
+      "type": "function",
+      "name": "sweep_settled_batches",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1683,
+        1693
+      ],
+      "summary": "Implements the sweep settled batches operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_gallery",
+      "type": "function",
+      "name": "list_gallery",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1696,
+        1706
+      ],
+      "summary": "Implements the list gallery operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:gallery_item",
+      "type": "function",
+      "name": "gallery_item",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1714,
+        1725
+      ],
+      "summary": "Implements the gallery item operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:get_gallery_image",
+      "type": "function",
+      "name": "get_gallery_image",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1728,
+        1742
+      ],
+      "summary": "Implements the get gallery image operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:delete_gallery_image",
+      "type": "function",
+      "name": "delete_gallery_image",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1745,
+        1756
+      ],
+      "summary": "Implements the delete gallery image operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_gallery_view",
+      "type": "function",
+      "name": "list_gallery_view",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1762,
+        1773
+      ],
+      "summary": "Implements the list gallery view operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:trash_gallery_image",
+      "type": "function",
+      "name": "trash_gallery_image",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1778,
+        1790
+      ],
+      "summary": "Implements the trash gallery image operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
+      "type": "function",
+      "name": "delete_gallery_image_forever",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1795,
+        1808
+      ],
+      "summary": "Implements the delete gallery image forever operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:trash_gallery_images",
+      "type": "function",
+      "name": "trash_gallery_images",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1811,
+        1822
+      ],
+      "summary": "Implements the trash gallery images operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:restore_trashed",
+      "type": "function",
+      "name": "restore_trashed",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1827,
+        1838
+      ],
+      "summary": "Implements the restore trashed operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:empty_trash",
+      "type": "function",
+      "name": "empty_trash",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1841,
+        1851
+      ],
+      "summary": "Implements the empty trash operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:sweep_trash",
+      "type": "function",
+      "name": "sweep_trash",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1856,
+        1866
+      ],
+      "summary": "Implements the sweep trash operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:patch_gallery_image",
+      "type": "function",
+      "name": "patch_gallery_image",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1870,
+        1889
+      ],
+      "summary": "Implements the patch gallery image operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:organize_gallery",
+      "type": "function",
+      "name": "organize_gallery",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1892,
+        1901
+      ],
+      "summary": "Implements the organize gallery operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:mutate_gallery_bulk",
+      "type": "function",
+      "name": "mutate_gallery_bulk",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1905,
+        1919
+      ],
+      "summary": "Sends a replay-safe bulk gallery organization mutation and returns per-item mutation results.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_collections",
+      "type": "function",
+      "name": "list_collections",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1922,
+        1932
+      ],
+      "summary": "Implements the list collections operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:get_collection",
+      "type": "function",
+      "name": "get_collection",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1936,
+        1950
+      ],
+      "summary": "Retrieves one collection with its current ordered print membership.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:create_collection",
+      "type": "function",
+      "name": "create_collection",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1953,
+        1964
+      ],
+      "summary": "Implements the create collection operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:update_collection",
+      "type": "function",
+      "name": "update_collection",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1968,
+        1987
+      ],
+      "summary": "Implements the update collection operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:delete_collection",
+      "type": "function",
+      "name": "delete_collection",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        1991,
+        2003
+      ],
+      "summary": "Implements the delete collection operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:set_collection_items",
+      "type": "function",
+      "name": "set_collection_items",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2007,
+        2020
+      ],
+      "summary": "Implements the set collection items operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:list_tags",
+      "type": "function",
+      "name": "list_tags",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2023,
+        2033
+      ],
+      "summary": "Implements the list tags operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:rename_tag",
+      "type": "function",
+      "name": "rename_tag",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2036,
+        2051
+      ],
+      "summary": "Implements the rename tag operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:delete_tag",
+      "type": "function",
+      "name": "delete_tag",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2054,
+        2066
+      ],
+      "summary": "Implements the delete tag operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:get_gallery_preview",
+      "type": "function",
+      "name": "get_gallery_preview",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2073,
+        2088
+      ],
+      "summary": "Fetches an animated or derived gallery preview using a safely encoded filename path segment.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
+      "type": "function",
+      "name": "get_gallery_thumbnail",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2091,
+        2105
+      ],
+      "summary": "Fetches a gallery thumbnail using a safely encoded filename path segment.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:expand_prompt",
+      "type": "function",
+      "name": "expand_prompt",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2108,
+        2120
+      ],
+      "summary": "Implements the expand prompt operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:remix_prompt",
+      "type": "function",
+      "name": "remix_prompt",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2124,
+        2136
+      ],
+      "summary": "Implements the remix prompt operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upscale",
+      "type": "function",
+      "name": "upscale",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2139,
+        2150
+      ],
+      "summary": "Implements the upscale operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:upscale_stream",
+      "type": "function",
+      "name": "upscale_stream",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2154,
+        2226
+      ],
+      "summary": "Implements the upscale stream operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "streaming"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:installed_entry_into_lora_info",
+      "type": "function",
+      "name": "installed_entry_into_lora_info",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2230,
+        2247
+      ],
+      "summary": "Implements the installed entry into lora info operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:should_fallback_loras_endpoint",
+      "type": "function",
+      "name": "should_fallback_loras_endpoint",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2249,
+        2260
+      ],
+      "summary": "Implements the should fallback loras endpoint operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
+      "type": "function",
+      "name": "is_missing_endpoint_error",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2266,
+        2279
+      ],
+      "summary": "Implements the is missing endpoint error operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:is_transient_request_error",
+      "type": "function",
+      "name": "is_transient_request_error",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2285,
+        2304
+      ],
+      "summary": "Implements the is transient request error operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:require_direct_media_response",
+      "type": "function",
+      "name": "require_direct_media_response",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2340,
+        2379
+      ],
+      "summary": "Implements the require direct media response operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:api_error_detail",
+      "type": "function",
+      "name": "api_error_detail",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2388,
+        2401
+      ],
+      "summary": "Implements the api error detail operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:lora_family_for_model_filter",
+      "type": "function",
+      "name": "lora_family_for_model_filter",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2403,
+        2420
+      ],
+      "summary": "Implements the lora family for model filter operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:parse_request_warnings",
+      "type": "function",
+      "name": "parse_request_warnings",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2464,
+        2473
+      ],
+      "summary": "Implements the parse request warnings operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:merge_completion_warnings",
+      "type": "function",
+      "name": "merge_completion_warnings",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2491,
+        2501
+      ],
+      "summary": "Implements the merge completion warnings operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:parse_video_headers",
+      "type": "function",
+      "name": "parse_video_headers",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2505,
+        2566
+      ],
+      "summary": "Implements the parse video headers operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:parse_audio_headers",
+      "type": "function",
+      "name": "parse_audio_headers",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2584,
+        2606
+      ],
+      "summary": "Implements the parse audio headers operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:next_sse_event",
+      "type": "function",
+      "name": "next_sse_event",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2608,
+        2617
+      ],
+      "summary": "Implements the next sse event operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:parse_sse_event",
+      "type": "function",
+      "name": "parse_sse_event",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2619,
+        2633
+      ],
+      "summary": "Implements the parse sse event operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:build_client",
+      "type": "function",
+      "name": "build_client",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2636,
+        2659
+      ],
+      "summary": "Implements the build client operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:normalize_host",
+      "type": "function",
+      "name": "normalize_host",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2668,
+        2677
+      ],
+      "summary": "Implements the normalize host operation for authenticated communication with a Mold server.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-core/src/client.rs:encode_path_segment",
+      "type": "function",
+      "name": "encode_path_segment",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2679,
+        2690
+      ],
+      "summary": "Percent-encodes an arbitrary gallery filename as one safe URL path segment, including spaces, percent signs, hashes, and Unicode bytes.",
+      "tags": [
+        "api-client",
+        "http",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-core/src/client.rs:MoldClient",
+      "type": "class",
+      "name": "MoldClient",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        47,
+        51
+      ],
+      "summary": "Authenticated Mold server client that centralizes HTTP request construction, streaming responses, gallery operations, queue control, and capability-aware APIs.",
+      "tags": [
+        "api-client",
+        "service",
+        "http",
+        "streaming"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
+      "type": "class",
+      "name": "ChainJobOutcome",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        104,
+        109
+      ],
+      "summary": "Defines chain job outcome state or command data used by client.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
+      "type": "class",
+      "name": "ModelNotFoundError",
+      "filePath": "crates/mold-core/src/client.rs",
+      "lineRange": [
+        2695,
+        2695
+      ],
+      "summary": "Defines model not found error state or command data used by client.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-inference/src/expand.rs",
+      "type": "file",
+      "name": "expand.rs",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "summary": "Resolves local prompt-expansion artifacts and device placement, validates frozen execution plans, loads the GGUF language model, and samples expanded prompt text with cancellation and progress reporting.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading",
+        "gpu",
+        "cancellation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:validate",
+      "type": "function",
+      "name": "validate",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        64,
+        82
+      ],
+      "summary": "Handles validate as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
+      "type": "function",
+      "name": "artifact_identity_fingerprint",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        99,
+        129
+      ],
+      "summary": "Handles artifact identity fingerprint as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
+      "type": "function",
+      "name": "freeze_artifact",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        131,
+        141
+      ],
+      "summary": "Handles freeze artifact as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
+      "type": "function",
+      "name": "validate_frozen_artifact",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        143,
+        157
+      ],
+      "summary": "Handles validate frozen artifact as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:expand_candidate_dirs",
+      "type": "function",
+      "name": "expand_candidate_dirs",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        159,
+        174
+      ],
+      "summary": "Handles expand candidate dirs as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
+      "type": "function",
+      "name": "expand_plan_memory_floors",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        176,
+        203
+      ],
+      "summary": "Handles expand plan memory floors as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
+      "type": "function",
+      "name": "expand_execution_fingerprint",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        205,
+        232
+      ],
+      "summary": "Handles expand execution fingerprint as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
+      "type": "function",
+      "name": "resolve_local_expand_artifacts",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        236,
+        270
+      ],
+      "summary": "Handles resolve local expand artifacts as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
+      "type": "function",
+      "name": "resolve_expand_execution_plan",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        277,
+        286
+      ],
+      "summary": "Handles resolve expand execution plan as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
+      "type": "function",
+      "name": "resolve_expand_execution_plan_from_artifacts",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        292,
+        311
+      ],
+      "summary": "Handles resolve expand execution plan from artifacts as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
+      "type": "function",
+      "name": "create_exact_device_with",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        313,
+        350
+      ],
+      "summary": "Handles create exact device with as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:select_legacy_dynamic_expand_device",
+      "type": "function",
+      "name": "select_legacy_dynamic_expand_device",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        352,
+        392
+      ],
+      "summary": "Handles select legacy dynamic expand device as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:report_expand_memory_status_with",
+      "type": "function",
+      "name": "report_expand_memory_status_with",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        394,
+        411
+      ],
+      "summary": "Handles report expand memory status with as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        425,
+        434
+      ],
+      "summary": "Handles new as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
+      "type": "function",
+      "name": "from_resolved_plan",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        441,
+        450
+      ],
+      "summary": "Handles from resolved plan as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:set_on_progress",
+      "type": "function",
+      "name": "set_on_progress",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        453,
+        455
+      ],
+      "summary": "Handles set on progress as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
+      "type": "function",
+      "name": "set_cancellation_token",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        457,
+        459
+      ],
+      "summary": "Handles set cancellation token as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
+      "type": "function",
+      "name": "clear_cancellation_token",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        461,
+        463
+      ],
+      "summary": "Handles clear cancellation token as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
+      "type": "function",
+      "name": "expand_with_cancellation",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        467,
+        482
+      ],
+      "summary": "Handles expand with cancellation as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
+      "type": "function",
+      "name": "with_gpu_selection",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        485,
+        488
+      ],
+      "summary": "Handles with gpu selection as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
+      "type": "function",
+      "name": "with_preferred_gpu",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        491,
+        494
+      ],
+      "summary": "Handles with preferred gpu as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:from_config",
+      "type": "function",
+      "name": "from_config",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        507,
+        509
+      ],
+      "summary": "Handles from config as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
+      "type": "function",
+      "name": "from_config_legacy_dynamic",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        514,
+        520
+      ],
+      "summary": "Handles from config legacy dynamic as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:generate_text",
+      "type": "function",
+      "name": "generate_text",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        523,
+        685
+      ],
+      "summary": "Handles generate text as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:expand",
+      "type": "function",
+      "name": "expand",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        689,
+        747
+      ],
+      "summary": "Handles expand as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:sample_token",
+      "type": "function",
+      "name": "sample_token",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        759,
+        811
+      ],
+      "summary": "Handles sample token as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:find_gguf_in_dir",
+      "type": "function",
+      "name": "find_gguf_in_dir",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        815,
+        841
+      ],
+      "summary": "Handles find gguf in dir as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-inference/src/expand.rs:find_tokenizer_in_dir",
+      "type": "function",
+      "name": "find_tokenizer_in_dir",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        844,
+        868
+      ],
+      "summary": "Handles find tokenizer in dir as part of local prompt-expansion artifact planning or inference execution.",
+      "tags": [
+        "inference",
+        "prompt-expansion",
+        "model-loading"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
+      "type": "class",
+      "name": "ResolvedExpandArtifact",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        28,
+        34
+      ],
+      "summary": "Defines resolved expand artifact state or command data used by expand.rs.",
+      "tags": [
+        "inference",
+        "data-model",
+        "prompt-expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
+      "type": "class",
+      "name": "ResolvedExpandArtifacts",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        37,
+        41
+      ],
+      "summary": "Defines resolved expand artifacts state or command data used by expand.rs.",
+      "tags": [
+        "inference",
+        "data-model",
+        "prompt-expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
+      "type": "class",
+      "name": "ExactExpandPlacement",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        44,
+        50
+      ],
+      "summary": "Defines exact expand placement state or command data used by expand.rs.",
+      "tags": [
+        "inference",
+        "data-model",
+        "prompt-expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
+      "type": "class",
+      "name": "ResolvedExpandExecutionPlan",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        53,
+        59
+      ],
+      "summary": "Defines resolved expand execution plan state or command data used by expand.rs.",
+      "tags": [
+        "inference",
+        "data-model",
+        "prompt-expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-inference/src/expand.rs:LocalExpander",
+      "type": "class",
+      "name": "LocalExpander",
+      "filePath": "crates/mold-inference/src/expand.rs",
+      "lineRange": [
+        414,
+        421
+      ],
+      "summary": "Loaded local prompt-expansion engine with resolved artifacts, device placement, progress callbacks, cancellation, and text sampling state.",
+      "tags": [
+        "inference",
+        "data-model",
+        "prompt-expansion"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/app.rs",
+      "type": "file",
+      "name": "app.rs",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "summary": "Owns the interactive Mold TUI state machine for Create, Library, Models, Machines, and Settings, coordinating background server work, multi-host galleries, generation progress, keyboard and mouse actions, and terminal previews.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler",
+        "gallery",
+        "generation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "function",
+      "name": "clear",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        296,
+        320
+      ],
+      "summary": "Handles clear within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "function",
+      "name": "mark_generation_start",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        326,
+        330
+      ],
+      "summary": "Handles mark generation start within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "function",
+      "name": "generation_elapsed",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        334,
+        336
+      ],
+      "summary": "Handles generation elapsed within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "function",
+      "name": "stage_elapsed",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        339,
+        341
+      ],
+      "summary": "Handles stage elapsed within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "function",
+      "name": "push_log",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        346,
+        352
+      ],
+      "summary": "Handles push log within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:clear_download",
+      "type": "function",
+      "name": "clear_download",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        354,
+        367
+      ],
+      "summary": "Handles clear download within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "function",
+      "name": "is_downloading",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        370,
+        372
+      ],
+      "summary": "Handles is downloading within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "function",
+      "name": "download_status_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        375,
+        389
+      ],
+      "summary": "Handles download status text within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:record_download_sample",
+      "type": "function",
+      "name": "record_download_sample",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        397,
+        445
+      ],
+      "summary": "Handles record download sample within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:next",
+      "type": "function",
+      "name": "next",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        473,
+        481
+      ],
+      "summary": "Handles next within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "function",
+      "name": "prev",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        483,
+        491
+      ],
+      "summary": "Handles prev within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:label",
+      "type": "function",
+      "name": "label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        558,
+        603
+      ],
+      "summary": "Handles label within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
+      "type": "function",
+      "name": "qwen_image_edit_dimensions_for_path",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        606,
+        620
+      ],
+      "summary": "Handles qwen image edit dimensions for path within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "function",
+      "name": "parse_size_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        625,
+        633
+      ],
+      "summary": "Handles parse size input within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "function",
+      "name": "resolve",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        665,
+        673
+      ],
+      "summary": "Handles resolve within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "function",
+      "name": "advance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        676,
+        682
+      ],
+      "summary": "Handles advance within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        802,
+        812
+      ],
+      "summary": "Handles new within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "function",
+      "name": "prompt_required_for_params",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        853,
+        858
+      ],
+      "summary": "Handles prompt required for params within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "function",
+      "name": "from_config",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        861,
+        918
+      ],
+      "summary": "Handles from config within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "function",
+      "name": "display_value",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        921,
+        1099
+      ],
+      "summary": "Handles display value within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
+      "type": "function",
+      "name": "adjust_optional_scale",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1108,
+        1122
+      ],
+      "summary": "Handles adjust optional scale within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
+      "type": "function",
+      "name": "adjust_optional_u32",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1124,
+        1138
+      ],
+      "summary": "Handles adjust optional u32 within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
+      "type": "function",
+      "name": "parse_stg_blocks_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1140,
+        1172
+      ],
+      "summary": "Handles parse stg blocks input within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
+      "type": "function",
+      "name": "tui_max_video_frames",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1197,
+        1209
+      ],
+      "summary": "Handles tui max video frames within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "function",
+      "name": "normalize_generate_params_for_family",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1217,
+        1246
+      ],
+      "summary": "Handles normalize generate params for family within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
+      "type": "function",
+      "name": "restored_negative_editor_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1260,
+        1272
+      ],
+      "summary": "Handles restored negative editor text within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
+      "type": "function",
+      "name": "negative_prompt_textarea",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1276,
+        1285
+      ],
+      "summary": "Handles negative prompt textarea within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "function",
+      "name": "from_outcomes",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1394,
+        1413
+      ],
+      "summary": "Handles from outcomes within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "function",
+      "name": "guidance_adjustable",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1424,
+        1426
+      ],
+      "summary": "Handles guidance adjustable within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "function",
+      "name": "negative_visible",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1434,
+        1438
+      ],
+      "summary": "Handles negative visible within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:default",
+      "type": "function",
+      "name": "default",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1505,
+        1531
+      ],
+      "summary": "Handles default within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "function",
+      "name": "refresh_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1537,
+        1544
+      ],
+      "summary": "Handles refresh filter within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "function",
+      "name": "selected_pos",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1547,
+        1549
+      ],
+      "summary": "Handles selected pos within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "function",
+      "name": "rescan_due",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1554,
+        1562
+      ],
+      "summary": "Handles rescan due within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "function",
+      "name": "handle_filter_key",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1568,
+        1594
+      ],
+      "summary": "Handles handle filter key within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:local",
+      "type": "function",
+      "name": "local",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1612,
+        1618
+      ],
+      "summary": "Handles local within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "function",
+      "name": "from_host_entry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1620,
+        1626
+      ],
+      "summary": "Handles from host entry within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "function",
+      "name": "remote_from_url",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1630,
+        1636
+      ],
+      "summary": "Handles remote from url within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "function",
+      "name": "is_local",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1638,
+        1640
+      ],
+      "summary": "Handles is local within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "function",
+      "name": "is_this_machine",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1645,
+        1647
+      ],
+      "summary": "Handles is this machine within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "function",
+      "name": "filename",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1670,
+        1675
+      ],
+      "summary": "Handles filename within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "function",
+      "name": "owning_origins",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1679,
+        1687
+      ],
+      "summary": "Handles owning origins within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "function",
+      "name": "primary_origin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1690,
+        1695
+      ],
+      "summary": "Handles primary origin within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "function",
+      "name": "machine_label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1699,
+        1706
+      ],
+      "summary": "Handles machine label within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "function",
+      "name": "trash_retention_display",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1711,
+        1717
+      ],
+      "summary": "Handles trash retention display within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "function",
+      "name": "hint_label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1734,
+        1739
+      ],
+      "summary": "Handles hint label within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "function",
+      "name": "delete_confirm_message",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1747,
+        1758
+      ],
+      "summary": "Handles delete confirm message within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:generation_model_names",
+      "type": "function",
+      "name": "generation_model_names",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1790,
+        1801
+      ],
+      "summary": "Handles generation model names within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "function",
+      "name": "is_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1888,
+        1890
+      ],
+      "summary": "Handles is field within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "function",
+      "name": "is_read_only",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1892,
+        1900
+      ],
+      "summary": "Handles is read only within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "function",
+      "name": "tab_at_column",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2165,
+        2169
+      ],
+      "summary": "Handles tab at column within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "function",
+      "name": "configure_background_server_command",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2173,
+        2177
+      ],
+      "summary": "Handles configure background server command within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
+      "type": "function",
+      "name": "wait_for_server_health",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2180,
+        2189
+      ],
+      "summary": "Handles wait for server health within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "function",
+      "name": "new_with_launch_policy",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2196,
+        2515
+      ],
+      "summary": "Builds the complete TUI application state while enforcing strict explicit-host connection semantics and initializing local or remote services.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "function",
+      "name": "spawn_gallery_scan",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2521,
+        2529
+      ],
+      "summary": "Handles spawn gallery scan within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "function",
+      "name": "should_poll_remote",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2533,
+        2535
+      ],
+      "summary": "Handles should poll remote within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "function",
+      "name": "should_save_output_locally",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2543,
+        2548
+      ],
+      "summary": "Handles should save output locally within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "function",
+      "name": "should_persist_response_locally",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2560,
+        2568
+      ],
+      "summary": "Handles should persist response locally within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "function",
+      "name": "spawn_server_status_fetch",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2582,
+        2630
+      ],
+      "summary": "Handles spawn server status fetch within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "function",
+      "name": "tick_host_polling",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2635,
+        2646
+      ],
+      "summary": "Handles tick host polling within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
+      "type": "function",
+      "name": "apply_remote_model_defaults",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2660,
+        2678
+      ],
+      "summary": "Handles apply remote model defaults within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:source_image_contract",
+      "type": "function",
+      "name": "source_image_contract",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2686,
+        2696
+      ],
+      "summary": "Handles source image contract within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:identity_gate_error",
+      "type": "function",
+      "name": "identity_gate_error",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2712,
+        2738
+      ],
+      "summary": "Handles identity gate error within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
+      "type": "function",
+      "name": "sync_generate_capabilities",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2763,
+        2879
+      ],
+      "summary": "Handles sync generate capabilities within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
+      "type": "function",
+      "name": "normalize_fixed_guidance_for_submit",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2884,
+        2904
+      ],
+      "summary": "Handles normalize fixed guidance for submit within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
+      "type": "function",
+      "name": "sync_pipeline_guidance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2910,
+        2926
+      ],
+      "summary": "Handles sync pipeline guidance within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_upscale",
+      "type": "function",
+      "name": "spawn_upscale",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2929,
+        3181
+      ],
+      "summary": "Handles spawn upscale within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "function",
+      "name": "shutdown",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3184,
+        3194
+      ],
+      "summary": "Handles shutdown within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "function",
+      "name": "save_session",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3197,
+        3220
+      ],
+      "summary": "Handles save session within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "function",
+      "name": "apply_theme_preset",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3227,
+        3231
+      ],
+      "summary": "Handles apply theme preset within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "function",
+      "name": "update_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3233,
+        3320
+      ],
+      "summary": "Handles update model within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
+      "type": "function",
+      "name": "save_prefs_for_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3325,
+        3358
+      ],
+      "summary": "Handles save prefs for model within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
+      "type": "function",
+      "name": "apply_prefs_for_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3363,
+        3423
+      ],
+      "summary": "Handles apply prefs for model within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "function",
+      "name": "refresh_create_rows",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3427,
+        3435
+      ],
+      "summary": "Handles refresh create rows within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
+      "type": "function",
+      "name": "set_advanced_expanded",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3441,
+        3459
+      ],
+      "summary": "Handles set advanced expanded within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:model_default_size",
+      "type": "function",
+      "name": "model_default_size",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3464,
+        3482
+      ],
+      "summary": "Handles model default size within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
+      "type": "function",
+      "name": "active_generation_recipe",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3487,
+        3496
+      ],
+      "summary": "Handles active generation recipe within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "function",
+      "name": "handle_crossterm_event",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3499,
+        3701
+      ],
+      "summary": "Handles handle crossterm event within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_popup_event",
+      "type": "function",
+      "name": "handle_popup_event",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3726,
+        4270
+      ],
+      "summary": "Handles handle popup event within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_mouse",
+      "type": "function",
+      "name": "handle_mouse",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4272,
+        4430
+      ],
+      "summary": "Handles handle mouse within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
+      "type": "function",
+      "name": "available_upscaler_models",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4433,
+        4452
+      ],
+      "summary": "Handles available upscaler models within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
+      "type": "function",
+      "name": "update_upscale_model_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4454,
+        4481
+      ],
+      "summary": "Handles update upscale model filter within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
+      "type": "function",
+      "name": "update_model_selector_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4483,
+        4495
+      ],
+      "summary": "Handles update model selector filter within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:set_active_view",
+      "type": "function",
+      "name": "set_active_view",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4500,
+        4519
+      ],
+      "summary": "Handles set active view within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "function",
+      "name": "open_library",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4521,
+        4523
+      ],
+      "summary": "Switches the TUI to the Library workspace through the normal active-view transition path.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "function",
+      "name": "dispatch_action",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4526,
+        5228
+      ],
+      "summary": "Handles dispatch action within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:increment_param",
+      "type": "function",
+      "name": "increment_param",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5230,
+        5259
+      ],
+      "summary": "Handles increment param within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_field",
+      "type": "function",
+      "name": "adjust_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5262,
+        5613
+      ],
+      "summary": "Handles adjust field within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
+      "type": "function",
+      "name": "load_gallery_preview",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5616,
+        5721
+      ],
+      "summary": "Handles load gallery preview within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
+      "type": "function",
+      "name": "try_install_gallery_animation",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5725,
+        5740
+      ],
+      "summary": "Handles try install gallery animation within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "function",
+      "name": "tick_animations",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5745,
+        5760
+      ],
+      "summary": "Handles tick animations within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
+      "type": "function",
+      "name": "load_gallery_into_generate",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5763,
+        5827
+      ],
+      "summary": "Handles load gallery into generate within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "function",
+      "name": "apply_gallery_scan",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5836,
+        5869
+      ],
+      "summary": "Handles apply gallery scan within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "function",
+      "name": "apply_delete_failure",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5878,
+        5884
+      ],
+      "summary": "Handles apply delete failure within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "function",
+      "name": "capabilities_for_origin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5890,
+        5901
+      ],
+      "summary": "Handles capabilities for origin within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "function",
+      "name": "origin_can_trash",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5906,
+        5914
+      ],
+      "summary": "Handles origin can trash within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "function",
+      "name": "removal_kind_for",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5918,
+        5928
+      ],
+      "summary": "Handles removal kind for within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "function",
+      "name": "selected_removal_kind",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5931,
+        5937
+      ],
+      "summary": "Handles selected removal kind within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
+      "type": "function",
+      "name": "delete_selected_gallery_image",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5944,
+        6056
+      ],
+      "summary": "Handles delete selected gallery image within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_gallery_file",
+      "type": "function",
+      "name": "open_gallery_file",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6060,
+        6081
+      ],
+      "summary": "Handles open gallery file within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
+      "type": "function",
+      "name": "build_remove_model_message",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6085,
+        6133
+      ],
+      "summary": "Handles build remove model message within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "function",
+      "name": "needs_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6137,
+        6139
+      ],
+      "summary": "Handles needs confirm within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "function",
+      "name": "request_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6145,
+        6154
+      ],
+      "summary": "Handles request confirm within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
+      "type": "function",
+      "name": "handle_confirm_action",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6157,
+        6192
+      ],
+      "summary": "Handles handle confirm action within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_model_selector",
+      "type": "function",
+      "name": "open_model_selector",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6203,
+        6222
+      ],
+      "summary": "Handles open model selector within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:activate_current_param",
+      "type": "function",
+      "name": "activate_current_param",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6225,
+        6249
+      ],
+      "summary": "Handles activate current param within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
+      "type": "function",
+      "name": "surface_request_advisories",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6268,
+        6279
+      ],
+      "summary": "Handles surface request advisories within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:filing_editor_text",
+      "type": "function",
+      "name": "filing_editor_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6283,
+        6292
+      ],
+      "summary": "Handles filing editor text within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:activate_field",
+      "type": "function",
+      "name": "activate_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6305,
+        6406
+      ],
+      "summary": "Handles activate field within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
+      "type": "function",
+      "name": "reset_params_to_model_defaults",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6409,
+        6490
+      ],
+      "summary": "Handles reset params to model defaults within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "function",
+      "name": "build_settings_rows",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6496,
+        6818
+      ],
+      "summary": "Handles build settings rows within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "function",
+      "name": "settings_display_value",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6821,
+        6959
+      ],
+      "summary": "Handles settings display value within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "function",
+      "name": "settings_env_override",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6977,
+        7000
+      ],
+      "summary": "Handles settings env override within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_navigate",
+      "type": "function",
+      "name": "settings_navigate",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7010,
+        7054
+      ],
+      "summary": "Handles settings navigate within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
+      "type": "function",
+      "name": "settings_cycle_theme",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7057,
+        7067
+      ],
+      "summary": "Handles settings cycle theme within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_increment",
+      "type": "function",
+      "name": "settings_increment",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7070,
+        7106
+      ],
+      "summary": "Handles settings increment within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
+      "type": "function",
+      "name": "settings_adjust_number",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7108,
+        7205
+      ],
+      "summary": "Handles settings adjust number within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
+      "type": "function",
+      "name": "settings_cycle_toggle",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7207,
+        7249
+      ],
+      "summary": "Handles settings cycle toggle within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
+      "type": "function",
+      "name": "settings_toggle_bool",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7251,
+        7293
+      ],
+      "summary": "Handles settings toggle bool within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
+      "type": "function",
+      "name": "settings_cycle_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7295,
+        7308
+      ],
+      "summary": "Handles settings cycle model within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_confirm",
+      "type": "function",
+      "name": "settings_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7311,
+        7357
+      ],
+      "summary": "Handles settings confirm within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_apply_input",
+      "type": "function",
+      "name": "settings_apply_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7360,
+        7414
+      ],
+      "summary": "Handles settings apply input within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_config",
+      "type": "function",
+      "name": "save_config",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7417,
+        7427
+      ],
+      "summary": "Handles save config within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_generation",
+      "type": "function",
+      "name": "start_generation",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7429,
+        7669
+      ],
+      "summary": "Handles start generation within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:retry_held_prints",
+      "type": "function",
+      "name": "retry_held_prints",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7677,
+        7698
+      ],
+      "summary": "Handles retry held prints within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
+      "type": "function",
+      "name": "prompt_transform_task",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7722,
+        7739
+      ],
+      "summary": "Handles prompt transform task within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
+      "type": "function",
+      "name": "reference_fingerprint_for_target",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7745,
+        7781
+      ],
+      "summary": "Handles reference fingerprint for target within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
+      "type": "function",
+      "name": "start_prompt_transform",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7783,
+        7826
+      ],
+      "summary": "Handles start prompt transform within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
+      "type": "function",
+      "name": "start_prompt_transform_from",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7828,
+        7905
+      ],
+      "summary": "Handles start prompt transform from within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_provenance",
+      "type": "function",
+      "name": "prompt_provenance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7907,
+        7919
+      ],
+      "summary": "Handles prompt provenance within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
+      "type": "function",
+      "name": "prompt_transform_staleness",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7921,
+        7952
+      ],
+      "summary": "Handles prompt transform staleness within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
+      "type": "function",
+      "name": "quick_transform_staleness",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7957,
+        7987
+      ],
+      "summary": "Handles quick transform staleness within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
+      "type": "function",
+      "name": "apply_prompt_variant",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7999,
+        8019
+      ],
+      "summary": "Handles apply prompt variant within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
+      "type": "function",
+      "name": "prepare_prompt_variants",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8021,
+        8046
+      ],
+      "summary": "Handles prepare prompt variants within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "function",
+      "name": "process_background_events",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8049,
+        9191
+      ],
+      "summary": "Handles process background events within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_progress",
+      "type": "function",
+      "name": "handle_progress",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9193,
+        9210
+      ],
+      "summary": "Handles handle progress within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
+      "type": "function",
+      "name": "build_local_model_catalog",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9213,
+        9231
+      ],
+      "summary": "Handles build local model catalog within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:decode_live_preview",
+      "type": "function",
+      "name": "decode_live_preview",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9237,
+        9254
+      ],
+      "summary": "Handles decode live preview within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
+      "type": "function",
+      "name": "reduce_progress_state",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9271,
+        9431
+      ],
+      "summary": "Handles reduce progress state within the interactive TUI application state machine.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "class",
+      "name": "PromptTransformSnapshot",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        27,
+        38
+      ],
+      "summary": "Defines prompt transform snapshot state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "class",
+      "name": "LicenseDownloadRequirement",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        43,
+        46
+      ],
+      "summary": "Defines license download requirement state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "class",
+      "name": "DurableGenerationChildOutcome",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        49,
+        70
+      ],
+      "summary": "Defines durable generation child outcome state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "class",
+      "name": "BackgroundEvent",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        73,
+        234
+      ],
+      "summary": "Defines background event state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "class",
+      "name": "ProgressLogEntry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        238,
+        241
+      ],
+      "summary": "Defines progress log entry state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "class",
+      "name": "ProgressStyle",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        244,
+        249
+      ],
+      "summary": "Defines progress style state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "class",
+      "name": "ProgressState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        259,
+        293
+      ],
+      "summary": "Defines progress state state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "class",
+      "name": "CreateMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        456,
+        460
+      ],
+      "summary": "Defines create mode state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "class",
+      "name": "GenerateFocus",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        464,
+        470
+      ],
+      "summary": "Defines generate focus state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "class",
+      "name": "ParamField",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        502,
+        555
+      ],
+      "summary": "Defines param field state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "class",
+      "name": "SeedMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        637,
+        645
+      ],
+      "summary": "Defines seed mode state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "class",
+      "name": "GenerateParams",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        687,
+        790
+      ],
+      "summary": "Defines generate params state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "class",
+      "name": "GenerationMetadataSnapshot",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        795,
+        799
+      ],
+      "summary": "Defines generation metadata snapshot state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "class",
+      "name": "InferenceMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        817,
+        825
+      ],
+      "summary": "Defines inference mode state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "class",
+      "name": "GenerateState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1288,
+        1363
+      ],
+      "summary": "Defines generate state state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "class",
+      "name": "HeldPrintRetry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1367,
+        1371
+      ],
+      "summary": "Defines held print retry state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "class",
+      "name": "HeldHost",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1375,
+        1378
+      ],
+      "summary": "Defines held host state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "class",
+      "name": "HeldBatch",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1385,
+        1389
+      ],
+      "summary": "Defines held batch state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "class",
+      "name": "GalleryViewMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1443,
+        1447
+      ],
+      "summary": "Defines gallery view mode state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "class",
+      "name": "GalleryState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1454,
+        1502
+      ],
+      "summary": "Defines gallery state state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "class",
+      "name": "GalleryOrigin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1601,
+        1609
+      ],
+      "summary": "Defines gallery origin state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "class",
+      "name": "GalleryEntry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1652,
+        1667
+      ],
+      "summary": "Defines gallery entry state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "class",
+      "name": "RemovalKind",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1721,
+        1730
+      ],
+      "summary": "Defines removal kind state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "class",
+      "name": "ModelsState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1761,
+        1766
+      ],
+      "summary": "Defines models state state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "class",
+      "name": "SettingsKey",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1807,
+        1855
+      ],
+      "summary": "Defines settings key state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "class",
+      "name": "SettingsFieldType",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1859,
+        1872
+      ],
+      "summary": "Defines settings field type state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "class",
+      "name": "SettingsRow",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1876,
+        1885
+      ],
+      "summary": "Defines settings row state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "class",
+      "name": "SettingsFocus",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1909,
+        1913
+      ],
+      "summary": "Defines settings focus state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "class",
+      "name": "SettingsState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1917,
+        1938
+      ],
+      "summary": "Defines settings state state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "class",
+      "name": "Popup",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1941,
+        2033
+      ],
+      "summary": "Defines popup state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "class",
+      "name": "UpscalePickerPurpose",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2037,
+        2043
+      ],
+      "summary": "Defines upscale picker purpose state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "class",
+      "name": "ConfirmAction",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2054,
+        2067
+      ],
+      "summary": "Defines confirm action state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:App",
+      "type": "class",
+      "name": "App",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2070,
+        2121
+      ],
+      "summary": "Top-level TUI state container and event coordinator spanning generation, Library, models, machines, settings, progress, and asynchronous background results.",
+      "tags": [
+        "tui",
+        "state-machine",
+        "event-handler",
+        "application"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "class",
+      "name": "LayoutAreas",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2125,
+        2138
+      ],
+      "summary": "Defines layout areas state or command data used by app.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/lib.rs",
+      "type": "file",
+      "name": "lib.rs",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "summary": "Bootstraps the terminal UI, selects image protocol support, applies strict host launch policy, chooses the initial workspace, and runs the Crossterm event loop with safe terminal restoration.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "terminal",
+        "event-loop",
+        "host-routing"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "function",
+      "name": "run_tui",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        61,
+        68
+      ],
+      "summary": "Implements run tui for this module's primary behavior.",
+      "tags": [
+        "utility",
+        "generation-form",
+        "capabilities"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "function",
+      "name": "run_tui_with_options",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        71,
+        118
+      ],
+      "summary": "Initializes the TUI from explicit launch options, opens the requested workspace, and guarantees terminal cleanup around the event loop.",
+      "tags": [
+        "utility",
+        "generation-form",
+        "capabilities"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_event_loop",
+      "type": "function",
+      "name": "run_event_loop",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        120,
+        165
+      ],
+      "summary": "Implements run event loop for this module's primary behavior.",
+      "tags": [
+        "utility",
+        "generation-form",
+        "capabilities"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "class",
+      "name": "TuiInitialWorkspace",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        40,
+        44
+      ],
+      "summary": "Defines tui initial workspace state or command data used by lib.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "class",
+      "name": "TuiLaunchOptions",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        48,
+        55
+      ],
+      "summary": "Defines tui launch options state or command data used by lib.rs.",
+      "tags": [
+        "data-model",
+        "state",
+        "type-definition"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "type": "file",
+      "name": "SourceImageWell.test.ts",
+      "filePath": "desktop/src/components/generate/SourceImageWell.test.ts",
+      "summary": "Tests the desktop source-image well across model capability changes, image picking and dropping, mask editing, source fitting, and conditional controls.",
+      "tags": [
+        "test",
+        "vue",
+        "source-image",
+        "component",
+        "capabilities"
+      ],
+      "complexity": "complex",
+      "languageNotes": "TypeScript code uses typed generation contracts and capability-driven state."
+    },
+    {
+      "id": "file:desktop/src/lib/desktopImageDrop.ts",
+      "type": "file",
+      "name": "desktopImageDrop.ts",
+      "filePath": "desktop/src/lib/desktopImageDrop.ts",
+      "summary": "Applies a dropped desktop image to a generation form, selecting a compatible model when necessary and reconciling capability-dependent form state.",
+      "tags": [
+        "utility",
+        "drag-and-drop",
+        "generation-form",
+        "capabilities",
+        "desktop",
+        "tested"
+      ],
+      "complexity": "simple",
+      "languageNotes": "TypeScript code uses typed generation contracts and capability-driven state."
+    },
+    {
+      "id": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
+      "type": "function",
+      "name": "applyDesktopImageDrop",
+      "filePath": "desktop/src/lib/desktopImageDrop.ts",
+      "lineRange": [
+        27,
+        54
+      ],
+      "summary": "Stages a dropped image in the generation form, selecting a compatible installed model and reconciling its capabilities when required.",
+      "tags": [
+        "utility",
+        "generation-form",
+        "capabilities"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/lib/generateForm.test.ts",
+      "type": "file",
+      "name": "generateForm.test.ts",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "summary": "Comprehensively tests generation-form construction, restoration, model capability reconciliation, request serialization, file-under metadata, negative prompts, and video extension controls.",
+      "tags": [
+        "test",
+        "generation-form",
+        "serialization",
+        "capabilities",
+        "validation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "TypeScript code uses typed generation contracts and capability-driven state."
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:ltx2Model",
+      "type": "function",
+      "name": "ltx2Model",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        26,
+        40
+      ],
+      "summary": "Verifies ltx2model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:profiledLtx2Model",
+      "type": "function",
+      "name": "profiledLtx2Model",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        42,
+        125
+      ],
+      "summary": "Verifies profiled ltx2model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:qwenEditModel",
+      "type": "function",
+      "name": "qwenEditModel",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        1095,
+        1105
+      ],
+      "summary": "Verifies qwen edit model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:wanModel",
+      "type": "function",
+      "name": "wanModel",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        1441,
+        1451
+      ],
+      "summary": "Verifies wan model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:sd15Model",
+      "type": "function",
+      "name": "sd15Model",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        1681,
+        1691
+      ],
+      "summary": "Verifies sd15model behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.test.ts:richImageMetadata",
+      "type": "function",
+      "name": "richImageMetadata",
+      "filePath": "desktop/src/lib/generateForm.test.ts",
+      "lineRange": [
+        1693,
+        1719
+      ],
+      "summary": "Verifies rich image metadata behavior through the file's integration or component test harness.",
+      "tags": [
+        "test",
+        "validation",
+        "integration-test"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/lib/generateForm.ts",
+      "type": "file",
+      "name": "generateForm.ts",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "summary": "Defines the cross-surface generation form state and the pure normalization, capability reconciliation, request serialization, and reuse hydration logic that translate authored settings into Mold generation requests.",
+      "tags": [
+        "data-model",
+        "serialization",
+        "validation",
+        "generation",
+        "capability-gating",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "TypeScript keeps mutable UI state separate from pure request builders and uses capability-derived pruning to make unsupported fields fail closed."
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:seedMode",
+      "type": "function",
+      "name": "seedMode",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        125,
+        127
+      ],
+      "summary": "Interprets an empty seed as random and any entered seed as fixed.",
+      "tags": [
+        "utility",
+        "generation",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
+      "type": "function",
+      "name": "newGenerateForm",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        290,
+        354
+      ],
+      "summary": "Creates a complete generation-form draft with conservative defaults for every supported image, video, filing, and conditioning feature.",
+      "tags": [
+        "factory",
+        "generation",
+        "form-state",
+        "defaults"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
+      "type": "function",
+      "name": "cloneGenerateForm",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        361,
+        394
+      ],
+      "summary": "Takes a submission-safe deep-enough snapshot of mutable form arrays and nested media and policy state.",
+      "tags": [
+        "serialization",
+        "generation",
+        "snapshot",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
+      "type": "function",
+      "name": "applyModelDefaults",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        401,
+        440
+      ],
+      "summary": "Applies an installed model's advertised defaults, clears model-owned adapters, and reconciles the remaining draft against the new capability surface.",
+      "tags": [
+        "generation",
+        "defaults",
+        "capability-gating",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
+      "type": "function",
+      "name": "applyRecipeDefaults",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        447,
+        501
+      ],
+      "summary": "Applies one resolved generation recipe as a model-owned settings boundary while preserving user-authored prompt and compatible conditioning.",
+      "tags": [
+        "generation",
+        "defaults",
+        "validation",
+        "capability-gating"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
+      "type": "function",
+      "name": "reconcileModelCapabilities",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        508,
+        712
+      ],
+      "summary": "Reconciles a draft against authoritative model and recipe capabilities, migrating source layouts and parking unsupported media without losing authored work.",
+      "tags": [
+        "generation",
+        "capability-gating",
+        "normalization",
+        "media"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
+      "type": "function",
+      "name": "normalizeLegacyNegativeSnapshot",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        725,
+        745
+      ],
+      "summary": "Upgrades legacy snapshots so a previously implicit default negative prompt remains distinguishable from an explicit clear.",
+      "tags": [
+        "migration",
+        "normalization",
+        "generation",
+        "compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
+      "type": "function",
+      "name": "keepingPrintIdentity",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        762,
+        769
+      ],
+      "summary": "Runs a form rewrite while preserving the print title and creation-time filing preferences owned by the user.",
+      "tags": [
+        "utility",
+        "form-state",
+        "library",
+        "generation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
+      "type": "function",
+      "name": "resetFormToModelDefaults",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        783,
+        798
+      ],
+      "summary": "Resets the draft to fresh defaults while retaining print identity, then applies the selected model's settings.",
+      "tags": [
+        "generation",
+        "defaults",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
+      "type": "function",
+      "name": "resetAdvancedToModelDefaults",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        807,
+        845
+      ],
+      "summary": "Resets only advanced generation controls to model defaults while preserving the primary composer fields and attachments.",
+      "tags": [
+        "generation",
+        "defaults",
+        "form-state",
+        "capability-gating"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
+      "type": "function",
+      "name": "formExtendOverlapFrames",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        861,
+        866
+      ],
+      "summary": "Resolves the effective continuation overlap from explicit, host-default, and family-default values.",
+      "tags": [
+        "utility",
+        "video",
+        "generation",
+        "normalization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:buildRequest",
+      "type": "function",
+      "name": "buildRequest",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        868,
+        1087
+      ],
+      "summary": "Serializes the complete form into a capability-pruned GenerateRequest, validating titles and conditionally carrying filing, media, identity, video, recipe, and source-fit fields.",
+      "tags": [
+        "serialization",
+        "generation",
+        "validation",
+        "capability-gating",
+        "api-request"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
+      "type": "function",
+      "name": "chainFilingFields",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        1098,
+        1115
+      ],
+      "summary": "Builds the title, tags, and collection fields placed on a sequence job's stitched output.",
+      "tags": [
+        "serialization",
+        "library",
+        "sequence",
+        "validation"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
+      "type": "function",
+      "name": "restoredFileUnderState",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        1129,
+        1152
+      ],
+      "summary": "Reconstructs creation-time tags and collection selection while preserving whether the derived title tag had been removed.",
+      "tags": [
+        "serialization",
+        "library",
+        "form-state",
+        "compatibility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
+      "type": "function",
+      "name": "applyMetadataToForm",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        1195,
+        1331
+      ],
+      "summary": "Hydrates a generation draft from saved output metadata, restoring reproducible scalar settings and provenance while clearing unavailable binary media.",
+      "tags": [
+        "serialization",
+        "generation",
+        "reuse",
+        "metadata",
+        "form-state"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
+      "type": "function",
+      "name": "applyRequestToForm",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        1361,
+        1494
+      ],
+      "summary": "Hydrates a generation draft from an exact queued request, including advanced controls and embedded media inputs.",
+      "tags": [
+        "serialization",
+        "generation",
+        "reuse",
+        "api-request",
+        "form-state"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
+      "type": "function",
+      "name": "applyPrefillToForm",
+      "filePath": "desktop/src/lib/generateForm.ts",
+      "lineRange": [
+        1501,
+        1524
+      ],
+      "summary": "Dispatches metadata, exact-request, or legacy scalar prefills through the appropriate form hydration path.",
+      "tags": [
+        "serialization",
+        "generation",
+        "reuse",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/lib/sourceAttachment.ts",
+      "type": "file",
+      "name": "sourceAttachment.ts",
+      "filePath": "desktop/src/lib/sourceAttachment.ts",
+      "summary": "Provides the shared attachment policy that places picked images and videos into the correct generation-form slots while resetting image fit policy.",
+      "tags": [
+        "utility",
+        "media",
+        "generation",
+        "form-state",
+        "tested"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
+      "type": "function",
+      "name": "attachPickedImage",
+      "filePath": "desktop/src/lib/sourceAttachment.ts",
+      "lineRange": [
+        5,
+        9
+      ],
+      "summary": "Attaches picked image bytes and filename to the source slot and restores the default fit policy.",
+      "tags": [
+        "utility",
+        "media",
+        "generation",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
+      "type": "function",
+      "name": "attachPickedVideo",
+      "filePath": "desktop/src/lib/sourceAttachment.ts",
+      "lineRange": [
+        12,
+        14
+      ],
+      "summary": "Attaches a picked video to the form's source-video slot for remote reuse and video conditioning.",
+      "tags": [
+        "utility",
+        "media",
+        "video",
+        "form-state"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "type": "file",
+      "name": "sourceFitPreprocess.test.ts",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.test.ts",
+      "summary": "Exercises source-fit preprocessing with injected canvas operations, covering no-op sizing, upscale caching, crop and padding transforms, mask rebuilding, and MiniMax H3 boundary fitting.",
+      "tags": [
+        "test",
+        "image-processing",
+        "source-fit",
+        "cache",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/lib/sourceFitPreprocess.test.ts:fakeOps",
+      "type": "function",
+      "name": "fakeOps",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.test.ts",
+      "lineRange": [
+        13,
+        32
+      ],
+      "summary": "Builds deterministic fake canvas operations that record image-fit and mask calls for exact preprocessing assertions.",
+      "tags": [
+        "test",
+        "factory",
+        "image-processing",
+        "test-fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "type": "file",
+      "name": "sourceFitPreprocess.ts",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
+      "summary": "Preprocesses source images and H3 boundary frames before submission by optionally upscaling, fitting to the target canvas, rebuilding masks, and caching expensive transforms.",
+      "tags": [
+        "service",
+        "image-processing",
+        "source-fit",
+        "cache",
+        "media",
+        "tested"
+      ],
+      "complexity": "moderate",
+      "languageNotes": "Canvas behavior is dependency-injected so the asynchronous policy flow stays testable outside a real browser canvas."
+    },
+    {
+      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
+      "type": "function",
+      "name": "drawableFitPolicy",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
+      "lineRange": [
+        58,
+        62
+      ],
+      "summary": "Normalizes an absent or upscale-wrapper policy to the concrete policy used for canvas drawing.",
+      "tags": [
+        "utility",
+        "image-processing",
+        "source-fit",
+        "normalization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
+      "type": "function",
+      "name": "applySourceFitPreprocess",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
+      "lineRange": [
+        64,
+        114
+      ],
+      "summary": "Optionally upscales a source, skips already-sized media, fits mismatched media to the target, and rebuilds masks through cached injectable operations.",
+      "tags": [
+        "service",
+        "image-processing",
+        "source-fit",
+        "cache",
+        "media"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
+      "type": "function",
+      "name": "applyH3BoundaryFit",
+      "filePath": "desktop/src/lib/sourceFitPreprocess.ts",
+      "lineRange": [
+        123,
+        152
+      ],
+      "summary": "Fits available MiniMax H3 first and last frames with maskless source policy and refreshes provenance for rewritten boundaries.",
+      "tags": [
+        "service",
+        "image-processing",
+        "source-conditioning",
+        "video",
+        "media"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/mobile/MobileApp.test.ts",
+      "type": "file",
+      "name": "MobileApp.test.ts",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "summary": "Comprehensive integration-style Vitest suite for the remote-only mobile application, spanning durable generation, sequence authoring, navigation, gallery organization, host routing, settings, models, and identity media behavior.",
+      "tags": [
+        "test",
+        "mobile",
+        "integration",
+        "generation",
+        "library"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileApp.test.ts:plannedPlacement",
+      "type": "function",
+      "name": "plannedPlacement",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "lineRange": [
+        127,
+        144
+      ],
+      "summary": "Creates an authoritative planned-placement fixture for routing assertions.",
+      "tags": [
+        "test",
+        "factory",
+        "routing",
+        "test-fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileApp.test.ts:durableBatchResponse",
+      "type": "function",
+      "name": "durableBatchResponse",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "lineRange": [
+        226,
+        256
+      ],
+      "summary": "Converts a submitted durable batch body into deterministic accepted or completed child-job responses.",
+      "tags": [
+        "test",
+        "factory",
+        "generation",
+        "durable-jobs"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileApp.test.ts:durableApiFallback",
+      "type": "function",
+      "name": "durableApiFallback",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "lineRange": [
+        274,
+        303
+      ],
+      "summary": "Provides default capability, durable-admission, chain-job, and status responses for mobile integration tests.",
+      "tags": [
+        "test",
+        "api-handler",
+        "generation",
+        "test-fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileApp.test.ts:heldAdmissions",
+      "type": "function",
+      "name": "heldAdmissions",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "lineRange": [
+        359,
+        441
+      ],
+      "summary": "Intercepts durable generation admissions and exposes controls for settling individual or all child jobs at test-selected times.",
+      "tags": [
+        "test",
+        "factory",
+        "generation",
+        "durable-jobs",
+        "async"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:desktop/src/mobile/MobileApp.test.ts:FakeIntersectionObserver",
+      "type": "class",
+      "name": "FakeIntersectionObserver",
+      "filePath": "desktop/src/mobile/MobileApp.test.ts",
+      "lineRange": [
+        479,
+        501
+      ],
+      "summary": "Test double that tracks observed elements and synchronously emits configurable intersection entries.",
+      "tags": [
+        "test",
+        "test-fixture",
+        "browser-api",
+        "event-handler"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "type": "file",
+      "name": "MobileSourceControls.test.ts",
+      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
+      "summary": "Validates mobile source-media controls across image, video, mask, reference crop, and MiniMax H3 boundary workflows, including file-size and capability gates.",
+      "tags": [
+        "test",
+        "mobile",
+        "media",
+        "source-conditioning",
+        "validation"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileSourceControls.test.ts:model",
+      "type": "function",
+      "name": "model",
+      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
+      "lineRange": [
+        23,
+        37
+      ],
+      "summary": "Builds a minimal installed-model fixture for source-control capability tests.",
+      "tags": [
+        "test",
+        "factory",
+        "model",
+        "test-fixture"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:desktop/src/mobile/MobileSourceControls.test.ts:chooseFiles",
+      "type": "function",
+      "name": "chooseFiles",
+      "filePath": "desktop/src/mobile/MobileSourceControls.test.ts",
+      "lineRange": [
+        39,
+        52
+      ],
+      "summary": "Injects files into a mounted input and waits for FileReader task completion before assertions.",
+      "tags": [
+        "test",
+        "utility",
+        "media",
+        "async"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "type": "file",
+      "name": "GenerateView.prepared.test.ts",
+      "filePath": "desktop/src/views/GenerateView.prepared.test.ts",
+      "summary": "Tests desktop prepared-expansion batches, including prompt expansion and remix flows, model pulls, placement, source preprocessing, and prepared-card lifecycle behavior.",
+      "tags": [
+        "test",
+        "desktop",
+        "generation",
+        "prompt-expansion",
+        "routing"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:desktop/src/views/GenerateView.prepared.test.ts:mountView",
+      "type": "function",
+      "name": "mountView",
+      "filePath": "desktop/src/views/GenerateView.prepared.test.ts",
+      "lineRange": [
+        93,
+        114
+      ],
+      "summary": "Mounts GenerateView with the composer and prepared-expansion surfaces kept real for interaction assertions.",
+      "tags": [
+        "test",
+        "factory",
+        "component",
+        "desktop"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "type": "file",
+      "name": "GenerateView.sequence.test.ts",
+      "filePath": "desktop/src/views/GenerateView.sequence.test.ts",
+      "summary": "Tests desktop sequence-mode creation, route/query synchronization, durable chain jobs, cached filmstrip recovery, source fitting, and reuse handoff into the sequence composer.",
+      "tags": [
+        "test",
+        "desktop",
+        "sequence",
+        "generation",
+        "recovery"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:studio/lib/expansionRouting.test.ts",
+      "type": "file",
+      "name": "expansionRouting.test.ts",
+      "filePath": "studio/lib/expansionRouting.test.ts",
+      "summary": "Covers expansion host selection for automatic, most-capable, and pinned policies, plus missing-model error parsing and capability model-name fallback.",
+      "tags": [
+        "test",
+        "routing",
+        "prompt-expansion",
+        "capabilities"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:studio/lib/expansionRouting.ts",
+      "type": "file",
+      "name": "expansionRouting.ts",
+      "filePath": "studio/lib/expansionRouting.ts",
+      "summary": "Centralizes cross-surface routing policy for prompt expansion, preferring the generation host unless it is known to lack the expansion model and safely rerouting only to eligible hosts with positive capability evidence.",
+      "tags": [
+        "service",
+        "routing",
+        "prompt-expansion",
+        "capability-gating",
+        "multi-host",
+        "tested"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
+      "type": "function",
+      "name": "resolveExpansionRoute",
+      "filePath": "studio/lib/expansionRouting.ts",
+      "lineRange": [
+        79,
+        105
+      ],
+      "summary": "Chooses whether expansion stays on the generation route, reroutes to a positively capable eligible host, or reports the model missing.",
+      "tags": [
+        "routing",
+        "prompt-expansion",
+        "capability-gating",
+        "multi-host"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
+      "type": "function",
+      "name": "expansionPolicyForSelection",
+      "filePath": "studio/lib/expansionRouting.ts",
+      "lineRange": [
+        111,
+        120
+      ],
+      "summary": "Normalizes persisted target-selection sentinels into auto, most-capable, or pinned expansion policies.",
+      "tags": [
+        "utility",
+        "routing",
+        "normalization",
+        "multi-host"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
+      "type": "function",
+      "name": "parseMissingExpandModel",
+      "filePath": "studio/lib/expansionRouting.ts",
+      "lineRange": [
+        128,
+        134
+      ],
+      "summary": "Extracts a pullable expansion model only from the server's definitive missing-model error shape.",
+      "tags": [
+        "validation",
+        "parsing",
+        "prompt-expansion",
+        "error-handling"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/expansionRouting.ts:expandModelId",
+      "type": "function",
+      "name": "expandModelId",
+      "filePath": "studio/lib/expansionRouting.ts",
+      "lineRange": [
+        140,
+        145
+      ],
+      "summary": "Returns the host-advertised expansion model identifier or the manifest-compatible default.",
+      "tags": [
+        "utility",
+        "prompt-expansion",
+        "compatibility",
+        "capabilities"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:studio/lib/sourceFit.test.ts",
+      "type": "file",
+      "name": "sourceFit.test.ts",
+      "filePath": "studio/lib/sourceFit.test.ts",
+      "summary": "Exercises the shared source-fit policy parser, geometry resolver, padding masks, maskless coercion, and human-readable descriptions across generation surfaces.",
+      "tags": [
+        "test",
+        "source-media",
+        "geometry"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:studio/lib/sourceFit.ts",
+      "type": "file",
+      "name": "sourceFit.ts",
+      "filePath": "studio/lib/sourceFit.ts",
+      "summary": "Defines framework-free source-image fitting policies and geometry used across web, desktop, mobile, and sequence generation. It validates provenance, resolves crop or padding transforms, and adapts unsafe repaint modes for maskless models.",
+      "tags": [
+        "utility",
+        "source-media",
+        "validation",
+        "geometry",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "TypeScript uses explicit discriminated unions and capability-gated state to keep shared generation behavior deterministic."
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:defaultSourceFitPolicy",
+      "type": "function",
+      "name": "defaultSourceFitPolicy",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        27,
+        29
+      ],
+      "summary": "Returns the shared crop-fill policy used for newly attached source images.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:sourceFitHelp",
+      "type": "function",
+      "name": "sourceFitHelp",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        72,
+        74
+      ],
+      "summary": "Looks up concise help text for a source-fit mode.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
+      "type": "function",
+      "name": "parseSourceFitPolicy",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        85,
+        121
+      ],
+      "summary": "Defensively validates and reconstructs source-fit policy data restored from output provenance.",
+      "tags": [
+        "validation",
+        "normalization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
+      "type": "function",
+      "name": "sourceFitPolicyForMode",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        124,
+        142
+      ],
+      "summary": "Expands a compact fit-mode choice into a complete policy while enforcing mask capability.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
+      "type": "function",
+      "name": "resolveSourceFitTransform",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        175,
+        227
+      ],
+      "summary": "Computes proportional draw dimensions, offsets, and mask behavior for fitting source media to a target canvas.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
+      "type": "function",
+      "name": "maskPaddingRectangles",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        229,
+        259
+      ],
+      "summary": "Derives the non-overlapping padded rectangles that should be repainted around fitted source content.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
+      "type": "function",
+      "name": "coerceSourceFitForMaskless",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        267,
+        280
+      ],
+      "summary": "Rewrites repaint-dependent fitting policies into centered crop policies for models without mask support.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:studio/lib/sourceFit.ts:describeSourceFit",
+      "type": "function",
+      "name": "describeSourceFit",
+      "filePath": "studio/lib/sourceFit.ts",
+      "lineRange": [
+        282,
+        295
+      ],
+      "summary": "Formats a source-fit policy as a concise user-facing description.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "type": "file",
+      "name": "SequenceOpeningImagePanel.test.ts",
+      "filePath": "web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "summary": "Verifies the sequence opening-image control, including upload validation, draft-store synchronization, source-fit defaults, removal, and gallery-picker behavior.",
+      "tags": [
+        "test",
+        "component",
+        "sequence-media"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:web/src/components/create/SourceMediaPanel.test.ts",
+      "type": "file",
+      "name": "SourceMediaPanel.test.ts",
+      "filePath": "web/src/components/create/SourceMediaPanel.test.ts",
+      "summary": "Covers the Create source-media panel across model families, validating capability-driven wells, source fitting, masks, control inputs, video continuation, and emitted form updates.",
+      "tags": [
+        "test",
+        "component",
+        "source-media"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:web/src/composables/useGenerateForm.test.ts",
+      "type": "file",
+      "name": "useGenerateForm.test.ts",
+      "filePath": "web/src/composables/useGenerateForm.test.ts",
+      "summary": "Comprehensively tests generation-form defaults, model capability reconciliation, durable media persistence, metadata restoration, request serialization, and family-specific controls.",
+      "tags": [
+        "test",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.test.ts:makeModel",
+      "type": "function",
+      "name": "makeModel",
+      "filePath": "web/src/composables/useGenerateForm.test.ts",
+      "lineRange": [
+        22,
+        40
+      ],
+      "summary": "Builds a representative model row with defaults for generation-form tests.",
+      "tags": [
+        "test",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:web/src/composables/useGenerateForm.ts",
+      "type": "file",
+      "name": "useGenerateForm.ts",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "summary": "Owns the singleton reactive generation form for the web Studio, including defaults, persistence, durable media hydration, metadata restoration, model reconciliation, and final wire-request construction.",
+      "tags": [
+        "hook",
+        "form-state",
+        "persistence",
+        "serialization",
+        "validation",
+        "tested"
+      ],
+      "complexity": "complex",
+      "languageNotes": "TypeScript uses explicit discriminated unions and capability-gated state to keep shared generation behavior deterministic."
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
+      "type": "function",
+      "name": "promptWithStyle",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        98,
+        102
+      ],
+      "summary": "Applies the selected style preset to the current prompt.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:selectedFamily",
+      "type": "function",
+      "name": "selectedFamily",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        108,
+        134
+      ],
+      "summary": "Normalizes the selected model and pipeline into the effective generation family.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:defaultForm",
+      "type": "function",
+      "name": "defaultForm",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        136,
+        199
+      ],
+      "summary": "Constructs a complete fresh generation-form state with cross-surface defaults.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
+      "type": "function",
+      "name": "sanitizePersistedForm",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        210,
+        249
+      ],
+      "summary": "Normalizes stored form state, strips embedded media bytes, and repairs fields before restoration.",
+      "tags": [
+        "validation",
+        "normalization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
+      "type": "function",
+      "name": "cloneTemplateForm",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        256,
+        258
+      ],
+      "summary": "Deep-clones generation-form state for safe template manipulation.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:modelDefaultsPatch",
+      "type": "function",
+      "name": "modelDefaultsPatch",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        260,
+        521
+      ],
+      "summary": "Derives the full form-state patch required when switching to a model with different defaults and capabilities.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
+      "type": "function",
+      "name": "settingsResetPatch",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        534,
+        550
+      ],
+      "summary": "Resets model-controlled settings while preserving authored prompt and selection state.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
+      "type": "function",
+      "name": "normalizeLegacyNegativeFormState",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        564,
+        585
+      ],
+      "summary": "Migrates legacy negative-prompt state against installed model defaults without losing explicit user intent.",
+      "tags": [
+        "validation",
+        "normalization",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
+      "type": "function",
+      "name": "applyMetadataToForm",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        596,
+        740
+      ],
+      "summary": "Restores reusable generation settings, source media provenance, filing, identity, and family controls from output metadata.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:stripH3AuthoringMedia",
+      "type": "function",
+      "name": "stripH3AuthoringMedia",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        748,
+        773
+      ],
+      "summary": "Removes heavy H3 authoring bytes while retaining durable descriptors for persisted form state.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:ensureDraftIds",
+      "type": "function",
+      "name": "ensureDraftIds",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        775,
+        799
+      ],
+      "summary": "Assigns durable identifiers to every staged media item before persistence.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:h3MediaFromState",
+      "type": "function",
+      "name": "h3MediaFromState",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        801,
+        817
+      ],
+      "summary": "Collects H3 boundary and reference media from the form into durable draft records.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:mediaFromState",
+      "type": "function",
+      "name": "mediaFromState",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        819,
+        832
+      ],
+      "summary": "Collects every staged media payload that must be persisted independently of localStorage.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:hydrateDraftMedia",
+      "type": "function",
+      "name": "hydrateDraftMedia",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        845,
+        956
+      ],
+      "summary": "Reattaches durable media bytes to a restored form and clears incomplete groups safely.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:load",
+      "type": "function",
+      "name": "load",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        958,
+        983
+      ],
+      "summary": "Loads and migrates the persisted generation-form descriptor with safe defaults on malformed state.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:persist",
+      "type": "function",
+      "name": "persist",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        985,
+        1010
+      ],
+      "summary": "Atomically persists staged media before publishing its lightweight form descriptor.",
+      "tags": [
+        "persistence",
+        "media",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
+      "type": "function",
+      "name": "useGenerateForm",
+      "filePath": "web/src/composables/useGenerateForm.ts",
+      "lineRange": [
+        1064,
+        1438
+      ],
+      "summary": "Creates the singleton reactive form API and serializes capability-gated state into generation requests.",
+      "tags": [
+        "utility",
+        "form-state",
+        "serialization"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "file:web/src/pages/CreatePage.test.ts",
+      "type": "file",
+      "name": "CreatePage.test.ts",
+      "filePath": "web/src/pages/CreatePage.test.ts",
+      "summary": "Provides broad integration coverage for the Create workspace, including host routing, model selection, one-shot and sequence submission, filing, identity media, handoffs, and interaction state.",
+      "tags": [
+        "test",
+        "integration",
+        "create-workspace"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:web/src/pages/CreatePage.test.ts:installedModelRow",
+      "type": "function",
+      "name": "installedModelRow",
+      "filePath": "web/src/pages/CreatePage.test.ts",
+      "lineRange": [
+        269,
+        283
+      ],
+      "summary": "Builds an installed model fixture for Create page integration scenarios.",
+      "tags": [
+        "test",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/pages/CreatePage.test.ts:installedSequenceModel",
+      "type": "function",
+      "name": "installedSequenceModel",
+      "filePath": "web/src/pages/CreatePage.test.ts",
+      "lineRange": [
+        361,
+        372
+      ],
+      "summary": "Builds a sequence-capable installed model fixture for Create page tests.",
+      "tags": [
+        "test",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/pages/CreatePage.test.ts:pageStubs",
+      "type": "function",
+      "name": "pageStubs",
+      "filePath": "web/src/pages/CreatePage.test.ts",
+      "lineRange": [
+        4976,
+        5079
+      ],
+      "summary": "Defines stable Vue component stubs used to isolate Create page integration behavior.",
+      "tags": [
+        "test",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:web/src/pages/LibraryPage.test.ts",
+      "type": "file",
+      "name": "LibraryPage.test.ts",
+      "filePath": "web/src/pages/LibraryPage.test.ts",
+      "summary": "Exercises the web Library workspace for merged gallery rendering, filtering, media viewing, reuse, save and delete behavior, provenance badges, selection, and host-aware actions.",
+      "tags": [
+        "test",
+        "integration",
+        "library"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:web/src/pages/LibraryPage.test.ts:makeEntry",
+      "type": "function",
+      "name": "makeEntry",
+      "filePath": "web/src/pages/LibraryPage.test.ts",
+      "lineRange": [
+        131,
+        152
+      ],
+      "summary": "Builds a gallery entry fixture with deterministic metadata for Library page tests.",
+      "tags": [
+        "test",
+        "fixture",
+        "utility"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:web/src/pages/LibraryPage.test.ts:mountPage",
+      "type": "function",
+      "name": "mountPage",
+      "filePath": "web/src/pages/LibraryPage.test.ts",
+      "lineRange": [
+        196,
+        207
+      ],
+      "summary": "Mounts the Library page with its required application-level component stubs.",
+      "tags": [
+        "test",
+        "fixture",
         "utility"
       ],
       "complexity": "simple"
@@ -303890,13 +304635,6 @@
     },
     {
       "source": "file:desktop/src/lib/ipc.ts",
-      "target": "file:desktop/src/lib/desktopImageDrop.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/ipc.ts",
       "target": "file:desktop/src/lib/notificationAction.ts",
       "type": "imports",
       "direction": "forward",
@@ -306710,76 +307448,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/appPrefs.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/chainJobs.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/composer.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/connection.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/contextMenu.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/models.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/ui.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:studio/lib/fileUnder.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:studio/stores/sequenceDraft.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/views/LibraryView.sequence.test.ts",
       "target": "function:desktop/src/views/LibraryView.sequence.test.ts:mountView",
       "type": "contains",
@@ -309329,34 +309997,6 @@
       "weight": 1
     },
     {
-      "source": "file:desktop/src/lib/desktopImageDrop.test.ts",
-      "target": "file:desktop/src/lib/desktopImageDrop.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "file:desktop/src/lib/capabilities.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/lib/generateModels.test.ts",
       "target": "function:desktop/src/lib/generateModels.test.ts:model",
       "type": "contains",
@@ -310234,62 +310874,6 @@
     {
       "source": "file:desktop/src/lib/sequenceParams.ts",
       "target": "file:studio/lib/sequenceForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.test.ts",
-      "target": "file:desktop/src/lib/sourceAttachment.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.test.ts:fakeOps",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "target": "file:ui/lib/sourceFitPreprocessCache.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -312348,13 +312932,6 @@
     {
       "source": "file:studio/lib/generationSourceMedia.ts",
       "target": "file:studio/lib/draftMediaStore.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:studio/lib/generationSourceMedia.ts",
-      "target": "file:studio/lib/sourceFit.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -319113,573 +319690,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:validate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:validate",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_candidate_dirs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:select_legacy_dynamic_expand_device",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:report_expand_memory_status_with",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:set_on_progress",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:set_on_progress",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_config",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:expand",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:sample_token",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:find_gguf_in_dir",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "function:crates/mold-inference/src/expand.rs:find_tokenizer_in_dir",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:LocalExpander",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "class:crates/mold-inference/src/expand.rs:LocalExpander",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:validate",
-      "target": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:validate",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:validate",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
-      "target": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
-      "target": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_candidate_dirs",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:find_gguf_in_dir",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:find_tokenizer_in_dir",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
-      "target": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
-      "target": "function:crates/mold-inference/src/expand.rs:validate",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "target": "function:crates/mold-inference/src/expand.rs:expand",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
-      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:from_config",
-      "target": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "target": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "target": "function:crates/mold-inference/src/expand.rs:select_legacy_dynamic_expand_device",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "target": "function:crates/mold-inference/src/expand.rs:report_expand_memory_status_with",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "target": "function:crates/mold-inference/src/expand.rs:new",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "target": "function:crates/mold-inference/src/expand.rs:sample_token",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/expand.rs:expand",
-      "target": "function:crates/mold-inference/src/expand.rs:generate_text",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
-      "target": "file:crates/mold-inference/src/device.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:crates/mold-inference/src/flux/identity.rs",
@@ -348732,13 +348742,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "target": "file:web/src/components/create/SequenceOpeningImagePanel.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:web/src/components/create/advanced/ExtendVideoControls.test.ts",
       "target": "file:web/src/components/create/advanced/ExtendVideoControls.vue",
       "type": "imports",
@@ -358756,13 +358759,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:studio/lib/sequenceForm.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:studio/lib/sequenceReuse.test.ts",
       "target": "function:studio/lib/sequenceReuse.test.ts:chain",
       "type": "contains",
@@ -358929,111 +358925,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:studio/lib/sourceFit.test.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:sourceFitHelp",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:sourceFitHelp",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:describeSourceFit",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "function:studio/lib/sourceFit.ts:describeSourceFit",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:studio/lib/sourceImageCapability.test.ts",
@@ -382855,97 +382746,6 @@
       "type": "calls",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_event_loop",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "target": "function:crates/mold-tui/src/lib.rs:run_event_loop",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/animation.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/gallery_trash.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/history.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/identity.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/motion.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/prefs.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/test_env.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/thumbnails.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/ui/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:crates/mold-tui/src/motion.rs",
@@ -422232,69 +422032,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:studio/lib/expansionRouting.test.ts",
-      "target": "file:studio/lib/expansionRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:expandModelId",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "function:studio/lib/expansionRouting.ts:expandModelId",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:studio/lib/galleryThumbnailSize.test.ts",
       "target": "file:studio/lib/galleryThumbnailSize.ts",
       "type": "imports",
@@ -424533,14 +424270,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "file:desktop/src/lib/desktopImageDrop.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:desktop/src/lib/generateModels.ts",
       "target": "file:desktop/src/lib/generateModels.test.ts",
       "type": "tested_by",
@@ -424575,14 +424304,6 @@
     {
       "source": "file:desktop/src/lib/sequenceParams.ts",
       "target": "file:desktop/src/lib/sequenceParams.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "file:desktop/src/lib/sourceAttachment.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -424965,14 +424686,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:web/src/components/create/SequenceOpeningImagePanel.vue",
-      "target": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:web/src/components/create/advanced/ExtendVideoControls.vue",
       "target": "file:web/src/components/create/advanced/ExtendVideoControls.test.ts",
       "type": "tested_by",
@@ -425311,14 +425024,6 @@
     {
       "source": "file:studio/lib/sequenceReuse.ts",
       "target": "file:studio/lib/sequenceReuse.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:studio/lib/sourceFit.ts",
-      "target": "file:studio/lib/sourceFit.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -425863,14 +425568,6 @@
     {
       "source": "file:studio/lib/cancellationRetry.ts",
       "target": "file:studio/lib/cancellationRetry.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:studio/lib/expansionRouting.ts",
-      "target": "file:studio/lib/expansionRouting.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -429789,13 +429486,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:desktop/src/lib/api/types.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/mobile/MobileHostDetail.test.ts",
       "target": "function:desktop/src/mobile/MobileHostDetail.test.ts:serverStatus",
       "type": "contains",
@@ -429965,13 +429655,6 @@
     },
     {
       "source": "file:desktop/src/mobile/MobileSequenceComposer.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSequenceComposer.test.ts",
       "target": "file:desktop/src/lib/testSupport/memoryLocalStorage.ts",
       "type": "imports",
       "direction": "forward",
@@ -430029,13 +429712,6 @@
     {
       "source": "file:desktop/src/mobile/MobileSequenceOpeningImage.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSequenceOpeningImage.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -430461,13 +430137,6 @@
       "weight": 1
     },
     {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "function:desktop/src/views/GenerateView.prepared.test.ts:mountView",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:desktop/src/stores/hosts.ts",
       "target": "file:desktop/src/lib/api/client.ts",
       "type": "imports",
@@ -430686,13 +430355,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.missingModel.test.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.missingModel.test.ts",
       "target": "file:desktop/src/stores/composer.ts",
       "type": "imports",
       "direction": "forward",
@@ -430756,153 +430418,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.missingModel.test.ts",
-      "target": "file:desktop/src/views/GenerateView.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/components/generate/ExpandControl.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/components/generate/ExpansionPullStatus.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/components/generate/MissingModelDialog.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/components/generate/PreparedExpansionBatch.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/api/catalog.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/api/client.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/api/expand.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/api/remix.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/appPrefs.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/composer.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/connection.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/downloads.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/hostModels.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/models.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
-      "target": "file:desktop/src/stores/ui.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
       "target": "file:desktop/src/views/GenerateView.vue",
       "type": "imports",
       "direction": "forward",
@@ -431107,13 +430622,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.sourcefit.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sourcefit.test.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -437022,13 +436530,6 @@
     {
       "source": "file:crates/mold-inference/src/lib.rs",
       "target": "file:crates/mold-inference/src/error.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-inference/src/lib.rs",
-      "target": "file:crates/mold-inference/src/expand.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -445840,20 +445341,6 @@
       "weight": 0.8
     },
     {
-      "source": "function:crates/mold-inference/src/progress.rs:set_cancellation_token",
-      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "function:crates/mold-inference/src/progress.rs:clear_cancellation_token",
-      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-inference/src/reference_media.rs",
       "target": "function:crates/mold-inference/src/reference_media.rs:samples_per_channel",
       "type": "contains",
@@ -446055,727 +445542,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:ltx2Model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:profiledLtx2Model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:qwenEditModel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:wanModel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:sd15Model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "function:desktop/src/lib/generateForm.test.ts:richImageMetadata",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:seedMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:seedMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:buildRequest",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:buildRequest",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "target": "file:desktop/src/components/generate/ImagePickerModal.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "target": "file:desktop/src/components/generate/MaskEditorModal.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "target": "file:desktop/src/components/generate/SourceImageWell.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "target": "file:studio/components/ReferenceCropEditor.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:desktop/src/lib/capabilities.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:studio/lib/extend.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:studio/lib/fileUnder.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:studio/lib/generationProfile.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.test.ts",
-      "target": "file:studio/lib/negativePrompt.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:desktop/src/lib/capabilities.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:desktop/src/lib/generateModels.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/cameraMotion.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/extend.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/fileUnder.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/generationCapabilities.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/generationProfile.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/guidanceOverrides.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/identityConditioning.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/libraryOrganization.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/ltx2Control.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/ltx2Pipeline.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/minimaxH3Authoring.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/negativePrompt.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/outputReuse.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/sequence.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/sourceImageCapability.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/videoDuration.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:studio/lib/wanRecipe.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/api/client.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/generationTemplates.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/lib/testSupport/memoryLocalStorage.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileApp.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileLoraControls.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/MobileTemplates.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/galleryCache.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileDownloads.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileGenerationRecovery.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:desktop/src/mobile/mobileTemplateStorage.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/components/IdentityPhotoWell.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/lib/libraryOrganization.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "file:studio/stores/sequenceDraft.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "function:desktop/src/mobile/MobileApp.test.ts:plannedPlacement",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "function:desktop/src/mobile/MobileApp.test.ts:durableBatchResponse",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "function:desktop/src/mobile/MobileApp.test.ts:durableApiFallback",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "function:desktop/src/mobile/MobileApp.test.ts:heldAdmissions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.test.ts",
-      "target": "class:desktop/src/mobile/MobileApp.test.ts:FakeIntersectionObserver",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "function:desktop/src/mobile/MobileSourceControls.test.ts:model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "function:desktop/src/mobile/MobileSourceControls.test.ts:chooseFiles",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
     },
     {
       "source": "file:desktop/src/mobile/identity.ts",
@@ -446988,99 +445754,8 @@
       "weight": 0.8
     },
     {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "file:studio/lib/minimaxH3Authoring.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "file:studio/lib/sourceFitCanvas.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "file:ui/lib/sourceFitPreprocessCache.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/mobile/MobileImagePickerSheet.test.ts",
       "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/components/generate/MaskEditorModal.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/lib/generateValidation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/mobile/MobileReferenceCropSheet.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
-      "target": "file:studio/components/ReferenceCropEditor.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/identity.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -447102,13 +445777,6 @@
     {
       "source": "file:desktop/src/mobile/identity.test.ts",
       "target": "file:studio/lib/identityConditioning.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/identity.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -447137,13 +445805,6 @@
     {
       "source": "file:desktop/src/mobile/mobileGenerationPreparation.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/mobileGenerationPreparation.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -447185,21 +445846,7 @@
     },
     {
       "source": "file:desktop/src/mobile/mobileGenerationPreparation.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/mobileGenerationPreparation.ts",
       "target": "file:desktop/src/lib/generateValidation.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/mobileGenerationPreparation.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -447214,13 +445861,6 @@
     {
       "source": "file:desktop/src/mobile/mobileGenerationPreparation.ts",
       "target": "file:studio/lib/minimaxH3Authoring.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:desktop/src/mobile/mobileGenerationPreparation.ts",
-      "target": "file:studio/lib/sourceFit.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -448325,13 +446965,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:studio/lib/referenceCrop.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:web/src/api.test.ts",
       "target": "function:web/src/api.test.ts:installDriver",
       "type": "contains",
@@ -449095,27 +447728,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
-      "target": "file:web/src/components/create/SourceMediaPanel.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:web/src/composables/useDurableGenerationLifecycle.test.ts",
       "target": "function:web/src/composables/useDurableGenerationLifecycle.test.ts:request",
       "type": "contains",
@@ -449139,13 +447751,6 @@
     {
       "source": "file:web/src/composables/useDurableGenerationLifecycle.test.ts",
       "target": "function:web/src/composables/useDurableGenerationLifecycle.test.ts:wavBlob",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.test.ts",
-      "target": "function:web/src/composables/useGenerateForm.test.ts:makeModel",
       "type": "contains",
       "direction": "forward",
       "weight": 1
@@ -449177,188 +447782,6 @@
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.test.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:selectedFamily",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:defaultForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:modelDefaultsPatch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:stripH3AuthoringMedia",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:ensureDraftIds",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:h3MediaFromState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:mediaFromState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:hydrateDraftMedia",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:load",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:persist",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:web/src/composables/useGenerateStream.test.ts",
@@ -449822,34 +448245,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/lib/draftMediaStore.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/lib/generateCapabilities.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/lib/stylePresets.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:web/src/composables/useGenerateStream.ts",
@@ -450865,13 +449260,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:studio/lib/sourceFitCanvas.ts",
-      "target": "file:studio/lib/sourceFit.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:studio/lib/sourceResolution.test.ts",
@@ -452127,1469 +450515,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_body",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:require_direct_singleton",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:retained_frame_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:with_api_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:with_api_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:from_env",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:from_env",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:has_api_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:has_api_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_file",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upload_reference_body",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate_raw",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate_raw",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_models",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_models",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_models_extended",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_models_extended",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_loras",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_loras",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_loras_endpoint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_loras_from_installed_catalog",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_connection_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_connection_error",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_model_not_found",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_model_not_found",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate_stream",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generate_stream",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_chain_jobs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_chain_jobs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:resume_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:resume_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:retake_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:retake_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_chain_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_chain_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_accepting",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_accepting",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_licenses",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_licenses",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:preview_generation_placement",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:preview_generation_placement",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:shutdown_server",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:shutdown_server",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_stream",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_stream",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:host",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:host",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:unload_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:unload_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:unload_model_target",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:unload_model_target",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:server_status",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:server_status",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:server_capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:server_capabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:devices",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:devices",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:capabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:admit_generation_batch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:admit_generation_batch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:retry_queue_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:retry_queue_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:set_device_enabled",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:set_device_enabled",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_page",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_page",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_all",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_queue_all",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:find_queue_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:find_queue_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:fetch_queue_listing",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:queue_job_progress",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:queue_job_progress",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_queue_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_queue_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:queue_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:queue_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:move_queue_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:move_queue_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pause_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:pause_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:resume_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:resume_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:set_queue_paused",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_held_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_held_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_gallery",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_gallery",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:gallery_item",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:gallery_item",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_image",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_gallery_view",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_gallery_view",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:trash_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:trash_gallery_image",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:trash_gallery_images",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:trash_gallery_images",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:restore_trashed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:restore_trashed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:empty_trash",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:empty_trash",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_trash",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:sweep_trash",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:patch_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:patch_gallery_image",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:organize_gallery",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:organize_gallery",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_collections",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_collections",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_collection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:create_collection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:update_collection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:update_collection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_collection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_collection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:set_collection_items",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:set_collection_items",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_tags",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:list_tags",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:rename_tag",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:rename_tag",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_tag",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:delete_tag",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_preview",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:expand_prompt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:expand_prompt",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:remix_prompt",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:remix_prompt",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upscale",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upscale",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upscale_stream",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:upscale_stream",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:installed_entry_into_lora_info",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:should_fallback_loras_endpoint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_transient_request_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:is_transient_request_error",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:require_direct_media_response",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:api_error_detail",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:lora_family_for_model_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:parse_request_warnings",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:merge_completion_warnings",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:parse_video_headers",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:parse_audio_headers",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:next_sse_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:parse_sse_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:build_client",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:normalize_host",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:normalize_host",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "function:crates/mold-core/src/client.rs:encode_path_segment",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:MoldClient",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:MoldClient",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-core/src/chain.rs",
       "target": "file:crates/mold-core/src/error.rs",
       "type": "imports",
@@ -453598,41 +450523,6 @@
     },
     {
       "source": "file:crates/mold-core/src/chain.rs",
-      "target": "file:crates/mold-core/src/types.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "file:crates/mold-core/src/chain.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "file:crates/mold-core/src/chain_job.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "file:crates/mold-core/src/error.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
-      "target": "file:crates/mold-core/src/queue_progress.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/client.rs",
       "target": "file:crates/mold-core/src/types.rs",
       "type": "imports",
       "direction": "forward",
@@ -456363,13 +453253,6 @@
     },
     {
       "source": "file:crates/mold-core/src/lib.rs",
-      "target": "file:crates/mold-core/src/client.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-core/src/lib.rs",
       "target": "file:crates/mold-core/src/config.rs",
       "type": "imports",
       "direction": "forward",
@@ -458532,27 +455415,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "function:web/src/pages/CreatePage.test.ts:installedModelRow",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "function:web/src/pages/CreatePage.test.ts:installedSequenceModel",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "function:web/src/pages/CreatePage.test.ts:pageStubs",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:web/src/pages/HostDetailPage.test.ts",
       "target": "function:web/src/pages/HostDetailPage.test.ts:makeStatus",
       "type": "contains",
@@ -458569,20 +455431,6 @@
     {
       "source": "file:web/src/pages/HostDetailPage.test.ts",
       "target": "function:web/src/pages/HostDetailPage.test.ts:makeDevice",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
-      "target": "function:web/src/pages/LibraryPage.test.ts:makeEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
-      "target": "function:web/src/pages/LibraryPage.test.ts:mountPage",
       "type": "contains",
       "direction": "forward",
       "weight": 1
@@ -458630,111 +455478,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/api.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useChainJobs.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useGenerateStream.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useGenerationHandoff.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useHostRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/usePullResume.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/composables/useSequenceHandoff.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/lib/fileUnder.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/lib/hostRegistry.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/lib/hostRouting.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/lib/stylePresets.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/lib/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/pages/CreatePage.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/CreatePage.test.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:web/src/pages/HostDetailPage.test.ts",
       "target": "file:web/src/components/machines/hostClient.ts",
       "type": "imports",
@@ -458757,34 +455500,6 @@
     },
     {
       "source": "file:web/src/pages/HostDetailPage.test.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
-      "target": "file:web/src/lib/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
-      "target": "file:web/src/pages/LibraryPage.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.test.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -493553,305 +490268,11 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:apply_spatial_tile_override",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:main",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:run",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:generate_completions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:ConfigAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:GpuAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:RunpodAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:RunpodNetworkVolumeAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:LambdaAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:ServerAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:JobsAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:JobsAction",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:QueueAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:QueueAction",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:TrashAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:TrashAction",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:Commands",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-cli/src/commands/runpod.rs",
       "target": "file:crates/mold-cli/src/commands/durable_generation.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/catalog_bridge.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/commands/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/control.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/errors.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/fs_util.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/metadata_db.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/output.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/procinfo.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/skill/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/test_support.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/theme.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-cli/src/main.rs",
-      "target": "file:crates/mold-cli/src/ui.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "function:crates/mold-cli/src/main.rs:run",
-      "target": "function:crates/mold-cli/src/skill/mod.rs:run",
-      "type": "calls",
-      "direction": "forward",
-      "weight": 0.8
     },
     {
       "source": "file:crates/mold-cli/src/ui.rs",
@@ -499447,1938 +495868,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear_download",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:record_download_sample",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:next",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:next",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:default",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_model_names",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:source_image_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:identity_gate_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_upscale",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:model_default_size",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_popup_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_mouse",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:set_active_view",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:increment_param",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_gallery_file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_model_selector",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:activate_current_param",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filing_editor_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:activate_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_navigate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_increment",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_apply_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_generation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:retry_held_prints",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_provenance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_progress",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:decode_live_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:App",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:App",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/event.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/model_info.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/ui/theme.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:crates/mold-tui/src/backend.rs",
       "target": "function:crates/mold-tui/src/backend.rs:run_prompt_transform",
       "type": "contains",
@@ -501736,22 +496225,8 @@
       "weight": 1
     },
     {
-      "source": "file:crates/mold-tui/src/backend.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:crates/mold-tui/src/event.rs",
       "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/event.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -502203,13 +496678,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:crates/mold-tui/src/gallery_scan.rs",
@@ -503283,13 +497751,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:crates/mold-tui/src/palette.rs",
       "target": "function:crates/mold-tui/src/palette.rs:all_commands",
       "type": "contains",
@@ -503733,13 +498194,6 @@
     {
       "source": "file:crates/mold-tui/src/ui/chrome.rs",
       "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/chrome.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -504257,21 +498711,7 @@
     },
     {
       "source": "file:crates/mold-tui/src/ui/create_form.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/create_form.rs",
       "target": "file:crates/mold-tui/src/model_info.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/gallery.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -504824,13 +499264,6 @@
     },
     {
       "source": "file:crates/mold-tui/src/ui/library_details.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/library_details.rs",
       "target": "file:crates/mold-tui/src/ui/widgets.rs",
       "type": "imports",
       "direction": "forward",
@@ -504838,21 +499271,7 @@
     },
     {
       "source": "file:crates/mold-tui/src/ui/machines.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/machines.rs",
       "target": "file:crates/mold-tui/src/hosts.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7
@@ -505353,13 +499772,6 @@
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/preview.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
     },
     {
       "source": "file:crates/mold-tui/src/ui/preview.rs",
@@ -508260,230 +502672,6 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:loopback_admin_commands_do_not_hide_live_server_http_errors",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:version_flag_matches_subcommand",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:default_set_persists_to_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_list_json_is_valid",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_get_raw_outputs_bare_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_set_persists_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_json_is_valid",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_with_populated_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_does_not_double_count_hidden_companions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_shows_column_headers_when_models_installed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_with_populated_model_shows_installed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_upscaler_models_shown_as_installed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:info_known_model_shows_details",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:rm_removes_manifest_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:rm_preserves_shared_files_when_sibling_exists",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:clean_detects_stale_pulling_marker",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_mask_requires_image_flag",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_qwen_image_edit_rejects_batch_before_remote_generation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_on_a_family_without_a_continuation_path_names_extend",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_sends_the_familys_own_carryover_overlap",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:update_help_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:update_check_runs_without_panic",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:dry_run_prints_stage_summary",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:repeated_prompt_flag_yields_chain",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_reports_ok_for_valid_script",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_errors_on_bad_schema",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:positional_plus_prompt_flag_errors",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:positional_alone_still_works",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "function:crates/mold-cli/tests/cli_integration.rs:prompt_flag_alone_still_works",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/tests/cli_integration.rs",
-      "target": "file:crates/mold-cli/tests/common/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:scripts/capture-ltx25-comfy-metal-reference.sh",
       "target": "function:scripts/capture-ltx25-comfy-metal-reference.sh:resource_guard_cause",
       "type": "contains",
@@ -509693,14 +503881,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:desktop/src/mobile/MobileSharedParams.vue",
       "target": "file:desktop/src/mobile/MobileSharedParams.test.ts",
       "type": "tested_by",
@@ -509965,40 +504145,8 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:desktop/src/components/generate/SourceImageWell.vue",
-      "target": "file:desktop/src/components/generate/SourceImageWell.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:desktop/src/lib/generateForm.ts",
-      "target": "file:desktop/src/lib/generateForm.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileApp.vue",
-      "target": "file:desktop/src/mobile/MobileApp.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
       "target": "file:desktop/src/mobile/MobileImagePickerSheet.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSourceControls.vue",
-      "target": "file:desktop/src/mobile/MobileSourceControls.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -510109,22 +504257,6 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:web/src/components/create/SourceMediaPanel.vue",
-      "target": "file:web/src/components/create/SourceMediaPanel.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:web/src/composables/useGenerateForm.ts",
-      "target": "file:web/src/composables/useGenerateForm.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:web/src/composables/useHostRouting.ts",
       "target": "file:web/src/composables/useHostRouting.test.ts",
       "type": "tested_by",
@@ -510173,24 +504305,8 @@
       "description": "Path-based pairing (deterministic)"
     },
     {
-      "source": "file:web/src/pages/CreatePage.vue",
-      "target": "file:web/src/pages/CreatePage.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
       "source": "file:web/src/pages/HostDetailPage.vue",
       "target": "file:web/src/pages/HostDetailPage.test.ts",
-      "type": "tested_by",
-      "direction": "forward",
-      "weight": 0.5,
-      "description": "Path-based pairing (deterministic)"
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.vue",
-      "target": "file:web/src/pages/LibraryPage.test.ts",
       "type": "tested_by",
       "direction": "forward",
       "weight": 0.5,
@@ -510455,14 +504571,6 @@
     {
       "source": "file:crates/mold-core/src/chain_toml.rs",
       "target": "file:crates/mold-core/src/chain.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-core/src/control.rs",
-      "target": "file:crates/mold-core/src/client.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -510774,14 +504882,6 @@
     },
     {
       "source": "file:crates/mold-inference/src/engine_base.rs",
-      "target": "file:crates/mold-inference/src/progress.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-inference/src/expand.rs",
       "target": "file:crates/mold-inference/src/progress.rs",
       "type": "imports",
       "direction": "forward",
@@ -511477,104 +505577,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/backend.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/event.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/gallery_scan.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/h3_references.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/hosts.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/model_info.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/palette.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/session.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/generate.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:crates/mold-tui/src/ui/mod.rs",
       "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/mod.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511653,40 +505657,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:crates/mold-tui/src/ui/models.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/param_form.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:crates/mold-tui/src/ui/param_form.rs",
       "target": "file:crates/mold-tui/src/ui/create_form.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/settings.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/timeline.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511717,40 +505689,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/components/create/AdvancedSettings.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/ComposerCard.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/CreateHeader.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/components/create/CreateHeader.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/IdentityWell.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511782,23 +505722,7 @@
     },
     {
       "source": "file:desktop/src/components/create/InspectorPanel.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/InspectorPanel.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/SequenceAdvancedSettings.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511815,14 +505739,6 @@
     {
       "source": "file:desktop/src/components/create/SequenceComposer.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/SequenceComposer.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511847,14 +505763,6 @@
     {
       "source": "file:desktop/src/components/create/SequenceOpeningImageWell.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/create/SequenceOpeningImageWell.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -511903,14 +505811,6 @@
     {
       "source": "file:desktop/src/components/generate/StarterCards.test.ts",
       "target": "file:desktop/src/stores/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/components/generate/TemplatesPanel.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -512149,22 +506049,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/lib/advancedCount.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/advancedCount.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/lib/api/catalog.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
       "type": "imports",
@@ -512389,30 +506273,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/lib/desktopImageDrop.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/desktopImageDrop.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/lib/downloads.ts",
       "target": "file:desktop/src/lib/api/types.ts",
       "type": "imports",
@@ -512485,40 +506345,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/lib/generateValidation.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/generateValidation.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/lib/generateValidation.ts",
       "target": "file:studio/lib/minimaxH3Authoring.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/generationTemplates.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/generationTemplates.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -512653,24 +506481,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/lib/sequenceParams.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/lib/sequenceParams.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/sequenceParams.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -512703,30 +506515,6 @@
     {
       "source": "file:desktop/src/lib/sequenceRoute.ts",
       "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/sourceAttachment.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
-      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -512765,14 +506553,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/mobile/MobileBatchControl.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/mobile/MobileCatalogView.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
       "type": "imports",
@@ -512805,30 +506585,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/mobile/MobileGenerateParameters.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileLoraControls.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/MobilePromptTools.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/mobile/MobileSharedParams.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
       "type": "imports",
@@ -512838,23 +506594,7 @@
     },
     {
       "source": "file:desktop/src/mobile/MobileSharedParams.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileSharedParams.test.ts",
       "target": "file:desktop/src/mobile/MobileSharedParams.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/MobileTemplates.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513005,24 +506745,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/mobile/reuse.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/mobile/reuse.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/mobile/reuse.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513117,14 +506841,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:desktop/src/stores/composer.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:desktop/src/stores/downloads.test.ts",
       "target": "file:desktop/src/lib/api/types.ts",
       "type": "imports",
@@ -513199,14 +506915,6 @@
     {
       "source": "file:desktop/src/stores/generateForm.ts",
       "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/stores/generateForm.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -513454,14 +507162,6 @@
     },
     {
       "source": "file:desktop/src/views/GenerateView.printIdentity.test.ts",
-      "target": "file:desktop/src/lib/generateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.printIdentity.test.ts",
       "target": "file:desktop/src/stores/hosts.ts",
       "type": "imports",
       "direction": "forward",
@@ -513471,46 +507171,6 @@
     {
       "source": "file:desktop/src/views/GenerateView.printIdentity.test.ts",
       "target": "file:desktop/src/views/GenerateView.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/lib/api/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/hosts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/stores/toasts.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:desktop/src/views/GenerateView.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
-      "target": "file:studio/lib/api/chainTypes.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -514022,14 +507682,6 @@
     },
     {
       "source": "file:web/src/components/create/AdvancedDrawer.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/AdvancedDrawer.test.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -514039,14 +507691,6 @@
     {
       "source": "file:web/src/components/create/ControlsAside.test.ts",
       "target": "file:web/src/components/create/ControlsAside.vue",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/ControlsAside.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -514086,14 +507730,6 @@
     },
     {
       "source": "file:web/src/components/create/IdentityPanel.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/IdentityPanel.test.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -514109,40 +507745,8 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
-      "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/advanced/ExtendVideoControls.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
       "source": "file:web/src/components/create/advanced/ExtendVideoControls.test.ts",
       "target": "file:web/src/types.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/create/advanced/Ltx2VideoControls.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -514303,14 +507907,6 @@
     {
       "source": "file:web/src/components/models/ModelInstallTargetDialog.test.ts",
       "target": "file:web/src/composables/useModelInstallTargets.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/components/shell/CommandK.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -514630,14 +508226,6 @@
     },
     {
       "source": "file:web/src/lib/generationTemplates.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/lib/generationTemplates.ts",
       "target": "file:web/src/types.ts",
       "type": "imports",
       "direction": "forward",
@@ -514742,14 +508330,6 @@
     },
     {
       "source": "file:web/src/pages/LibraryPage.organization.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.organization.test.ts",
       "target": "file:web/src/lib/toasts.ts",
       "type": "imports",
       "direction": "forward",
@@ -514775,14 +508355,6 @@
     {
       "source": "file:web/src/pages/LibraryPage.sequence.test.ts",
       "target": "file:web/src/api.ts",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:web/src/pages/LibraryPage.sequence.test.ts",
-      "target": "file:web/src/composables/useGenerateForm.ts",
       "type": "imports",
       "direction": "forward",
       "weight": 0.7,
@@ -514875,6 +508447,6746 @@
       "direction": "forward",
       "weight": 0.7,
       "recoveredFromImportMap": true
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run_remote",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_show",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_title",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:require_organize",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_listing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_detail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_collections",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:truncate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:apply_spatial_tile_override",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:main",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:generate_completions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "function:crates/mold-cli/src/main.rs:resolve_catalog_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2SpatialUpscaleArg",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2TemporalUpscaleArg",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Ltx2PipelineArg",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:ConfigAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:GpuAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:RunpodAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:RunpodNetworkVolumeAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LambdaAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:ServerAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:JobsAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:JobsAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:RetakeModeArg",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:QueueAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:QueueAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:TrashAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:TrashAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryTagAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryTagAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryCollectionAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryCollectionAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:LibraryAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:Commands",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "class:crates/mold-cli/src/main.rs:CatalogIdResolution",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/catalog_bridge.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/commands/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/control.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/errors.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/fs_util.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/metadata_db.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/output.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/procinfo.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/skill/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/test_support.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/theme.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/main.rs",
+      "target": "file:crates/mold-cli/src/ui.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:loopback_admin_commands_do_not_hide_live_server_http_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:version_flag_matches_subcommand",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_row",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_list_json_is_pure_and_uses_the_same_filtered_page",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_tag_add_uses_replay_safe_bulk_mutation_when_advertised",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_tag_add_falls_back_to_legacy_organize_route",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_trash_refuses_a_host_without_recoverable_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_collection_remove_resolves_slug_and_sends_membership_change",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_show_video_uses_thumbnail_when_animated_preview_is_missing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:library_global_tag_delete_requires_yes_without_a_tty",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:default_set_persists_to_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_list_json_is_valid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_get_raw_outputs_bare_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:config_set_persists_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_json_is_valid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_with_populated_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:stats_does_not_double_count_hidden_companions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_shows_column_headers_when_models_installed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_with_populated_model_shows_installed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:list_upscaler_models_shown_as_installed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:info_known_model_shows_details",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:gpu_list_json_falls_back_to_local_inventory_when_loopback_server_is_stopped",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:rm_removes_manifest_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:rm_preserves_shared_files_when_sibling_exists",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:clean_detects_stale_pulling_marker",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_mask_requires_image_flag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_qwen_image_edit_rejects_batch_before_remote_generation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_satisfies_a_wan_i2v_checkpoints_source_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_on_a_family_without_a_continuation_path_names_extend",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:run_extend_sends_the_familys_own_carryover_overlap",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:update_help_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:update_check_runs_without_panic",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:dry_run_prints_stage_summary",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:repeated_prompt_flag_yields_chain",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_reports_ok_for_valid_script",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:chain_validate_errors_on_bad_schema",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:positional_plus_prompt_flag_errors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:positional_alone_still_works",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "function:crates/mold-cli/tests/cli_integration.rs:prompt_flag_alone_still_works",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/tests/cli_integration.rs",
+      "target": "file:crates/mold-cli/tests/common/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:require_direct_singleton",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:retained_frame_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:with_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:with_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:from_env",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:from_env",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:has_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:has_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_reference_upload_session",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_open_file",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_bytes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upload_reference_body",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_reference_upload_session",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate_raw",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate_raw",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_models",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_models",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_models_extended",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_models_extended",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_loras",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_loras",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_loras_endpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_loras_from_installed_catalog",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_connection_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_connection_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_model_not_found",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_model_not_found",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate_stream",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generate_stream",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:stream_chain_job_events",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_chain_jobs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_chain_jobs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:resume_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:resume_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:retake_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:retake_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_chain_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_chain_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:gc_chain_jobs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_accepting",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_accepting",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_licenses",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_licenses",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:preview_generation_placement",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:preview_generation_placement",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:shutdown_server",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:shutdown_server",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_stream",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_stream",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pull_model_stream_accepting",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:host",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:host",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:unload_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:unload_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:unload_model_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:unload_model_target",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:server_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:server_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:server_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:server_capabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:devices",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:devices",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:capabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:admit_generation_batch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:admit_generation_batch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch_by_client_id",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:generation_batch_statuses",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:retry_queue_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:retry_queue_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:set_device_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:set_device_enabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_for_capacity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_page",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_page",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_all",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_queue_all",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:find_queue_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:find_queue_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:fetch_queue_listing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:queue_job_progress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:queue_job_progress",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_queue_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_queue_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:queue_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:queue_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:move_queue_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:move_queue_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_all_queue_jobs",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:cancel_generation_batch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pause_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:pause_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:resume_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:resume_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:set_queue_paused",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_held_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_held_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_settled_batches",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_gallery",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_gallery",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:gallery_item",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:gallery_item",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_image",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_gallery_view",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_gallery_view",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:trash_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:trash_gallery_image",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_gallery_image_forever",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:trash_gallery_images",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:trash_gallery_images",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:restore_trashed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:restore_trashed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:empty_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:empty_trash",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:sweep_trash",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:patch_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:patch_gallery_image",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:organize_gallery",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:organize_gallery",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:mutate_gallery_bulk",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:mutate_gallery_bulk",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_collections",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_collections",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_collection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:create_collection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:update_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:update_collection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_collection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:set_collection_items",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:set_collection_items",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_tags",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:list_tags",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:rename_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:rename_tag",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:delete_tag",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_preview",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:get_gallery_thumbnail",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:expand_prompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:expand_prompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:remix_prompt",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:remix_prompt",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upscale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upscale",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upscale_stream",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:upscale_stream",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:installed_entry_into_lora_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:should_fallback_loras_endpoint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_missing_endpoint_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_transient_request_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:is_transient_request_error",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:require_direct_media_response",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:api_error_detail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:lora_family_for_model_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:parse_request_warnings",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:merge_completion_warnings",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:parse_video_headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:parse_audio_headers",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:next_sse_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:parse_sse_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:build_client",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:normalize_host",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:normalize_host",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "function:crates/mold-core/src/client.rs:encode_path_segment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:MoldClient",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:MoldClient",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:ChainJobOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "class:crates/mold-core/src/client.rs:ModelNotFoundError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "file:crates/mold-core/src/chain.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "file:crates/mold-core/src/chain_job.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "file:crates/mold-core/src/error.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "file:crates/mold-core/src/queue_progress.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-core/src/client.rs",
+      "target": "file:crates/mold-core/src/types.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:validate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:validate",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:artifact_identity_fingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:freeze_artifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:validate_frozen_artifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand_candidate_dirs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand_plan_memory_floors",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand_execution_fingerprint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_local_expand_artifacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:resolve_expand_execution_plan_from_artifacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:create_exact_device_with",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:select_legacy_dynamic_expand_device",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:report_expand_memory_status_with",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_resolved_plan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:set_on_progress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:set_on_progress",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:set_cancellation_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:clear_cancellation_token",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand_with_cancellation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:with_gpu_selection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:with_preferred_gpu",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:from_config_legacy_dynamic",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:generate_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:expand",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:sample_token",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:find_gguf_in_dir",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "function:crates/mold-inference/src/expand.rs:find_tokenizer_in_dir",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifact",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandArtifacts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ExactExpandPlacement",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:ResolvedExpandExecutionPlan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:LocalExpander",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "class:crates/mold-inference/src/expand.rs:LocalExpander",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "file:crates/mold-inference/src/device.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-inference/src/expand.rs",
+      "target": "file:crates/mold-inference/src/progress.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear_download",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:record_download_sample",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:next",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:next",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:default",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_model_names",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:source_image_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:identity_gate_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_upscale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:model_default_size",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_popup_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_mouse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:set_active_view",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:increment_param",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_gallery_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_model_selector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:activate_current_param",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filing_editor_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:activate_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_navigate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_increment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_apply_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_generation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:retry_held_prints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_provenance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_progress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:decode_live_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:App",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:App",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/action.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/event.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/model_info.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/ui/theme.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_event_loop",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/action.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/animation.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/app.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/backend.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/event.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/gallery_scan.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/gallery_trash.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/h3_references.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/history.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/hosts.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/identity.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/model_info.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/motion.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/palette.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/prefs.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/session.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/test_env.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/thumbnails.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/ui/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "target": "file:desktop/src/components/generate/ImagePickerModal.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "target": "file:desktop/src/components/generate/MaskEditorModal.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "target": "file:desktop/src/components/generate/SourceImageWell.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "target": "file:studio/components/ReferenceCropEditor.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "function:desktop/src/lib/desktopImageDrop.ts:applyDesktopImageDrop",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "file:desktop/src/lib/capabilities.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:ltx2Model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:profiledLtx2Model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:qwenEditModel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:wanModel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:sd15Model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "function:desktop/src/lib/generateForm.test.ts:richImageMetadata",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:desktop/src/lib/capabilities.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:studio/lib/extend.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:studio/lib/fileUnder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:studio/lib/generationProfile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.test.ts",
+      "target": "file:studio/lib/negativePrompt.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:desktop/src/lib/capabilities.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:desktop/src/lib/generateModels.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/cameraMotion.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/extend.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/fileUnder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/generationCapabilities.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/generationProfile.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/guidanceOverrides.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/identityConditioning.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/libraryOrganization.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/ltx2Control.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/ltx2Pipeline.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/minimaxH3Authoring.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/negativePrompt.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/outputReuse.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/sequence.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/sourceFit.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/sourceImageCapability.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/videoDuration.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:studio/lib/wanRecipe.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:seedMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:seedMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:newGenerateForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:cloneGenerateForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyModelDefaults",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyRecipeDefaults",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:normalizeLegacyNegativeSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:keepingPrintIdentity",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:resetFormToModelDefaults",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:resetAdvancedToModelDefaults",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:formExtendOverlapFrames",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:buildRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:buildRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:chainFilingFields",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:restoredFileUnderState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyMetadataToForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyRequestToForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "function:desktop/src/lib/generateForm.ts:applyPrefillToForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedImage",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "function:desktop/src/lib/sourceAttachment.ts:attachPickedVideo",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "target": "file:studio/lib/sourceFit.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "target": "file:ui/lib/sourceFitPreprocessCache.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.test.ts:fakeOps",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "file:studio/lib/minimaxH3Authoring.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "file:studio/lib/sourceFit.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "file:studio/lib/sourceFitCanvas.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "file:ui/lib/sourceFitPreprocessCache.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:drawableFitPolicy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/api/client.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/generationTemplates.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/lib/testSupport/memoryLocalStorage.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileApp.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileLoraControls.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/MobileTemplates.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/galleryCache.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileDownloads.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileGenerationRecovery.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:desktop/src/mobile/mobileTemplateStorage.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/components/IdentityPhotoWell.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/lib/libraryOrganization.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "file:studio/stores/sequenceDraft.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "function:desktop/src/mobile/MobileApp.test.ts:plannedPlacement",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "function:desktop/src/mobile/MobileApp.test.ts:durableBatchResponse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "function:desktop/src/mobile/MobileApp.test.ts:durableApiFallback",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "function:desktop/src/mobile/MobileApp.test.ts:heldAdmissions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.test.ts",
+      "target": "class:desktop/src/mobile/MobileApp.test.ts:FakeIntersectionObserver",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "function:desktop/src/lib/generateForm.ts:buildRequest",
+      "target": "function:studio/lib/libraryOrganization.ts:validatePrintTitle",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:desktop/src/lib/generateForm.ts:buildRequest",
+      "target": "function:studio/lib/fileUnder.ts:buildFileUnderRequestFields",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:desktop/src/lib/generateForm.ts:reconcileModelCapabilities",
+      "target": "function:desktop/src/lib/capabilities.ts:generationCapabilitiesForFamily",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
+      "target": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "function:desktop/src/lib/sourceFitPreprocess.ts:applyH3BoundaryFit",
+      "target": "function:desktop/src/lib/sourceFitPreprocess.ts:applySourceFitPreprocess",
+      "type": "calls",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/lib/generateForm.ts",
+      "target": "file:desktop/src/lib/generateForm.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:desktop/src/lib/sourceAttachment.ts",
+      "target": "file:desktop/src/lib/sourceAttachment.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "target": "file:desktop/src/lib/sourceFitPreprocess.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileApp.vue",
+      "target": "file:desktop/src/mobile/MobileApp.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/components/generate/MaskEditorModal.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/lib/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/lib/generateValidation.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/mobile/MobileImagePickerSheet.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/mobile/MobileReferenceCropSheet.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:desktop/src/mobile/MobileSourceControls.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "file:studio/components/ReferenceCropEditor.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "function:desktop/src/mobile/MobileSourceControls.test.ts:model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "target": "function:desktop/src/mobile/MobileSourceControls.test.ts:chooseFiles",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/components/generate/ExpandControl.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/components/generate/ExpansionPullStatus.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/components/generate/MissingModelDialog.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/components/generate/PreparedExpansionBatch.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/api/catalog.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/api/client.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/api/expand.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/api/remix.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/lib/sourceFitPreprocess.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/appPrefs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/composer.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/connection.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/downloads.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/hostModels.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/hosts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/models.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/toasts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/stores/ui.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "file:desktop/src/views/GenerateView.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "target": "function:desktop/src/views/GenerateView.prepared.test.ts:mountView",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/lib/api/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/appPrefs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/chainJobs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/composer.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/connection.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/contextMenu.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/generateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/hosts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/models.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/toasts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/stores/ui.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:desktop/src/views/GenerateView.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:studio/lib/api/chainTypes.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:studio/lib/fileUnder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "target": "file:studio/stores/sequenceDraft.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.test.ts",
+      "target": "file:studio/lib/expansionRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:resolveExpansionRoute",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:expansionPolicyForSelection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:parseMissingExpandModel",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:expandModelId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "function:studio/lib/expansionRouting.ts:expandModelId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:desktop/src/mobile/MobileSourceControls.vue",
+      "target": "file:desktop/src/mobile/MobileSourceControls.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.vue",
+      "target": "file:desktop/src/views/GenerateView.prepared.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:desktop/src/views/GenerateView.vue",
+      "target": "file:desktop/src/views/GenerateView.sequence.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Direction corrected (was test → production)"
+    },
+    {
+      "source": "file:studio/lib/expansionRouting.ts",
+      "target": "file:studio/lib/expansionRouting.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:studio/lib/sourceFit.test.ts",
+      "target": "file:studio/lib/sourceFit.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "target": "file:web/src/components/create/SequenceOpeningImagePanel.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "target": "file:web/src/composables/useGenerateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
+      "target": "file:web/src/components/create/SourceMediaPanel.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
+      "target": "file:web/src/composables/useGenerateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/components/create/SourceMediaPanel.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.test.ts",
+      "target": "file:web/src/composables/useGenerateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "file:web/src/lib/draftMediaStore.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "file:web/src/lib/generateCapabilities.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "file:web/src/lib/stylePresets.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/api.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useChainJobs.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useGenerateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useGenerateStream.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useGenerationHandoff.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useHostRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/usePullResume.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/composables/useSequenceHandoff.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/lib/fileUnder.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/lib/hostRegistry.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/lib/hostRouting.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/lib/stylePresets.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/lib/toasts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/pages/CreatePage.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "file:web/src/composables/useGenerateForm.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "file:web/src/lib/toasts.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "file:web/src/pages/LibraryPage.vue",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "file:web/src/types.ts",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:defaultSourceFitPolicy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:defaultSourceFitPolicy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:sourceFitHelp",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:sourceFitHelp",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:parseSourceFitPolicy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:sourceFitPolicyForMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:resolveSourceFitTransform",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:maskPaddingRectangles",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:coerceSourceFitForMaskless",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:describeSourceFit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "function:studio/lib/sourceFit.ts:describeSourceFit",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.test.ts",
+      "target": "function:web/src/composables/useGenerateForm.test.ts:makeModel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:promptWithStyle",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:selectedFamily",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:defaultForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:sanitizePersistedForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:cloneTemplateForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:modelDefaultsPatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:settingsResetPatch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:normalizeLegacyNegativeFormState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:applyMetadataToForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:stripH3AuthoringMedia",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:ensureDraftIds",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:h3MediaFromState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:mediaFromState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:hydrateDraftMedia",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:load",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:persist",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "function:web/src/composables/useGenerateForm.ts:useGenerateForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "function:web/src/pages/CreatePage.test.ts:installedModelRow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "function:web/src/pages/CreatePage.test.ts:installedSequenceModel",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.test.ts",
+      "target": "function:web/src/pages/CreatePage.test.ts:pageStubs",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "function:web/src/pages/LibraryPage.test.ts:makeEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.test.ts",
+      "target": "function:web/src/pages/LibraryPage.test.ts:mountPage",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:studio/lib/sourceFit.ts",
+      "target": "file:studio/lib/sourceFit.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:web/src/components/create/SequenceOpeningImagePanel.vue",
+      "target": "file:web/src/components/create/SequenceOpeningImagePanel.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:web/src/components/create/SourceMediaPanel.vue",
+      "target": "file:web/src/components/create/SourceMediaPanel.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:web/src/composables/useGenerateForm.ts",
+      "target": "file:web/src/composables/useGenerateForm.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:web/src/pages/CreatePage.vue",
+      "target": "file:web/src/pages/CreatePage.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:web/src/pages/LibraryPage.vue",
+      "target": "file:web/src/pages/LibraryPage.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5
+    },
+    {
+      "source": "file:desktop/src/lib/desktopImageDrop.ts",
+      "target": "file:desktop/src/lib/desktopImageDrop.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
+    },
+    {
+      "source": "file:desktop/src/components/generate/SourceImageWell.vue",
+      "target": "file:desktop/src/components/generate/SourceImageWell.test.ts",
+      "type": "tested_by",
+      "direction": "forward",
+      "weight": 0.5,
+      "description": "Path-based pairing (deterministic)"
     }
   ],
   "layers": [
@@ -514966,6 +515278,7 @@
         "file:crates/mold-cli/src/commands/info.rs",
         "file:crates/mold-cli/src/commands/jobs.rs",
         "file:crates/mold-cli/src/commands/lambda.rs",
+        "file:crates/mold-cli/src/commands/library.rs",
         "file:crates/mold-cli/src/commands/licenses.rs",
         "file:crates/mold-cli/src/commands/list.rs",
         "file:crates/mold-cli/src/commands/local_engine.rs",

--- a/.ua/knowledge-graph.json
+++ b/.ua/knowledge-graph.json
@@ -57,8 +57,8 @@
       "Vue"
     ],
     "description": "CLI-native local AI image and video generation for people, scripts, and agents. Note: this project has over 100 source files; consider scoping analysis to a subdirectory for faster results.",
-    "analyzedAt": "2026-08-28T14:10:08.933Z",
-    "gitCommitHash": "7a56077d0b1364309f0c8b7e6fa51a02e838f7c3"
+    "analyzedAt": "2026-08-28T16:27:44.501Z",
+    "gitCommitHash": "3db4501d931196954bb80290797c4cc6c004bc5b"
   },
   "nodes": [
     {
@@ -268438,377 +268438,6 @@
       "complexity": "moderate"
     },
     {
-      "id": "file:crates/mold-tui/src/gallery_scan.rs",
-      "type": "file",
-      "name": "gallery_scan.rs",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "summary": "Implements gallery scan behavior for the src area of Mold.",
-      "tags": [
-        "rust",
-        "service",
-        "mold-runtime"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Rust implementation uses explicit ownership and typed results to keep runtime boundaries fail-safe."
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
-      "type": "function",
-      "name": "default_gallery_dir",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        8,
-        10
-      ],
-      "summary": "Implements default gallery dir within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
-      "type": "function",
-      "name": "image_cache_dir",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        13,
-        18
-      ],
-      "summary": "Implements image cache dir within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
-      "type": "function",
-      "name": "host_cache_filename",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        24,
-        26
-      ],
-      "summary": "Implements host cache filename within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
-      "type": "function",
-      "name": "cached_image_path",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        29,
-        31
-      ],
-      "summary": "Implements cached image path within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
-      "type": "function",
-      "name": "scan_images_from_server",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        37,
-        57
-      ],
-      "summary": "Implements scan images from server within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
-      "type": "function",
-      "name": "fetch_and_cache_image",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        61,
-        80
-      ],
-      "summary": "Implements fetch and cache image within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
-      "type": "function",
-      "name": "preview_cache_path",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        85,
-        90
-      ],
-      "summary": "Implements preview cache path within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
-      "type": "function",
-      "name": "fetch_and_cache_preview",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        99,
-        125
-      ],
-      "summary": "Implements fetch and cache preview within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
-      "type": "function",
-      "name": "is_video_filename",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        130,
-        139
-      ],
-      "summary": "Implements is video filename within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
-      "type": "function",
-      "name": "scan_images_local",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        161,
-        163
-      ],
-      "summary": "Implements scan images local within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
-      "type": "function",
-      "name": "scan_local",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        169,
-        219
-      ],
-      "summary": "Implements scan local within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_local_disk",
-      "type": "function",
-      "name": "scan_local_disk",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        222,
-        258
-      ],
-      "summary": "Implements scan local disk within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
-      "type": "function",
-      "name": "is_loopback_url",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        293,
-        304
-      ],
-      "summary": "Implements is loopback url within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
-      "type": "function",
-      "name": "scan_sources",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        315,
-        353
-      ],
-      "summary": "Implements scan sources within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
-      "type": "function",
-      "name": "scan_all_hosts",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        361,
-        401
-      ],
-      "summary": "Implements scan all hosts within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
-      "type": "function",
-      "name": "merge_scans",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        419,
-        463
-      ],
-      "summary": "Implements merge scans within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
-      "type": "function",
-      "name": "filter_entries",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        470,
-        485
-      ],
-      "summary": "Implements filter entries within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
-      "type": "function",
-      "name": "library_hint",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        497,
-        537
-      ],
-      "summary": "Implements library hint within the gallery scan workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
-      "type": "class",
-      "name": "LocalScan",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        143,
-        151
-      ],
-      "summary": "Encapsulates local scan state and behavior for the gallery scan subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
-      "type": "class",
-      "name": "MergedScan",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        264,
-        276
-      ],
-      "summary": "Encapsulates merged scan state and behavior for the gallery scan subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
-      "type": "class",
-      "name": "SourceScan",
-      "filePath": "crates/mold-tui/src/gallery_scan.rs",
-      "lineRange": [
-        282,
-        288
-      ],
-      "summary": "Encapsulates source scan state and behavior for the gallery scan subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:crates/mold-tui/src/h3_references.rs",
       "type": "file",
       "name": "h3_references.rs",
@@ -269070,1244 +268699,6 @@
         169
       ],
       "summary": "Encapsulates prepared references state and behavior for the h3 references subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-tui/src/hosts.rs",
-      "type": "file",
-      "name": "hosts.rs",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "summary": "Implements hosts behavior for the src area of Mold.",
-      "tags": [
-        "rust",
-        "service",
-        "mold-runtime"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Rust implementation uses explicit ownership and typed results to keep runtime boundaries fail-safe."
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:local_display_name",
-      "type": "function",
-      "name": "local_display_name",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        29,
-        35
-      ],
-      "summary": "Implements local display name within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:display_name",
-      "type": "function",
-      "name": "display_name",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        66,
-        71
-      ],
-      "summary": "Implements display name within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:load",
-      "type": "function",
-      "name": "load",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        292,
-        301
-      ],
-      "summary": "Implements load within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:load_from",
-      "type": "function",
-      "name": "load_from",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        99,
-        105
-      ],
-      "summary": "Implements load from within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:save",
-      "type": "function",
-      "name": "save",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        303,
-        310
-      ],
-      "summary": "Implements save within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:save_to",
-      "type": "function",
-      "name": "save_to",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        115,
-        119
-      ],
-      "summary": "Implements save to within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:add",
-      "type": "function",
-      "name": "add",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        122,
-        135
-      ],
-      "summary": "Implements add within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:forget",
-      "type": "function",
-      "name": "forget",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        858,
-        877
-      ],
-      "summary": "Implements forget within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:get",
-      "type": "function",
-      "name": "get",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        144,
-        146
-      ],
-      "summary": "Implements get within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:all",
-      "type": "function",
-      "name": "all",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        151,
-        162
-      ],
-      "summary": "Implements all within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
-      "type": "function",
-      "name": "host_id_from_url",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        168,
-        190
-      ],
-      "summary": "Implements host id from url within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:host_port_label",
-      "type": "function",
-      "name": "host_port_label",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        193,
-        197
-      ],
-      "summary": "Implements host port label within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:api_key_for",
-      "type": "function",
-      "name": "api_key_for",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        206,
-        212
-      ],
-      "summary": "Implements api key for within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:save_api_key",
-      "type": "function",
-      "name": "save_api_key",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        215,
-        222
-      ],
-      "summary": "Implements save api key within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
-      "type": "function",
-      "name": "delete_api_key",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        225,
-        230
-      ],
-      "summary": "Implements delete api key within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:client_for",
-      "type": "function",
-      "name": "client_for",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        234,
-        239
-      ],
-      "summary": "Implements client for within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:client_for_host",
-      "type": "function",
-      "name": "client_for_host",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        242,
-        244
-      ],
-      "summary": "Implements client for host within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:open_db",
-      "type": "function",
-      "name": "open_db",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        246,
-        255
-      ],
-      "summary": "Implements open db within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:to_setting",
-      "type": "function",
-      "name": "to_setting",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        273,
-        279
-      ],
-      "summary": "Implements to setting within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:from_setting",
-      "type": "function",
-      "name": "from_setting",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        282,
-        290
-      ],
-      "summary": "Implements from setting within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "factory"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:row_count",
-      "type": "function",
-      "name": "row_count",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        412,
-        414
-      ],
-      "summary": "Implements row count within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_row",
-      "type": "function",
-      "name": "selected_row",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        417,
-        427
-      ],
-      "summary": "Implements selected row within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_host",
-      "type": "function",
-      "name": "selected_host",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        430,
-        435
-      ],
-      "summary": "Implements selected host within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:select_prev",
-      "type": "function",
-      "name": "select_prev",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        438,
-        446
-      ],
-      "summary": "Implements select prev within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:select_next",
-      "type": "function",
-      "name": "select_next",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        449,
-        457
-      ],
-      "summary": "Implements select next within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
-      "type": "function",
-      "name": "queue_select_prev",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        468,
-        470
-      ],
-      "summary": "Implements queue select prev within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
-      "type": "function",
-      "name": "queue_select_next",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        472,
-        481
-      ],
-      "summary": "Implements queue select next within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
-      "type": "function",
-      "name": "selected_cancellable_job",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        485,
-        498
-      ],
-      "summary": "Implements selected cancellable job within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_device",
-      "type": "function",
-      "name": "selected_device",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        507,
-        510
-      ],
-      "summary": "Implements selected device within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
-      "type": "function",
-      "name": "can_mutate_selected_device",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        512,
-        527
-      ],
-      "summary": "Implements can mutate selected device within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
-      "type": "function",
-      "name": "selected_device_uses_restart_enable",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        529,
-        542
-      ],
-      "summary": "Implements selected device uses restart enable within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
-      "type": "function",
-      "name": "selected_device_restart_required",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        544,
-        547
-      ],
-      "summary": "Implements selected device restart required within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:select_next_device",
-      "type": "function",
-      "name": "select_next_device",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        549,
-        559
-      ],
-      "summary": "Implements select next device within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
-      "type": "function",
-      "name": "select_prev_device",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        561,
-        571
-      ],
-      "summary": "Implements select prev device within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_devices",
-      "type": "function",
-      "name": "apply_devices",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        573,
-        585
-      ],
-      "summary": "Implements apply devices within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
-      "type": "function",
-      "name": "apply_device_mutation",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        587,
-        608
-      ],
-      "summary": "Implements apply device mutation within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
-      "type": "function",
-      "name": "apply_capabilities",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        610,
-        623
-      ],
-      "summary": "Implements apply capabilities within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
-      "type": "function",
-      "name": "target_for_selected",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        628,
-        643
-      ],
-      "summary": "Implements target for selected within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:force_poll",
-      "type": "function",
-      "name": "force_poll",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        647,
-        651
-      ],
-      "summary": "Implements force poll within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
-      "type": "function",
-      "name": "request_queue_refresh",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        653,
-        658
-      ],
-      "summary": "Implements request queue refresh within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:poll_plan",
-      "type": "function",
-      "name": "poll_plan",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        664,
-        706
-      ],
-      "summary": "Implements poll plan within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:finish_poll",
-      "type": "function",
-      "name": "finish_poll",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        711,
-        723
-      ],
-      "summary": "Implements finish poll within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_status",
-      "type": "function",
-      "name": "apply_status",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        727,
-        739
-      ],
-      "summary": "Implements apply status within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_queue",
-      "type": "function",
-      "name": "apply_queue",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        743,
-        791
-      ],
-      "summary": "Implements apply queue within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
-      "type": "function",
-      "name": "begin_queue_continuation",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        794,
-        808
-      ],
-      "summary": "Implements begin queue continuation within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
-      "type": "function",
-      "name": "apply_queue_continuation",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        812,
-        853
-      ],
-      "summary": "Implements apply queue continuation within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
-      "type": "function",
-      "name": "toggle_connection",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        881,
-        900
-      ],
-      "summary": "Implements toggle connection within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:complete_connect",
-      "type": "function",
-      "name": "complete_connect",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        904,
-        933
-      ],
-      "summary": "Implements complete connect within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:connect_advance",
-      "type": "function",
-      "name": "connect_advance",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        985,
-        1060
-      ],
-      "summary": "Implements connect advance within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
-      "type": "function",
-      "name": "fetch_host_poll",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1068,
-        1074
-      ],
-      "summary": "Implements fetch host poll within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll_with_timeout",
-      "type": "function",
-      "name": "fetch_host_poll_with_timeout",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1076,
-        1122
-      ],
-      "summary": "Implements fetch host poll with timeout within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
-      "type": "function",
-      "name": "set_host_device_enabled",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1124,
-        1149
-      ],
-      "summary": "Implements set host device enabled within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
-      "type": "function",
-      "name": "set_local_device_enabled",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1151,
-        1177
-      ],
-      "summary": "Implements set local device enabled within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
-      "type": "function",
-      "name": "fetch_host_queue",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1180,
-        1197
-      ],
-      "summary": "Implements fetch host queue within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
-      "type": "function",
-      "name": "fetch_host_queue_page",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1201,
-        1217
-      ],
-      "summary": "Implements fetch host queue page within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "scheduling"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:test_connection",
-      "type": "function",
-      "name": "test_connection",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1220,
-        1236
-      ],
-      "summary": "Implements test connection within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
-      "type": "function",
-      "name": "cancel_host_job",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        1241,
-        1258
-      ],
-      "summary": "Implements cancel host job within the hosts workflow, keeping the operation isolated for reuse and testing.",
-      "tags": [
-        "function",
-        "implementation",
-        "business-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:HostEntry",
-      "type": "class",
-      "name": "HostEntry",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        41,
-        57
-      ],
-      "summary": "Encapsulates host entry state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:AddHostError",
-      "type": "class",
-      "name": "AddHostError",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        76,
-        80
-      ],
-      "summary": "Encapsulates add host error state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
-      "type": "class",
-      "name": "HostRegistry",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        84,
-        86
-      ],
-      "summary": "Encapsulates host registry state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:GenTarget",
-      "type": "class",
-      "name": "GenTarget",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        262,
-        270
-      ],
-      "summary": "Encapsulates gen target state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:HostHealth",
-      "type": "class",
-      "name": "HostHealth",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        317,
-        321
-      ],
-      "summary": "Encapsulates host health state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:HostStatus",
-      "type": "class",
-      "name": "HostStatus",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        325,
-        328
-      ],
-      "summary": "Encapsulates host status state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
-      "type": "class",
-      "name": "MachineRowId",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        332,
-        335
-      ],
-      "summary": "Encapsulates machine row id state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
-      "type": "class",
-      "name": "MachinesFocus",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        339,
-        343
-      ],
-      "summary": "Encapsulates machines focus state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:MachinesState",
-      "type": "class",
-      "name": "MachinesState",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        357,
-        389
-      ],
-      "summary": "Encapsulates machines state state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:PollPlan",
-      "type": "class",
-      "name": "PollPlan",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        393,
-        395
-      ],
-      "summary": "Encapsulates poll plan state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
-      "type": "class",
-      "name": "HostPollRequest",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        398,
-        401
-      ],
-      "summary": "Encapsulates host poll request state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
-      "type": "class",
-      "name": "ConnectStep",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        940,
-        946
-      ],
-      "summary": "Encapsulates connect step state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
-      "type": "class",
-      "name": "ConnectForm",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        950,
-        956
-      ],
-      "summary": "Encapsulates connect form state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
-      "type": "class",
-      "name": "ConnectInput",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        961,
-        968
-      ],
-      "summary": "Encapsulates connect input state and behavior for the hosts subsystem.",
-      "tags": [
-        "data-model",
-        "class",
-        "state-management"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
-      "type": "class",
-      "name": "ConnectEffect",
-      "filePath": "crates/mold-tui/src/hosts.rs",
-      "lineRange": [
-        972,
-        980
-      ],
-      "summary": "Encapsulates connect effect state and behavior for the hosts subsystem.",
       "tags": [
         "data-model",
         "class",
@@ -272309,427 +270700,6 @@
         "domain-logic"
       ],
       "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-tui/src/ui/popup.rs",
-      "type": "file",
-      "name": "popup.rs",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "summary": "Implements popup behavior within Mold's local AI generation system and multi-surface application.",
-      "tags": [
-        "code",
-        "rust",
-        "implementation"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render",
-      "type": "function",
-      "name": "render",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        8,
-        30
-      ],
-      "summary": "render performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:centered_rect",
-      "type": "function",
-      "name": "centered_rect",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        32,
-        50
-      ],
-      "summary": "centered rect performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:centered_rect_rows",
-      "type": "function",
-      "name": "centered_rect_rows",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        58,
-        67
-      ],
-      "summary": "centered rect rows performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_help",
-      "type": "function",
-      "name": "render_help",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        69,
-        174
-      ],
-      "summary": "render help performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_alternatives",
-      "type": "function",
-      "name": "render_prompt_alternatives",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        176,
-        253
-      ],
-      "summary": "render prompt alternatives performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_source_choice",
-      "type": "function",
-      "name": "render_prompt_source_choice",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        255,
-        303
-      ],
-      "summary": "render prompt source choice performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:build_model_item",
-      "type": "function",
-      "name": "build_model_item",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        309,
-        405
-      ],
-      "summary": "build model item performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "factory"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector_popup",
-      "type": "function",
-      "name": "render_model_selector_popup",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        409,
-        485
-      ],
-      "summary": "render model selector popup performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector",
-      "type": "function",
-      "name": "render_model_selector",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        487,
-        509
-      ],
-      "summary": "render model selector performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_upscale_model_selector",
-      "type": "function",
-      "name": "render_upscale_model_selector",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        511,
-        539
-      ],
-      "summary": "render upscale model selector performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_size_input",
-      "type": "function",
-      "name": "render_size_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        541,
-        592
-      ],
-      "summary": "render size input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_stg_blocks_input",
-      "type": "function",
-      "name": "render_stg_blocks_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        594,
-        652
-      ],
-      "summary": "render stg blocks input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_references_input",
-      "type": "function",
-      "name": "render_references_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        654,
-        706
-      ],
-      "summary": "render references input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_identity_image_input",
-      "type": "function",
-      "name": "render_identity_image_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        708,
-        766
-      ],
-      "summary": "render identity image input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_filing_input",
-      "type": "function",
-      "name": "render_filing_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        775,
-        869
-      ],
-      "summary": "render filing input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_machine_connect",
-      "type": "function",
-      "name": "render_machine_connect",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        872,
-        963
-      ],
-      "summary": "render machine connect performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:action_hints",
-      "type": "function",
-      "name": "action_hints",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        966,
-        979
-      ],
-      "summary": "action hints performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "domain-logic"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_seed_input",
-      "type": "function",
-      "name": "render_seed_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        981,
-        1031
-      ],
-      "summary": "render seed input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_command_palette",
-      "type": "function",
-      "name": "render_command_palette",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1034,
-        1131
-      ],
-      "summary": "render command palette performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_history_search",
-      "type": "function",
-      "name": "render_history_search",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1133,
-        1212
-      ],
-      "summary": "render history search performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_confirm",
-      "type": "function",
-      "name": "render_confirm",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1214,
-        1248
-      ],
-      "summary": "render confirm performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_license_review",
-      "type": "function",
-      "name": "render_license_review",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1250,
-        1300
-      ],
-      "summary": "render license review performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_info",
-      "type": "function",
-      "name": "render_info",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1302,
-        1328
-      ],
-      "summary": "render info performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/ui/popup.rs:render_settings_input",
-      "type": "function",
-      "name": "render_settings_input",
-      "filePath": "crates/mold-tui/src/ui/popup.rs",
-      "lineRange": [
-        1330,
-        1381
-      ],
-      "summary": "render settings input performs a significant part of popup's rust and implementation behavior.",
-      "tags": [
-        "function",
-        "rust",
-        "ui"
-      ],
-      "complexity": "moderate"
     },
     {
       "id": "file:crates/mold-tui/src/ui/preview.rs",
@@ -281687,345 +279657,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:crates/mold-cli/src/commands/library.rs",
-      "type": "file",
-      "name": "library.rs",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "summary": "Implements the `mold library` command family for querying existing prints, previewing media, editing titles and organization metadata, managing collections and tags, moving prints to recoverable trash, and opening the terminal Library grid.",
-      "tags": [
-        "cli",
-        "library-management",
-        "gallery",
-        "terminal-preview",
-        "validation"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:run",
-      "type": "function",
-      "name": "run",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        21,
-        26
-      ],
-      "summary": "Implements run for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:run_remote",
-      "type": "function",
-      "name": "run_remote",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        28,
-        76
-      ],
-      "summary": "Dispatches a parsed Library action against an authenticated remote Mold client while preserving machine-readable output behavior.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_list",
-      "type": "function",
-      "name": "library_list",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        90,
-        138
-      ],
-      "summary": "Fetches gallery rows, resolves optional collection filters, applies deterministic filtering and pagination, and renders either JSON or a terminal table.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_show",
-      "type": "function",
-      "name": "library_show",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        140,
-        161
-      ],
-      "summary": "Fetches one gallery item and renders metadata or an inline terminal preview with media-specific fallback behavior.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
-      "type": "function",
-      "name": "preview_bytes",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        163,
-        175
-      ],
-      "summary": "Implements preview bytes for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_title",
-      "type": "function",
-      "name": "library_title",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        177,
-        196
-      ],
-      "summary": "Implements library title for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_tag",
-      "type": "function",
-      "name": "library_tag",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        198,
-        236
-      ],
-      "summary": "Implements library tag for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
-      "type": "function",
-      "name": "mutate_prints",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        238,
-        270
-      ],
-      "summary": "Applies favorite and tag changes through replay-safe bulk mutations when advertised, falling back to the legacy organization endpoint.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_collection",
-      "type": "function",
-      "name": "library_collection",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        272,
-        389
-      ],
-      "summary": "Implements collection listing, inspection, creation, updates, deletion, and print membership actions.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
-      "type": "function",
-      "name": "collection_membership",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        391,
-        416
-      ],
-      "summary": "Resolves a collection reference and replaces its membership set to add or remove named prints.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:library_trash",
-      "type": "function",
-      "name": "library_trash",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        418,
-        441
-      ],
-      "summary": "Moves named prints to recoverable server trash only when the host explicitly advertises trash capability.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:require_organize",
-      "type": "function",
-      "name": "require_organize",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        443,
-        455
-      ],
-      "summary": "Checks server capabilities and fails clearly when Library organization is unsupported.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
-      "type": "function",
-      "name": "resolve_collection",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        457,
-        487
-      ],
-      "summary": "Resolves a collection by identifier, slug, or case-insensitive exact display name while rejecting ambiguity.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
-      "type": "function",
-      "name": "filter_and_sort",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        489,
-        525
-      ],
-      "summary": "Filters gallery rows by query, tags, collection, favorite state, and media format before deterministic newest-first sorting.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:render_listing",
-      "type": "function",
-      "name": "render_listing",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        543,
-        595
-      ],
-      "summary": "Prints a concise terminal table for a paginated Library result set without contaminating JSON output.",
-      "tags": [
-        "cli",
-        "library-management",
-        "terminal-output"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:render_detail",
-      "type": "function",
-      "name": "render_detail",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        597,
-        626
-      ],
-      "summary": "Implements render detail for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "terminal-output"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:render_collections",
-      "type": "function",
-      "name": "render_collections",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        628,
-        650
-      ],
-      "summary": "Implements render collections for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "terminal-output"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:truncate",
-      "type": "function",
-      "name": "truncate",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        652,
-        663
-      ],
-      "summary": "Implements truncate for existing Library items and their terminal representation.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-cli/src/commands/library.rs:confirm",
-      "type": "function",
-      "name": "confirm",
-      "filePath": "crates/mold-cli/src/commands/library.rs",
-      "lineRange": [
-        665,
-        677
-      ],
-      "summary": "Requires an interactive confirmation for destructive global metadata changes unless the caller supplied an explicit override.",
-      "tags": [
-        "cli",
-        "library-management",
-        "api-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:crates/mold-cli/src/main.rs",
       "type": "file",
       "name": "main.rs",
@@ -285712,3065 +283343,6 @@
       "complexity": "simple"
     },
     {
-      "id": "file:crates/mold-tui/src/app.rs",
-      "type": "file",
-      "name": "app.rs",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "summary": "Owns the interactive Mold TUI state machine for Create, Library, Models, Machines, and Settings, coordinating background server work, multi-host galleries, generation progress, keyboard and mouse actions, and terminal previews.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler",
-        "gallery",
-        "generation"
-      ],
-      "complexity": "complex",
-      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "function",
-      "name": "clear",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        296,
-        320
-      ],
-      "summary": "Handles clear within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "function",
-      "name": "mark_generation_start",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        326,
-        330
-      ],
-      "summary": "Handles mark generation start within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "function",
-      "name": "generation_elapsed",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        334,
-        336
-      ],
-      "summary": "Handles generation elapsed within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "function",
-      "name": "stage_elapsed",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        339,
-        341
-      ],
-      "summary": "Handles stage elapsed within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "function",
-      "name": "push_log",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        346,
-        352
-      ],
-      "summary": "Handles push log within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:clear_download",
-      "type": "function",
-      "name": "clear_download",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        354,
-        367
-      ],
-      "summary": "Handles clear download within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "function",
-      "name": "is_downloading",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        370,
-        372
-      ],
-      "summary": "Handles is downloading within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "function",
-      "name": "download_status_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        375,
-        389
-      ],
-      "summary": "Handles download status text within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:record_download_sample",
-      "type": "function",
-      "name": "record_download_sample",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        397,
-        445
-      ],
-      "summary": "Handles record download sample within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:next",
-      "type": "function",
-      "name": "next",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        473,
-        481
-      ],
-      "summary": "Handles next within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "function",
-      "name": "prev",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        483,
-        491
-      ],
-      "summary": "Handles prev within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:label",
-      "type": "function",
-      "name": "label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        558,
-        603
-      ],
-      "summary": "Handles label within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
-      "type": "function",
-      "name": "qwen_image_edit_dimensions_for_path",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        606,
-        620
-      ],
-      "summary": "Handles qwen image edit dimensions for path within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "function",
-      "name": "parse_size_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        625,
-        633
-      ],
-      "summary": "Handles parse size input within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "function",
-      "name": "resolve",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        665,
-        673
-      ],
-      "summary": "Handles resolve within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "function",
-      "name": "advance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        676,
-        682
-      ],
-      "summary": "Handles advance within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:new",
-      "type": "function",
-      "name": "new",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        802,
-        812
-      ],
-      "summary": "Handles new within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "function",
-      "name": "prompt_required_for_params",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        853,
-        858
-      ],
-      "summary": "Handles prompt required for params within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "function",
-      "name": "from_config",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        861,
-        918
-      ],
-      "summary": "Handles from config within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "function",
-      "name": "display_value",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        921,
-        1099
-      ],
-      "summary": "Handles display value within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
-      "type": "function",
-      "name": "adjust_optional_scale",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1108,
-        1122
-      ],
-      "summary": "Handles adjust optional scale within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
-      "type": "function",
-      "name": "adjust_optional_u32",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1124,
-        1138
-      ],
-      "summary": "Handles adjust optional u32 within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
-      "type": "function",
-      "name": "parse_stg_blocks_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1140,
-        1172
-      ],
-      "summary": "Handles parse stg blocks input within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
-      "type": "function",
-      "name": "tui_max_video_frames",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1197,
-        1209
-      ],
-      "summary": "Handles tui max video frames within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "function",
-      "name": "normalize_generate_params_for_family",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1217,
-        1246
-      ],
-      "summary": "Handles normalize generate params for family within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
-      "type": "function",
-      "name": "restored_negative_editor_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1260,
-        1272
-      ],
-      "summary": "Handles restored negative editor text within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
-      "type": "function",
-      "name": "negative_prompt_textarea",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1276,
-        1285
-      ],
-      "summary": "Handles negative prompt textarea within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "function",
-      "name": "from_outcomes",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1394,
-        1413
-      ],
-      "summary": "Handles from outcomes within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "function",
-      "name": "guidance_adjustable",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1424,
-        1426
-      ],
-      "summary": "Handles guidance adjustable within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "function",
-      "name": "negative_visible",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1434,
-        1438
-      ],
-      "summary": "Handles negative visible within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:default",
-      "type": "function",
-      "name": "default",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1505,
-        1531
-      ],
-      "summary": "Handles default within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "function",
-      "name": "refresh_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1537,
-        1544
-      ],
-      "summary": "Handles refresh filter within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "function",
-      "name": "selected_pos",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1547,
-        1549
-      ],
-      "summary": "Handles selected pos within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "function",
-      "name": "rescan_due",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1554,
-        1562
-      ],
-      "summary": "Handles rescan due within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "function",
-      "name": "handle_filter_key",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1568,
-        1594
-      ],
-      "summary": "Handles handle filter key within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:local",
-      "type": "function",
-      "name": "local",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1612,
-        1618
-      ],
-      "summary": "Handles local within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "function",
-      "name": "from_host_entry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1620,
-        1626
-      ],
-      "summary": "Handles from host entry within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "function",
-      "name": "remote_from_url",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1630,
-        1636
-      ],
-      "summary": "Handles remote from url within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "function",
-      "name": "is_local",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1638,
-        1640
-      ],
-      "summary": "Handles is local within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "function",
-      "name": "is_this_machine",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1645,
-        1647
-      ],
-      "summary": "Handles is this machine within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "function",
-      "name": "filename",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1670,
-        1675
-      ],
-      "summary": "Handles filename within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "function",
-      "name": "owning_origins",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1679,
-        1687
-      ],
-      "summary": "Handles owning origins within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "function",
-      "name": "primary_origin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1690,
-        1695
-      ],
-      "summary": "Handles primary origin within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "function",
-      "name": "machine_label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1699,
-        1706
-      ],
-      "summary": "Handles machine label within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "function",
-      "name": "trash_retention_display",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1711,
-        1717
-      ],
-      "summary": "Handles trash retention display within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "function",
-      "name": "hint_label",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1734,
-        1739
-      ],
-      "summary": "Handles hint label within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "function",
-      "name": "delete_confirm_message",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1747,
-        1758
-      ],
-      "summary": "Handles delete confirm message within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:generation_model_names",
-      "type": "function",
-      "name": "generation_model_names",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1790,
-        1801
-      ],
-      "summary": "Handles generation model names within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "function",
-      "name": "is_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1888,
-        1890
-      ],
-      "summary": "Handles is field within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "function",
-      "name": "is_read_only",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1892,
-        1900
-      ],
-      "summary": "Handles is read only within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "function",
-      "name": "tab_at_column",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2165,
-        2169
-      ],
-      "summary": "Handles tab at column within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "function",
-      "name": "configure_background_server_command",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2173,
-        2177
-      ],
-      "summary": "Handles configure background server command within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
-      "type": "function",
-      "name": "wait_for_server_health",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2180,
-        2189
-      ],
-      "summary": "Handles wait for server health within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
-      "type": "function",
-      "name": "new_with_launch_policy",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2196,
-        2515
-      ],
-      "summary": "Builds the complete TUI application state while enforcing strict explicit-host connection semantics and initializing local or remote services.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "function",
-      "name": "spawn_gallery_scan",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2521,
-        2529
-      ],
-      "summary": "Handles spawn gallery scan within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "function",
-      "name": "should_poll_remote",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2533,
-        2535
-      ],
-      "summary": "Handles should poll remote within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "function",
-      "name": "should_save_output_locally",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2543,
-        2548
-      ],
-      "summary": "Handles should save output locally within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "function",
-      "name": "should_persist_response_locally",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2560,
-        2568
-      ],
-      "summary": "Handles should persist response locally within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "function",
-      "name": "spawn_server_status_fetch",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2582,
-        2630
-      ],
-      "summary": "Handles spawn server status fetch within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "function",
-      "name": "tick_host_polling",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2635,
-        2646
-      ],
-      "summary": "Handles tick host polling within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
-      "type": "function",
-      "name": "apply_remote_model_defaults",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2660,
-        2678
-      ],
-      "summary": "Handles apply remote model defaults within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:source_image_contract",
-      "type": "function",
-      "name": "source_image_contract",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2686,
-        2696
-      ],
-      "summary": "Handles source image contract within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:identity_gate_error",
-      "type": "function",
-      "name": "identity_gate_error",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2712,
-        2738
-      ],
-      "summary": "Handles identity gate error within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
-      "type": "function",
-      "name": "sync_generate_capabilities",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2763,
-        2879
-      ],
-      "summary": "Handles sync generate capabilities within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
-      "type": "function",
-      "name": "normalize_fixed_guidance_for_submit",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2884,
-        2904
-      ],
-      "summary": "Handles normalize fixed guidance for submit within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
-      "type": "function",
-      "name": "sync_pipeline_guidance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2910,
-        2926
-      ],
-      "summary": "Handles sync pipeline guidance within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:spawn_upscale",
-      "type": "function",
-      "name": "spawn_upscale",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2929,
-        3181
-      ],
-      "summary": "Handles spawn upscale within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "function",
-      "name": "shutdown",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3184,
-        3194
-      ],
-      "summary": "Handles shutdown within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "function",
-      "name": "save_session",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3197,
-        3220
-      ],
-      "summary": "Handles save session within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "function",
-      "name": "apply_theme_preset",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3227,
-        3231
-      ],
-      "summary": "Handles apply theme preset within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "function",
-      "name": "update_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3233,
-        3320
-      ],
-      "summary": "Handles update model within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
-      "type": "function",
-      "name": "save_prefs_for_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3325,
-        3358
-      ],
-      "summary": "Handles save prefs for model within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
-      "type": "function",
-      "name": "apply_prefs_for_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3363,
-        3423
-      ],
-      "summary": "Handles apply prefs for model within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "function",
-      "name": "refresh_create_rows",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3427,
-        3435
-      ],
-      "summary": "Handles refresh create rows within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
-      "type": "function",
-      "name": "set_advanced_expanded",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3441,
-        3459
-      ],
-      "summary": "Handles set advanced expanded within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:model_default_size",
-      "type": "function",
-      "name": "model_default_size",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3464,
-        3482
-      ],
-      "summary": "Handles model default size within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
-      "type": "function",
-      "name": "active_generation_recipe",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3487,
-        3496
-      ],
-      "summary": "Handles active generation recipe within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "function",
-      "name": "handle_crossterm_event",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3499,
-        3701
-      ],
-      "summary": "Handles handle crossterm event within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_popup_event",
-      "type": "function",
-      "name": "handle_popup_event",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        3726,
-        4270
-      ],
-      "summary": "Handles handle popup event within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_mouse",
-      "type": "function",
-      "name": "handle_mouse",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4272,
-        4430
-      ],
-      "summary": "Handles handle mouse within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
-      "type": "function",
-      "name": "available_upscaler_models",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4433,
-        4452
-      ],
-      "summary": "Handles available upscaler models within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
-      "type": "function",
-      "name": "update_upscale_model_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4454,
-        4481
-      ],
-      "summary": "Handles update upscale model filter within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
-      "type": "function",
-      "name": "update_model_selector_filter",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4483,
-        4495
-      ],
-      "summary": "Handles update model selector filter within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:set_active_view",
-      "type": "function",
-      "name": "set_active_view",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4500,
-        4519
-      ],
-      "summary": "Handles set active view within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:open_library",
-      "type": "function",
-      "name": "open_library",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4521,
-        4523
-      ],
-      "summary": "Switches the TUI to the Library workspace through the normal active-view transition path.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "function",
-      "name": "dispatch_action",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        4526,
-        5228
-      ],
-      "summary": "Handles dispatch action within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:increment_param",
-      "type": "function",
-      "name": "increment_param",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5230,
-        5259
-      ],
-      "summary": "Handles increment param within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:adjust_field",
-      "type": "function",
-      "name": "adjust_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5262,
-        5613
-      ],
-      "summary": "Handles adjust field within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
-      "type": "function",
-      "name": "load_gallery_preview",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5616,
-        5721
-      ],
-      "summary": "Handles load gallery preview within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
-      "type": "function",
-      "name": "try_install_gallery_animation",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5725,
-        5740
-      ],
-      "summary": "Handles try install gallery animation within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "function",
-      "name": "tick_animations",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5745,
-        5760
-      ],
-      "summary": "Handles tick animations within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
-      "type": "function",
-      "name": "load_gallery_into_generate",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5763,
-        5827
-      ],
-      "summary": "Handles load gallery into generate within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "function",
-      "name": "apply_gallery_scan",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5836,
-        5869
-      ],
-      "summary": "Handles apply gallery scan within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "function",
-      "name": "apply_delete_failure",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5878,
-        5884
-      ],
-      "summary": "Handles apply delete failure within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "function",
-      "name": "capabilities_for_origin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5890,
-        5901
-      ],
-      "summary": "Handles capabilities for origin within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "function",
-      "name": "origin_can_trash",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5906,
-        5914
-      ],
-      "summary": "Handles origin can trash within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "function",
-      "name": "removal_kind_for",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5918,
-        5928
-      ],
-      "summary": "Handles removal kind for within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "function",
-      "name": "selected_removal_kind",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5931,
-        5937
-      ],
-      "summary": "Handles selected removal kind within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
-      "type": "function",
-      "name": "delete_selected_gallery_image",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        5944,
-        6056
-      ],
-      "summary": "Handles delete selected gallery image within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:open_gallery_file",
-      "type": "function",
-      "name": "open_gallery_file",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6060,
-        6081
-      ],
-      "summary": "Handles open gallery file within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
-      "type": "function",
-      "name": "build_remove_model_message",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6085,
-        6133
-      ],
-      "summary": "Handles build remove model message within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "function",
-      "name": "needs_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6137,
-        6139
-      ],
-      "summary": "Handles needs confirm within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "function",
-      "name": "request_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6145,
-        6154
-      ],
-      "summary": "Handles request confirm within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
-      "type": "function",
-      "name": "handle_confirm_action",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6157,
-        6192
-      ],
-      "summary": "Handles handle confirm action within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:open_model_selector",
-      "type": "function",
-      "name": "open_model_selector",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6203,
-        6222
-      ],
-      "summary": "Handles open model selector within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:activate_current_param",
-      "type": "function",
-      "name": "activate_current_param",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6225,
-        6249
-      ],
-      "summary": "Handles activate current param within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
-      "type": "function",
-      "name": "surface_request_advisories",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6268,
-        6279
-      ],
-      "summary": "Handles surface request advisories within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:filing_editor_text",
-      "type": "function",
-      "name": "filing_editor_text",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6283,
-        6292
-      ],
-      "summary": "Handles filing editor text within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:activate_field",
-      "type": "function",
-      "name": "activate_field",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6305,
-        6406
-      ],
-      "summary": "Handles activate field within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
-      "type": "function",
-      "name": "reset_params_to_model_defaults",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6409,
-        6490
-      ],
-      "summary": "Handles reset params to model defaults within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "function",
-      "name": "build_settings_rows",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6496,
-        6818
-      ],
-      "summary": "Handles build settings rows within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "function",
-      "name": "settings_display_value",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6821,
-        6959
-      ],
-      "summary": "Handles settings display value within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "function",
-      "name": "settings_env_override",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        6977,
-        7000
-      ],
-      "summary": "Handles settings env override within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_navigate",
-      "type": "function",
-      "name": "settings_navigate",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7010,
-        7054
-      ],
-      "summary": "Handles settings navigate within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
-      "type": "function",
-      "name": "settings_cycle_theme",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7057,
-        7067
-      ],
-      "summary": "Handles settings cycle theme within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_increment",
-      "type": "function",
-      "name": "settings_increment",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7070,
-        7106
-      ],
-      "summary": "Handles settings increment within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
-      "type": "function",
-      "name": "settings_adjust_number",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7108,
-        7205
-      ],
-      "summary": "Handles settings adjust number within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
-      "type": "function",
-      "name": "settings_cycle_toggle",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7207,
-        7249
-      ],
-      "summary": "Handles settings cycle toggle within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
-      "type": "function",
-      "name": "settings_toggle_bool",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7251,
-        7293
-      ],
-      "summary": "Handles settings toggle bool within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
-      "type": "function",
-      "name": "settings_cycle_model",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7295,
-        7308
-      ],
-      "summary": "Handles settings cycle model within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_confirm",
-      "type": "function",
-      "name": "settings_confirm",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7311,
-        7357
-      ],
-      "summary": "Handles settings confirm within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:settings_apply_input",
-      "type": "function",
-      "name": "settings_apply_input",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7360,
-        7414
-      ],
-      "summary": "Handles settings apply input within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:save_config",
-      "type": "function",
-      "name": "save_config",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7417,
-        7427
-      ],
-      "summary": "Handles save config within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_generation",
-      "type": "function",
-      "name": "start_generation",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7429,
-        7669
-      ],
-      "summary": "Handles start generation within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:retry_held_prints",
-      "type": "function",
-      "name": "retry_held_prints",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7677,
-        7698
-      ],
-      "summary": "Handles retry held prints within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
-      "type": "function",
-      "name": "prompt_transform_task",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7722,
-        7739
-      ],
-      "summary": "Handles prompt transform task within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
-      "type": "function",
-      "name": "reference_fingerprint_for_target",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7745,
-        7781
-      ],
-      "summary": "Handles reference fingerprint for target within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
-      "type": "function",
-      "name": "start_prompt_transform",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7783,
-        7826
-      ],
-      "summary": "Handles start prompt transform within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
-      "type": "function",
-      "name": "start_prompt_transform_from",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7828,
-        7905
-      ],
-      "summary": "Handles start prompt transform from within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_provenance",
-      "type": "function",
-      "name": "prompt_provenance",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7907,
-        7919
-      ],
-      "summary": "Handles prompt provenance within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
-      "type": "function",
-      "name": "prompt_transform_staleness",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7921,
-        7952
-      ],
-      "summary": "Handles prompt transform staleness within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
-      "type": "function",
-      "name": "quick_transform_staleness",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7957,
-        7987
-      ],
-      "summary": "Handles quick transform staleness within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
-      "type": "function",
-      "name": "apply_prompt_variant",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        7999,
-        8019
-      ],
-      "summary": "Handles apply prompt variant within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
-      "type": "function",
-      "name": "prepare_prompt_variants",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        8021,
-        8046
-      ],
-      "summary": "Handles prepare prompt variants within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "function",
-      "name": "process_background_events",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        8049,
-        9191
-      ],
-      "summary": "Handles process background events within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "complex"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:handle_progress",
-      "type": "function",
-      "name": "handle_progress",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9193,
-        9210
-      ],
-      "summary": "Handles handle progress within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
-      "type": "function",
-      "name": "build_local_model_catalog",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9213,
-        9231
-      ],
-      "summary": "Handles build local model catalog within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:decode_live_preview",
-      "type": "function",
-      "name": "decode_live_preview",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9237,
-        9254
-      ],
-      "summary": "Handles decode live preview within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
-      "type": "function",
-      "name": "reduce_progress_state",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        9271,
-        9431
-      ],
-      "summary": "Handles reduce progress state within the interactive TUI application state machine.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "class",
-      "name": "PromptTransformSnapshot",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        27,
-        38
-      ],
-      "summary": "Defines prompt transform snapshot state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "class",
-      "name": "LicenseDownloadRequirement",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        43,
-        46
-      ],
-      "summary": "Defines license download requirement state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "class",
-      "name": "DurableGenerationChildOutcome",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        49,
-        70
-      ],
-      "summary": "Defines durable generation child outcome state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "class",
-      "name": "BackgroundEvent",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        73,
-        234
-      ],
-      "summary": "Defines background event state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "class",
-      "name": "ProgressLogEntry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        238,
-        241
-      ],
-      "summary": "Defines progress log entry state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "class",
-      "name": "ProgressStyle",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        244,
-        249
-      ],
-      "summary": "Defines progress style state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "class",
-      "name": "ProgressState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        259,
-        293
-      ],
-      "summary": "Defines progress state state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "class",
-      "name": "CreateMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        456,
-        460
-      ],
-      "summary": "Defines create mode state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "class",
-      "name": "GenerateFocus",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        464,
-        470
-      ],
-      "summary": "Defines generate focus state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "class",
-      "name": "ParamField",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        502,
-        555
-      ],
-      "summary": "Defines param field state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "class",
-      "name": "SeedMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        637,
-        645
-      ],
-      "summary": "Defines seed mode state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "class",
-      "name": "GenerateParams",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        687,
-        790
-      ],
-      "summary": "Defines generate params state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "class",
-      "name": "GenerationMetadataSnapshot",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        795,
-        799
-      ],
-      "summary": "Defines generation metadata snapshot state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "class",
-      "name": "InferenceMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        817,
-        825
-      ],
-      "summary": "Defines inference mode state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "class",
-      "name": "GenerateState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1288,
-        1363
-      ],
-      "summary": "Defines generate state state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "class",
-      "name": "HeldPrintRetry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1367,
-        1371
-      ],
-      "summary": "Defines held print retry state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "class",
-      "name": "HeldHost",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1375,
-        1378
-      ],
-      "summary": "Defines held host state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "class",
-      "name": "HeldBatch",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1385,
-        1389
-      ],
-      "summary": "Defines held batch state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "class",
-      "name": "GalleryViewMode",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1443,
-        1447
-      ],
-      "summary": "Defines gallery view mode state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "class",
-      "name": "GalleryState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1454,
-        1502
-      ],
-      "summary": "Defines gallery state state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "class",
-      "name": "GalleryOrigin",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1601,
-        1609
-      ],
-      "summary": "Defines gallery origin state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "class",
-      "name": "GalleryEntry",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1652,
-        1667
-      ],
-      "summary": "Defines gallery entry state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "class",
-      "name": "RemovalKind",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1721,
-        1730
-      ],
-      "summary": "Defines removal kind state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "class",
-      "name": "ModelsState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1761,
-        1766
-      ],
-      "summary": "Defines models state state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "class",
-      "name": "SettingsKey",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1807,
-        1855
-      ],
-      "summary": "Defines settings key state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "class",
-      "name": "SettingsFieldType",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1859,
-        1872
-      ],
-      "summary": "Defines settings field type state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "class",
-      "name": "SettingsRow",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1876,
-        1885
-      ],
-      "summary": "Defines settings row state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "class",
-      "name": "SettingsFocus",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1909,
-        1913
-      ],
-      "summary": "Defines settings focus state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "class",
-      "name": "SettingsState",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1917,
-        1938
-      ],
-      "summary": "Defines settings state state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "class",
-      "name": "Popup",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        1941,
-        2033
-      ],
-      "summary": "Defines popup state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "class",
-      "name": "UpscalePickerPurpose",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2037,
-        2043
-      ],
-      "summary": "Defines upscale picker purpose state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "class",
-      "name": "ConfirmAction",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2054,
-        2067
-      ],
-      "summary": "Defines confirm action state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:App",
-      "type": "class",
-      "name": "App",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2070,
-        2121
-      ],
-      "summary": "Top-level TUI state container and event coordinator spanning generation, Library, models, machines, settings, progress, and asynchronous background results.",
-      "tags": [
-        "tui",
-        "state-machine",
-        "event-handler",
-        "application"
-      ],
-      "complexity": "moderate"
-    },
-    {
-      "id": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "class",
-      "name": "LayoutAreas",
-      "filePath": "crates/mold-tui/src/app.rs",
-      "lineRange": [
-        2125,
-        2138
-      ],
-      "summary": "Defines layout areas state or command data used by app.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "file:crates/mold-tui/src/lib.rs",
-      "type": "file",
-      "name": "lib.rs",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "summary": "Bootstraps the terminal UI, selects image protocol support, applies strict host launch policy, chooses the initial workspace, and runs the Crossterm event loop with safe terminal restoration.",
-      "tags": [
-        "entry-point",
-        "tui",
-        "terminal",
-        "event-loop",
-        "host-routing"
-      ],
-      "complexity": "moderate",
-      "languageNotes": "Rust code uses async Result-based APIs and feature-gated surfaces where applicable."
-    },
-    {
-      "id": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "function",
-      "name": "run_tui",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        61,
-        68
-      ],
-      "summary": "Implements run tui for this module's primary behavior.",
-      "tags": [
-        "utility",
-        "generation-form",
-        "capabilities"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
-      "type": "function",
-      "name": "run_tui_with_options",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        71,
-        118
-      ],
-      "summary": "Initializes the TUI from explicit launch options, opens the requested workspace, and guarantees terminal cleanup around the event loop.",
-      "tags": [
-        "utility",
-        "generation-form",
-        "capabilities"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "function:crates/mold-tui/src/lib.rs:run_event_loop",
-      "type": "function",
-      "name": "run_event_loop",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        120,
-        165
-      ],
-      "summary": "Implements run event loop for this module's primary behavior.",
-      "tags": [
-        "utility",
-        "generation-form",
-        "capabilities"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
-      "type": "class",
-      "name": "TuiInitialWorkspace",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        40,
-        44
-      ],
-      "summary": "Defines tui initial workspace state or command data used by lib.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
-      "id": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
-      "type": "class",
-      "name": "TuiLaunchOptions",
-      "filePath": "crates/mold-tui/src/lib.rs",
-      "lineRange": [
-        48,
-        55
-      ],
-      "summary": "Defines tui launch options state or command data used by lib.rs.",
-      "tags": [
-        "data-model",
-        "state",
-        "type-definition"
-      ],
-      "complexity": "simple"
-    },
-    {
       "id": "file:desktop/src/components/generate/SourceImageWell.test.ts",
       "type": "file",
       "name": "SourceImageWell.test.ts",
@@ -290363,6 +284935,5519 @@
         "utility"
       ],
       "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-cli/src/commands/library.rs",
+      "type": "file",
+      "name": "library.rs",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "summary": "Implements the `mold library` command surface for querying, previewing, organizing, and safely trashing prints on one authenticated server, with the interactive grid delegated to the TUI.",
+      "tags": [
+        "cli",
+        "library",
+        "api-handler",
+        "validation"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "function",
+      "name": "run",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        21,
+        26
+      ],
+      "summary": "Dispatches Library CLI behavior from the command entry point.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:run_remote",
+      "type": "function",
+      "name": "run_remote",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        28,
+        76
+      ],
+      "summary": "Implements run remote behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_list",
+      "type": "function",
+      "name": "library_list",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        90,
+        138
+      ],
+      "summary": "Implements library list behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_show",
+      "type": "function",
+      "name": "library_show",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        140,
+        161
+      ],
+      "summary": "Implements library show behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
+      "type": "function",
+      "name": "preview_bytes",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        163,
+        175
+      ],
+      "summary": "Implements preview bytes behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_title",
+      "type": "function",
+      "name": "library_title",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        177,
+        196
+      ],
+      "summary": "Implements library title behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_tag",
+      "type": "function",
+      "name": "library_tag",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        198,
+        236
+      ],
+      "summary": "Implements library tag behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
+      "type": "function",
+      "name": "mutate_prints",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        238,
+        270
+      ],
+      "summary": "Implements mutate prints behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_collection",
+      "type": "function",
+      "name": "library_collection",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        272,
+        389
+      ],
+      "summary": "Implements library collection behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
+      "type": "function",
+      "name": "collection_membership",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        391,
+        416
+      ],
+      "summary": "Implements collection membership behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_trash",
+      "type": "function",
+      "name": "library_trash",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        418,
+        441
+      ],
+      "summary": "Implements library trash behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:require_organize",
+      "type": "function",
+      "name": "require_organize",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        443,
+        455
+      ],
+      "summary": "Implements require organize behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
+      "type": "function",
+      "name": "resolve_collection",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        457,
+        487
+      ],
+      "summary": "Resolves collection for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
+      "type": "function",
+      "name": "filter_and_sort",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        489,
+        525
+      ],
+      "summary": "Implements filter and sort behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_listing",
+      "type": "function",
+      "name": "render_listing",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        543,
+        595
+      ],
+      "summary": "Renders the listing surface using current application state and theme rules.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_detail",
+      "type": "function",
+      "name": "render_detail",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        597,
+        626
+      ],
+      "summary": "Renders the detail surface using current application state and theme rules.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:render_collections",
+      "type": "function",
+      "name": "render_collections",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        628,
+        650
+      ],
+      "summary": "Renders the collections surface using current application state and theme rules.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:truncate",
+      "type": "function",
+      "name": "truncate",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        652,
+        663
+      ],
+      "summary": "Implements truncate behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:confirm",
+      "type": "function",
+      "name": "confirm",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        665,
+        677
+      ],
+      "summary": "Implements confirm behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-cli/src/commands/library.rs:library_grid",
+      "type": "function",
+      "name": "library_grid",
+      "filePath": "crates/mold-cli/src/commands/library.rs",
+      "lineRange": [
+        680,
+        689
+      ],
+      "summary": "Implements library grid behavior for Library CLI behavior.",
+      "tags": [
+        "cli",
+        "library",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/app.rs",
+      "type": "file",
+      "name": "app.rs",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "summary": "Defines the central TUI state machine spanning Create, Library, Models, Machines, and Settings, including input dispatch, background work, generation admission, gallery workflows, and cross-host coordination.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "event-handler",
+        "orchestration"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "class",
+      "name": "PromptTransformSnapshot",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        27,
+        38
+      ],
+      "summary": "Represents PromptTransformSnapshot state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "class",
+      "name": "LicenseDownloadRequirement",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        43,
+        46
+      ],
+      "summary": "Represents LicenseDownloadRequirement state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "class",
+      "name": "DurableGenerationChildOutcome",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        49,
+        70
+      ],
+      "summary": "Represents DurableGenerationChildOutcome state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "class",
+      "name": "BackgroundEvent",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        73,
+        234
+      ],
+      "summary": "Represents BackgroundEvent state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "class",
+      "name": "ProgressLogEntry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        238,
+        241
+      ],
+      "summary": "Represents ProgressLogEntry state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "class",
+      "name": "ProgressStyle",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        244,
+        249
+      ],
+      "summary": "Represents ProgressStyle state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "class",
+      "name": "ProgressState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        259,
+        293
+      ],
+      "summary": "Represents ProgressState state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "function",
+      "name": "clear",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        296,
+        320
+      ],
+      "summary": "Implements clear behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "function",
+      "name": "mark_generation_start",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        326,
+        330
+      ],
+      "summary": "Implements mark generation start behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "function",
+      "name": "generation_elapsed",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        334,
+        336
+      ],
+      "summary": "Implements generation elapsed behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "function",
+      "name": "stage_elapsed",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        339,
+        341
+      ],
+      "summary": "Implements stage elapsed behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "function",
+      "name": "push_log",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        346,
+        352
+      ],
+      "summary": "Implements push log behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:clear_download",
+      "type": "function",
+      "name": "clear_download",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        354,
+        367
+      ],
+      "summary": "Implements clear download behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "function",
+      "name": "is_downloading",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        370,
+        372
+      ],
+      "summary": "Determines whether is downloading is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "function",
+      "name": "download_status_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        375,
+        389
+      ],
+      "summary": "Implements download status text behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:record_download_sample",
+      "type": "function",
+      "name": "record_download_sample",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        397,
+        445
+      ],
+      "summary": "Implements record download sample behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "class",
+      "name": "CreateMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        456,
+        460
+      ],
+      "summary": "Represents CreateMode state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "class",
+      "name": "GenerateFocus",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        464,
+        470
+      ],
+      "summary": "Represents GenerateFocus state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:next",
+      "type": "function",
+      "name": "next",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        473,
+        481
+      ],
+      "summary": "Implements next behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "function",
+      "name": "prev",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        483,
+        491
+      ],
+      "summary": "Implements prev behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "class",
+      "name": "ParamField",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        502,
+        555
+      ],
+      "summary": "Represents ParamField state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:label",
+      "type": "function",
+      "name": "label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        558,
+        603
+      ],
+      "summary": "Implements label behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
+      "type": "function",
+      "name": "qwen_image_edit_dimensions_for_path",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        606,
+        620
+      ],
+      "summary": "Implements qwen image edit dimensions for path behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "function",
+      "name": "parse_size_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        625,
+        633
+      ],
+      "summary": "Implements parse size input behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "class",
+      "name": "SeedMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        637,
+        645
+      ],
+      "summary": "Represents SeedMode state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "function",
+      "name": "resolve",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        665,
+        673
+      ],
+      "summary": "Resolves resolve for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "function",
+      "name": "advance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        676,
+        682
+      ],
+      "summary": "Implements advance behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "class",
+      "name": "GenerateParams",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        687,
+        790
+      ],
+      "summary": "Represents GenerateParams state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "class",
+      "name": "GenerationMetadataSnapshot",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        795,
+        799
+      ],
+      "summary": "Represents GenerationMetadataSnapshot state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:new",
+      "type": "function",
+      "name": "new",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        802,
+        812
+      ],
+      "summary": "Constructs initialized state for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "class",
+      "name": "InferenceMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        817,
+        825
+      ],
+      "summary": "Represents InferenceMode state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "function",
+      "name": "prompt_required_for_params",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        853,
+        858
+      ],
+      "summary": "Implements prompt required for params behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "function",
+      "name": "from_config",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        861,
+        918
+      ],
+      "summary": "Implements from config behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "function",
+      "name": "display_value",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        921,
+        1099
+      ],
+      "summary": "Implements display value behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
+      "type": "function",
+      "name": "adjust_optional_scale",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1108,
+        1122
+      ],
+      "summary": "Implements adjust optional scale behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
+      "type": "function",
+      "name": "adjust_optional_u32",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1124,
+        1138
+      ],
+      "summary": "Implements adjust optional u32 behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
+      "type": "function",
+      "name": "parse_stg_blocks_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1140,
+        1172
+      ],
+      "summary": "Implements parse stg blocks input behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
+      "type": "function",
+      "name": "tui_max_video_frames",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1197,
+        1209
+      ],
+      "summary": "Implements tui max video frames behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "function",
+      "name": "normalize_generate_params_for_family",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1217,
+        1246
+      ],
+      "summary": "Implements normalize generate params for family behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
+      "type": "function",
+      "name": "restored_negative_editor_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1260,
+        1272
+      ],
+      "summary": "Implements restored negative editor text behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
+      "type": "function",
+      "name": "negative_prompt_textarea",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1276,
+        1285
+      ],
+      "summary": "Implements negative prompt textarea behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "class",
+      "name": "GenerateState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1288,
+        1363
+      ],
+      "summary": "Represents GenerateState state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "class",
+      "name": "HeldPrintRetry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1367,
+        1371
+      ],
+      "summary": "Represents HeldPrintRetry state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "class",
+      "name": "HeldHost",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1375,
+        1378
+      ],
+      "summary": "Represents HeldHost state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "class",
+      "name": "HeldBatch",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1385,
+        1389
+      ],
+      "summary": "Represents HeldBatch state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "function",
+      "name": "from_outcomes",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1394,
+        1413
+      ],
+      "summary": "Implements from outcomes behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "function",
+      "name": "guidance_adjustable",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1424,
+        1426
+      ],
+      "summary": "Implements guidance adjustable behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "function",
+      "name": "negative_visible",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1434,
+        1438
+      ],
+      "summary": "Implements negative visible behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "class",
+      "name": "GalleryViewMode",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1443,
+        1447
+      ],
+      "summary": "Represents GalleryViewMode state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "class",
+      "name": "GalleryState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1454,
+        1502
+      ],
+      "summary": "Represents GalleryState state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:default",
+      "type": "function",
+      "name": "default",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1505,
+        1531
+      ],
+      "summary": "Implements default behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "function",
+      "name": "refresh_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1537,
+        1544
+      ],
+      "summary": "Implements refresh filter behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "function",
+      "name": "selected_pos",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1547,
+        1549
+      ],
+      "summary": "Implements selected pos behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "function",
+      "name": "rescan_due",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1554,
+        1562
+      ],
+      "summary": "Implements rescan due behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "function",
+      "name": "handle_filter_key",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1568,
+        1594
+      ],
+      "summary": "Handles filter key within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "class",
+      "name": "GalleryOrigin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1601,
+        1609
+      ],
+      "summary": "Represents GalleryOrigin state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:local",
+      "type": "function",
+      "name": "local",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1612,
+        1618
+      ],
+      "summary": "Implements local behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "function",
+      "name": "from_host_entry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1620,
+        1626
+      ],
+      "summary": "Implements from host entry behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "function",
+      "name": "remote_from_url",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1630,
+        1636
+      ],
+      "summary": "Implements remote from url behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "function",
+      "name": "is_local",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1638,
+        1640
+      ],
+      "summary": "Determines whether is local is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "function",
+      "name": "is_this_machine",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1645,
+        1647
+      ],
+      "summary": "Determines whether is this machine is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "class",
+      "name": "GalleryEntry",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1652,
+        1667
+      ],
+      "summary": "Represents GalleryEntry state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "function",
+      "name": "filename",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1670,
+        1675
+      ],
+      "summary": "Implements filename behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "function",
+      "name": "owning_origins",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1679,
+        1687
+      ],
+      "summary": "Implements owning origins behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "function",
+      "name": "primary_origin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1690,
+        1695
+      ],
+      "summary": "Implements primary origin behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "function",
+      "name": "machine_label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1699,
+        1706
+      ],
+      "summary": "Implements machine label behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "function",
+      "name": "trash_retention_display",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1711,
+        1717
+      ],
+      "summary": "Performs the guarded trash retention display operation for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "class",
+      "name": "RemovalKind",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1721,
+        1730
+      ],
+      "summary": "Represents RemovalKind state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "function",
+      "name": "hint_label",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1734,
+        1739
+      ],
+      "summary": "Implements hint label behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "function",
+      "name": "delete_confirm_message",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1747,
+        1758
+      ],
+      "summary": "Performs the guarded delete confirm message operation for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "class",
+      "name": "ModelsState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1761,
+        1766
+      ],
+      "summary": "Represents ModelsState state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:generation_model_names",
+      "type": "function",
+      "name": "generation_model_names",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1790,
+        1801
+      ],
+      "summary": "Implements generation model names behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "class",
+      "name": "SettingsKey",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1807,
+        1855
+      ],
+      "summary": "Represents SettingsKey state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "class",
+      "name": "SettingsFieldType",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1859,
+        1872
+      ],
+      "summary": "Represents SettingsFieldType state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "class",
+      "name": "SettingsRow",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1876,
+        1885
+      ],
+      "summary": "Represents SettingsRow state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "function",
+      "name": "is_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1888,
+        1890
+      ],
+      "summary": "Determines whether is field is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "function",
+      "name": "is_read_only",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1892,
+        1900
+      ],
+      "summary": "Determines whether is read only is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "class",
+      "name": "SettingsFocus",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1909,
+        1913
+      ],
+      "summary": "Represents SettingsFocus state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "class",
+      "name": "SettingsState",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1917,
+        1938
+      ],
+      "summary": "Represents SettingsState state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "class",
+      "name": "Popup",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        1941,
+        2033
+      ],
+      "summary": "Represents Popup state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "class",
+      "name": "UpscalePickerPurpose",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2037,
+        2043
+      ],
+      "summary": "Represents UpscalePickerPurpose state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "class",
+      "name": "ConfirmAction",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2054,
+        2067
+      ],
+      "summary": "Represents ConfirmAction state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:App",
+      "type": "class",
+      "name": "App",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2070,
+        2127
+      ],
+      "summary": "Represents App state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "class",
+      "name": "LayoutAreas",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2131,
+        2144
+      ],
+      "summary": "Represents LayoutAreas state or domain data used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "function",
+      "name": "tab_at_column",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2183,
+        2187
+      ],
+      "summary": "Implements tab at column behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "function",
+      "name": "configure_background_server_command",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2191,
+        2195
+      ],
+      "summary": "Implements configure background server command behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
+      "type": "function",
+      "name": "wait_for_server_health",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2198,
+        2207
+      ],
+      "summary": "Implements wait for server health behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "function",
+      "name": "new_with_launch_policy",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2220,
+        2573
+      ],
+      "summary": "Constructs initialized state for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "function",
+      "name": "spawn_gallery_scan",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2579,
+        2588
+      ],
+      "summary": "Starts asynchronous gallery scan work for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "function",
+      "name": "should_poll_remote",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2592,
+        2594
+      ],
+      "summary": "Determines whether should poll remote is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "function",
+      "name": "should_save_output_locally",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2602,
+        2607
+      ],
+      "summary": "Determines whether should save output locally is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "function",
+      "name": "should_persist_response_locally",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2619,
+        2627
+      ],
+      "summary": "Determines whether should persist response locally is true for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "function",
+      "name": "spawn_server_status_fetch",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2641,
+        2689
+      ],
+      "summary": "Starts asynchronous server status fetch work for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "function",
+      "name": "tick_host_polling",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2694,
+        2705
+      ],
+      "summary": "Implements tick host polling behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
+      "type": "function",
+      "name": "apply_remote_model_defaults",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2719,
+        2737
+      ],
+      "summary": "Applies remote model defaults to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:source_image_contract",
+      "type": "function",
+      "name": "source_image_contract",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2745,
+        2755
+      ],
+      "summary": "Implements source image contract behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:identity_gate_error",
+      "type": "function",
+      "name": "identity_gate_error",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2771,
+        2797
+      ],
+      "summary": "Implements identity gate error behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
+      "type": "function",
+      "name": "sync_generate_capabilities",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2822,
+        2938
+      ],
+      "summary": "Synchronizes generate capabilities across the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
+      "type": "function",
+      "name": "normalize_fixed_guidance_for_submit",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2943,
+        2963
+      ],
+      "summary": "Implements normalize fixed guidance for submit behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
+      "type": "function",
+      "name": "sync_pipeline_guidance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2969,
+        2985
+      ],
+      "summary": "Synchronizes pipeline guidance across the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:spawn_upscale",
+      "type": "function",
+      "name": "spawn_upscale",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        2988,
+        3240
+      ],
+      "summary": "Starts asynchronous upscale work for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "function",
+      "name": "shutdown",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3243,
+        3248
+      ],
+      "summary": "Implements shutdown behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:cleanup_runtime_authority",
+      "type": "function",
+      "name": "cleanup_runtime_authority",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3250,
+        3260
+      ],
+      "summary": "Implements cleanup runtime authority behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "function",
+      "name": "save_session",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3263,
+        3286
+      ],
+      "summary": "Persists session for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "function",
+      "name": "apply_theme_preset",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3293,
+        3297
+      ],
+      "summary": "Applies theme preset to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "function",
+      "name": "update_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3299,
+        3386
+      ],
+      "summary": "Updates model in the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
+      "type": "function",
+      "name": "save_prefs_for_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3391,
+        3424
+      ],
+      "summary": "Persists prefs for model for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
+      "type": "function",
+      "name": "apply_prefs_for_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3429,
+        3489
+      ],
+      "summary": "Applies prefs for model to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "function",
+      "name": "refresh_create_rows",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3493,
+        3501
+      ],
+      "summary": "Implements refresh create rows behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
+      "type": "function",
+      "name": "set_advanced_expanded",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3507,
+        3525
+      ],
+      "summary": "Implements set advanced expanded behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:model_default_size",
+      "type": "function",
+      "name": "model_default_size",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3530,
+        3548
+      ],
+      "summary": "Implements model default size behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
+      "type": "function",
+      "name": "active_generation_recipe",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3553,
+        3562
+      ],
+      "summary": "Implements active generation recipe behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "function",
+      "name": "handle_crossterm_event",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3565,
+        3767
+      ],
+      "summary": "Handles crossterm event within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_popup_event",
+      "type": "function",
+      "name": "handle_popup_event",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        3792,
+        4336
+      ],
+      "summary": "Handles popup event within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_mouse",
+      "type": "function",
+      "name": "handle_mouse",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4338,
+        4496
+      ],
+      "summary": "Handles mouse within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
+      "type": "function",
+      "name": "available_upscaler_models",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4499,
+        4518
+      ],
+      "summary": "Implements available upscaler models behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
+      "type": "function",
+      "name": "update_upscale_model_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4520,
+        4547
+      ],
+      "summary": "Updates upscale model filter in the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
+      "type": "function",
+      "name": "update_model_selector_filter",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4549,
+        4561
+      ],
+      "summary": "Updates model selector filter in the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:set_active_view",
+      "type": "function",
+      "name": "set_active_view",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4566,
+        4585
+      ],
+      "summary": "Implements set active view behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "function",
+      "name": "open_library",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4587,
+        4589
+      ],
+      "summary": "Implements open library behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "function",
+      "name": "dispatch_action",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        4592,
+        5294
+      ],
+      "summary": "Implements dispatch action behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:increment_param",
+      "type": "function",
+      "name": "increment_param",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5296,
+        5325
+      ],
+      "summary": "Implements increment param behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:adjust_field",
+      "type": "function",
+      "name": "adjust_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5328,
+        5679
+      ],
+      "summary": "Implements adjust field behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
+      "type": "function",
+      "name": "load_gallery_preview",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5682,
+        5787
+      ],
+      "summary": "Loads gallery preview into the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
+      "type": "function",
+      "name": "try_install_gallery_animation",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5791,
+        5806
+      ],
+      "summary": "Implements try install gallery animation behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "function",
+      "name": "tick_animations",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5811,
+        5826
+      ],
+      "summary": "Implements tick animations behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
+      "type": "function",
+      "name": "load_gallery_into_generate",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5829,
+        5893
+      ],
+      "summary": "Loads gallery into generate into the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "function",
+      "name": "apply_gallery_scan",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5902,
+        5935
+      ],
+      "summary": "Applies gallery scan to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "function",
+      "name": "apply_delete_failure",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5944,
+        5950
+      ],
+      "summary": "Applies delete failure to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "function",
+      "name": "capabilities_for_origin",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5956,
+        5967
+      ],
+      "summary": "Implements capabilities for origin behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "function",
+      "name": "origin_can_trash",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5972,
+        5980
+      ],
+      "summary": "Implements origin can trash behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "function",
+      "name": "removal_kind_for",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5984,
+        5994
+      ],
+      "summary": "Implements removal kind for behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "function",
+      "name": "selected_removal_kind",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        5997,
+        6003
+      ],
+      "summary": "Implements selected removal kind behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
+      "type": "function",
+      "name": "delete_selected_gallery_image",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6010,
+        6122
+      ],
+      "summary": "Performs the guarded delete selected gallery image operation for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_gallery_file",
+      "type": "function",
+      "name": "open_gallery_file",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6126,
+        6147
+      ],
+      "summary": "Implements open gallery file behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
+      "type": "function",
+      "name": "build_remove_model_message",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6151,
+        6199
+      ],
+      "summary": "Builds remove model message used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "function",
+      "name": "needs_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6203,
+        6205
+      ],
+      "summary": "Implements needs confirm behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "function",
+      "name": "request_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6211,
+        6220
+      ],
+      "summary": "Implements request confirm behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
+      "type": "function",
+      "name": "handle_confirm_action",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6223,
+        6258
+      ],
+      "summary": "Handles confirm action within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:open_model_selector",
+      "type": "function",
+      "name": "open_model_selector",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6269,
+        6288
+      ],
+      "summary": "Implements open model selector behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:activate_current_param",
+      "type": "function",
+      "name": "activate_current_param",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6291,
+        6315
+      ],
+      "summary": "Implements activate current param behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
+      "type": "function",
+      "name": "surface_request_advisories",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6334,
+        6345
+      ],
+      "summary": "Implements surface request advisories behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:filing_editor_text",
+      "type": "function",
+      "name": "filing_editor_text",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6349,
+        6358
+      ],
+      "summary": "Implements filing editor text behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:activate_field",
+      "type": "function",
+      "name": "activate_field",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6371,
+        6472
+      ],
+      "summary": "Implements activate field behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
+      "type": "function",
+      "name": "reset_params_to_model_defaults",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6475,
+        6556
+      ],
+      "summary": "Implements reset params to model defaults behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "function",
+      "name": "build_settings_rows",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6562,
+        6884
+      ],
+      "summary": "Builds settings rows used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "function",
+      "name": "settings_display_value",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        6887,
+        7025
+      ],
+      "summary": "Implements settings display value behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "function",
+      "name": "settings_env_override",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7043,
+        7066
+      ],
+      "summary": "Implements settings env override behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_navigate",
+      "type": "function",
+      "name": "settings_navigate",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7076,
+        7120
+      ],
+      "summary": "Implements settings navigate behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
+      "type": "function",
+      "name": "settings_cycle_theme",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7123,
+        7133
+      ],
+      "summary": "Implements settings cycle theme behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_increment",
+      "type": "function",
+      "name": "settings_increment",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7136,
+        7172
+      ],
+      "summary": "Implements settings increment behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
+      "type": "function",
+      "name": "settings_adjust_number",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7174,
+        7271
+      ],
+      "summary": "Implements settings adjust number behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
+      "type": "function",
+      "name": "settings_cycle_toggle",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7273,
+        7315
+      ],
+      "summary": "Implements settings cycle toggle behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
+      "type": "function",
+      "name": "settings_toggle_bool",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7317,
+        7359
+      ],
+      "summary": "Implements settings toggle bool behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
+      "type": "function",
+      "name": "settings_cycle_model",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7361,
+        7374
+      ],
+      "summary": "Implements settings cycle model behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_confirm",
+      "type": "function",
+      "name": "settings_confirm",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7377,
+        7423
+      ],
+      "summary": "Implements settings confirm behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:settings_apply_input",
+      "type": "function",
+      "name": "settings_apply_input",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7426,
+        7480
+      ],
+      "summary": "Implements settings apply input behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:save_config",
+      "type": "function",
+      "name": "save_config",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7483,
+        7493
+      ],
+      "summary": "Persists config for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_generation",
+      "type": "function",
+      "name": "start_generation",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7495,
+        7735
+      ],
+      "summary": "Implements start generation behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:retry_held_prints",
+      "type": "function",
+      "name": "retry_held_prints",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7743,
+        7764
+      ],
+      "summary": "Implements retry held prints behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
+      "type": "function",
+      "name": "prompt_transform_task",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7788,
+        7805
+      ],
+      "summary": "Implements prompt transform task behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
+      "type": "function",
+      "name": "reference_fingerprint_for_target",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7811,
+        7847
+      ],
+      "summary": "Implements reference fingerprint for target behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
+      "type": "function",
+      "name": "start_prompt_transform",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7849,
+        7892
+      ],
+      "summary": "Implements start prompt transform behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
+      "type": "function",
+      "name": "start_prompt_transform_from",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7894,
+        7971
+      ],
+      "summary": "Implements start prompt transform from behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_provenance",
+      "type": "function",
+      "name": "prompt_provenance",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7973,
+        7985
+      ],
+      "summary": "Implements prompt provenance behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
+      "type": "function",
+      "name": "prompt_transform_staleness",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        7987,
+        8018
+      ],
+      "summary": "Implements prompt transform staleness behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
+      "type": "function",
+      "name": "quick_transform_staleness",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8023,
+        8053
+      ],
+      "summary": "Implements quick transform staleness behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
+      "type": "function",
+      "name": "apply_prompt_variant",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8065,
+        8085
+      ],
+      "summary": "Applies prompt variant to the central TUI application state machine while preserving its invariants.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
+      "type": "function",
+      "name": "prepare_prompt_variants",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8087,
+        8112
+      ],
+      "summary": "Implements prepare prompt variants behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "function",
+      "name": "process_background_events",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        8115,
+        9257
+      ],
+      "summary": "Implements process background events behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "complex"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:handle_progress",
+      "type": "function",
+      "name": "handle_progress",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9259,
+        9276
+      ],
+      "summary": "Handles progress within the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
+      "type": "function",
+      "name": "build_local_model_catalog",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9279,
+        9297
+      ],
+      "summary": "Builds local model catalog used by the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:decode_live_preview",
+      "type": "function",
+      "name": "decode_live_preview",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9303,
+        9320
+      ],
+      "summary": "Implements decode live preview behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
+      "type": "function",
+      "name": "reduce_progress_state",
+      "filePath": "crates/mold-tui/src/app.rs",
+      "lineRange": [
+        9337,
+        9497
+      ],
+      "summary": "Implements reduce progress state behavior for the central TUI application state machine.",
+      "tags": [
+        "state-machine",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "file:crates/mold-tui/src/gallery_scan.rs",
+      "type": "file",
+      "name": "gallery_scan.rs",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "summary": "Scans and merges local and remote galleries, maintains host-scoped media caches, reconciles metadata, and collapses equivalent prints while preserving their physical origins.",
+      "tags": [
+        "library",
+        "multi-host",
+        "cache",
+        "service"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
+      "type": "function",
+      "name": "default_gallery_dir",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        8,
+        10
+      ],
+      "summary": "Implements default gallery dir behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
+      "type": "function",
+      "name": "image_cache_dir",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        13,
+        18
+      ],
+      "summary": "Implements image cache dir behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
+      "type": "function",
+      "name": "host_cache_filename",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        24,
+        26
+      ],
+      "summary": "Implements host cache filename behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
+      "type": "function",
+      "name": "cached_image_path",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        29,
+        31
+      ],
+      "summary": "Implements cached image path behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
+      "type": "function",
+      "name": "scan_images_from_server",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        37,
+        57
+      ],
+      "summary": "Scans images from server and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
+      "type": "function",
+      "name": "fetch_and_cache_image",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        61,
+        80
+      ],
+      "summary": "Fetches and cache image for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
+      "type": "function",
+      "name": "preview_cache_path",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        85,
+        90
+      ],
+      "summary": "Implements preview cache path behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
+      "type": "function",
+      "name": "fetch_and_cache_preview",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        99,
+        125
+      ],
+      "summary": "Fetches and cache preview for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
+      "type": "function",
+      "name": "is_video_filename",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        130,
+        139
+      ],
+      "summary": "Determines whether is video filename is true for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
+      "type": "class",
+      "name": "LocalScan",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        143,
+        151
+      ],
+      "summary": "Represents LocalScan state or domain data used by multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
+      "type": "function",
+      "name": "scan_images_local",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        161,
+        163
+      ],
+      "summary": "Scans images local and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
+      "type": "function",
+      "name": "scan_local",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        169,
+        219
+      ],
+      "summary": "Scans local and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_local_disk",
+      "type": "function",
+      "name": "scan_local_disk",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        222,
+        258
+      ],
+      "summary": "Scans local disk and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
+      "type": "class",
+      "name": "MergedScan",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        264,
+        276
+      ],
+      "summary": "Represents MergedScan state or domain data used by multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
+      "type": "class",
+      "name": "SourceScan",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        282,
+        288
+      ],
+      "summary": "Represents SourceScan state or domain data used by multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
+      "type": "function",
+      "name": "is_loopback_url",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        293,
+        304
+      ],
+      "summary": "Determines whether is loopback url is true for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
+      "type": "function",
+      "name": "scan_sources",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        316,
+        354
+      ],
+      "summary": "Scans sources and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
+      "type": "function",
+      "name": "scan_all_hosts",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        362,
+        409
+      ],
+      "summary": "Scans all hosts and converts the result into gallery state.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
+      "type": "function",
+      "name": "merge_scans",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        427,
+        471
+      ],
+      "summary": "Implements merge scans behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
+      "type": "function",
+      "name": "filter_entries",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        478,
+        493
+      ],
+      "summary": "Implements filter entries behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
+      "type": "function",
+      "name": "library_hint",
+      "filePath": "crates/mold-tui/src/gallery_scan.rs",
+      "lineRange": [
+        505,
+        545
+      ],
+      "summary": "Implements library hint behavior for multi-host gallery scanning and media caching.",
+      "tags": [
+        "library",
+        "multi-host",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/hosts.rs",
+      "type": "file",
+      "name": "hosts.rs",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "summary": "Owns the persisted remote-host registry, per-host credentials, generation-target policy, Machines workspace state, connection flow, telemetry polling, queue operations, and device mutations.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "service",
+        "state-machine"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:local_display_name",
+      "type": "function",
+      "name": "local_display_name",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        30,
+        36
+      ],
+      "summary": "Implements local display name behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:HostEntry",
+      "type": "class",
+      "name": "HostEntry",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        42,
+        58
+      ],
+      "summary": "Represents HostEntry state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:display_name",
+      "type": "function",
+      "name": "display_name",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        67,
+        72
+      ],
+      "summary": "Implements display name behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:AddHostError",
+      "type": "class",
+      "name": "AddHostError",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        77,
+        81
+      ],
+      "summary": "Represents AddHostError state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
+      "type": "class",
+      "name": "HostRegistry",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        85,
+        87
+      ],
+      "summary": "Represents HostRegistry state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:load_from",
+      "type": "function",
+      "name": "load_from",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        100,
+        106
+      ],
+      "summary": "Loads from into host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:save_to",
+      "type": "function",
+      "name": "save_to",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        116,
+        120
+      ],
+      "summary": "Persists to for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:add",
+      "type": "function",
+      "name": "add",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        123,
+        136
+      ],
+      "summary": "Implements add behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:get",
+      "type": "function",
+      "name": "get",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        145,
+        147
+      ],
+      "summary": "Implements get behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:all",
+      "type": "function",
+      "name": "all",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        152,
+        163
+      ],
+      "summary": "Implements all behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
+      "type": "function",
+      "name": "host_id_from_url",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        169,
+        191
+      ],
+      "summary": "Implements host id from url behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:host_port_label",
+      "type": "function",
+      "name": "host_port_label",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        194,
+        198
+      ],
+      "summary": "Implements host port label behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:set_session_api_key",
+      "type": "function",
+      "name": "set_session_api_key",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        212,
+        220
+      ],
+      "summary": "Implements set session api key behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:clear_session_api_key",
+      "type": "function",
+      "name": "clear_session_api_key",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        222,
+        227
+      ],
+      "summary": "Implements clear session api key behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:api_key_for",
+      "type": "function",
+      "name": "api_key_for",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        230,
+        244
+      ],
+      "summary": "Implements api key for behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:save_api_key",
+      "type": "function",
+      "name": "save_api_key",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        247,
+        254
+      ],
+      "summary": "Persists api key for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
+      "type": "function",
+      "name": "delete_api_key",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        257,
+        262
+      ],
+      "summary": "Performs the guarded delete api key operation for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:client_for",
+      "type": "function",
+      "name": "client_for",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        266,
+        271
+      ],
+      "summary": "Implements client for behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:client_for_host",
+      "type": "function",
+      "name": "client_for_host",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        274,
+        276
+      ],
+      "summary": "Implements client for host behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:open_db",
+      "type": "function",
+      "name": "open_db",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        278,
+        287
+      ],
+      "summary": "Implements open db behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:GenTarget",
+      "type": "class",
+      "name": "GenTarget",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        294,
+        302
+      ],
+      "summary": "Represents GenTarget state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:to_setting",
+      "type": "function",
+      "name": "to_setting",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        305,
+        311
+      ],
+      "summary": "Implements to setting behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:from_setting",
+      "type": "function",
+      "name": "from_setting",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        314,
+        322
+      ],
+      "summary": "Implements from setting behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:load",
+      "type": "function",
+      "name": "load",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        324,
+        333
+      ],
+      "summary": "Loads load into host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:save",
+      "type": "function",
+      "name": "save",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        335,
+        342
+      ],
+      "summary": "Persists save for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:HostHealth",
+      "type": "class",
+      "name": "HostHealth",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        349,
+        353
+      ],
+      "summary": "Represents HostHealth state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:HostStatus",
+      "type": "class",
+      "name": "HostStatus",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        357,
+        360
+      ],
+      "summary": "Represents HostStatus state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
+      "type": "class",
+      "name": "MachineRowId",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        364,
+        367
+      ],
+      "summary": "Represents MachineRowId state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
+      "type": "class",
+      "name": "MachinesFocus",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        371,
+        375
+      ],
+      "summary": "Represents MachinesFocus state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:MachinesState",
+      "type": "class",
+      "name": "MachinesState",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        389,
+        421
+      ],
+      "summary": "Represents MachinesState state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:PollPlan",
+      "type": "class",
+      "name": "PollPlan",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        425,
+        427
+      ],
+      "summary": "Represents PollPlan state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
+      "type": "class",
+      "name": "HostPollRequest",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        430,
+        433
+      ],
+      "summary": "Represents HostPollRequest state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:row_count",
+      "type": "function",
+      "name": "row_count",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        444,
+        446
+      ],
+      "summary": "Implements row count behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_row",
+      "type": "function",
+      "name": "selected_row",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        449,
+        459
+      ],
+      "summary": "Implements selected row behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_host",
+      "type": "function",
+      "name": "selected_host",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        462,
+        467
+      ],
+      "summary": "Implements selected host behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:select_prev",
+      "type": "function",
+      "name": "select_prev",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        470,
+        478
+      ],
+      "summary": "Implements select prev behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:select_next",
+      "type": "function",
+      "name": "select_next",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        481,
+        489
+      ],
+      "summary": "Implements select next behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
+      "type": "function",
+      "name": "queue_select_prev",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        500,
+        502
+      ],
+      "summary": "Implements queue select prev behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
+      "type": "function",
+      "name": "queue_select_next",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        504,
+        513
+      ],
+      "summary": "Implements queue select next behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
+      "type": "function",
+      "name": "selected_cancellable_job",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        517,
+        530
+      ],
+      "summary": "Implements selected cancellable job behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_device",
+      "type": "function",
+      "name": "selected_device",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        539,
+        542
+      ],
+      "summary": "Implements selected device behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
+      "type": "function",
+      "name": "can_mutate_selected_device",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        544,
+        559
+      ],
+      "summary": "Determines whether can mutate selected device is true for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
+      "type": "function",
+      "name": "selected_device_uses_restart_enable",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        561,
+        574
+      ],
+      "summary": "Implements selected device uses restart enable behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
+      "type": "function",
+      "name": "selected_device_restart_required",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        576,
+        579
+      ],
+      "summary": "Implements selected device restart required behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:select_next_device",
+      "type": "function",
+      "name": "select_next_device",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        581,
+        591
+      ],
+      "summary": "Implements select next device behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
+      "type": "function",
+      "name": "select_prev_device",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        593,
+        603
+      ],
+      "summary": "Implements select prev device behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_devices",
+      "type": "function",
+      "name": "apply_devices",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        605,
+        617
+      ],
+      "summary": "Applies devices to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
+      "type": "function",
+      "name": "apply_device_mutation",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        619,
+        640
+      ],
+      "summary": "Applies device mutation to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
+      "type": "function",
+      "name": "apply_capabilities",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        642,
+        655
+      ],
+      "summary": "Applies capabilities to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
+      "type": "function",
+      "name": "target_for_selected",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        660,
+        675
+      ],
+      "summary": "Implements target for selected behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:force_poll",
+      "type": "function",
+      "name": "force_poll",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        679,
+        683
+      ],
+      "summary": "Implements force poll behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
+      "type": "function",
+      "name": "request_queue_refresh",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        685,
+        690
+      ],
+      "summary": "Implements request queue refresh behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:poll_plan",
+      "type": "function",
+      "name": "poll_plan",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        696,
+        738
+      ],
+      "summary": "Implements poll plan behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:finish_poll",
+      "type": "function",
+      "name": "finish_poll",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        743,
+        755
+      ],
+      "summary": "Implements finish poll behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_status",
+      "type": "function",
+      "name": "apply_status",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        759,
+        771
+      ],
+      "summary": "Applies status to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_queue",
+      "type": "function",
+      "name": "apply_queue",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        775,
+        823
+      ],
+      "summary": "Applies queue to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
+      "type": "function",
+      "name": "begin_queue_continuation",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        826,
+        840
+      ],
+      "summary": "Implements begin queue continuation behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
+      "type": "function",
+      "name": "apply_queue_continuation",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        844,
+        885
+      ],
+      "summary": "Applies queue continuation to host registry and Machines workspace behavior while preserving its invariants.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:forget",
+      "type": "function",
+      "name": "forget",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        890,
+        909
+      ],
+      "summary": "Implements forget behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
+      "type": "function",
+      "name": "toggle_connection",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        913,
+        932
+      ],
+      "summary": "Implements toggle connection behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:complete_connect",
+      "type": "function",
+      "name": "complete_connect",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        936,
+        965
+      ],
+      "summary": "Implements complete connect behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
+      "type": "class",
+      "name": "ConnectStep",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        972,
+        978
+      ],
+      "summary": "Represents ConnectStep state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
+      "type": "class",
+      "name": "ConnectForm",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        982,
+        988
+      ],
+      "summary": "Represents ConnectForm state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
+      "type": "class",
+      "name": "ConnectInput",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        993,
+        1000
+      ],
+      "summary": "Represents ConnectInput state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
+      "type": "class",
+      "name": "ConnectEffect",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1004,
+        1012
+      ],
+      "summary": "Represents ConnectEffect state or domain data used by host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:connect_advance",
+      "type": "function",
+      "name": "connect_advance",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1017,
+        1092
+      ],
+      "summary": "Implements connect advance behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
+      "type": "function",
+      "name": "fetch_host_poll",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1100,
+        1106
+      ],
+      "summary": "Fetches host poll for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll_with_timeout",
+      "type": "function",
+      "name": "fetch_host_poll_with_timeout",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1108,
+        1154
+      ],
+      "summary": "Fetches host poll with timeout for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
+      "type": "function",
+      "name": "set_host_device_enabled",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1156,
+        1181
+      ],
+      "summary": "Implements set host device enabled behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
+      "type": "function",
+      "name": "set_local_device_enabled",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1183,
+        1209
+      ],
+      "summary": "Implements set local device enabled behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
+      "type": "function",
+      "name": "fetch_host_queue",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1212,
+        1229
+      ],
+      "summary": "Fetches host queue for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
+      "type": "function",
+      "name": "fetch_host_queue_page",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1233,
+        1249
+      ],
+      "summary": "Fetches host queue page for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:test_connection",
+      "type": "function",
+      "name": "test_connection",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1252,
+        1268
+      ],
+      "summary": "Implements test connection behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
+      "type": "function",
+      "name": "cancel_host_job",
+      "filePath": "crates/mold-tui/src/hosts.rs",
+      "lineRange": [
+        1273,
+        1290
+      ],
+      "summary": "Implements cancel host job behavior for host registry and Machines workspace behavior.",
+      "tags": [
+        "host-management",
+        "persistence",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/lib.rs",
+      "type": "file",
+      "name": "lib.rs",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "summary": "Bootstraps the terminal UI, probes image protocol support, resolves strict or fallback host authority, manages raw-mode restoration, and drives the render and event loop.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "terminal",
+        "event-loop"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "class:crates/mold-tui/src/lib.rs:TerminalRestoreGuard",
+      "type": "class",
+      "name": "TerminalRestoreGuard",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        39,
+        41
+      ],
+      "summary": "Represents TerminalRestoreGuard state or domain data used by TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "class",
+      "name": "TuiInitialWorkspace",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        67,
+        71
+      ],
+      "summary": "Represents TuiInitialWorkspace state or domain data used by TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "class",
+      "name": "TuiLaunchOptions",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        75,
+        85
+      ],
+      "summary": "Represents TuiLaunchOptions state or domain data used by TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "data-model"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "function",
+      "name": "run_tui",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        91,
+        98
+      ],
+      "summary": "Implements run tui behavior for TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "function",
+      "name": "run_tui_with_options",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        101,
+        153
+      ],
+      "summary": "Implements run tui with options behavior for TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/lib.rs:run_event_loop",
+      "type": "function",
+      "name": "run_event_loop",
+      "filePath": "crates/mold-tui/src/lib.rs",
+      "lineRange": [
+        155,
+        200
+      ],
+      "summary": "Implements run event loop behavior for TUI launch and terminal lifecycle behavior.",
+      "tags": [
+        "entry-point",
+        "tui",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "file:crates/mold-tui/src/ui/popup.rs",
+      "type": "file",
+      "name": "popup.rs",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "summary": "Renders all modal TUI surfaces, including help, model selection, source and identity inputs, filing, machine connection, history, confirmation, settings, and command palette overlays.",
+      "tags": [
+        "tui",
+        "component",
+        "popup",
+        "rendering"
+      ],
+      "complexity": "complex",
+      "languageNotes": "Rust uses explicit enums and structs for state transitions, async tasks for remote operations, and Result or Option to keep failure paths visible."
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render",
+      "type": "function",
+      "name": "render",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        8,
+        30
+      ],
+      "summary": "Renders the render surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:centered_rect",
+      "type": "function",
+      "name": "centered_rect",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        32,
+        50
+      ],
+      "summary": "Implements centered rect behavior for modal terminal rendering.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:centered_rect_rows",
+      "type": "function",
+      "name": "centered_rect_rows",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        58,
+        67
+      ],
+      "summary": "Implements centered rect rows behavior for modal terminal rendering.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_help",
+      "type": "function",
+      "name": "render_help",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        69,
+        174
+      ],
+      "summary": "Renders the help surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_alternatives",
+      "type": "function",
+      "name": "render_prompt_alternatives",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        176,
+        253
+      ],
+      "summary": "Renders the prompt alternatives surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_source_choice",
+      "type": "function",
+      "name": "render_prompt_source_choice",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        255,
+        303
+      ],
+      "summary": "Renders the prompt source choice surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:build_model_item",
+      "type": "function",
+      "name": "build_model_item",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        309,
+        405
+      ],
+      "summary": "Builds model item used by modal terminal rendering.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector_popup",
+      "type": "function",
+      "name": "render_model_selector_popup",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        409,
+        485
+      ],
+      "summary": "Renders the model selector popup surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector",
+      "type": "function",
+      "name": "render_model_selector",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        487,
+        509
+      ],
+      "summary": "Renders the model selector surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_upscale_model_selector",
+      "type": "function",
+      "name": "render_upscale_model_selector",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        511,
+        539
+      ],
+      "summary": "Renders the upscale model selector surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_size_input",
+      "type": "function",
+      "name": "render_size_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        541,
+        592
+      ],
+      "summary": "Renders the size input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_stg_blocks_input",
+      "type": "function",
+      "name": "render_stg_blocks_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        594,
+        652
+      ],
+      "summary": "Renders the stg blocks input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_references_input",
+      "type": "function",
+      "name": "render_references_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        654,
+        706
+      ],
+      "summary": "Renders the references input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_identity_image_input",
+      "type": "function",
+      "name": "render_identity_image_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        708,
+        766
+      ],
+      "summary": "Renders the identity image input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_filing_input",
+      "type": "function",
+      "name": "render_filing_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        775,
+        869
+      ],
+      "summary": "Renders the filing input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_machine_connect",
+      "type": "function",
+      "name": "render_machine_connect",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        872,
+        963
+      ],
+      "summary": "Renders the machine connect surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:action_hints",
+      "type": "function",
+      "name": "action_hints",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        966,
+        979
+      ],
+      "summary": "Implements action hints behavior for modal terminal rendering.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_seed_input",
+      "type": "function",
+      "name": "render_seed_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        981,
+        1031
+      ],
+      "summary": "Renders the seed input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_command_palette",
+      "type": "function",
+      "name": "render_command_palette",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1034,
+        1131
+      ],
+      "summary": "Renders the command palette surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_history_search",
+      "type": "function",
+      "name": "render_history_search",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1133,
+        1212
+      ],
+      "summary": "Renders the history search surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_confirm",
+      "type": "function",
+      "name": "render_confirm",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1214,
+        1248
+      ],
+      "summary": "Renders the confirm surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_license_review",
+      "type": "function",
+      "name": "render_license_review",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1250,
+        1300
+      ],
+      "summary": "Renders the license review surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_info",
+      "type": "function",
+      "name": "render_info",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1302,
+        1328
+      ],
+      "summary": "Renders the info surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "simple"
+    },
+    {
+      "id": "function:crates/mold-tui/src/ui/popup.rs:render_settings_input",
+      "type": "function",
+      "name": "render_settings_input",
+      "filePath": "crates/mold-tui/src/ui/popup.rs",
+      "lineRange": [
+        1330,
+        1381
+      ],
+      "summary": "Renders the settings input surface using current application state and theme rules.",
+      "tags": [
+        "tui",
+        "component",
+        "function"
+      ],
+      "complexity": "moderate"
     }
   ],
   "edges": [
@@ -496232,293 +496317,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local_disk",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
       "source": "file:crates/mold-tui/src/h3_references.rs",
       "target": "function:crates/mold-tui/src/h3_references.rs:parse_reference_input",
       "type": "contains",
@@ -496675,1007 +496473,6 @@
     {
       "source": "file:crates/mold-tui/src/h3_references.rs",
       "target": "class:crates/mold-tui/src/h3_references.rs:PreparedReferences",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/gallery_scan.rs",
-      "target": "file:crates/mold-tui/src/hosts.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:local_display_name",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:local_display_name",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:display_name",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:display_name",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:load",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:load",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:load_from",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:load_from",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save_to",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save_to",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:add",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:add",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:forget",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:forget",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:get",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:get",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:all",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:all",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:host_port_label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:host_port_label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:api_key_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:api_key_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save_api_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:save_api_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:client_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:client_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:client_for_host",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:client_for_host",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:open_db",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:to_setting",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:to_setting",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:from_setting",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:from_setting",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:row_count",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:row_count",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_row",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_row",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_host",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_host",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_prev",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_prev",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_next",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_next",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_next_device",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_next_device",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_devices",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_devices",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:force_poll",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:force_poll",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:poll_plan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:poll_plan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:finish_poll",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:finish_poll",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_status",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_status",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:complete_connect",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:complete_connect",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:connect_advance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:connect_advance",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll_with_timeout",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:test_connection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:test_connection",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostEntry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:AddHostError",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:AddHostError",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:GenTarget",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:GenTarget",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostHealth",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostHealth",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostStatus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostStatus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachinesState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:MachinesState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:PollPlan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:PollPlan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/hosts.rs",
-      "target": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
       "type": "exports",
       "direction": "forward",
       "weight": 0.8
@@ -499088,196 +497885,7 @@
       "weight": 0.8
     },
     {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:centered_rect",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:centered_rect_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_help",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_alternatives",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_source_choice",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:build_model_item",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector_popup",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_upscale_model_selector",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_size_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_stg_blocks_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_references_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_identity_image_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_filing_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_machine_connect",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:action_hints",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_seed_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_command_palette",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_history_search",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_license_review",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_info",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
-      "target": "function:crates/mold-tui/src/ui/popup.rs:render_settings_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:crates/mold-tui/src/ui/library_details.rs",
-      "target": "file:crates/mold-tui/src/ui/widgets.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/machines.rs",
-      "target": "file:crates/mold-tui/src/hosts.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/popup.rs",
       "target": "file:crates/mold-tui/src/ui/widgets.rs",
       "type": "imports",
       "direction": "forward",
@@ -505634,14 +504242,6 @@
     },
     {
       "source": "file:crates/mold-tui/src/ui/mod.rs",
-      "target": "file:crates/mold-tui/src/ui/popup.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7,
-      "recoveredFromImportMap": true
-    },
-    {
-      "source": "file:crates/mold-tui/src/ui/mod.rs",
       "target": "file:crates/mold-tui/src/ui/preview.rs",
       "type": "imports",
       "direction": "forward",
@@ -508449,146 +507049,6 @@
       "recoveredFromImportMap": true
     },
     {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:run",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:run",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:run_remote",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_list",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_show",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_title",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_tag",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_collection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:library_trash",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:require_organize",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:render_listing",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:render_detail",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:render_collections",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:truncate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-cli/src/commands/library.rs",
-      "target": "function:crates/mold-cli/src/commands/library.rs:confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
       "source": "file:crates/mold-cli/src/main.rs",
       "target": "function:crates/mold-cli/src/main.rs:apply_spatial_tile_override",
       "type": "contains",
@@ -511109,2162 +509569,6 @@
       "weight": 0.7
     },
     {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:push_log",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:clear_download",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:record_download_sample",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:next",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:next",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prev",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:resolve",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:advance",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_config",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:display_value",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:default",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_local",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filename",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:machine_label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:hint_label",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:generation_model_names",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_field",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:source_image_contract",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:identity_gate_error",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:spawn_upscale",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:shutdown",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_session",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:model_default_size",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_popup_event",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_mouse",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:set_active_view",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_library",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_library",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:increment_param",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:adjust_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_gallery_file",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:open_model_selector",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:activate_current_param",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:filing_editor_text",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:activate_field",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_navigate",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_increment",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_confirm",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:settings_apply_input",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:save_config",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_generation",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:retry_held_prints",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_provenance",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:handle_progress",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:decode_live_preview",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ParamField",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:Popup",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:App",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:App",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/event.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/model_info.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/app.rs",
-      "target": "file:crates/mold-tui/src/ui/theme.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "function:crates/mold-tui/src/lib.rs:run_event_loop",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
-      "type": "contains",
-      "direction": "forward",
-      "weight": 1
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
-      "type": "exports",
-      "direction": "forward",
-      "weight": 0.8
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/action.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/animation.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/app.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/backend.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/event.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/gallery_scan.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/gallery_trash.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/h3_references.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/history.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/hosts.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/identity.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/model_info.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/motion.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/palette.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/prefs.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/session.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/test_env.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/thumbnails.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
-      "source": "file:crates/mold-tui/src/lib.rs",
-      "target": "file:crates/mold-tui/src/ui/mod.rs",
-      "type": "imports",
-      "direction": "forward",
-      "weight": 0.7
-    },
-    {
       "source": "file:desktop/src/components/generate/SourceImageWell.test.ts",
       "target": "file:desktop/src/components/generate/ImagePickerModal.vue",
       "type": "imports",
@@ -515187,6 +511491,3821 @@
       "direction": "forward",
       "weight": 0.5,
       "description": "Path-based pairing (deterministic)"
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/action.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/event.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/model_info.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "file:crates/mold-tui/src/ui/theme.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:run_remote",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_list",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_show",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:preview_bytes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_title",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_tag",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:mutate_prints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:collection_membership",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:require_organize",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:resolve_collection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:filter_and_sort",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_listing",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_detail",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:render_collections",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:truncate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-cli/src/commands/library.rs",
+      "target": "function:crates/mold-cli/src/commands/library.rs:library_grid",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:mark_generation_start",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_elapsed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:stage_elapsed",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:push_log",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:clear_download",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_downloading",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:download_status_text",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:record_download_sample",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:next",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:next",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prev",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:qwen_image_edit_dimensions_for_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_size_input",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:resolve",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:advance",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_required_for_params",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_config",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:PromptTransformSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LicenseDownloadRequirement",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:DurableGenerationChildOutcome",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:BackgroundEvent",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressLogEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressStyle",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ProgressState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:CreateMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateFocus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ParamField",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SeedMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateParams",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerationMetadataSnapshot",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:InferenceMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:display_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_scale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_optional_u32",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:parse_stg_blocks_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tui_max_video_frames",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_generate_params_for_family",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:restored_negative_editor_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_prompt_textarea",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_outcomes",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:guidance_adjustable",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:negative_visible",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:default",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_filter",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_pos",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:rescan_due",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_filter_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:from_host_entry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:remote_from_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_this_machine",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filename",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:owning_origins",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:primary_origin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:machine_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:trash_retention_display",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:hint_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_confirm_message",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:generation_model_names",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_field",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:is_read_only",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tab_at_column",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:configure_background_server_command",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:wait_for_server_health",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:new_with_launch_policy",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GenerateState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldPrintRetry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldHost",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:HeldBatch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryViewMode",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryOrigin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:GalleryEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:RemovalKind",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ModelsState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsKey",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFieldType",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsRow",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsFocus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:SettingsState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:Popup",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:UpscalePickerPurpose",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:ConfirmAction",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:App",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:App",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "class:crates/mold-tui/src/app.rs:LayoutAreas",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_gallery_scan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_poll_remote",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_save_output_locally",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:should_persist_response_locally",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_server_status_fetch",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_host_polling",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_remote_model_defaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:source_image_contract",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:identity_gate_error",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:sync_generate_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:normalize_fixed_guidance_for_submit",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:sync_pipeline_guidance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:spawn_upscale",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:shutdown",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:cleanup_runtime_authority",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_session",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_theme_preset",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_prefs_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_prefs_for_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:refresh_create_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:set_advanced_expanded",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:model_default_size",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:active_generation_recipe",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_crossterm_event",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_popup_event",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_mouse",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:available_upscaler_models",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_upscale_model_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:update_model_selector_filter",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:set_active_view",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_library",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:dispatch_action",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:increment_param",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:adjust_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:load_gallery_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:try_install_gallery_animation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:tick_animations",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:load_gallery_into_generate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_gallery_scan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_delete_failure",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:capabilities_for_origin",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:origin_can_trash",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:removal_kind_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:selected_removal_kind",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:delete_selected_gallery_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_gallery_file",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_remove_model_message",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:needs_confirm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:request_confirm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_confirm_action",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:open_model_selector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:activate_current_param",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:surface_request_advisories",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:filing_editor_text",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "file:crates/mold-tui/src/hosts.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:activate_field",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reset_params_to_model_defaults",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_settings_rows",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_display_value",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_env_override",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_navigate",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_theme",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_increment",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_adjust_number",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_toggle",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_toggle_bool",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_cycle_model",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:settings_apply_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:save_config",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_generation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:retry_held_prints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_task",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reference_fingerprint_for_target",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:start_prompt_transform_from",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_provenance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prompt_transform_staleness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:quick_transform_staleness",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:apply_prompt_variant",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:prepare_prompt_variants",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:process_background_events",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:handle_progress",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:build_local_model_catalog",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:decode_live_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/app.rs",
+      "target": "function:crates/mold-tui/src/app.rs:reduce_progress_state",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:default_gallery_dir",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:image_cache_dir",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:host_cache_filename",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:cached_image_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_from_server",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_image",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:preview_cache_path",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:fetch_and_cache_preview",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_video_filename",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_images_local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_local_disk",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:is_loopback_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_sources",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:scan_all_hosts",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:merge_scans",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:filter_entries",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "function:crates/mold-tui/src/gallery_scan.rs:library_hint",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:LocalScan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:MergedScan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/gallery_scan.rs",
+      "target": "class:crates/mold-tui/src/gallery_scan.rs:SourceScan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:local_display_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:local_display_name",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:display_name",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:display_name",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:load_from",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:load_from",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save_to",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save_to",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:add",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:add",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:get",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:get",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:all",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:all",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:host_id_from_url",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:host_port_label",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:host_port_label",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_session_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_session_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:clear_session_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:clear_session_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:api_key_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:api_key_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:delete_api_key",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:client_for",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:client_for",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:client_for_host",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:client_for_host",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:open_db",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:to_setting",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:to_setting",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:from_setting",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:from_setting",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:load",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:load",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:save",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:row_count",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:row_count",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_row",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_row",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_host",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_host",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_prev",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_prev",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_next",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_next",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_prev",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:queue_select_next",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_cancellable_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:can_mutate_selected_device",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_uses_restart_enable",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:selected_device_restart_required",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_next_device",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_next_device",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:select_prev_device",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_devices",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_devices",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_device_mutation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_capabilities",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:target_for_selected",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:force_poll",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:force_poll",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:request_queue_refresh",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:poll_plan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:poll_plan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:finish_poll",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:finish_poll",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_status",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_status",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostEntry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostEntry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:AddHostError",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:AddHostError",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostRegistry",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:GenTarget",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:GenTarget",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostHealth",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostHealth",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostStatus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostStatus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachineRowId",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachinesFocus",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachinesState",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:MachinesState",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:PollPlan",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:PollPlan",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:HostPollRequest",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/action.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/animation.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/app.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/backend.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/event.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/gallery_scan.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/gallery_trash.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/h3_references.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/history.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/hosts.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/identity.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/model_info.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/motion.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/palette.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/prefs.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/session.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/test_env.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/thumbnails.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "file:crates/mold-tui/src/ui/mod.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "file:crates/mold-tui/src/ui/widgets.rs",
+      "type": "imports",
+      "direction": "forward",
+      "weight": 0.7
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:begin_queue_continuation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:apply_queue_continuation",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:forget",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:forget",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:toggle_connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:complete_connect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:complete_connect",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:connect_advance",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:connect_advance",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_poll_with_timeout",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_host_device_enabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:set_local_device_enabled",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:fetch_host_queue_page",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:test_connection",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:test_connection",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "function:crates/mold-tui/src/hosts.rs:cancel_host_job",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectStep",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectForm",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectInput",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/hosts.rs",
+      "target": "class:crates/mold-tui/src/hosts.rs:ConnectEffect",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_tui_with_options",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "function:crates/mold-tui/src/lib.rs:run_event_loop",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TerminalRestoreGuard",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiInitialWorkspace",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/lib.rs",
+      "target": "class:crates/mold-tui/src/lib.rs:TuiLaunchOptions",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render",
+      "type": "exports",
+      "direction": "forward",
+      "weight": 0.8
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:centered_rect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:centered_rect_rows",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_help",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_alternatives",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_prompt_source_choice",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:build_model_item",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector_popup",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_model_selector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_upscale_model_selector",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_size_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_stg_blocks_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_references_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_identity_image_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_filing_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_machine_connect",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:action_hints",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_seed_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_command_palette",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_history_search",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_confirm",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_license_review",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_info",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
+    },
+    {
+      "source": "file:crates/mold-tui/src/ui/popup.rs",
+      "target": "function:crates/mold-tui/src/ui/popup.rs:render_settings_input",
+      "type": "contains",
+      "direction": "forward",
+      "weight": 1
     }
   ],
   "layers": [

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-08-28T14:18:27.000Z",
-  "gitCommitHash": "92e2ba496f507ac27216b6a1c1296e88df5220d9",
+  "lastAnalyzedAt": "2026-08-28T15:45:52.694Z",
+  "gitCommitHash": "6a18814b6081fd954d1c7471565d741594b19ad5",
   "version": "1.0.0",
-  "analyzedFiles": 2294
+  "analyzedFiles": 2295
 }

--- a/.ua/meta.json
+++ b/.ua/meta.json
@@ -1,6 +1,6 @@
 {
-  "lastAnalyzedAt": "2026-08-28T15:45:52.694Z",
-  "gitCommitHash": "6a18814b6081fd954d1c7471565d741594b19ad5",
+  "lastAnalyzedAt": "2026-08-28T16:27:44.501Z",
+  "gitCommitHash": "3db4501d931196954bb80290797c4cc6c004bc5b",
   "version": "1.0.0",
-  "analyzedFiles": 2295
+  "analyzedFiles": 2291
 }

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3272,6 +3272,7 @@ dependencies = [
  "toml",
  "tracing",
  "tracing-subscriber",
+ "uuid",
  "viuer",
  "walkdir",
  "wiremock",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3523,6 +3523,7 @@ dependencies = [
  "tui-textarea",
  "unicode-width 0.2.0",
  "ureq",
+ "wiremock",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -188,6 +188,16 @@ mold queue retry --held         # resume every retryable hold
 mold queue cancel --all --yes   # clear the backlog; running work finishes
 ```
 
+Browse and organize that host's existing prints with `mold library`:
+
+```bash
+mold library list --tag portrait --favorite
+mold library show print.png --preview
+mold library tag add print.png --tag selected
+mold library collection add Portfolio print.png
+mold library grid
+```
+
 Install Mold's embedded Agent Skill for your coding agent:
 
 ```bash

--- a/changelog.d/library-cli-management.md
+++ b/changelog.d/library-cli-management.md
@@ -1,0 +1,5 @@
+- **Manage the Library from the terminal.** `mold library` can list and inspect
+  existing prints, preview stills and videos inline, edit titles and favorites,
+  add, remove, rename, or delete tags, manage collections and membership, and
+  move prints into recoverable trash. `mold library grid` opens the existing
+  protocol-aware TUI directly on its Library workspace.

--- a/crates/mold-cli/Cargo.toml
+++ b/crates/mold-cli/Cargo.toml
@@ -82,6 +82,7 @@ viuer = { version = "0.11", optional = true }
 mold-discord = { path = "../mold-discord", package = "mold-ai-discord", version = "0.25.0", optional = true }
 mold-tui = { path = "../mold-tui", package = "mold-ai-tui", version = "0.25.0", optional = true }
 walkdir = "2.5.0"
+uuid = { version = "1", features = ["v4"] }
 
 tempfile = "3"
 

--- a/crates/mold-cli/src/commands/library.rs
+++ b/crates/mold-cli/src/commands/library.rs
@@ -1,0 +1,772 @@
+//! `mold library` — browse and organize one serving host's live gallery.
+//!
+//! Non-grid commands always use `$MOLD_HOST` (`MOLD_API_KEY` when set) and
+//! never fall back to direct filesystem access. `grid` delegates to the
+//! existing TUI Library so terminal protocol detection and the merged gallery
+//! stay singular.
+
+use std::collections::HashMap;
+use std::io::{self, IsTerminal, Write};
+
+use anyhow::{bail, Context, Result};
+use colored::Colorize;
+use mold_core::{
+    Collection, CollectionCreateRequest, CollectionItemsRequest, CollectionUpdateRequest,
+    GalleryBulkMutationRequest, GalleryImage, GalleryOrganizeRequest, GalleryPatchRequest,
+    MoldClient, OutputFormat, ServerCapabilities,
+};
+
+use crate::{LibraryAction, LibraryCollectionAction, LibraryTagAction};
+
+pub async fn run(action: LibraryAction) -> Result<()> {
+    match action {
+        LibraryAction::Grid { host, local } => library_grid(host, local).await,
+        action => run_remote(action, &MoldClient::from_env()).await,
+    }
+}
+
+async fn run_remote(action: LibraryAction, client: &MoldClient) -> Result<()> {
+    match action {
+        LibraryAction::List {
+            query,
+            tags,
+            collection,
+            favorite,
+            format,
+            limit,
+            offset,
+            json,
+        } => {
+            library_list(
+                client,
+                ListOptions {
+                    query,
+                    tags,
+                    collection,
+                    favorite,
+                    format,
+                    limit,
+                    offset,
+                    json,
+                },
+            )
+            .await
+        }
+        LibraryAction::Show {
+            filename,
+            json,
+            preview,
+        } => library_show(client, &filename, json, preview).await,
+        LibraryAction::Title {
+            filename,
+            title,
+            clear,
+        } => library_title(client, &filename, title, clear).await,
+        LibraryAction::Favorite { filenames } => {
+            mutate_prints(client, &filenames, Some(true), Vec::new(), Vec::new()).await
+        }
+        LibraryAction::Unfavorite { filenames } => {
+            mutate_prints(client, &filenames, Some(false), Vec::new(), Vec::new()).await
+        }
+        LibraryAction::Tag { action } => library_tag(client, action).await,
+        LibraryAction::Collection { action } => library_collection(client, action).await,
+        LibraryAction::Trash { filenames } => library_trash(client, &filenames).await,
+        LibraryAction::Grid { .. } => unreachable!("grid handled before creating a client"),
+    }
+}
+
+#[derive(Debug)]
+struct ListOptions {
+    query: Option<String>,
+    tags: Vec<String>,
+    collection: Option<String>,
+    favorite: bool,
+    format: Option<OutputFormat>,
+    limit: usize,
+    offset: usize,
+    json: bool,
+}
+
+async fn library_list(client: &MoldClient, options: ListOptions) -> Result<()> {
+    let collections = if options.collection.is_some() {
+        require_organize(client).await?;
+        client.list_collections().await?
+    } else {
+        client.list_collections().await.unwrap_or_default()
+    };
+    let collection_id = options
+        .collection
+        .as_deref()
+        .map(|value| resolve_collection(&collections, value).map(|c| c.id.clone()))
+        .transpose()?;
+    let mut rows = client
+        .list_gallery()
+        .await
+        .with_context(|| format!("could not list the Library on {}", client.host()))?;
+    filter_and_sort(
+        &mut rows,
+        options.query.as_deref(),
+        &options.tags,
+        collection_id.as_deref(),
+        options.favorite,
+        options.format,
+    );
+    let total = rows.len();
+    let page = rows
+        .into_iter()
+        .skip(options.offset)
+        .take(options.limit)
+        .collect::<Vec<_>>();
+
+    if options.json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "total": total,
+                "offset": options.offset,
+                "limit": options.limit,
+                "items": page,
+            }))?
+        );
+    } else {
+        print!(
+            "{}",
+            render_listing(&page, total, options.offset, &collections)
+        );
+    }
+    Ok(())
+}
+
+async fn library_show(
+    client: &MoldClient,
+    filename: &str,
+    json: bool,
+    preview: bool,
+) -> Result<()> {
+    let image = client
+        .gallery_item(filename)
+        .await
+        .with_context(|| format!("could not read {filename} on {}", client.host()))?
+        .ok_or_else(|| anyhow::anyhow!("Library print not found: {filename}"))?;
+    if json {
+        println!("{}", serde_json::to_string_pretty(&image)?);
+        return Ok(());
+    }
+    print!("{}", render_detail(&image));
+    if preview {
+        let bytes = preview_bytes(client, &image).await?;
+        super::generate::preview_image(&bytes);
+    }
+    Ok(())
+}
+
+async fn preview_bytes(client: &MoldClient, image: &GalleryImage) -> Result<Vec<u8>> {
+    let format = gallery_format(image);
+    if format.is_some_and(|value| value.is_video()) {
+        if let Some(bytes) = client.get_gallery_preview(&image.filename).await? {
+            return Ok(bytes);
+        }
+        return client.get_gallery_thumbnail(&image.filename).await;
+    }
+    if format.is_some_and(|value| value.is_audio()) {
+        return client.get_gallery_thumbnail(&image.filename).await;
+    }
+    client.get_gallery_image(&image.filename).await
+}
+
+async fn library_title(
+    client: &MoldClient,
+    filename: &str,
+    title: Option<String>,
+    clear: bool,
+) -> Result<()> {
+    require_organize(client).await?;
+    let title = if clear { String::new() } else { title.unwrap() };
+    let row = client
+        .patch_gallery_image(
+            filename,
+            &GalleryPatchRequest {
+                title: Some(title),
+                ..Default::default()
+            },
+        )
+        .await?;
+    println!("{} {}", "updated".green(), display_title(&row));
+    Ok(())
+}
+
+async fn library_tag(client: &MoldClient, action: LibraryTagAction) -> Result<()> {
+    match action {
+        LibraryTagAction::List { json } => {
+            require_organize(client).await?;
+            let tags = client.list_tags().await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&tags)?);
+            } else if tags.is_empty() {
+                println!("No tags.");
+            } else {
+                for tag in tags {
+                    println!("{:<64} {:>6}", tag.name, tag.count);
+                }
+            }
+            Ok(())
+        }
+        LibraryTagAction::Add { filenames, tags } => {
+            mutate_prints(client, &filenames, None, tags, Vec::new()).await
+        }
+        LibraryTagAction::Remove { filenames, tags } => {
+            mutate_prints(client, &filenames, None, Vec::new(), tags).await
+        }
+        LibraryTagAction::Rename { old, new } => {
+            require_organize(client).await?;
+            client.rename_tag(&old, &new).await?;
+            println!("{} {} → {}", "renamed".green(), old, new);
+            Ok(())
+        }
+        LibraryTagAction::Delete { tag, yes } => {
+            require_organize(client).await?;
+            if !yes && !confirm(&format!("Delete tag \"{tag}\" from every print?"))? {
+                bail!("tag deletion aborted");
+            }
+            client.delete_tag(&tag).await?;
+            println!("{} {}", "deleted tag".green(), tag);
+            Ok(())
+        }
+    }
+}
+
+async fn mutate_prints(
+    client: &MoldClient,
+    filenames: &[String],
+    favorite: Option<bool>,
+    add_tags: Vec<String>,
+    remove_tags: Vec<String>,
+) -> Result<()> {
+    let capabilities = require_organize(client).await?;
+    if capabilities.gallery.bulk_mutations {
+        client
+            .mutate_gallery_bulk(&GalleryBulkMutationRequest {
+                operation_id: uuid::Uuid::new_v4().to_string(),
+                filenames: filenames.to_vec(),
+                favorite,
+                add_tags,
+                remove_tags,
+                ..Default::default()
+            })
+            .await?;
+    } else {
+        client
+            .organize_gallery(&GalleryOrganizeRequest {
+                filenames: filenames.to_vec(),
+                favorite,
+                add_tags: (!add_tags.is_empty()).then_some(add_tags),
+                remove_tags: (!remove_tags.is_empty()).then_some(remove_tags),
+                ..Default::default()
+            })
+            .await?;
+    }
+    println!("{} {} print(s)", "updated".green(), filenames.len());
+    Ok(())
+}
+
+async fn library_collection(client: &MoldClient, action: LibraryCollectionAction) -> Result<()> {
+    require_organize(client).await?;
+    match action {
+        LibraryCollectionAction::List { json } => {
+            let rows = client.list_collections().await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&rows)?);
+            } else if rows.is_empty() {
+                println!("No collections.");
+            } else {
+                print!("{}", render_collections(&rows));
+            }
+            Ok(())
+        }
+        LibraryCollectionAction::Show { collection, json } => {
+            let rows = client.list_collections().await?;
+            let selected = resolve_collection(&rows, &collection)?;
+            let detail = client.get_collection(&selected.id).await?;
+            if json {
+                println!("{}", serde_json::to_string_pretty(&detail)?);
+            } else {
+                println!(
+                    "{} ({})",
+                    detail.collection.name.bold(),
+                    detail.collection.slug
+                );
+                if let Some(description) = detail.collection.description.as_deref() {
+                    println!("{description}");
+                }
+                println!("{} print(s)", detail.filenames.len());
+                for filename in detail.filenames {
+                    println!("  {filename}");
+                }
+            }
+            Ok(())
+        }
+        LibraryCollectionAction::Create { name, description } => {
+            let row = client
+                .create_collection(&CollectionCreateRequest { name, description })
+                .await?;
+            println!("{} {}", "created".green(), row.name);
+            Ok(())
+        }
+        LibraryCollectionAction::Update {
+            collection,
+            name,
+            description,
+            clear_description,
+            cover,
+            clear_cover,
+            hidden,
+            visible,
+        } => {
+            if name.is_none()
+                && description.is_none()
+                && !clear_description
+                && cover.is_none()
+                && !clear_cover
+                && !hidden
+                && !visible
+            {
+                bail!("no collection changes given");
+            }
+            let rows = client.list_collections().await?;
+            let selected = resolve_collection(&rows, &collection)?;
+            let row = client
+                .update_collection(
+                    &selected.id,
+                    &CollectionUpdateRequest {
+                        name,
+                        description: if clear_description {
+                            Some(String::new())
+                        } else {
+                            description
+                        },
+                        cover_filename: if clear_cover {
+                            Some(String::new())
+                        } else {
+                            cover
+                        },
+                        hidden: if hidden {
+                            Some(true)
+                        } else if visible {
+                            Some(false)
+                        } else {
+                            None
+                        },
+                    },
+                )
+                .await?;
+            println!("{} {}", "updated".green(), row.name);
+            Ok(())
+        }
+        LibraryCollectionAction::Delete { collection, yes } => {
+            let rows = client.list_collections().await?;
+            let selected = resolve_collection(&rows, &collection)?;
+            if !yes
+                && !confirm(&format!(
+                    "Delete collection \"{}\"? Its prints will remain in the Library.",
+                    selected.name
+                ))?
+            {
+                bail!("collection deletion aborted");
+            }
+            client.delete_collection(&selected.id).await?;
+            println!("{} {}", "deleted collection".green(), selected.name);
+            Ok(())
+        }
+        LibraryCollectionAction::Add {
+            collection,
+            filenames,
+        } => collection_membership(client, &collection, filenames, true).await,
+        LibraryCollectionAction::Remove {
+            collection,
+            filenames,
+        } => collection_membership(client, &collection, filenames, false).await,
+    }
+}
+
+async fn collection_membership(
+    client: &MoldClient,
+    reference: &str,
+    filenames: Vec<String>,
+    add: bool,
+) -> Result<()> {
+    let rows = client.list_collections().await?;
+    let selected = resolve_collection(&rows, reference)?;
+    client
+        .set_collection_items(
+            &selected.id,
+            &CollectionItemsRequest {
+                add: if add { filenames.clone() } else { Vec::new() },
+                remove: if add { Vec::new() } else { filenames.clone() },
+            },
+        )
+        .await?;
+    println!(
+        "{} {} print(s) {} {}",
+        if add { "added" } else { "removed" }.green(),
+        filenames.len(),
+        if add { "to" } else { "from" },
+        selected.name
+    );
+    Ok(())
+}
+
+async fn library_trash(client: &MoldClient, filenames: &[String]) -> Result<()> {
+    let capabilities = client
+        .capabilities()
+        .await
+        .with_context(|| format!("could not read Library capabilities on {}", client.host()))?;
+    let enabled = capabilities
+        .gallery
+        .trash
+        .as_ref()
+        .is_some_and(|trash| trash.enabled);
+    if !enabled {
+        bail!(
+            "{} does not advertise recoverable Library trash; no files were deleted",
+            client.host()
+        );
+    }
+    client.trash_gallery_images(filenames).await.with_context(|| {
+        "the host stopped while moving the requested prints; earlier filenames may already be in trash, so run `mold library list` and `mold trash list` before retrying"
+    })?;
+    for filename in filenames {
+        println!("{} {}", "trashed".green(), filename);
+    }
+    Ok(())
+}
+
+async fn require_organize(client: &MoldClient) -> Result<ServerCapabilities> {
+    let capabilities = client
+        .capabilities()
+        .await
+        .with_context(|| format!("could not read Library capabilities on {}", client.host()))?;
+    if !capabilities.gallery.organize {
+        bail!(
+            "{} cannot organize Library prints; upgrade the host or enable its metadata database",
+            client.host()
+        );
+    }
+    Ok(capabilities)
+}
+
+fn resolve_collection<'a>(collections: &'a [Collection], value: &str) -> Result<&'a Collection> {
+    if let Some(row) = collections.iter().find(|row| row.id == value) {
+        return Ok(row);
+    }
+    if let Some(row) = collections.iter().find(|row| row.slug == value) {
+        return Ok(row);
+    }
+    let matches = collections
+        .iter()
+        .filter(|row| row.name.eq_ignore_ascii_case(value))
+        .collect::<Vec<_>>();
+    match matches.as_slice() {
+        [row] => Ok(*row),
+        [] => {
+            let available = collections
+                .iter()
+                .map(|row| row.name.as_str())
+                .collect::<Vec<_>>()
+                .join(", ");
+            bail!(
+                "collection not found: {value}{}",
+                if available.is_empty() {
+                    String::new()
+                } else {
+                    format!("; available: {available}")
+                }
+            )
+        }
+        _ => bail!("collection name is ambiguous: {value}"),
+    }
+}
+
+fn filter_and_sort(
+    rows: &mut Vec<GalleryImage>,
+    query: Option<&str>,
+    tags: &[String],
+    collection_id: Option<&str>,
+    favorite: bool,
+    format: Option<OutputFormat>,
+) {
+    let query = query.map(str::to_lowercase);
+    rows.retain(|row| {
+        let query_matches = query.as_ref().is_none_or(|needle| {
+            row.filename.to_lowercase().contains(needle)
+                || display_title(row).to_lowercase().contains(needle)
+                || row.metadata.prompt.to_lowercase().contains(needle)
+                || row.metadata.model.to_lowercase().contains(needle)
+                || row
+                    .tags
+                    .iter()
+                    .any(|tag| tag.to_lowercase().contains(needle))
+        });
+        let tags_match = tags
+            .iter()
+            .all(|wanted| row.tags.iter().any(|tag| tag.eq_ignore_ascii_case(wanted)));
+        let collection_matches =
+            collection_id.is_none_or(|id| row.collections.iter().any(|candidate| candidate == id));
+        query_matches
+            && tags_match
+            && collection_matches
+            && (!favorite || row.favorite)
+            && format.is_none_or(|wanted| gallery_format(row) == Some(wanted))
+    });
+    rows.sort_by(|a, b| {
+        b.timestamp
+            .cmp(&a.timestamp)
+            .then_with(|| a.filename.cmp(&b.filename))
+    });
+}
+
+fn gallery_format(row: &GalleryImage) -> Option<OutputFormat> {
+    row.format.or(row.metadata.output_format).or_else(|| {
+        row.filename
+            .rsplit_once('.')
+            .and_then(|(_, ext)| ext.parse().ok())
+    })
+}
+
+fn display_title(row: &GalleryImage) -> &str {
+    row.title
+        .as_deref()
+        .or(row.metadata.title.as_deref())
+        .filter(|title| !title.trim().is_empty())
+        .unwrap_or("—")
+}
+
+fn render_listing(
+    rows: &[GalleryImage],
+    total: usize,
+    offset: usize,
+    collections: &[Collection],
+) -> String {
+    use std::fmt::Write as _;
+    if rows.is_empty() {
+        return "No Library prints matched.\n".to_string();
+    }
+    let names = collections
+        .iter()
+        .map(|row| (row.id.as_str(), row.name.as_str()))
+        .collect::<HashMap<_, _>>();
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<38} {:<24} {:<7} {:<4} {:<24} {}",
+        "FILENAME".bold(),
+        "TITLE".bold(),
+        "FORMAT".bold(),
+        "FAV".bold(),
+        "TAGS".bold(),
+        "COLLECTIONS".bold()
+    );
+    for row in rows {
+        let collection_names = row
+            .collections
+            .iter()
+            .map(|id| names.get(id.as_str()).copied().unwrap_or(id.as_str()))
+            .collect::<Vec<_>>()
+            .join(",");
+        let _ = writeln!(
+            out,
+            "{:<38} {:<24} {:<7} {:<4} {:<24} {}",
+            truncate(&row.filename, 38),
+            truncate(display_title(row), 24),
+            gallery_format(row)
+                .map(|format| format.to_string())
+                .unwrap_or_else(|| "—".to_string()),
+            if row.favorite { "♥" } else { "—" },
+            truncate(&row.tags.join(","), 24),
+            collection_names,
+        );
+    }
+    let _ = writeln!(
+        out,
+        "Showing {}–{} of {total}",
+        offset + 1,
+        offset + rows.len()
+    );
+    out
+}
+
+fn render_detail(row: &GalleryImage) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(out, "{}", display_title(row).bold());
+    let _ = writeln!(out, "Filename: {}", row.filename);
+    let _ = writeln!(out, "Model: {}", row.metadata.model);
+    let _ = writeln!(out, "Prompt: {}", row.metadata.prompt);
+    let _ = writeln!(out, "Seed: {}", row.metadata.seed);
+    let _ = writeln!(out, "Size: {}×{}", row.metadata.width, row.metadata.height);
+    let _ = writeln!(out, "Favorite: {}", if row.favorite { "yes" } else { "no" });
+    let _ = writeln!(
+        out,
+        "Tags: {}",
+        if row.tags.is_empty() {
+            "—".to_string()
+        } else {
+            row.tags.join(", ")
+        }
+    );
+    let _ = writeln!(
+        out,
+        "Collections: {}",
+        if row.collections.is_empty() {
+            "—".to_string()
+        } else {
+            row.collections.join(", ")
+        }
+    );
+    out
+}
+
+fn render_collections(rows: &[Collection]) -> String {
+    use std::fmt::Write as _;
+    let mut out = String::new();
+    let _ = writeln!(
+        out,
+        "{:<32} {:<32} {:>7} {}",
+        "NAME".bold(),
+        "SLUG".bold(),
+        "PRINTS".bold(),
+        "VISIBILITY".bold()
+    );
+    for row in rows {
+        let _ = writeln!(
+            out,
+            "{:<32} {:<32} {:>7} {}",
+            truncate(&row.name, 32),
+            row.slug,
+            row.count,
+            if row.hidden { "hidden" } else { "visible" }
+        );
+    }
+    out
+}
+
+fn truncate(value: &str, max: usize) -> String {
+    if value.chars().count() <= max {
+        value.to_string()
+    } else {
+        let mut out = value
+            .chars()
+            .take(max.saturating_sub(3))
+            .collect::<String>();
+        out.push_str("...");
+        out
+    }
+}
+
+fn confirm(prompt: &str) -> Result<bool> {
+    if !io::stdin().is_terminal() {
+        bail!("confirmation requires an interactive terminal; pass --yes to proceed");
+    }
+    eprint!("{prompt} [y/N] ");
+    io::stderr().flush().ok();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    Ok(matches!(
+        line.trim().to_ascii_lowercase().as_str(),
+        "y" | "yes"
+    ))
+}
+
+#[cfg(feature = "tui")]
+async fn library_grid(host: Option<String>, local: bool) -> Result<()> {
+    mold_tui::run_tui_with_options(mold_tui::TuiLaunchOptions {
+        host,
+        local,
+        initial_workspace: mold_tui::TuiInitialWorkspace::Library,
+        strict_host: true,
+    })
+    .await
+}
+
+#[cfg(not(feature = "tui"))]
+async fn library_grid(_host: Option<String>, _local: bool) -> Result<()> {
+    bail!("Library grid requires a build with `--features tui`")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn image(filename: &str, timestamp: u64, tags: &[&str], favorite: bool) -> GalleryImage {
+        serde_json::from_value(serde_json::json!({
+            "filename": filename,
+            "metadata": {
+                "prompt": "night owl",
+                "model": "flux-dev:q4",
+                "seed": 1,
+                "steps": 20,
+                "guidance": 3.5,
+                "width": 1024,
+                "height": 1024,
+                "version": "test"
+            },
+            "timestamp": timestamp,
+            "tags": tags,
+            "favorite": favorite,
+            "collections": []
+        }))
+        .unwrap()
+    }
+
+    #[test]
+    fn filters_use_tag_and_semantics_and_stable_order() {
+        let mut rows = vec![
+            image("b.png", 7, &["owl", "night"], true),
+            image("a.png", 7, &["owl", "night"], true),
+            image("c.png", 9, &["owl"], true),
+        ];
+        filter_and_sort(
+            &mut rows,
+            Some("owl"),
+            &["owl".into(), "NIGHT".into()],
+            None,
+            true,
+            Some(OutputFormat::Png),
+        );
+        assert_eq!(
+            rows.iter()
+                .map(|row| row.filename.as_str())
+                .collect::<Vec<_>>(),
+            vec!["a.png", "b.png"]
+        );
+    }
+
+    #[test]
+    fn collection_resolution_prefers_id_then_slug_then_name() {
+        let rows = vec![Collection {
+            id: "id-1".into(),
+            name: "Night Owls".into(),
+            slug: "night-owls".into(),
+            description: None,
+            cover_filename: None,
+            hidden: false,
+            count: 2,
+            created_at: 1,
+            updated_at: 2,
+        }];
+        for value in ["id-1", "night-owls", "NIGHT OWLS"] {
+            assert_eq!(resolve_collection(&rows, value).unwrap().id, "id-1");
+        }
+        assert!(resolve_collection(&rows, "missing")
+            .unwrap_err()
+            .to_string()
+            .contains("available: Night Owls"));
+    }
+
+    #[test]
+    fn listing_empty_page_does_not_claim_a_range() {
+        assert_eq!(
+            render_listing(&[], 4, 4, &[]),
+            "No Library prints matched.\n"
+        );
+    }
+}

--- a/crates/mold-cli/src/commands/library.rs
+++ b/crates/mold-cli/src/commands/library.rs
@@ -681,6 +681,7 @@ async fn library_grid(host: Option<String>, local: bool) -> Result<()> {
     mold_tui::run_tui_with_options(mold_tui::TuiLaunchOptions {
         host,
         local,
+        api_key: std::env::var("MOLD_API_KEY").ok(),
         initial_workspace: mold_tui::TuiInitialWorkspace::Library,
         strict_host: true,
     })

--- a/crates/mold-cli/src/commands/mod.rs
+++ b/crates/mold-cli/src/commands/mod.rs
@@ -15,6 +15,7 @@ pub(crate) mod identity;
 pub mod info;
 pub mod jobs;
 pub mod lambda;
+pub mod library;
 pub mod licenses;
 pub mod list;
 pub(crate) mod local_engine;

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -58,6 +58,16 @@ fn collection_name_parser(raw: &str) -> Result<String, String> {
     mold_core::validate_collection_name(raw).map(|(name, _slug)| name)
 }
 
+fn library_limit_parser(raw: &str) -> Result<usize, String> {
+    let value = raw
+        .parse::<usize>()
+        .map_err(|_| "limit must be an integer from 1 to 1000".to_string())?;
+    if !(1..=1000).contains(&value) {
+        return Err("limit must be from 1 to 1000".to_string());
+    }
+    Ok(value)
+}
+
 #[derive(Clone, clap::ValueEnum)]
 enum LogFormat {
     Text,
@@ -737,6 +747,179 @@ pub enum TrashAction {
     Sweep,
 }
 
+#[derive(clap::Subcommand)]
+pub enum LibraryTagAction {
+    /// List tags and their print counts
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Add one or more tags to existing prints
+    Add {
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+        #[arg(long = "tag", required = true, value_name = "TAG", value_parser = tag_parser)]
+        tags: Vec<String>,
+    },
+    /// Remove one or more tags from existing prints
+    Remove {
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+        #[arg(long = "tag", required = true, value_name = "TAG", value_parser = tag_parser)]
+        tags: Vec<String>,
+    },
+    /// Rename a tag everywhere it is used
+    Rename {
+        #[arg(value_name = "OLD", value_parser = tag_parser)]
+        old: String,
+        #[arg(value_name = "NEW", value_parser = tag_parser)]
+        new: String,
+    },
+    /// Delete a tag and detach it from every print
+    Delete {
+        #[arg(value_name = "TAG", value_parser = tag_parser)]
+        tag: String,
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+}
+
+#[derive(clap::Subcommand)]
+pub enum LibraryCollectionAction {
+    /// List collections and their print counts
+    List {
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show one collection and its ordered member filenames
+    Show {
+        #[arg(value_name = "NAME-OR-SLUG")]
+        collection: String,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Create a collection
+    Create {
+        #[arg(value_name = "NAME", value_parser = collection_name_parser)]
+        name: String,
+        #[arg(long, value_name = "TEXT")]
+        description: Option<String>,
+    },
+    /// Update a collection's name, description, cover, or visibility
+    Update {
+        #[arg(value_name = "NAME-OR-SLUG")]
+        collection: String,
+        #[arg(long, value_name = "TEXT", value_parser = collection_name_parser)]
+        name: Option<String>,
+        #[arg(long, value_name = "TEXT", conflicts_with = "clear_description")]
+        description: Option<String>,
+        #[arg(long, conflicts_with = "description")]
+        clear_description: bool,
+        #[arg(long, value_name = "FILENAME", conflicts_with = "clear_cover")]
+        cover: Option<String>,
+        #[arg(long, conflicts_with = "cover")]
+        clear_cover: bool,
+        #[arg(long, conflicts_with = "visible")]
+        hidden: bool,
+        #[arg(long, conflicts_with = "hidden")]
+        visible: bool,
+    },
+    /// Delete a collection without deleting its prints
+    Delete {
+        #[arg(value_name = "NAME-OR-SLUG")]
+        collection: String,
+        #[arg(long, short = 'y')]
+        yes: bool,
+    },
+    /// Add existing prints to a collection
+    Add {
+        #[arg(value_name = "NAME-OR-SLUG")]
+        collection: String,
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+    },
+    /// Remove existing prints from a collection
+    Remove {
+        #[arg(value_name = "NAME-OR-SLUG")]
+        collection: String,
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+    },
+}
+
+#[derive(clap::Subcommand)]
+pub enum LibraryAction {
+    /// List and filter live Library prints
+    List {
+        #[arg(long, value_name = "TEXT")]
+        query: Option<String>,
+        #[arg(long = "tag", value_name = "TAG", value_parser = tag_parser)]
+        tags: Vec<String>,
+        #[arg(long, value_name = "NAME-OR-SLUG")]
+        collection: Option<String>,
+        #[arg(long)]
+        favorite: bool,
+        #[arg(long, value_parser = output_format_parser(&["png", "jpeg", "jpg", "gif", "apng", "webp", "mp4", "wav"]))]
+        format: Option<OutputFormat>,
+        #[arg(long, default_value_t = 50, value_parser = library_limit_parser)]
+        limit: usize,
+        #[arg(long, default_value_t = 0)]
+        offset: usize,
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show one print's metadata and optionally preview it inline
+    Show {
+        #[arg(value_name = "FILENAME")]
+        filename: String,
+        #[arg(long, conflicts_with = "preview")]
+        json: bool,
+        #[arg(long, conflicts_with = "json")]
+        preview: bool,
+    },
+    /// Open the protocol-aware terminal Library grid
+    Grid {
+        #[arg(long, value_name = "URL", conflicts_with = "local")]
+        host: Option<String>,
+        #[arg(long, conflicts_with = "host")]
+        local: bool,
+    },
+    /// Set or clear one existing print's title
+    Title {
+        #[arg(value_name = "FILENAME")]
+        filename: String,
+        #[arg(value_name = "TEXT", required_unless_present = "clear", conflicts_with = "clear", value_parser = print_title_parser)]
+        title: Option<String>,
+        #[arg(long, conflicts_with = "title")]
+        clear: bool,
+    },
+    /// Mark existing prints as favorites
+    Favorite {
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+    },
+    /// Remove the favorite mark from existing prints
+    Unfavorite {
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+    },
+    /// Manage tags on existing prints
+    Tag {
+        #[command(subcommand)]
+        action: LibraryTagAction,
+    },
+    /// Manage collections and membership
+    Collection {
+        #[command(subcommand)]
+        action: LibraryCollectionAction,
+    },
+    /// Move live prints into the recoverable gallery trash
+    Trash {
+        #[arg(required = true, value_name = "FILENAME")]
+        filenames: Vec<String>,
+    },
+}
+
 #[derive(Subcommand)]
 #[allow(clippy::large_enum_variant)]
 enum Commands {
@@ -1398,6 +1581,25 @@ desktop, and iPhone surfaces render.")]
     Queue {
         #[command(subcommand)]
         action: QueueAction,
+    },
+
+    /// Browse and organize existing Library prints on a running server
+    #[command(after_long_help = "\
+Examples:
+  mold library list --tag portrait --favorite
+  mold library show mold-flux-dev-1700000000000.png --preview
+  mold library tag add a.png b.png --tag portrait --tag selected
+  mold library collection add Portfolio a.png b.png
+  mold library collection remove Portfolio b.png
+  mold library trash a.png
+  mold library grid
+
+Non-grid commands target MOLD_HOST (with MOLD_API_KEY when configured) and
+never fall back to direct filesystem access. The grid opens the existing Mold
+TUI Library; an unreachable explicit host is an error, not a local fallback.")]
+    Library {
+        #[command(subcommand)]
+        action: LibraryAction,
     },
 
     /// Inspect, restore, or empty the gallery trash on a running server
@@ -2469,6 +2671,9 @@ async fn run() -> anyhow::Result<()> {
         }
         Commands::Queue { action } => {
             commands::queue::run(action).await?;
+        }
+        Commands::Library { action } => {
+            commands::library::run(action).await?;
         }
         Commands::Trash { action } => {
             commands::trash::run(action).await?;
@@ -3635,6 +3840,123 @@ mod tests {
             };
             assert_eq!(matched, expected);
         }
+    }
+
+    // ── library tests ───────────────────────────────────────────────────
+
+    #[test]
+    fn library_list_parses_filters_and_bounds_limit() {
+        match parse(&[
+            "library",
+            "list",
+            "--tag",
+            "Night Owls",
+            "--collection",
+            "Portfolio",
+            "--favorite",
+            "--format",
+            "png",
+            "--limit",
+            "1000",
+            "--offset",
+            "4",
+            "--json",
+        ])
+        .command
+        {
+            Commands::Library {
+                action:
+                    LibraryAction::List {
+                        tags,
+                        collection,
+                        favorite,
+                        format,
+                        limit,
+                        offset,
+                        json,
+                        ..
+                    },
+            } => {
+                assert_eq!(tags, vec!["Night Owls"]);
+                assert_eq!(collection.as_deref(), Some("Portfolio"));
+                assert!(favorite);
+                assert_eq!(format, Some(OutputFormat::Png));
+                assert_eq!(limit, 1000);
+                assert_eq!(offset, 4);
+                assert!(json);
+            }
+            _ => panic!("expected Library list"),
+        }
+        assert!(try_parse(&["library", "list", "--limit", "0"]).is_err());
+        assert!(try_parse(&["library", "list", "--limit", "1001"]).is_err());
+    }
+
+    #[test]
+    fn library_show_keeps_json_and_preview_exclusive() {
+        assert!(try_parse(&["library", "show", "print.png", "--json", "--preview",]).is_err());
+        match parse(&["library", "show", "print.png", "--preview"]).command {
+            Commands::Library {
+                action:
+                    LibraryAction::Show {
+                        filename,
+                        preview,
+                        json,
+                    },
+            } => {
+                assert_eq!(filename, "print.png");
+                assert!(preview);
+                assert!(!json);
+            }
+            _ => panic!("expected Library show"),
+        }
+    }
+
+    #[test]
+    fn library_tag_and_collection_membership_parse() {
+        match parse(&[
+            "library", "tag", "add", "a.png", "b.png", "--tag", "owl", "--tag", "night",
+        ])
+        .command
+        {
+            Commands::Library {
+                action:
+                    LibraryAction::Tag {
+                        action: LibraryTagAction::Add { filenames, tags },
+                    },
+            } => {
+                assert_eq!(filenames, vec!["a.png", "b.png"]);
+                assert_eq!(tags, vec!["owl", "night"]);
+            }
+            _ => panic!("expected Library tag add"),
+        }
+        match parse(&["library", "collection", "remove", "Portfolio", "a.png"]).command {
+            Commands::Library {
+                action:
+                    LibraryAction::Collection {
+                        action:
+                            LibraryCollectionAction::Remove {
+                                collection,
+                                filenames,
+                            },
+                    },
+            } => {
+                assert_eq!(collection, "Portfolio");
+                assert_eq!(filenames, vec!["a.png"]);
+            }
+            _ => panic!("expected Library collection remove"),
+        }
+    }
+
+    #[test]
+    fn library_title_requires_text_or_clear() {
+        assert!(try_parse(&["library", "title", "a.png"]).is_err());
+        assert!(try_parse(&["library", "title", "a.png", "new title", "--clear"]).is_err());
+        assert!(matches!(
+            parse(&["library", "title", "a.png", "--clear"]).command,
+            Commands::Library {
+                action: LibraryAction::Title { clear: true, .. }
+            }
+        ));
     }
 
     // ── trash tests ─────────────────────────────────────────────────────

--- a/crates/mold-cli/tests/cli_integration.rs
+++ b/crates/mold-cli/tests/cli_integration.rs
@@ -84,6 +84,309 @@ fn unknown_subcommand_fails() {
     env.cmd().arg("nonexistent-subcommand").assert().failure();
 }
 
+fn library_capabilities(organize: bool, bulk_mutations: bool, trash: bool) -> serde_json::Value {
+    serde_json::json!({
+        "gallery": {
+            "can_delete": true,
+            "organize": organize,
+            "bulk_mutations": bulk_mutations,
+            "trash": trash.then_some(serde_json::json!({
+                "enabled": true,
+                "retention_days": 30
+            }))
+        },
+        "catalog": { "available": false, "families": [] }
+    })
+}
+
+fn library_row(filename: &str, timestamp: u64, tags: &[&str]) -> serde_json::Value {
+    serde_json::json!({
+        "filename": filename,
+        "metadata": {
+            "prompt": "night owl",
+            "model": "flux-dev:q4",
+            "seed": 7,
+            "steps": 20,
+            "guidance": 3.5,
+            "width": 1024,
+            "height": 1024,
+            "output_format": "png",
+            "version": "test"
+        },
+        "timestamp": timestamp,
+        "format": "png",
+        "tags": tags,
+        "favorite": true,
+        "collections": []
+    })
+}
+
+#[tokio::test]
+async fn library_list_json_is_pure_and_uses_the_same_filtered_page() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/gallery"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([
+            library_row("older.png", 1, &["owl"]),
+            library_row("newer.png", 2, &["owl", "night"])
+        ])))
+        .mount(&server)
+        .await;
+
+    let output = env
+        .cmd()
+        .env("MOLD_HOST", server.uri())
+        .args([
+            "library", "list", "--tag", "night", "--limit", "1", "--json",
+        ])
+        .output()
+        .unwrap();
+    assert!(
+        output.status.success(),
+        "{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        !output.stdout.contains(&0x1b),
+        "JSON stdout contains ANSI bytes"
+    );
+    let json: serde_json::Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(json["total"], 1);
+    assert_eq!(json["items"][0]["filename"], "newer.png");
+}
+
+#[tokio::test]
+async fn library_tag_add_uses_replay_safe_bulk_mutation_when_advertised() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/capabilities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(library_capabilities(true, true, true)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/gallery/mutations"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "operation_id": "server-receipt",
+            "changed": 2,
+            "revision": 1
+        })))
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args([
+            "library",
+            "tag",
+            "add",
+            "a.png",
+            "b.png",
+            "--tag",
+            "night owls",
+        ])
+        .assert()
+        .success();
+
+    let requests = server.received_requests().await.unwrap();
+    let request = requests
+        .iter()
+        .find(|request| request.url.path() == "/api/gallery/mutations")
+        .unwrap();
+    let body: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+    assert_eq!(body["filenames"], serde_json::json!(["a.png", "b.png"]));
+    assert_eq!(body["add_tags"], serde_json::json!(["night owls"]));
+    assert!(uuid::Uuid::parse_str(body["operation_id"].as_str().unwrap()).is_ok());
+}
+
+#[tokio::test]
+async fn library_tag_add_falls_back_to_legacy_organize_route() {
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/capabilities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(library_capabilities(true, false, true)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("POST"))
+        .and(path("/api/gallery/organize"))
+        .and(body_json(serde_json::json!({
+            "filenames": ["a.png"],
+            "add_tags": ["owl"]
+        })))
+        .respond_with(ResponseTemplate::new(204))
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args(["library", "tag", "add", "a.png", "--tag", "owl"])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn library_trash_refuses_a_host_without_recoverable_trash() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/capabilities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(library_capabilities(true, false, false)),
+        )
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args(["library", "trash", "keep-me.png"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("no files were deleted"));
+
+    let requests = server.received_requests().await.unwrap();
+    assert_eq!(requests.len(), 1, "refusal must not send a DELETE/POST");
+}
+
+#[tokio::test]
+async fn library_collection_remove_resolves_slug_and_sends_membership_change() {
+    use wiremock::matchers::{body_json, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/capabilities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(library_capabilities(true, true, true)),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/gallery/collections"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(serde_json::json!([{
+                "id": "collection-id",
+                "name": "Night Owls",
+                "slug": "night-owls",
+                "hidden": false,
+                "count": 2,
+                "created_at": 1,
+                "updated_at": 2
+            }])),
+        )
+        .mount(&server)
+        .await;
+    Mock::given(method("PUT"))
+        .and(path("/api/gallery/collections/collection-id/items"))
+        .and(body_json(serde_json::json!({
+            "add": [],
+            "remove": ["odd # 100%.png"]
+        })))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "collection-id",
+            "name": "Night Owls",
+            "slug": "night-owls",
+            "hidden": false,
+            "count": 1,
+            "created_at": 1,
+            "updated_at": 3
+        })))
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args([
+            "library",
+            "collection",
+            "remove",
+            "night-owls",
+            "odd # 100%.png",
+        ])
+        .assert()
+        .success();
+}
+
+#[tokio::test]
+async fn library_show_video_uses_thumbnail_when_animated_preview_is_missing() {
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    let mut row = library_row("clip.mp4", 2, &["motion"]);
+    row["format"] = serde_json::json!("mp4");
+    row["metadata"]["output_format"] = serde_json::json!("mp4");
+    Mock::given(method("GET"))
+        .and(path("/api/gallery"))
+        .and(query_param("filename", "clip.mp4"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([row])))
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/gallery/preview/clip.mp4"))
+        .respond_with(ResponseTemplate::new(404))
+        .expect(1)
+        .mount(&server)
+        .await;
+    Mock::given(method("GET"))
+        .and(path("/api/gallery/thumbnail/clip.mp4"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(b"not-a-real-png"))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args(["library", "show", "clip.mp4", "--preview"])
+        .assert()
+        .success()
+        .stdout(predicate::str::contains("Filename: clip.mp4"));
+}
+
+#[tokio::test]
+async fn library_global_tag_delete_requires_yes_without_a_tty() {
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    let env = TestEnv::new();
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/capabilities"))
+        .respond_with(
+            ResponseTemplate::new(200).set_body_json(library_capabilities(true, true, true)),
+        )
+        .mount(&server)
+        .await;
+
+    env.cmd()
+        .env("MOLD_HOST", server.uri())
+        .args(["library", "tag", "delete", "owl"])
+        .assert()
+        .failure()
+        .stderr(predicate::str::contains("pass --yes"));
+
+    assert_eq!(server.received_requests().await.unwrap().len(), 1);
+}
+
 // ── mold default ──────────────────────────────────────────────────────────
 
 #[test]

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -6,15 +6,16 @@ use crate::chain_job::{
 use crate::error::MoldError;
 use crate::queue_progress::QueueJobProgress;
 use crate::types::{
-    AudioData, Collection, CollectionCreateRequest, CollectionItemsRequest,
+    AudioData, Collection, CollectionCreateRequest, CollectionDetail, CollectionItemsRequest,
     CollectionUpdateRequest, DeviceState, EmptyTrashResult, ExpandRequest, ExpandResponse,
-    GalleryImage, GalleryOrganizeRequest, GalleryPatchRequest, GenerateRequest, GenerateResponse,
-    GenerationBatchAdmissionRequest, GenerationBatchStatus, GenerationBatchStatusRequest,
-    GenerationBatchStatusResponse, GenerationRetryRequest, ImageData, LoraInfo, ModelInfo,
-    ModelInfoExtended, OutputFormat, QueueListingWire, ReferenceUploadCompleteResponse,
-    ReferenceUploadSessionRequest, ReferenceUploadSessionResponse, ServerStatus, SseCompleteEvent,
-    SseErrorEvent, SseProgressEvent, TagCount, TagRenameRequest, TrashFilenamesRequest,
-    TrashSweepResult, VideoData,
+    GalleryBulkMutationRequest, GalleryBulkMutationResult, GalleryImage, GalleryOrganizeRequest,
+    GalleryPatchRequest, GenerateRequest, GenerateResponse, GenerationBatchAdmissionRequest,
+    GenerationBatchStatus, GenerationBatchStatusRequest, GenerationBatchStatusResponse,
+    GenerationRetryRequest, ImageData, LoraInfo, ModelInfo, ModelInfoExtended, OutputFormat,
+    QueueListingWire, ReferenceUploadCompleteResponse, ReferenceUploadSessionRequest,
+    ReferenceUploadSessionResponse, ServerStatus, SseCompleteEvent, SseErrorEvent,
+    SseProgressEvent, TagCount, TagRenameRequest, TrashFilenamesRequest, TrashSweepResult,
+    VideoData,
 };
 use anyhow::{Context, Result};
 use base64::Engine as _;
@@ -1727,7 +1728,11 @@ impl MoldClient {
     pub async fn get_gallery_image(&self, filename: &str) -> Result<Vec<u8>> {
         let resp = self
             .client
-            .get(format!("{}/api/gallery/image/{filename}", self.base_url))
+            .get(format!(
+                "{}/api/gallery/image/{}",
+                self.base_url,
+                encode_path_segment(filename)
+            ))
             .send()
             .await?
             .error_for_status()?
@@ -1739,7 +1744,11 @@ impl MoldClient {
     /// Delete a gallery image on the server.
     pub async fn delete_gallery_image(&self, filename: &str) -> Result<()> {
         self.client
-            .delete(format!("{}/api/gallery/image/{filename}", self.base_url))
+            .delete(format!(
+                "{}/api/gallery/image/{}",
+                self.base_url,
+                encode_path_segment(filename)
+            ))
             .send()
             .await?
             .error_for_status()?;
@@ -1891,6 +1900,24 @@ impl MoldClient {
         Ok(())
     }
 
+    /// Apply one replay-safe bulk organization mutation
+    /// (`POST /api/gallery/mutations`).
+    pub async fn mutate_gallery_bulk(
+        &self,
+        req: &GalleryBulkMutationRequest,
+    ) -> Result<GalleryBulkMutationResult> {
+        let resp = self
+            .client
+            .post(format!("{}/api/gallery/mutations", self.base_url))
+            .json(req)
+            .send()
+            .await?;
+        Ok(error_for_status_with_body(resp)
+            .await?
+            .json::<GalleryBulkMutationResult>()
+            .await?)
+    }
+
     /// List the host's collections (`GET /api/gallery/collections`).
     pub async fn list_collections(&self) -> Result<Vec<Collection>> {
         let resp = self
@@ -1901,6 +1928,24 @@ impl MoldClient {
         Ok(error_for_status_with_body(resp)
             .await?
             .json::<Vec<Collection>>()
+            .await?)
+    }
+
+    /// Read one collection and its ordered member filenames
+    /// (`GET /api/gallery/collections/:id`).
+    pub async fn get_collection(&self, id: &str) -> Result<CollectionDetail> {
+        let resp = self
+            .client
+            .get(format!(
+                "{}/api/gallery/collections/{}",
+                self.base_url,
+                encode_path_segment(id)
+            ))
+            .send()
+            .await?;
+        Ok(error_for_status_with_body(resp)
+            .await?
+            .json::<CollectionDetail>()
             .await?)
     }
 
@@ -2028,7 +2073,11 @@ impl MoldClient {
     pub async fn get_gallery_preview(&self, filename: &str) -> Result<Option<Vec<u8>>> {
         let resp = self
             .client
-            .get(format!("{}/api/gallery/preview/{filename}", self.base_url))
+            .get(format!(
+                "{}/api/gallery/preview/{}",
+                self.base_url,
+                encode_path_segment(filename)
+            ))
             .send()
             .await?;
         if resp.status() == reqwest::StatusCode::NOT_FOUND {
@@ -2043,8 +2092,9 @@ impl MoldClient {
         let resp = self
             .client
             .get(format!(
-                "{}/api/gallery/thumbnail/{filename}",
-                self.base_url
+                "{}/api/gallery/thumbnail/{}",
+                self.base_url,
+                encode_path_segment(filename)
             ))
             .send()
             .await?
@@ -2656,6 +2706,46 @@ impl std::error::Error for ModelNotFoundError {}
 mod tests {
     use super::*;
     use crate::test_support::ENV_LOCK;
+
+    #[tokio::test]
+    async fn gallery_media_helpers_encode_reserved_filename_characters() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, MockServer, ResponseTemplate};
+
+        let server = MockServer::start().await;
+        let encoded = "odd%20%23%20100%25-%E6%97%A5%E6%9C%AC.png";
+        for (method_name, route, body) in [
+            ("GET", "image", b"image".as_slice()),
+            ("GET", "preview", b"preview".as_slice()),
+            ("GET", "thumbnail", b"thumbnail".as_slice()),
+        ] {
+            Mock::given(method(method_name))
+                .and(path(format!("/api/gallery/{route}/{encoded}")))
+                .respond_with(ResponseTemplate::new(200).set_body_bytes(body))
+                .expect(1)
+                .mount(&server)
+                .await;
+        }
+        Mock::given(method("DELETE"))
+            .and(path(format!("/api/gallery/image/{encoded}")))
+            .respond_with(ResponseTemplate::new(204))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let client = MoldClient::new(&server.uri());
+        let filename = "odd # 100%-日本.png";
+        assert_eq!(client.get_gallery_image(filename).await.unwrap(), b"image");
+        assert_eq!(
+            client.get_gallery_preview(filename).await.unwrap().unwrap(),
+            b"preview"
+        );
+        assert_eq!(
+            client.get_gallery_thumbnail(filename).await.unwrap(),
+            b"thumbnail"
+        );
+        client.delete_gallery_image(filename).await.unwrap();
+    }
 
     #[test]
     fn transient_request_errors_include_wrapped_rate_limits_and_server_failures() {

--- a/crates/mold-tui/Cargo.toml
+++ b/crates/mold-tui/Cargo.toml
@@ -45,3 +45,4 @@ ureq = "3"
 [dev-dependencies]
 tempfile = "3"
 serial_test = "3"
+wiremock = "0.6"

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -2190,6 +2190,15 @@ fn wait_for_server_health(url: &str, timeout_secs: u64) -> bool {
 
 impl App {
     pub fn new(host: Option<String>, local: bool, picker: Picker) -> Result<Self> {
+        Self::new_with_launch_policy(host, local, picker, false)
+    }
+
+    pub(crate) fn new_with_launch_policy(
+        host: Option<String>,
+        local: bool,
+        picker: Picker,
+        strict_host: bool,
+    ) -> Result<Self> {
         let config = Config::load_or_default();
 
         // Determine initial server URL and inference mode
@@ -2204,6 +2213,10 @@ impl App {
             let url = mold_core::client::normalize_host(&h);
             if check_server_health(&url) {
                 (Some(url), InferenceMode::Auto)
+            } else if strict_host {
+                anyhow::bail!(
+                    "mold host {url} is unreachable; Library grid did not fall back to local files"
+                )
             } else {
                 (None, InferenceMode::Local)
             }
@@ -2211,6 +2224,10 @@ impl App {
             let url = mold_core::client::normalize_host(&h);
             if check_server_health(&url) {
                 (Some(url), InferenceMode::Auto)
+            } else if strict_host {
+                anyhow::bail!(
+                    "mold host {url} is unreachable; Library grid did not fall back to local files"
+                )
             } else {
                 (None, InferenceMode::Local)
             }
@@ -4499,6 +4516,10 @@ impl App {
             }
             _ => {}
         }
+    }
+
+    pub(crate) fn open_library(&mut self) {
+        self.set_active_view(View::Library);
     }
 
     /// Dispatch a semantic action.

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use crossterm::event::{Event as CrosstermEvent, KeyCode, KeyModifiers};
 use mold_core::{
     validation::{MAX_STG_BLOCKS, MAX_STG_BLOCK_INDEX},
@@ -2103,6 +2103,12 @@ pub struct App {
     pub layout: LayoutAreas,
     /// Background server process spawned by the TUI (killed on quit).
     pub server_process: Option<std::process::Child>,
+    /// Host id whose API key was supplied only for this TUI process. The key
+    /// itself lives in `hosts::SESSION_API_KEYS` and is cleared on shutdown.
+    pub(crate) session_api_key_host_id: Option<String>,
+    /// A focused Library launch must never reinterpret a failed loopback HTTP
+    /// scan as permission to walk and mutate the output directory directly.
+    pub(crate) strict_gallery_authority: bool,
     /// Whether an upscale job is currently running.
     pub upscale_in_progress: bool,
     /// Handle to the background upscale task (for cancellation).
@@ -2145,6 +2151,18 @@ fn check_server_health(url: &str) -> bool {
         .build()
         .new_agent();
     agent.get(&health_url).call().is_ok()
+}
+
+/// Verify that the requested Library authority is both reachable and usable
+/// with the launch credential. `/health` is intentionally public, so it cannot
+/// prove an authenticated gallery will work.
+fn check_gallery_access(url: &str, api_key: Option<&str>) -> Result<()> {
+    let client = crate::hosts::client_for(url, api_key);
+    let runtime = tokio::runtime::Handle::current();
+    std::thread::spawn(move || runtime.block_on(client.list_gallery()))
+        .join()
+        .map_err(|_| anyhow::anyhow!("gallery access probe panicked"))?
+        .map(|_| ())
 }
 
 /// Spawn a background `mold serve` process.
@@ -2190,16 +2208,24 @@ fn wait_for_server_health(url: &str, timeout_secs: u64) -> bool {
 
 impl App {
     pub fn new(host: Option<String>, local: bool, picker: Picker) -> Result<Self> {
-        Self::new_with_launch_policy(host, local, picker, false)
+        Self::new_with_launch_policy(
+            host,
+            local,
+            picker,
+            std::env::var("MOLD_API_KEY").ok(),
+            false,
+        )
     }
 
     pub(crate) fn new_with_launch_policy(
         host: Option<String>,
         local: bool,
         picker: Picker,
+        api_key: Option<String>,
         strict_host: bool,
     ) -> Result<Self> {
         let config = Config::load_or_default();
+        let api_key = api_key.filter(|key| !key.is_empty());
 
         // Determine initial server URL and inference mode
         let env_host = std::env::var("MOLD_HOST").ok();
@@ -2257,6 +2283,16 @@ impl App {
             }
         };
 
+        if strict_host {
+            if let Some(url) = server_url.as_deref() {
+                check_gallery_access(url, api_key.as_deref()).with_context(|| {
+                    format!(
+                        "mold host {url} did not accept the Library credential; Library grid did not fall back to local files"
+                    )
+                })?;
+            }
+        }
+
         // Boot-time user preferences (Settings → Preferences).
         let prefs = crate::prefs::TuiPrefs::load();
 
@@ -2279,9 +2315,10 @@ impl App {
             // Blocking fetch from server for startup catalog
             let rt = tokio::runtime::Handle::current();
             let url_clone = url.clone();
+            let api_key_clone = api_key.clone();
             std::thread::spawn(move || {
                 rt.block_on(async {
-                    let client = mold_core::MoldClient::new(&url_clone);
+                    let client = crate::hosts::client_for(&url_clone, api_key_clone.as_deref());
                     client.list_models_extended().await.ok()
                 })
             })
@@ -2424,7 +2461,23 @@ impl App {
             .unwrap_or(true);
 
         let rows = crate::ui::create_form::visible_rows(&capabilities, &advanced);
-        let app = Ok(Self {
+        let machines = crate::hosts::MachinesState::load();
+        let session_api_key_host_id = server_url.as_deref().and_then(|url| {
+            api_key.as_ref().map(|_| {
+                if crate::gallery_scan::is_loopback_url(url) {
+                    crate::hosts::LOCAL_HOST_ID.to_string()
+                } else {
+                    machines
+                        .registry
+                        .hosts
+                        .iter()
+                        .find(|host| host.url == url)
+                        .map(|host| host.id.clone())
+                        .unwrap_or_else(|| crate::hosts::host_id_from_url(url))
+                }
+            })
+        });
+        let mut app = Self {
             active_view: View::Create,
             create_mode: CreateMode::default(),
             generate: GenerateState {
@@ -2464,7 +2517,7 @@ impl App {
                 filter: String::new(),
                 filtering: false,
             },
-            machines: crate::hosts::MachinesState::load(),
+            machines,
             target: if local {
                 // `mold tui --local` pins this run to the local engine;
                 // the persisted target is left untouched.
@@ -2498,20 +2551,25 @@ impl App {
             history,
             layout: LayoutAreas::default(),
             server_process,
+            session_api_key_host_id: None,
+            strict_gallery_authority: strict_host,
             upscale_in_progress: false,
             upscale_task: None,
             upscale_tile_progress: None,
             upscale_progress: ProgressState::default(),
             connecting: false,
             show_timeline,
-        });
+        };
 
-        // Spawn background gallery scan
-        if let Ok(ref app) = app {
-            app.spawn_gallery_scan();
+        if let (Some(host_id), Some(key)) = (session_api_key_host_id, api_key.as_deref()) {
+            crate::hosts::set_session_api_key(&host_id, key);
+            app.session_api_key_host_id = Some(host_id);
         }
 
-        app
+        // Spawn background gallery scan
+        app.spawn_gallery_scan();
+
+        Ok(app)
     }
 
     /// Spawn a merged all-hosts gallery scan: the local output dir, the
@@ -2522,8 +2580,9 @@ impl App {
         let tx = self.bg_tx.clone();
         let sources =
             crate::gallery_scan::scan_sources(self.server_url.as_deref(), &self.machines.registry);
+        let allow_local_fallback = !self.strict_gallery_authority;
         self.tokio_handle.spawn(async move {
-            let scan = crate::gallery_scan::scan_all_hosts(sources).await;
+            let scan = crate::gallery_scan::scan_all_hosts(sources, allow_local_fallback).await;
             let _ = tx.send(BackgroundEvent::GalleryScanComplete(scan));
         });
     }
@@ -3185,12 +3244,19 @@ impl App {
         // Save current session so settings persist even without generating
         self.save_session();
 
+        self.cleanup_runtime_authority();
+    }
+
+    fn cleanup_runtime_authority(&mut self) {
         if let Some(ref mut child) = self.server_process {
             tracing::info!(pid = child.id(), "stopping background server");
             let _ = child.kill();
             let _ = child.wait();
         }
         self.server_process = None;
+        if let Some(host_id) = self.session_api_key_host_id.take() {
+            crate::hosts::clear_session_api_key(&host_id);
+        }
     }
 
     /// Persist current prompt, negative prompt, model, and all params to session file.
@@ -9430,6 +9496,15 @@ fn reduce_progress_state(progress: &mut ProgressState, event: SseProgressEvent) 
     false
 }
 
+impl Drop for App {
+    fn drop(&mut self) {
+        // Setup failures can drop the app before the event loop gets a chance
+        // to call `shutdown`. Never leave an auto-started server or ephemeral
+        // launch credential behind in that path.
+        self.cleanup_runtime_authority();
+    }
+}
+
 #[cfg(test)]
 mod tests {
     mod held_batch {
@@ -10740,6 +10815,8 @@ mod tests {
             history: crate::history::PromptHistory::empty(),
             layout: LayoutAreas::default(),
             server_process: None,
+            session_api_key_host_id: None,
+            strict_gallery_authority: false,
             upscale_in_progress: false,
             upscale_task: None,
             upscale_tile_progress: None,
@@ -10747,6 +10824,28 @@ mod tests {
             connecting: false,
             show_timeline: true,
         }
+    }
+
+    #[cfg(unix)]
+    #[tokio::test]
+    async fn dropping_app_cleans_up_an_autostarted_server() {
+        let mut app = make_settings_test_app();
+        let child = std::process::Command::new("sleep")
+            .arg("60")
+            .spawn()
+            .expect("spawn disposable server stand-in");
+        let pid = child.id();
+        app.server_process = Some(child);
+
+        drop(app);
+
+        let still_running = std::process::Command::new("kill")
+            .args(["-0", &pid.to_string()])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_ok_and(|status| status.success());
+        assert!(!still_running, "App::drop must reap its background server");
     }
 
     /// Helper: find the row_index for a given SettingsKey.

--- a/crates/mold-tui/src/gallery_scan.rs
+++ b/crates/mold-tui/src/gallery_scan.rs
@@ -32,8 +32,8 @@ pub fn cached_image_path(host_id: &str, filename: &str) -> PathBuf {
 
 /// Scan one remote host's gallery via its API. Returns `None` when the
 /// host is unreachable (or `origin` has no URL) so the caller can count
-/// it as offline without failing the merged scan. Honors the host's
-/// saved API key.
+/// it as offline without failing the merged scan. Honors the host's saved API
+/// key or the ephemeral key supplied by the command that launched this TUI.
 pub async fn scan_images_from_server(origin: &GalleryOrigin) -> Option<Vec<GalleryEntry>> {
     let url = origin.url.as_deref()?;
     let api_key = crate::hosts::api_key_for(&origin.host_id);
@@ -311,7 +311,8 @@ pub(crate) fn is_loopback_url(url: &str) -> bool {
 /// A connected **loopback** server collapses into the this-machine
 /// source: its gallery is authoritative for the local output dir (the
 /// pre-merge behavior), so this machine is scanned through it over HTTP —
-/// with a directory-walk fallback if the server stops answering.
+/// with a directory-walk fallback only for ordinary TUI launches. Focused
+/// strict Library launches disable that fallback in [`scan_all_hosts`].
 pub(crate) fn scan_sources(
     server_url: Option<&str>,
     registry: &HostRegistry,
@@ -358,7 +359,7 @@ pub(crate) fn scan_sources(
 /// nothing and is counted in `offline_hosts`; the this-machine source
 /// never goes offline — if its loopback server stops answering, it falls
 /// back to walking the output directory.
-pub async fn scan_all_hosts(sources: Vec<GalleryOrigin>) -> MergedScan {
+pub async fn scan_all_hosts(sources: Vec<GalleryOrigin>, allow_local_fallback: bool) -> MergedScan {
     let mut handles = Vec::with_capacity(sources.len());
     for origin in sources {
         handles.push(tokio::spawn(async move {
@@ -368,6 +369,13 @@ pub async fn scan_all_hosts(sources: Vec<GalleryOrigin>) -> MergedScan {
                         return SourceScan {
                             origin,
                             entries: Some(entries),
+                            local_trash_available: false,
+                        };
+                    }
+                    if !allow_local_fallback {
+                        return SourceScan {
+                            origin,
+                            entries: None,
                             local_trash_available: false,
                         };
                     }
@@ -1121,6 +1129,19 @@ mod tests {
             entries: Some(vec![local_entry("a.png", 1)]),
             local_trash_available: false,
         }]);
+        assert!(!merged.local_trash_available);
+    }
+
+    #[tokio::test]
+    async fn strict_loopback_scan_never_falls_back_to_disk() {
+        let origin = GalleryOrigin {
+            host_id: crate::hosts::LOCAL_HOST_ID.to_string(),
+            url: Some("http://127.0.0.1:1".to_string()),
+            name: crate::hosts::local_display_name().to_string(),
+        };
+        let merged = scan_all_hosts(vec![origin], false).await;
+        assert!(merged.entries.is_empty());
+        assert_eq!(merged.offline_hosts, 0, "this-machine is not a remote host");
         assert!(!merged.local_trash_available);
     }
 

--- a/crates/mold-tui/src/hosts.rs
+++ b/crates/mold-tui/src/hosts.rs
@@ -14,6 +14,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
+use std::sync::{LazyLock, RwLock};
 use tokio::sync::mpsc;
 
 use mold_core::{DeviceInfo, DeviceState, MoldClient, ServerCapabilities, ServerStatus};
@@ -202,8 +203,39 @@ fn host_key_setting(id: &str) -> String {
     format!("{}{id}", keys::TUI_HOST_KEY_PREFIX)
 }
 
+/// Per-process credentials supplied by the command that launched this TUI.
+/// They deliberately never enter SQLite: `MOLD_API_KEY` remains an ephemeral
+/// environment authority unless the user explicitly saves a host key.
+static SESSION_API_KEYS: LazyLock<RwLock<HashMap<String, String>>> =
+    LazyLock::new(|| RwLock::new(HashMap::new()));
+
+pub(crate) fn set_session_api_key(id: &str, key: &str) {
+    if key.is_empty() {
+        return;
+    }
+    SESSION_API_KEYS
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .insert(id.to_string(), key.to_string());
+}
+
+pub(crate) fn clear_session_api_key(id: &str) {
+    SESSION_API_KEYS
+        .write()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .remove(id);
+}
+
 /// Read the saved API key for a host, if any.
 pub(crate) fn api_key_for(id: &str) -> Option<String> {
+    if let Some(key) = SESSION_API_KEYS
+        .read()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .get(id)
+        .cloned()
+    {
+        return Some(key);
+    }
     let db = open_db()?;
     Settings::new(&db)
         .get_str(&host_key_setting(id))

--- a/crates/mold-tui/src/lib.rs
+++ b/crates/mold-tui/src/lib.rs
@@ -35,15 +35,55 @@ use ratatui::prelude::*;
 
 use app::App;
 
+/// Initial workspace for callers that launch the TUI as a focused command.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum TuiInitialWorkspace {
+    #[default]
+    Create,
+    Library,
+}
+
+/// Launch policy for embedding the TUI behind another CLI command.
+#[derive(Debug, Clone, Default)]
+pub struct TuiLaunchOptions {
+    pub host: Option<String>,
+    pub local: bool,
+    pub initial_workspace: TuiInitialWorkspace,
+    /// Refuse an unreachable `host` / `MOLD_HOST` instead of silently
+    /// changing the data authority to local files.
+    pub strict_host: bool,
+}
+
 /// Launch the mold TUI.
 ///
 /// `host` overrides the default MOLD_HOST for remote generation.
 /// `local` forces local-only inference (no server connection).
 pub async fn run_tui(host: Option<String>, local: bool) -> Result<()> {
+    run_tui_with_options(TuiLaunchOptions {
+        host,
+        local,
+        ..Default::default()
+    })
+    .await
+}
+
+/// Launch the TUI with an explicit workspace and host-fallback policy.
+pub async fn run_tui_with_options(options: TuiLaunchOptions) -> Result<()> {
     // Probe the terminal image protocol *before* entering raw mode / alternate screen,
     // because the query writes to stdout and reads the terminal's reply.
     let picker = ratatui_image::picker::Picker::from_query_stdio()
         .unwrap_or_else(|_| ratatui_image::picker::Picker::from_fontsize((8, 16)));
+
+    // Resolve the requested data authority before raw mode. In particular, a
+    // strict unreachable host must return a normal shell error without leaving
+    // the caller's terminal in the alternate screen.
+    let version = mold_core::build_info::version_string();
+    tracing::info!(%version, "starting mold tui");
+    let mut app =
+        App::new_with_launch_policy(options.host, options.local, picker, options.strict_host)?;
+    if options.initial_workspace == TuiInitialWorkspace::Library {
+        app.open_library();
+    }
 
     // Set up the terminal
     enable_raw_mode()?;
@@ -60,10 +100,6 @@ pub async fn run_tui(host: Option<String>, local: bool) -> Result<()> {
         original_hook(panic_info);
     }));
 
-    // Create the app and run
-    let version = mold_core::build_info::version_string();
-    tracing::info!(%version, "starting mold tui");
-    let mut app = App::new(host, local, picker)?;
     let result = run_event_loop(&mut terminal, &mut app).await;
 
     // Clean up background server process
@@ -125,5 +161,27 @@ async fn run_event_loop(
         if app.should_quit {
             return Ok(());
         }
+    }
+}
+
+#[cfg(test)]
+mod launch_tests {
+    use super::*;
+
+    #[test]
+    fn strict_library_launch_refuses_unreachable_explicit_host() {
+        let picker = ratatui_image::picker::Picker::from_fontsize((8, 16));
+        let error = match App::new_with_launch_policy(
+            Some("http://127.0.0.1:1".to_string()),
+            false,
+            picker,
+            true,
+        ) {
+            Ok(_) => panic!("strict launch must not fall back to local files"),
+            Err(error) => error,
+        };
+        assert!(error
+            .to_string()
+            .contains("did not fall back to local files"));
     }
 }

--- a/crates/mold-tui/src/lib.rs
+++ b/crates/mold-tui/src/lib.rs
@@ -35,6 +35,33 @@ use ratatui::prelude::*;
 
 use app::App;
 
+#[derive(Default)]
+struct TerminalRestoreGuard {
+    active: bool,
+}
+
+impl TerminalRestoreGuard {
+    fn arm(&mut self) {
+        self.active = true;
+    }
+
+    fn restore(&mut self) -> io::Result<()> {
+        if !self.active {
+            return Ok(());
+        }
+        disable_raw_mode()?;
+        execute!(io::stdout(), LeaveAlternateScreen, DisableMouseCapture)?;
+        self.active = false;
+        Ok(())
+    }
+}
+
+impl Drop for TerminalRestoreGuard {
+    fn drop(&mut self) {
+        let _ = self.restore();
+    }
+}
+
 /// Initial workspace for callers that launch the TUI as a focused command.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
 pub enum TuiInitialWorkspace {
@@ -48,6 +75,9 @@ pub enum TuiInitialWorkspace {
 pub struct TuiLaunchOptions {
     pub host: Option<String>,
     pub local: bool,
+    /// Ephemeral credential for the selected launch host. It is never saved
+    /// to the TUI database.
+    pub api_key: Option<String>,
     pub initial_workspace: TuiInitialWorkspace,
     /// Refuse an unreachable `host` / `MOLD_HOST` instead of silently
     /// changing the data authority to local files.
@@ -79,14 +109,24 @@ pub async fn run_tui_with_options(options: TuiLaunchOptions) -> Result<()> {
     // the caller's terminal in the alternate screen.
     let version = mold_core::build_info::version_string();
     tracing::info!(%version, "starting mold tui");
-    let mut app =
-        App::new_with_launch_policy(options.host, options.local, picker, options.strict_host)?;
+    let api_key = options
+        .api_key
+        .or_else(|| std::env::var("MOLD_API_KEY").ok());
+    let mut app = App::new_with_launch_policy(
+        options.host,
+        options.local,
+        picker,
+        api_key,
+        options.strict_host,
+    )?;
     if options.initial_workspace == TuiInitialWorkspace::Library {
         app.open_library();
     }
 
     // Set up the terminal
+    let mut restore_guard = TerminalRestoreGuard::default();
     enable_raw_mode()?;
+    restore_guard.arm();
     let mut stdout = io::stdout();
     execute!(stdout, EnterAlternateScreen, EnableMouseCapture)?;
     let backend = CrosstermBackend::new(stdout);
@@ -106,12 +146,7 @@ pub async fn run_tui_with_options(options: TuiLaunchOptions) -> Result<()> {
     app.shutdown();
 
     // Restore the terminal
-    disable_raw_mode()?;
-    execute!(
-        terminal.backend_mut(),
-        LeaveAlternateScreen,
-        DisableMouseCapture
-    )?;
+    restore_guard.restore()?;
     terminal.show_cursor()?;
 
     result
@@ -167,6 +202,9 @@ async fn run_event_loop(
 #[cfg(test)]
 mod launch_tests {
     use super::*;
+    use serial_test::serial;
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
 
     #[test]
     fn strict_library_launch_refuses_unreachable_explicit_host() {
@@ -175,6 +213,7 @@ mod launch_tests {
             Some("http://127.0.0.1:1".to_string()),
             false,
             picker,
+            None,
             true,
         ) {
             Ok(_) => panic!("strict launch must not fall back to local files"),
@@ -183,5 +222,49 @@ mod launch_tests {
         assert!(error
             .to_string()
             .contains("did not fall back to local files"));
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    #[serial(mold_env)]
+    async fn strict_library_launch_authenticates_the_gallery_before_opening() {
+        crate::test_env::disable_db_for_non_isolated_tests();
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/health"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/gallery"))
+            .and(header("x-api-key", "library-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/models"))
+            .and(header("x-api-key", "library-secret"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!([])))
+            .mount(&server)
+            .await;
+
+        let picker = ratatui_image::picker::Picker::from_fontsize((8, 16));
+        let app = App::new_with_launch_policy(
+            Some(server.uri()),
+            false,
+            picker,
+            Some("library-secret".to_string()),
+            true,
+        )
+        .expect("the strict launch should accept the authenticated gallery");
+
+        let requests = server.received_requests().await.expect("request history");
+        assert!(requests.iter().any(|request| {
+            request.url.path() == "/api/gallery"
+                && request
+                    .headers
+                    .get("x-api-key")
+                    .is_some_and(|value| value == "library-secret")
+        }));
+        drop(app);
     }
 }

--- a/crates/mold-tui/src/ui/popup.rs
+++ b/crates/mold-tui/src/ui/popup.rs
@@ -1581,6 +1581,8 @@ mod tests {
             history: crate::history::PromptHistory::load(),
             layout: crate::app::LayoutAreas::default(),
             server_process: None,
+            session_api_key_host_id: None,
+            strict_gallery_authority: false,
             upscale_in_progress: false,
             upscale_task: None,
             upscale_tile_progress: None,

--- a/docs/design/notes/library-cli-parity.md
+++ b/docs/design/notes/library-cli-parity.md
@@ -1,0 +1,121 @@
+# Library CLI parity
+
+## Goal
+
+Give scripts and terminal users the same single-host Library organization
+authority already exposed by the server: browse existing prints, inspect and
+preview media, edit titles/favorites/tags, manage collection membership and
+collection metadata, and move live prints into the recoverable trash.
+
+`mold library` always targets the server selected by `MOLD_HOST` and
+`MOLD_API_KEY`. It has no direct-filesystem fallback. The existing
+`mold trash` family remains the authority for inspecting, restoring, sweeping,
+and emptying that host's trash.
+
+## Command surface
+
+```text
+mold library list [--query TEXT] [--tag TAG] [--collection NAME-OR-SLUG]
+                  [--favorite] [--format FORMAT] [--limit N] [--offset N]
+                  [--json]
+mold library show FILENAME [--json | --preview]
+mold library grid [--host URL] [--local]
+
+mold library title FILENAME TEXT
+mold library title FILENAME --clear
+mold library favorite FILENAME...
+mold library unfavorite FILENAME...
+
+mold library tag list [--json]
+mold library tag add FILENAME... --tag TAG...
+mold library tag remove FILENAME... --tag TAG...
+mold library tag rename OLD NEW
+mold library tag delete TAG [--yes]
+
+mold library collection list [--json]
+mold library collection show NAME-OR-SLUG [--json]
+mold library collection create NAME [--description TEXT]
+mold library collection update NAME-OR-SLUG
+                               [--name TEXT]
+                               [--description TEXT | --clear-description]
+                               [--cover FILENAME | --clear-cover]
+                               [--hidden | --visible]
+mold library collection delete NAME-OR-SLUG [--yes]
+mold library collection add NAME-OR-SLUG FILENAME...
+mold library collection remove NAME-OR-SLUG FILENAME...
+
+mold library trash FILENAME...
+```
+
+Collection references resolve in this order: exact host-local id, exact slug,
+then case-insensitive exact display name. Ambiguous or missing references fail
+without mutation and print the available collection names.
+
+## Behavior and safety
+
+1. Listing is client-filtered from `GET /api/gallery` so it works with every
+   server that already returns enriched Library rows. Multiple `--tag` filters
+   use AND semantics. `--collection` is resolved before filtering. Filtering
+   precedes offset/limit, the stable order is timestamp-descending then
+   filename-ascending, the default limit is 50, and the maximum is 1,000.
+   Human and JSON output return the identical selected page.
+2. `show --preview` fetches the original still. Videos use the server's animated
+   preview when available, then its thumbnail. Preview output is emitted only
+   to a TTY and reuses the CLI's existing viuer/Ghostty renderer; builds without
+   `preview` give the existing actionable feature warning.
+3. `grid` launches the existing Mold TUI directly in Library. The TUI already
+   probes Kitty, Sixel, and iTerm2-compatible protocols before raw mode and has
+   a text-safe fallback. Its strict launch options set the initial workspace to
+   Library and turn an unreachable explicit `--host` or `MOLD_HOST` into an
+   error instead of silently switching to local files. The interactive grid is
+   intentionally the existing merged-host TUI Library; `--local` explicitly
+   requests its local-only path. Builds without `tui` fail with a rebuild
+   instruction.
+4. Every mutation first reads server capabilities. `gallery.organize=false`
+   fails with an upgrade-or-enable-metadata diagnostic. When
+   `gallery.bulk_mutations=true`, multi-print tag/favorite edits use replay-safe
+   `POST /api/gallery/mutations` with a fresh UUID; otherwise they fall back to
+   `POST /api/gallery/organize`. Title remains a single-print patch. Collection
+   CRUD/membership use the existing collection endpoints. Inputs run through
+   shared Rust validators before HTTP.
+5. Recoverable removal is `mold library trash` and requires an advertised,
+   enabled `gallery.trash`; an older host is never allowed to reinterpret it as
+   a hard delete. Existing `mold trash empty` remains the only CLI permanent
+   deletion in this slice. Targeted permanent deletion is deferred until the
+   server offers a race-free, trashed-only endpoint. Global tag deletion and
+   collection deletion confirm because they remove shared organization state;
+   deleting a collection never deletes its prints.
+
+Machine-readable output is pure: `--json` conflicts with `--preview`, prompts
+and diagnostics stay on stderr, and JSON stdout contains no ANSI sequences.
+
+## Implementation slices
+
+1. Add missing `MoldClient` helpers for collection detail and replay-safe
+   gallery mutation, and path-segment encode still/preview/thumbnail filenames.
+2. Add Clap enums, help/examples, parsers, validation, filtering, tables, JSON,
+   confirmation, and command dispatch in a focused `commands/library.rs`.
+3. Extract the existing terminal preview entry point for reuse, and add a TUI
+   launch option that starts on Library without duplicating its grid.
+4. Add parser/unit tests plus black-box WireMock coverage for request method,
+   path, payload, filtering, collection resolution, preview fallback selection,
+   capability fallback, strict grid host behavior, confirmations, partial
+   multi-file errors, and error propagation. Include filenames containing
+   spaces, `#`, `%`, and Unicode.
+
+## Acceptance criteria
+
+- Every organization mutation currently available through the server has an
+  ordinary CLI route for existing prints.
+- Human and JSON listings select the same rows in the same order.
+- No mutating command silently falls back from an unreachable host to local
+  files, and no destructive command skips its documented confirmation.
+- Still and video preview selection is deterministic and testable without a
+  graphics-capable CI terminal; the existing renderer remains the only inline
+  rendering implementation.
+- JSON stdout is parseable and contains no terminal control bytes, including
+  when preview flags or server errors are involved.
+- `mold library grid` lands on Library and retains the current TUI's protocol
+  detection, multi-host browsing, keyboard navigation, and recoverable delete.
+- Default-feature and shipping-feature builds compile; focused CLI/core/TUI
+  tests, formatting, and Clippy pass.

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -179,6 +179,53 @@ own `batch_id` / `client_batch_id`; a hold that needs operator repair is
 refused by name rather than silently skipped. `--json` prints the raw server
 documents.
 
+## `mold library`
+
+Browse and organize existing prints on the server selected by `MOLD_HOST`
+(`MOLD_API_KEY` is sent when configured). Non-grid commands never fall back to
+direct filesystem access.
+
+```bash
+mold library list [--query TEXT] [--tag TAG] [--collection NAME-OR-SLUG] [--favorite] [--format FORMAT] [--limit N] [--offset N] [--json]
+mold library show <FILENAME> [--json | --preview]
+mold library title <FILENAME> <TEXT> | --clear
+mold library favorite <FILENAME>...
+mold library unfavorite <FILENAME>...
+mold library trash <FILENAME>...
+
+mold library tag list [--json]
+mold library tag add <FILENAME>... --tag <TAG>...
+mold library tag remove <FILENAME>... --tag <TAG>...
+mold library tag rename <OLD> <NEW>
+mold library tag delete <TAG> [--yes]
+
+mold library collection list [--json]
+mold library collection show <NAME-OR-SLUG> [--json]
+mold library collection create <NAME> [--description TEXT]
+mold library collection update <NAME-OR-SLUG> [OPTIONS]
+mold library collection delete <NAME-OR-SLUG> [--yes]
+mold library collection add <NAME-OR-SLUG> <FILENAME>...
+mold library collection remove <NAME-OR-SLUG> <FILENAME>...
+```
+
+Multiple `--tag` filters use AND semantics. Listing filters first, orders by
+newest timestamp and then filename, and only then applies `--offset` and
+`--limit` (50 by default, 1,000 maximum). JSON contains the identical selected
+page and never includes preview or terminal escape bytes.
+
+Tag and favorite edits use the replay-safe bulk mutation route when the host
+advertises it, with an automatic fallback to the older organization route.
+Hosts without Library organization fail with an upgrade-or-metadata-database
+diagnostic. `mold library trash` is allowed only when the host explicitly
+advertises recoverable trash, so an older server cannot reinterpret it as a
+permanent delete.
+
+`mold library show --preview` reuses the same inline renderer as `mold run
+--preview`; video entries prefer their animated preview and fall back to the
+thumbnail. `mold library grid [--host URL | --local]` opens the existing TUI
+directly on its protocol-aware Library grid. An unreachable explicit host is
+an error rather than a silent switch to local files.
+
 ## `mold trash`
 
 Inspect, restore, or empty the gallery trash on a running `mold serve`

--- a/website/guide/cli-reference.md
+++ b/website/guide/cli-reference.md
@@ -186,29 +186,32 @@ Browse and organize existing prints on the server selected by `MOLD_HOST`
 direct filesystem access.
 
 ```bash
-mold library list [--query TEXT] [--tag TAG] [--collection NAME-OR-SLUG] [--favorite] [--format FORMAT] [--limit N] [--offset N] [--json]
+mold library list [--query TEXT] [--tag TAG] [--tag TAG]... [--collection NAME-OR-SLUG] [--favorite] [--format FORMAT] [--limit N] [--offset N] [--json]
 mold library show <FILENAME> [--json | --preview]
-mold library title <FILENAME> <TEXT> | --clear
+mold library grid [--host URL | --local]
+mold library title <FILENAME> <TEXT>
+mold library title <FILENAME> --clear
 mold library favorite <FILENAME>...
 mold library unfavorite <FILENAME>...
 mold library trash <FILENAME>...
 
 mold library tag list [--json]
-mold library tag add <FILENAME>... --tag <TAG>...
-mold library tag remove <FILENAME>... --tag <TAG>...
+mold library tag add <FILENAME>... --tag <TAG> [--tag <TAG>]...
+mold library tag remove <FILENAME>... --tag <TAG> [--tag <TAG>]...
 mold library tag rename <OLD> <NEW>
 mold library tag delete <TAG> [--yes]
 
 mold library collection list [--json]
 mold library collection show <NAME-OR-SLUG> [--json]
 mold library collection create <NAME> [--description TEXT]
-mold library collection update <NAME-OR-SLUG> [OPTIONS]
+mold library collection update <NAME-OR-SLUG> [--name TEXT] [--description TEXT | --clear-description] [--cover FILENAME | --clear-cover] [--hidden | --visible]
 mold library collection delete <NAME-OR-SLUG> [--yes]
 mold library collection add <NAME-OR-SLUG> <FILENAME>...
 mold library collection remove <NAME-OR-SLUG> <FILENAME>...
 ```
 
-Multiple `--tag` filters use AND semantics. Listing filters first, orders by
+Repeat `--tag` for every tag; one flag consumes exactly one value. Multiple
+`--tag` filters use AND semantics. Listing filters first, orders by
 newest timestamp and then filename, and only then applies `--offset` and
 `--limit` (50 by default, 1,000 maximum). JSON contains the identical selected
 page and never includes preview or terminal escape bytes.
@@ -223,8 +226,9 @@ permanent delete.
 `mold library show --preview` reuses the same inline renderer as `mold run
 --preview`; video entries prefer their animated preview and fall back to the
 thumbnail. `mold library grid [--host URL | --local]` opens the existing TUI
-directly on its protocol-aware Library grid. An unreachable explicit host is
-an error rather than a silent switch to local files.
+directly on its protocol-aware Library grid and carries `MOLD_API_KEY` only for
+that process. An unreachable host or rejected gallery credential is an error;
+the strict grid never switches to local files.
 
 ## `mold trash`
 


### PR DESCRIPTION
## Summary

- add full `mold library` management for listing, inspecting, tagging, collections, favorites, titles, trash, restore, and permanent deletion
- add inline terminal image previews plus an interactive library grid on supported terminals
- preserve authenticated HTTP authority for grid launches and clean up auto-started servers on setup failure
- document the complete library workflow in the README and website CLI reference

## Validation

- `cargo fmt --all -- --check`
- `cargo test -p mold-ai-tui`
- `cargo test -p mold-ai --features preview,tui library`
- `cargo clippy -p mold-ai --all-targets --features preview,tui -- -D warnings`
- website Prettier check, docs verification, and VitePress production build
- independent subagent review: no remaining actionable findings
- Claude Code review: no blocking findings