### PR TITLE
fix(web): honest thumbnail persistence, forget-host eviction, mobile rendition query

### DIFF
--- a/changelog.d/gallery-perf-web-followup.md
+++ b/changelog.d/gallery-perf-web-followup.md
@@ -1,3 +1,1 @@
-### Fixed
-
 - **Web thumbnail cache honesty and lifecycle.** Forgetting a machine now drops its persisted thumbnails with its API key; a retina display talking to an older host no longer stores that host's 256 px PNG under the 512 px key (the server's `x-mold-thumbnail-rendition` header, now CORS-exposed, confirms the rendition before it persists); and iPhone/Android tiles request the display's rendition like web and desktop.

--- a/changelog.d/gallery-perf-web-followup.md
+++ b/changelog.d/gallery-perf-web-followup.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- **Web thumbnail cache honesty and lifecycle.** Forgetting a machine now drops its persisted thumbnails with its API key; a retina display talking to an older host no longer stores that host's 256 px PNG under the 512 px key (the server's `x-mold-thumbnail-rendition` header, now CORS-exposed, confirms the rendition before it persists); and iPhone/Android tiles request the display's rendition like web and desktop.

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -1678,6 +1678,7 @@ fn build_cors_layer() -> Result<CorsLayer> {
                     axum::http::header::HeaderName::from_static("x-mold-video-audio-channels"),
                     axum::http::header::HeaderName::from_static("x-mold-dimension-warning"),
                     axum::http::header::HeaderName::from_static("x-mold-request-warning"),
+                    axum::http::header::HeaderName::from_static("x-mold-thumbnail-rendition"),
                 ])
         }
         _ => CorsLayer::permissive(),

--- a/desktop/src/lib/gallery/media.test.ts
+++ b/desktop/src/lib/gallery/media.test.ts
@@ -437,8 +437,10 @@ describe("prepareNativeThumbnail", () => {
 describe("galleryMediaPath", () => {
   it("keeps host gallery media on the authenticated API", () => {
     expect(galleryMediaPath("print one.png", "host")).toBe("/api/gallery/image/print%20one.png");
-    expect(galleryMediaPath("print one.png", "host", true)).toBe(
-      "/api/gallery/thumbnail/print%20one.png",
+    // The host tile carries the shared rendition query on every surface (the
+    // phone reaches the host through this path); an older server ignores it.
+    expect(galleryMediaPath("print one.png", "host", true)).toMatch(
+      /^\/api\/gallery\/thumbnail\/print%20one\.png\?size=(256|512)&fmt=jpeg$/,
     );
   });
 

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -1,6 +1,7 @@
 import { ApiError, apiFetch, apiFetchTo, currentTarget, type ApiTarget } from "../api/client";
 import type { GalleryImage } from "../api/types";
 import { inTauri, ipc } from "../ipc";
+import { thumbnailRenditionQuery } from "@studio/lib/thumbnailPersistentCache";
 
 /**
  * Gallery media sits behind X-Api-Key auth, and <img>/<video> cannot send
@@ -517,7 +518,9 @@ export const galleryMediaPath = (
       ? localThumbnailPath(filename, fromTrash)
       : localMediaPath(filename, fromTrash)
     : thumbnail
-      ? thumbnailPath(filename)
+      ? // The shared rendition policy rides every host tile request (this is
+        // the phone's thumbnail path); an older server ignores the query.
+        `${thumbnailPath(filename)}?${thumbnailRenditionQuery()}`
       : mediaPath(filename);
 
 /**

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -6488,7 +6488,9 @@ describe("MobileApp generation queue", () => {
       await vi.advanceTimersByTimeAsync(5_020);
 
       expect(stalledSignal?.aborted).toBe(true);
-      expect(requestedPaths).toContain("/api/gallery/thumbnail/stalled-pagination-print-39.mp4");
+      expect(requestedPaths).toContain(
+        "/api/gallery/thumbnail/stalled-pagination-print-39.mp4?size=256&fmt=jpeg",
+      );
       expect(wrapper.findAll("[data-test='gallery-item']")).toHaveLength(40);
       expect(wrapper.findAll("[data-test='gallery-thumbnail-pending']")).toHaveLength(1);
       expect(wrapper.find("[data-test='mobile-gallery-sentinel']").exists()).toBe(false);
@@ -6516,7 +6518,7 @@ describe("MobileApp generation queue", () => {
       apiFetchTo.mockImplementation((_target, path) => {
         const attempt = (attempts.get(path) ?? 0) + 1;
         attempts.set(path, attempt);
-        if (path.endsWith("retry-pagination-print-39.mp4") && attempt === 1) {
+        if (path.includes("retry-pagination-print-39.mp4") && attempt === 1) {
           return Promise.reject(new Error("temporary thumbnail failure"));
         }
         return Promise.resolve({
@@ -6538,7 +6540,9 @@ describe("MobileApp generation queue", () => {
       await vi.advanceTimersByTimeAsync(4_000);
 
       expect(wrapper.find("[data-test='gallery-thumbnail-pending']").exists()).toBe(false);
-      expect(attempts.get("/api/gallery/thumbnail/retry-pagination-print-39.mp4")).toBe(2);
+      expect(
+        attempts.get("/api/gallery/thumbnail/retry-pagination-print-39.mp4?size=256&fmt=jpeg"),
+      ).toBe(2);
     } finally {
       vi.useRealTimers();
     }
@@ -6559,7 +6563,7 @@ describe("MobileApp generation queue", () => {
     const lateThumbnail = deferred<Response>();
     let pendingSignal: AbortSignal | undefined;
     apiFetchTo.mockImplementation((_target, path, init) => {
-      if (path.endsWith("unmount-pagination-print-0.mp4")) {
+      if (path.includes("unmount-pagination-print-0.mp4")) {
         pendingSignal = init?.signal;
         return lateThumbnail.promise;
       }

--- a/desktop/src/stores/gallery.test.ts
+++ b/desktop/src/stores/gallery.test.ts
@@ -706,7 +706,7 @@ describe("remove", () => {
     expect(ipc.localGalleryDelete).not.toHaveBeenCalled();
     expect(gallery.buckets["hal9000-7680"]!.items).toHaveLength(0);
     expect(evictMedia).toHaveBeenCalledWith(
-      "/api/gallery/thumbnail/print%20one.png",
+      expect.stringMatching(/^\/api\/gallery\/thumbnail\/print%20one\.png\?size=/),
       "hal9000-7680",
     );
     expect(evictMedia).toHaveBeenCalledWith("/api/gallery/image/print%20one.png", "hal9000-7680");

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -1028,8 +1028,8 @@ describe("Trash-aware This-Mac media + file actions", () => {
     // Host-backed trash rows stay on the API path (their server resolves
     // trashed rows itself).
     const hostMedia = tileFor(wrapper, trashed.filename).get("[data-test='authed-media']");
-    expect(hostMedia.attributes("data-path")).toBe(
-      `/api/gallery/thumbnail/${encodeURIComponent(trashed.filename)}`,
+    expect(hostMedia.attributes("data-path")).toMatch(
+      new RegExp(`^/api/gallery/thumbnail/${encodeURIComponent(trashed.filename)}\\?size=`),
     );
     wrapper.unmount();
   });

--- a/web/src/lib/galleryMedia.test.ts
+++ b/web/src/lib/galleryMedia.test.ts
@@ -9,7 +9,12 @@ import {
   resolveStreamableSrc,
   resolveThumbnailSrc,
 } from "./galleryMedia";
-import { ORIGIN_HOST_ID, type HostEntry } from "./hostRegistry";
+import {
+  ORIGIN_HOST_ID,
+  addHost,
+  removeHost,
+  type HostEntry,
+} from "./hostRegistry";
 
 const origin: HostEntry = { id: ORIGIN_HOST_ID, name: "this server", url: "" };
 const keylessRemote: HostEntry = {
@@ -254,7 +259,102 @@ describe("fetchGalleryThumbnailBlob", () => {
   });
 });
 
+function installFakeCaches(): Map<string, Blob> {
+  const stored = new Map<string, Blob>();
+  const fakeCache = {
+    match: async (url: string) => {
+      const blob = stored.get(url);
+      return blob ? new Response(blob) : undefined;
+    },
+    put: async (url: string, response: Response) => {
+      stored.set(url, await response.blob());
+    },
+    keys: async () => [...stored.keys()].map((u) => new Request(u)),
+    delete: async (url: string | Request) =>
+      stored.delete(typeof url === "string" ? url : url.url),
+  };
+  (globalThis as { caches?: unknown }).caches = {
+    open: async () => fakeCache,
+  };
+  return stored;
+}
+
+describe("persistent tier honesty", () => {
+  afterEach(() => {
+    delete (globalThis as { caches?: unknown }).caches;
+    globalThis.devicePixelRatio = 1;
+  });
+
+  it("does not persist an older host's 256 px PNG under the 512 tier key", async () => {
+    const stored = installFakeCaches();
+    globalThis.devicePixelRatio = 2;
+    // An older server ignores `?size=512` and answers without the additive
+    // rendition header: the bytes are displayed but never keyed as 512.
+    mockFetch(() => ({
+      ok: true,
+      headers: new Headers(),
+      blob: async () => new Blob(["png-256"]),
+    }));
+    await resolveThumbnailSrc(authedRemote, "cat.png", {
+      mediaVersion: "1:10",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(stored.size).toBe(0);
+
+    // A current server confirms the rendition: persisted.
+    __resetGalleryMediaForTests();
+    mockFetch(() => ({
+      ok: true,
+      headers: new Headers({ "x-mold-thumbnail-rendition": "512-jpg" }),
+      blob: async () => new Blob(["jpg-512"]),
+    }));
+    await resolveThumbnailSrc(authedRemote, "cat.png", {
+      mediaVersion: "1:10",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(stored.size).toBe(1);
+    expect([...stored.keys()][0]).toContain(encodeURIComponent("|512"));
+  });
+
+  it("persists the 256 tier from an older host, whose PNG is that tier", async () => {
+    const stored = installFakeCaches();
+    globalThis.devicePixelRatio = 1;
+    mockFetch(() => ({
+      ok: true,
+      headers: new Headers(),
+      blob: async () => new Blob(["png-256"]),
+    }));
+    await resolveThumbnailSrc(authedRemote, "cat.png", {
+      mediaVersion: "1:10",
+    });
+    await new Promise((r) => setTimeout(r, 0));
+    expect(stored.size).toBe(1);
+  });
+});
+
 describe("evictHostMedia", () => {
+  it("drops a forgotten host's persistent tiles when the registry removes it", async () => {
+    const stored = installFakeCaches();
+    try {
+      const added = addHost({
+        url: "http://halcyon:7680",
+        name: "halcyon",
+        apiKey: "secret-key",
+      });
+      mockFetch(() => ({ ok: true, blob: async () => new Blob(["x"]) }));
+      await resolveThumbnailSrc(added, "cat.png", { mediaVersion: "1:10" });
+      await new Promise((r) => setTimeout(r, 0));
+      expect(stored.size).toBe(1);
+
+      removeHost(added.id);
+      await new Promise((r) => setTimeout(r, 0));
+      expect(stored.size).toBe(0);
+    } finally {
+      delete (globalThis as { caches?: unknown }).caches;
+      localStorage.clear();
+    }
+  });
+
   it("revokes cached object URLs for the host", async () => {
     mockFetch(() => ({ ok: true, blob: async () => new Blob(["x"]) }));
     const src = await resolveThumbnailSrc(authedRemote, "cat.png");

--- a/web/src/lib/galleryMedia.ts
+++ b/web/src/lib/galleryMedia.ts
@@ -24,7 +24,16 @@ import {
   thumbnailTier,
   type PersistentThumbnailStore,
 } from "@studio/lib/thumbnailPersistentCache";
-import { ORIGIN_HOST_ID, type HostEntry } from "./hostRegistry";
+import {
+  HOSTS_CHANGED_EVENT,
+  ORIGIN_HOST_ID,
+  listStoredHosts,
+  type HostEntry,
+} from "./hostRegistry";
+
+/** Additive response header a current server sets to the rendition it
+ *  actually produced (`256-png` / `512-jpg`). An older server omits it. */
+export const THUMBNAIL_RENDITION_HEADER = "x-mold-thumbnail-rendition";
 
 /** Blob object-URL cache, keyed by `${hostId}|${path}`. Ticket URLs are not
  *  cached — they are cheap to mint and expire, and the lightbox renews on open. */
@@ -107,6 +116,7 @@ async function fetchAuthedObjectUrl(
   path: string,
   signal?: AbortSignal,
   persistentKey?: string,
+  tier: 256 | 512 = 256,
 ): Promise<{ url: string; bytes: number }> {
   const store = persistentKey ? persistentStore() : null;
   if (store && persistentKey) {
@@ -125,7 +135,13 @@ async function fetchAuthedObjectUrl(
   const blob = await res.blob();
   if (signal?.aborted)
     throw new DOMException("Thumbnail cancelled", "AbortError");
-  if (store && persistentKey) void store.put(persistentKey, blob);
+  // An older server ignores `?size=512` and answers its 256 px PNG without
+  // the rendition header. Persisting that under the 512 key would pin the
+  // low-resolution bytes past the host's upgrade, so only a confirmed
+  // rendition — or the 256 tier, which IS the legacy answer — is stored.
+  const confirmed =
+    tier === 256 || res.headers?.get(THUMBNAIL_RENDITION_HEADER) != null;
+  if (store && persistentKey && confirmed) void store.put(persistentKey, blob);
   return { url: URL.createObjectURL(blob), bytes: blob.size };
 }
 
@@ -185,19 +201,16 @@ export function resolveThumbnailSrc(
     };
     // Only a print with a content version may persist: a "legacy" key would
     // pin stale bytes across reloads forever.
+    const tier = thumbnailTier();
     const persistentKey = options.mediaVersion
-      ? persistentThumbnailKey(
-          host.id,
-          filename,
-          options.mediaVersion,
-          thumbnailTier(),
-        )
+      ? persistentThumbnailKey(host.id, filename, options.mediaVersion, tier)
       : undefined;
     entry.url = fetchAuthedObjectUrl(
       host,
       path,
       options.signal,
       persistentKey,
+      tier,
     ).then(({ url, bytes }) => {
       if (cache.get(key) !== entry) {
         entry.settled = true;
@@ -309,6 +322,35 @@ export function evictHostMedia(hostId: string): void {
     void cached.url.then((u) => revokeIfObjectUrl(u)).catch(() => {});
   }
   void persistentStore()?.evictPrefix(prefix);
+}
+
+/**
+ * Forgetting a machine removes its key from the registry; its tiles must
+ * leave with it, or a private thumbnail outlives the credential that
+ * fetched it and a re-added machine under the same id could paint the old
+ * machine's cached image. The registry announces every write, so the
+ * removed ids are the difference between two listings.
+ */
+let rememberedHostIds: Set<string> | null = null;
+
+function rememberedIds(): Set<string> {
+  try {
+    return new Set(listStoredHosts().map((h) => h.id));
+  } catch {
+    return new Set();
+  }
+}
+
+function evictForgottenHosts(): void {
+  const before = rememberedHostIds ?? rememberedIds();
+  const after = rememberedIds();
+  rememberedHostIds = after;
+  for (const id of before) if (!after.has(id)) evictHostMedia(id);
+}
+
+if (typeof window !== "undefined") {
+  rememberedHostIds = rememberedIds();
+  window.addEventListener(HOSTS_CHANGED_EVENT, evictForgottenHosts);
 }
 
 function revokeIfObjectUrl(url: string): void {


### PR DESCRIPTION
Follow-up to #1447 addressing its Codex review (three P2s):

- **Legacy tier honesty:** a retina client talking to an older host no longer stores that host's 256 px PNG under the 512 key. The server's additive `x-mold-thumbnail-rendition` header — now in the CORS `expose_headers` list so a cross-origin web client can read it — must confirm the rendition before it persists; the 256 tier persists regardless because the legacy answer *is* that tier.
- **Forget machine evicts tiles:** `galleryMedia` listens to the host registry's change event and evicts the persistent + memory tiles of any host that disappeared, so private thumbnails leave with the API key and a re-added host under the same id cannot paint the old machine's image.
- **Mobile rendition query:** `galleryMediaPath(..., 'host', true)` (the phone's thumbnail path) now appends the shared `thumbnailRenditionQuery()`.

Tests: web `galleryMedia.test.ts` (+3), desktop/mobile expectations updated for the query string. Gates: web 1736, studio 1479, desktop suites, architecture, knip, prettier, `cargo check -p mold-ai-server`, `cargo fmt`.

https://claude.ai/code/session_0196Rqt8LuQyY18rodEM4hMT