### PR TITLE
fix(queue): sync pause controls across surfaces

### DIFF
--- a/changelog.d/mobile-machine-queue-actions.md
+++ b/changelog.d/mobile-machine-queue-actions.md
@@ -1,0 +1,4 @@
+- **Control host queues consistently from mobile.** Machines now exposes the
+  same Pause, Resume, and Cancel swipe actions as Create, adds a host-wide
+  pause control, and keeps paused status synchronized across mobile, desktop,
+  and web queue surfaces.

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -97,6 +97,7 @@ const queueStatus = computed(() =>
       hostId: snapshot.hostId,
       entries: snapshot.entries,
       plan: snapshot.plan,
+      paused: snapshot.paused,
     })),
   ),
 );

--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -78,6 +78,14 @@ beforeEach(() => {
 });
 
 describe("HostQueuePanel", () => {
+  it("updates queued row status when the host-wide queue is paused", async () => {
+    const { wrapper, jobs } = await mountPanel([], [queued("srv-queued", 0, 0)]);
+    jobs.queues.local!.paused = true;
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain("PAUSED");
+  });
+
   it("offers Resume for restart-paused work while the global gate is open", async () => {
     const entry = { ...queued("srv-paused", 0, 0), state: "paused" as const };
     const { wrapper, jobs } = await mountPanel([], [entry]);
@@ -89,6 +97,19 @@ describe("HostQueuePanel", () => {
     await wrapper.get("[data-test='pause-toggle']").trigger("click");
     await flushPromises();
     expect(resume).toHaveBeenCalledWith("local");
+  });
+
+  it("does not label other queued work paused when only one row is restart-paused", async () => {
+    const pausedEntry = { ...queued("srv-paused", 0, 0), state: "paused" as const };
+    const waitingEntry = { ...queued("srv-queued", 1, 0), model: "z-image" };
+    const { wrapper } = await mountPanel([], [pausedEntry, waitingEntry]);
+
+    const waitingRow = wrapper
+      .findAll("[data-test='queue-row']")
+      .find((row) => row.text().includes("z-image"));
+    expect(waitingRow?.text()).toContain("QUEUED #1");
+    expect(waitingRow?.text()).not.toContain("PAUSED");
+    expect(wrapper.get("[data-test='pause-toggle']").text()).toBe("Resume");
   });
 
   it("splits a multi-GPU host into per-GPU lanes", async () => {

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -72,7 +72,8 @@ const snapshot = computed(() => jobs.queues[props.host.id] ?? null);
 const restartPaused = computed(
   () => snapshot.value?.entries.some((entry) => entry.state === "paused") === true,
 );
-const paused = computed(() => snapshot.value?.paused === true || restartPaused.value);
+const dispatchPaused = computed(() => snapshot.value?.paused === true);
+const resumeNeeded = computed(() => dispatchPaused.value || restartPaused.value);
 const caps = computed(() => snapshot.value?.caps ?? null);
 
 const lanes = computed(() => {
@@ -105,6 +106,7 @@ function entryCode(entry: EnrichedQueueEntry): string {
     if (job && job.total > 0 && job.status === "denoising") return `${job.step}/${job.total}`;
     return entry.gpu !== undefined ? `RUNNING · GPU ${entry.gpu}` : "RUNNING";
   }
+  if (dispatchPaused.value && entry.state === "queued") return "PAUSED";
   // Same waiting vocabulary as Create and iPhone, resolved once in studio —
   // including "held", which is parked rather than in line.
   return queueWaitCode(resolveQueueWait({ state: entry.state, position: entry.position }));
@@ -213,7 +215,7 @@ async function cancelAll() {
 
 async function togglePause() {
   try {
-    if (paused.value) {
+    if (resumeNeeded.value) {
       await jobs.resume(props.host.id);
       toasts.push(`Queue resumed on ${props.host.label}`);
     } else {
@@ -385,10 +387,10 @@ async function retryFromDrawer(): Promise<void> {
   <div>
     <!-- Management controls -->
     <div
-      v-if="controls && (caps?.canPause || (caps?.canCancelAll && hasEntries) || paused)"
+      v-if="controls && (caps?.canPause || (caps?.canCancelAll && hasEntries) || resumeNeeded)"
       class="mb-2 flex items-center gap-2"
     >
-      <span v-if="paused" data-test="paused-chip" class="edge-code text-safelight">
+      <span v-if="resumeNeeded" data-test="paused-chip" class="edge-code text-safelight">
         {{ restartPaused && snapshot?.paused !== true ? "PAUSED AFTER RESTART" : "PAUSED" }}
       </span>
       <div class="flex-1" />
@@ -399,7 +401,7 @@ async function retryFromDrawer(): Promise<void> {
         class="border-edge h-7 rounded-control border px-2.5 text-body text-ink-2 hover:text-ink"
         @click="togglePause"
       >
-        {{ paused ? "Resume" : "Pause" }}
+        {{ resumeNeeded ? "Resume" : "Pause" }}
       </button>
       <button
         v-if="caps?.canCancelAll && hasEntries"

--- a/desktop/src/components/machines/QueueColumn.test.ts
+++ b/desktop/src/components/machines/QueueColumn.test.ts
@@ -65,6 +65,14 @@ describe("QueueColumn", () => {
     expect(rows[0]!.text()).toContain("queued · This device");
   });
 
+  it("updates queued row status when the host-wide queue is paused", async () => {
+    const { wrapper, jobs } = await mountColumn();
+    jobs.queues.local!.paused = true;
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='queue-surface-row']").text()).toContain("paused · This device");
+  });
+
   it("labels a running print as finalizing after denoising completes", async () => {
     setActivePinia(createPinia());
     const conn = useConnectionStore();

--- a/desktop/src/components/machines/QueueColumn.vue
+++ b/desktop/src/components/machines/QueueColumn.vue
@@ -45,6 +45,9 @@ function statusLine(row: QueueSurfaceRow): string {
     return `held${reason ? ` (${reason})` : ""} · ${row.hostLabel}`;
   }
   if (row.entry.state === "paused") return `paused after restart · ${row.hostLabel}`;
+  if (row.entry.state === "queued" && jobs.queues[row.hostId]?.paused === true) {
+    return `paused · ${row.hostLabel}`;
+  }
   const state =
     row.entry.state === "running"
       ? job?.status === "finishing"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -5721,12 +5721,14 @@ describe("MobileApp generation queue", () => {
     await control.trigger("click");
     await flushPromises();
     expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/queue/pause", { method: "POST" });
+    expect(row.get("[data-test='mobile-generation-status']").text()).toBe("QUEUE PAUSED");
     const resume = row.get("[data-test='swipe-action-queue-resume']");
     expect(resume.text()).toBe("Resume");
 
     await resume.trigger("click");
     await flushPromises();
     expect(apiFetchTo).toHaveBeenCalledWith(target, "/api/queue/resume", { method: "POST" });
+    expect(row.get("[data-test='mobile-generation-status']").text()).toBe("QUEUED");
     expect(row.get("[data-test='swipe-action-queue-pause']").text()).toBe("Pause");
   });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -168,6 +168,7 @@ import {
   mergeQueueEntries,
   queuePageRequestForCapacity,
   retryQueueJobRecoveringAmbiguity,
+  setQueuePaused as setQueueDispatchPaused,
   type QueueListing,
 } from "@studio/api/queuePlan";
 import {
@@ -523,6 +524,8 @@ type ActivityRow =
       print: Job;
       /** Live dispatch order from `/api/queue`; absent on older hosts. */
       queuePosition: number | null;
+      /** Effective lifecycle after applying the host-wide queue pause. */
+      queueState: string | null;
       blockedReason: string | null;
       sequence: null;
     }
@@ -2293,6 +2296,7 @@ const queueStatusIndex = computed(() =>
       hostId,
       entries: listing.entries,
       plan: listing.plan,
+      paused: hostTelemetry[hostId]?.queuePaused,
     })),
   ),
 );
@@ -2344,6 +2348,7 @@ const activityRows = computed<ActivityRow[]>(() =>
             sequence: null,
             print,
             queuePosition: vm.queuePosition ?? null,
+            queueState: vm.queueState ?? null,
             blockedReason: vm.blockedReason ?? null,
           },
         ]
@@ -2433,9 +2438,7 @@ async function setQueuePaused(
       throw new Error(`${host.name} now reaches a different Mold server instance.`);
     }
     captureHostTelemetry(hostId, status);
-    await apiFetchTo(target, paused ? "/api/queue/pause" : "/api/queue/resume", {
-      method: "POST",
-    });
+    await setQueueDispatchPaused(target, paused);
     if (hostTelemetry[hostId]) hostTelemetry[hostId]!.queuePaused = paused;
     setGenerationStatus(
       paused
@@ -2478,8 +2481,11 @@ function fleetQueueResumeNeeded(row: FleetActiveWork): boolean {
 function activityRowStatus(row: ActivityRow): string {
   if (!row.print) return "";
   if (row.print.status !== "queued") return jobStatusCode(row.print);
+  if (durableHold(row.print)) return "HELD";
+  if (activityRowQueuePaused(row)) return "QUEUE PAUSED";
   return queueWaitCode(
     resolveQueueWait({
+      state: row.queueState,
       position: row.queuePosition ?? row.print.queuePosition,
       blockedReason: row.blockedReason,
     }),

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -577,6 +577,182 @@ describe("MobileHostDetail remote host data", () => {
     expect(view.get("[data-test='host-detail-queue']").text()).toContain("flux-dev:q8");
   });
 
+  it("gives held machine rows the shared pause, resume, and cancel swipe actions", async () => {
+    let currentQueue: QueueEntry[] = [
+      { ...queueEntries[0]!, id: "job-held", state: "held", held_reason: "host memory" },
+      { ...queueEntries[1]!, position: 0 },
+    ];
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((requestTarget, path) => {
+      if (path === "/api/capabilities") {
+        return Promise.resolve({
+          events: { available: true },
+          devices: { available: true, lifecycle: true },
+          dispatch: { v2_authoritative: true },
+          queue: { can_pause: true },
+        });
+      }
+      if (path === "/api/queue?limit=8") return Promise.resolve({ entries: currentQueue });
+      return originalApi(requestTarget, path);
+    });
+    const fetchMock = vi.fn(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = String(input);
+      if (url.endsWith("/api/queue/job-held") && init?.method === "DELETE") {
+        currentQueue = currentQueue.filter((entry) => entry.id !== "job-held");
+        return new Response(null, { status: 204 });
+      }
+      return Response.json({ paused: url.endsWith("/pause") });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const view = await mountDetail();
+    const held = view.get("[data-test='host-detail-queue-row-job-held']");
+
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Pause");
+    expect(held.get("[data-test='swipe-action-queue-pause']").text()).toBe("Pause");
+    expect(held.get("[data-test='swipe-action-cancel']").text()).toBe("Cancel");
+
+    await held.get("[data-test='swipe-action-queue-pause']").trigger("click");
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${studio.baseUrl}/api/queue/pause`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(held.text()).toContain("HELD");
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain("PAUSED");
+    expect(view.get("[data-test='host-detail-queue-paused']").text()).toBe("PAUSED");
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Resume");
+
+    await held.get("[data-test='swipe-action-queue-resume']").trigger("click");
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${studio.baseUrl}/api/queue/resume`,
+      expect.objectContaining({ method: "POST" }),
+    );
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain("NEXT UP");
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Pause");
+
+    await held.get("[data-test='swipe-action-cancel']").trigger("click");
+    await flushPromises();
+    expect(fetchMock).toHaveBeenCalledWith(
+      `${studio.baseUrl}/api/queue/job-held`,
+      expect.objectContaining({ method: "DELETE" }),
+    );
+    expect(view.find("[data-test='host-detail-queue-row-job-held']").exists()).toBe(false);
+  });
+
+  it("keeps ordinary queued work waiting when only another row is restart-paused", async () => {
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((requestTarget, path) => {
+      if (path === "/api/capabilities") {
+        return Promise.resolve({
+          events: { available: true },
+          devices: { available: true, lifecycle: true },
+          dispatch: { v2_authoritative: true },
+          queue: { can_pause: true },
+        });
+      }
+      if (path === "/api/queue?limit=8") {
+        return Promise.resolve({
+          entries: [
+            { ...queueEntries[0]!, id: "job-paused", state: "paused", position: 0 },
+            { ...queueEntries[1]!, position: 1 },
+          ],
+        });
+      }
+      return originalApi(requestTarget, path);
+    });
+
+    const view = await mountDetail();
+
+    expect(view.get("[data-test='host-detail-queue-row-job-paused']").text()).toContain("PAUSED");
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain(
+      "QUEUED #1",
+    );
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).not.toContain(
+      "PAUSED",
+    );
+    expect(view.get("[data-test='host-detail-queue-paused']").text()).toBe("PAUSED AFTER RESTART");
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Resume");
+  });
+
+  it("refreshes host-wide pause state changed from another surface", async () => {
+    vi.useFakeTimers();
+    let queuePaused = false;
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((requestTarget, path) => {
+      if (path === "/api/status") {
+        return Promise.resolve(serverStatus({ queue_paused: queuePaused }));
+      }
+      if (path === "/api/capabilities") {
+        return Promise.resolve({
+          events: { available: true },
+          devices: { available: true, lifecycle: true },
+          dispatch: { v2_authoritative: true },
+          queue: { can_pause: true },
+        });
+      }
+      return originalApi(requestTarget, path);
+    });
+
+    const view = await mountDetail();
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Pause");
+
+    queuePaused = true;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain("PAUSED");
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Resume");
+
+    queuePaused = false;
+    await vi.advanceTimersByTimeAsync(5_000);
+    await flushPromises();
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain(
+      "QUEUED #2",
+    );
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Pause");
+  });
+
+  it("does not let an older status poll overwrite a queue pause action", async () => {
+    vi.useFakeTimers();
+    const staleStatus = deferred<ServerStatus>();
+    let statusCalls = 0;
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((requestTarget, path) => {
+      if (path === "/api/status") {
+        statusCalls += 1;
+        return statusCalls === 2
+          ? staleStatus.promise
+          : Promise.resolve(serverStatus({ queue_paused: false }));
+      }
+      if (path === "/api/capabilities") {
+        return Promise.resolve({
+          events: { available: true },
+          devices: { available: true, lifecycle: true },
+          dispatch: { v2_authoritative: true },
+          queue: { can_pause: true },
+        });
+      }
+      return originalApi(requestTarget, path);
+    });
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(Response.json({ paused: true }))),
+    );
+
+    const view = await mountDetail();
+    vi.advanceTimersByTime(5_000);
+    await flushPromises();
+
+    await view.get("[data-test='host-detail-queue-pause']").trigger("click");
+    await flushPromises();
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Resume");
+
+    staleStatus.resolve(serverStatus({ queue_paused: false }));
+    await flushPromises();
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain("PAUSED");
+    expect(view.get("[data-test='host-detail-queue-pause']").text()).toBe("Resume");
+  });
+
   it("confirms and cancels a running job when the host advertises cooperative support", async () => {
     const originalApi = apiJsonTo.getMockImplementation()!;
     apiJsonTo.mockImplementation((requestTarget, path) => {

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -7,6 +7,7 @@ import {
   mergeQueueEntries,
   moveQueueJobToBack,
   queuePageRequestForCapacity,
+  setQueuePaused as setQueueDispatchPaused,
   setQueueDevicePin,
   type QueuePlan,
 } from "@studio/api/queuePlan";
@@ -102,6 +103,7 @@ const renameValue = ref("");
 const forgetPending = ref(false);
 const unloading = ref<Set<string>>(new Set());
 const cancellingQueueIds = ref(new Set<string>());
+const queueControlBusy = ref(false);
 // ── Library card (per-host trash retention, #4 iPhone V3) ───────────────────
 const retentionEntry = ref<HostConfigEntry | null>(null);
 const retentionValue = ref<number | null>(null);
@@ -115,6 +117,7 @@ let loadEpoch = 0;
 let queueRequestGeneration = 0;
 let queueLoadMoreGeneration = 0;
 let deviceRequestGeneration = 0;
+let statusRequestGeneration = 0;
 let resourceAbort: AbortController | null = null;
 let downloadsAbort: AbortController | null = null;
 let deviceEventsAbort: AbortController | null = null;
@@ -428,13 +431,46 @@ async function refreshDevicesSafely(epoch: number): Promise<void> {
   }
 }
 
+async function refreshStatusSafely(epoch: number): Promise<void> {
+  if (queueControlBusy.value) return;
+  const generation = ++statusRequestGeneration;
+  const requestTarget = target.value;
+  try {
+    const nextStatus = await apiJsonTo<ServerStatus>(requestTarget, "/api/status");
+    if (
+      generation !== statusRequestGeneration ||
+      epoch !== loadEpoch ||
+      queueControlBusy.value ||
+      requestTarget.baseUrl !== target.value.baseUrl ||
+      requestTarget.apiKey !== target.value.apiKey
+    )
+      return;
+    const expectedInstanceId = props.host.instanceId?.trim() || status.value?.instance_id?.trim();
+    const reportedInstanceId = nextStatus.instance_id?.trim();
+    if (expectedInstanceId && reportedInstanceId && expectedInstanceId !== reportedInstanceId) {
+      emit("status", { id: props.host.id, status: nextStatus });
+      error.value = "This address now reports a different Mold server identity.";
+      return;
+    }
+    status.value = nextStatus;
+    emit("status", { id: props.host.id, status: nextStatus });
+  } catch {
+    // Queue and device polling remain useful during a transient status failure.
+    // The next five-second pass retries without clearing the last good state.
+  }
+}
+
 function scheduleLivePoll(epoch: number): void {
   if (epoch !== loadEpoch) return;
   livePollTimer = setTimeout(async () => {
     livePollTimer = null;
     // Queue authority has its own generation fence and must not hold device
     // freshness hostage if an older endpoint never settles.
-    await Promise.all([requestQueueRefresh(epoch), refreshDevicesSafely(epoch)]);
+    await Promise.all([
+      refreshStatusSafely(epoch),
+      requestQueueRefresh(epoch),
+      refreshDevicesSafely(epoch),
+    ]);
     scheduleLivePoll(epoch);
   }, 5_000);
 }
@@ -558,6 +594,7 @@ async function emptyTrashNow(): Promise<void> {
 
 async function loadHost(): Promise<void> {
   const epoch = ++loadEpoch;
+  statusRequestGeneration += 1;
   stopLiveServices();
   loading.value = true;
   error.value = "";
@@ -581,6 +618,7 @@ async function loadHost(): Promise<void> {
   renaming.value = false;
   forgetPending.value = false;
   cancellingQueueIds.value = new Set();
+  queueControlBusy.value = false;
   retentionEntry.value = null;
   retentionValue.value = null;
   retentionProbeFailed.value = false;
@@ -654,6 +692,8 @@ async function unpinWork(workId: string): Promise<void> {
 function queueEntryCancellable(entry: QueueEntry): boolean {
   return (
     entry.state === "queued" ||
+    entry.state === "paused" ||
+    entry.state === "held" ||
     (entry.state === "running" &&
       deviceCapabilities.value?.queue?.cooperative_cancellation === true)
   );
@@ -707,6 +747,10 @@ let stopQueuePreview: (() => void) | null = null;
 let queueDetailTimer: ReturnType<typeof setInterval> | null = null;
 
 const canReorderQueue = computed(() => deviceCapabilities.value?.queue?.can_reorder === true);
+const canPauseQueue = computed(() => deviceCapabilities.value?.queue?.can_pause === true);
+const dispatchPaused = computed(() => status.value?.queue_paused === true);
+const restartPaused = computed(() => queue.value.some((entry) => entry.state === "paused"));
+const resumeNeeded = computed(() => dispatchPaused.value || restartPaused.value);
 
 const inspectedQueueEntry = computed(
   () => queue.value.find((entry) => entry.id === inspectedQueueId.value) ?? null,
@@ -732,6 +776,12 @@ const inspectedQueueModel = computed(() => {
  *  non-destructive Move to back. */
 function queueRowActions(entry: QueueEntry): SwipeRowAction[] {
   const actions: SwipeRowAction[] = [];
+  if (canPauseQueue.value && ["queued", "paused", "held"].includes(entry.state)) {
+    actions.push({
+      id: resumeNeeded.value ? "queue-resume" : "queue-pause",
+      label: resumeNeeded.value ? "Resume" : "Pause",
+    });
+  }
   if (canReorderQueue.value && entry.state === "queued") {
     actions.push({ id: "back", label: "To back" });
   }
@@ -747,11 +797,47 @@ function queueRowActions(entry: QueueEntry): SwipeRowAction[] {
 }
 
 function queueRowBusy(entry: QueueEntry): boolean {
-  return cancellingQueueIds.value.has(entry.id) || reorderingQueueIds.value.has(entry.id);
+  return (
+    queueControlBusy.value ||
+    cancellingQueueIds.value.has(entry.id) ||
+    reorderingQueueIds.value.has(entry.id)
+  );
+}
+
+async function setHostQueuePaused(paused: boolean): Promise<void> {
+  if (!canPauseQueue.value || queueControlBusy.value) return;
+  const epoch = loadEpoch;
+  const requestTarget = target.value;
+  statusRequestGeneration += 1;
+  queueControlBusy.value = true;
+  queueRowError.value = null;
+  try {
+    const liveStatus = await apiJsonTo<ServerStatus>(requestTarget, "/api/status");
+    const expectedInstanceId = props.host.instanceId?.trim() || status.value?.instance_id?.trim();
+    if (expectedInstanceId && liveStatus.instance_id?.trim() !== expectedInstanceId) {
+      throw new Error("This address now reports a different Mold server identity.");
+    }
+    await setQueueDispatchPaused(requestTarget, paused);
+    if (epoch !== loadEpoch || requestTarget.baseUrl !== target.value.baseUrl) return;
+    const nextStatus = { ...liveStatus, queue_paused: paused };
+    status.value = nextStatus;
+    emit("status", { id: props.host.id, status: nextStatus });
+    await requestQueueRefresh(epoch);
+  } catch (caught) {
+    if (epoch === loadEpoch) {
+      queueRowError.value = describeTransportError(caught, props.host.name);
+    }
+  } finally {
+    if (epoch === loadEpoch) queueControlBusy.value = false;
+  }
 }
 
 async function onQueueRowAction(entry: QueueEntry, action: string) {
   queueRowError.value = null;
+  if (action === "queue-pause" || action === "queue-resume") {
+    await setHostQueuePaused(action === "queue-pause");
+    return;
+  }
   if (action === "cancel") {
     await cancelQueuedJob(entry);
     if (inspectedQueueId.value === entry.id) inspectedQueueId.value = null;
@@ -847,6 +933,7 @@ async function unload(name: string): Promise<void> {
 function queueCode(entry: QueueEntry): string {
   if (entry.state === "running")
     return entry.gpu == null ? "RUNNING" : `RUNNING · GPU ${entry.gpu}`;
+  if (dispatchPaused.value && entry.state === "queued") return "PAUSED";
   // Same waiting vocabulary as the Create queue, resolved once in studio —
   // a held row reads HELD, never a place in line.
   return queueWaitCode(resolveQueueWait({ state: entry.state, position: entry.position }));
@@ -1053,7 +1140,22 @@ onBeforeUnmount(() => {
       <section class="mobile-detail-section" aria-labelledby="host-queue-title">
         <div class="mobile-section-head">
           <h2 id="host-queue-title">Queue</h2>
-          <span data-test="host-detail-queue-total">{{ queueSummary }}</span>
+          <div class="mobile-host-queue-controls">
+            <span v-if="resumeNeeded" data-test="host-detail-queue-paused">
+              {{ restartPaused && !dispatchPaused ? "PAUSED AFTER RESTART" : "PAUSED" }}
+            </span>
+            <span data-test="host-detail-queue-total">{{ queueSummary }}</span>
+            <button
+              v-if="canPauseQueue"
+              type="button"
+              class="secondary-button mobile-host-queue-pause"
+              data-test="host-detail-queue-pause"
+              :disabled="queueControlBusy"
+              @click="setHostQueuePaused(!resumeNeeded)"
+            >
+              {{ queueControlBusy ? "Working…" : resumeNeeded ? "Resume" : "Pause" }}
+            </button>
+          </div>
         </div>
         <p class="mobile-empty-note" data-test="host-detail-queue-scope">
           <template v-if="queueApiAvailable">{{ queue.length }} loaded</template>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4381,6 +4381,23 @@ button:disabled {
   font: inherit;
 }
 
+.mobile-host-queue-controls {
+  display: flex;
+  min-width: 0;
+  align-items: center;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.mobile-host-queue-pause {
+  min-width: 72px;
+  min-height: 44px;
+  border: 0;
+  padding: 0 8px;
+  color: var(--safelight);
+  font: inherit;
+}
+
 .telemetry-panel {
   display: grid;
   gap: 11px;

--- a/studio/api/queuePlan.test.ts
+++ b/studio/api/queuePlan.test.ts
@@ -14,6 +14,7 @@ import {
   retryQueueJobRecoveringAmbiguity,
   moveQueueJobToBack,
   setQueueDevicePin,
+  setQueuePaused,
   type QueuePlan,
   type QueueListing,
 } from "./queuePlan";
@@ -24,6 +25,33 @@ afterEach(() => {
 });
 
 describe("queue plan contract", () => {
+  it.each([
+    [true, "/api/queue/pause"],
+    [false, "/api/queue/resume"],
+  ])(
+    "sets queue paused=%s on the explicit authenticated target",
+    async (paused, path) => {
+      const fetchMock = vi.fn(
+        async (_input: RequestInfo | URL, _init?: RequestInit) =>
+          Response.json({ paused }),
+      );
+      vi.stubGlobal("fetch", fetchMock);
+
+      await setQueuePaused(
+        { baseUrl: "https://gpu.example", apiKey: "secret" },
+        paused,
+      );
+
+      expect(fetchMock).toHaveBeenCalledWith(
+        `https://gpu.example${path}`,
+        expect.objectContaining({ method: "POST" }),
+      );
+      expect(
+        (fetchMock.mock.calls[0]?.[1]?.headers as Headers).get("x-api-key"),
+      ).toBe("secret");
+    },
+  );
+
   it("derives queue page size only from a positive host capacity", () => {
     expect(queuePageRequestForCapacity(8)).toEqual({ limit: 8 });
     for (const value of [

--- a/studio/api/queuePlan.ts
+++ b/studio/api/queuePlan.ts
@@ -352,6 +352,16 @@ export async function cancelQueueJob(
   });
 }
 
+/** Set the host-wide queue dispatch gate on one explicit authenticated host. */
+export async function setQueuePaused(
+  target: ApiTarget,
+  paused: boolean,
+): Promise<void> {
+  await apiFetchTo(target, paused ? "/api/queue/pause" : "/api/queue/resume", {
+    method: "POST",
+  });
+}
+
 export interface QueueJobAuthority {
   instanceId: string;
   batchId: string;

--- a/studio/lib/activity.ts
+++ b/studio/lib/activity.ts
@@ -49,6 +49,8 @@ export type ActivityJobVM =
        *  the one-shot SSE `Queued` frame. Absent when the host has not been
        *  read or is too old to list the job. */
       queuePosition?: number | null;
+      /** Effective waiting lifecycle after projecting host-wide pause state. */
+      queueState?: string | null;
       /** Raw scheduler `blocked_reason` for this job, when the plan named one. */
       blockedReason?: string | null;
     }
@@ -169,6 +171,7 @@ export function withLiveQueueStatus(
   const status = queueStatusFor(index, vm.hostId, serverJobId);
   if (!status) return vm;
   const next: PrintActivityVM = { ...vm };
+  if (status.state !== null) next.queueState = status.state;
   if (status.position !== null) next.queuePosition = status.position;
   if (status.blockedReason !== null) next.blockedReason = status.blockedReason;
   return next;
@@ -185,6 +188,7 @@ export function queueStatusLabel(vm: ActivityJobVM): string | null {
   if (vm.kind !== "print" || vm.phase !== "queued") return null;
   return queueWaitLabel(
     resolveQueueWait({
+      state: vm.queueState,
       position: vm.queuePosition,
       blockedReason: vm.blockedReason,
     }),

--- a/studio/lib/queuePosition.test.ts
+++ b/studio/lib/queuePosition.test.ts
@@ -43,6 +43,30 @@ function plan(blocked: Record<string, string>): QueuePlan {
 }
 
 describe("buildQueueStatusIndex", () => {
+  it("projects a host-wide pause onto queued rows without hiding held work", () => {
+    const index = buildQueueStatusIndex([
+      {
+        hostId: "alpha",
+        paused: true,
+        entries: [
+          { id: "waiting", state: "queued", position: 0 } as QueueEntry,
+          { id: "parked", state: "held", position: 1 } as QueueEntry,
+        ],
+      },
+    ]);
+
+    expect(
+      queueWaitLabel(
+        resolveQueueWait(queueStatusFor(index, "alpha", "waiting")),
+      ),
+    ).toBe("Queue paused");
+    expect(
+      queueWaitLabel(
+        resolveQueueWait(queueStatusFor(index, "alpha", "parked")),
+      ),
+    ).toBe("Held");
+  });
+
   it("carries the row's lifecycle so a held row resolves as held", () => {
     const index = buildQueueStatusIndex([
       {

--- a/studio/lib/queuePosition.ts
+++ b/studio/lib/queuePosition.ts
@@ -75,6 +75,10 @@ export interface QueueStatusSource {
   hostId: string;
   entries?: readonly QueueEntry[] | null | undefined;
   plan?: QueuePlan | null | undefined;
+  /** Host-wide dispatch gate from `/api/status.queue_paused`. A queued row
+   * remains `queued` on the wire while this gate is closed, so surfaces must
+   * project the pause into its visible waiting state. */
+  paused?: boolean | null | undefined;
 }
 
 export type QueueStatusIndex = ReadonlyMap<string, QueueStatus>;
@@ -245,10 +249,16 @@ export function buildQueueStatusIndex(
     for (const entry of source.entries ?? []) {
       if (!entry || typeof entry.id !== "string" || entry.id.length === 0)
         continue;
+      const state = typeof entry.state === "string" ? entry.state : null;
       index.set(queueStatusKey(source.hostId, entry.id), {
-        state: typeof entry.state === "string" ? entry.state : null,
+        state,
         position: finitePosition(entry.position),
-        blockedReason: planBlockedReason(source.plan, entry.id),
+        // Held is an operator-action state and running work continues through
+        // a queue pause. Only ordinary queued work inherits the global gate.
+        blockedReason:
+          source.paused === true && state === "queued"
+            ? "queue_paused"
+            : planBlockedReason(source.plan, entry.id),
         preparation: planPreparation(source.plan, entry.id),
       });
     }

--- a/web/src/components/machines/QueueCard.test.ts
+++ b/web/src/components/machines/QueueCard.test.ts
@@ -140,10 +140,33 @@ describe("held rows", () => {
       },
     });
 
-    expect(wrapper.text()).toContain("held");
+    expect(wrapper.text()).toContain("Held");
     expect(wrapper.text()).toContain("dispatch attempts exhausted");
     expect(wrapper.find("[data-test='queue-cancel']").exists()).toBe(true);
     expect(wrapper.find("[data-test='cancel-all']").exists()).toBe(false);
+  });
+});
+
+describe("host-wide pause presentation", () => {
+  it("updates queued row status while preserving a held row", () => {
+    const wrapper = mount(QueueCard, {
+      props: {
+        paused: true,
+        gpuOrdinals: [],
+        entries: [
+          { ...listing()[1]!, position: 0 },
+          {
+            ...listing()[2]!,
+            state: "held" as const,
+            held_reason: "operator action",
+          },
+        ],
+      },
+    });
+
+    const rows = wrapper.findAll("[data-test='queue-row']");
+    expect(rows[0]!.text()).toContain("Queue paused");
+    expect(rows[1]!.text()).toContain("Held");
   });
 });
 
@@ -188,6 +211,32 @@ describe("restart-paused rows", () => {
     expect(wrapper.find("[data-test='cancel-all']").exists()).toBe(true);
     await wrapper.get("[data-test='pause-toggle']").trigger("click");
     expect(wrapper.emitted("togglePause")).toHaveLength(1);
+  });
+
+  it("keeps an ordinary queued row waiting when only another row is restart-paused", () => {
+    const wrapper = mount(QueueCard, {
+      props: {
+        canPause: true,
+        paused: false,
+        gpuOrdinals: [],
+        entries: [
+          {
+            id: "srv-paused",
+            model: "flux2-klein",
+            state: "paused" as const,
+            started_at_unix_ms: 1,
+            position: 0,
+          },
+          { ...listing()[1]!, position: 1 },
+        ],
+      },
+    });
+
+    const rows = wrapper.findAll("[data-test='queue-row']");
+    expect(rows[0]!.text()).toContain("Paused");
+    expect(rows[1]!.text()).toContain("#1 in line");
+    expect(rows[1]!.text()).not.toContain("Queue paused");
+    expect(wrapper.get("[data-test='pause-toggle']").text()).toBe("Resume");
   });
 });
 

--- a/web/src/components/machines/QueueCard.vue
+++ b/web/src/components/machines/QueueCard.vue
@@ -17,6 +17,7 @@ import { modelDisplayNameForId } from "@studio/lib/modelDisplay";
 import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import type { QueuePlan } from "@studio/api/queuePlan";
 import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
+import { queueWaitLabel, resolveQueueWait } from "@studio/lib/queuePosition";
 
 const props = withDefaults(
   defineProps<{
@@ -80,6 +81,17 @@ const visibleWorkCount = computed(
 function laneValue(entry: QueueEntry): string {
   const lane = entry.target_gpu ?? null;
   return lane == null ? "" : String(lane);
+}
+
+function entryStateLabel(entry: QueueEntry): string {
+  return queueWaitLabel(
+    resolveQueueWait({
+      state: entry.state,
+      position: entry.position,
+      blockedReason:
+        props.paused && entry.state === "queued" ? "queue_paused" : null,
+    }),
+  );
 }
 
 function onLane(entry: QueueEntry, event: Event) {
@@ -169,7 +181,7 @@ function queuedIndexOf(id: string): number {
             :tone="entry.state === 'running' ? 'accent' : 'neutral'"
             outline
           >
-            {{ entry.state }}
+            {{ entryStateLabel(entry) }}
           </BadgePill>
           <button
             type="button"

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -99,6 +99,7 @@ interface HostTelemetry {
   version: string | null;
   instanceId: string | null;
   queueDepth: number | null;
+  queuePaused: boolean | null;
   gpu: RoutableGpu | null;
   predictedCompletionMs: number | null;
   /** Last good `/api/queue` read, retained through a blip so a live queue
@@ -344,7 +345,14 @@ const queueStatus = computed<QueueStatusIndex>(() =>
   buildQueueStatusIndex(
     Object.entries(telemetry.value).flatMap(([hostId, live]) =>
       live.queue
-        ? [{ hostId, entries: live.queue.entries, plan: live.queue.plan }]
+        ? [
+            {
+              hostId,
+              entries: live.queue.entries,
+              plan: live.queue.plan,
+              paused: live.queuePaused,
+            },
+          ]
         : [],
     ),
   ),
@@ -531,6 +539,7 @@ async function pollHost(entry: HostEntry): Promise<void> {
         version: null,
         instanceId: entry.instanceId ?? null,
         queueDepth: null,
+        queuePaused: null,
         gpu: null,
         predictedCompletionMs: null,
         queue: null,
@@ -571,6 +580,7 @@ async function pollHost(entry: HostEntry): Promise<void> {
         version: status.value.version ?? null,
         instanceId: nextInstanceId,
         queueDepth: status.value.queue_depth ?? null,
+        queuePaused: status.value.queue_paused ?? null,
         gpu: gpuFromStatus(status.value, inventory),
         predictedCompletionMs: mergedQueue?.plan
           ? predictedCompletionUnixMs(mergedQueue.plan)
@@ -598,6 +608,7 @@ async function pollHost(entry: HostEntry): Promise<void> {
             version: null,
             instanceId: entry.instanceId ?? null,
             queueDepth: null,
+            queuePaused: null,
             gpu: null,
             predictedCompletionMs: null,
             queue: null,

--- a/web/src/pages/HostDetailPage.vue
+++ b/web/src/pages/HostDetailPage.vue
@@ -1176,7 +1176,7 @@ onBeforeUnmount(() => {
           :can-cancel-all="caps?.queue?.can_cancel_all === true"
           :can-cancel-running="caps?.queue?.cooperative_cancellation === true"
           :cancelling-ids="cancellingIds"
-          :paused="resumeNeeded"
+          :paused="paused"
           :dimmed="reconnecting"
           @cancel="onCancel"
           @inspect="inspectedId = $event"


### PR DESCRIPTION
## Summary

- reuse shared host queue pause/resume APIs and queue-status projection across Create, Machines, and web/desktop/mobile surfaces
- add mobile Machines swipe actions for Pause/Resume and Cancel, plus a host-level 44pt Pause/Resume control
- keep held/restart-paused status distinct from the host-wide dispatch pause and refresh remote pause changes without stale-poll races

## Validation

- `nix develop -c bun run check:frontend`
- `nix develop -c bun run build:mobile`
- 390x844 in-app browser QA with mocked authenticated host: Pause/Resume, held row preservation, queued-row state update, and swipe trays
- independent agent peer review: approved with no remaining actionable findings