### PR TITLE
fix(mobile): reveal restored queue generation

### DIFF
--- a/changelog.d/mobile-queue-restore-generation.md
+++ b/changelog.d/mobile-queue-restore-generation.md
@@ -1,0 +1,3 @@
+- **Return to Create when restoring a queued print on mobile.** Tapping a
+  queued or recovered print now reloads its generation settings at the top of
+  the Create screen instead of leaving the view parked on the queue card.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -2751,8 +2751,12 @@ describe("MobileApp generation queue", () => {
     wrapper = mountMobileApp();
     await flushPromises();
     await flushPromises();
+    const content = wrapper.get(".mobile-content").element as HTMLElement;
+    content.scrollTop = 640;
     const row = wrapper.get("[data-test='mobile-generation-job']");
-    await row.get(".mobile-generation-job").trigger("click");
+    const rowButton = row.get(".mobile-generation-job");
+    (rowButton.element as HTMLElement).focus();
+    await rowButton.trigger("keydown", { key: "Enter" });
     await flushPromises();
     await flushPromises();
 
@@ -2762,6 +2766,8 @@ describe("MobileApp generation queue", () => {
     expect(wrapper.get("[data-test='mobile-generation-job']").text()).not.toContain(
       "Recovered print",
     );
+    expect(content.scrollTop).toBe(0);
+    expect(document.activeElement).toBe(wrapper.get("[data-test='mobile-create-heading']").element);
   });
 
   it("persists one pre-admission cancel tap until the exact server job id is reconciled", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -664,6 +664,7 @@ const draft = useSequenceDraftStore();
 const licenseAcceptance = useLicenseAcceptance();
 draft.hydrate();
 const mobileContent = ref<HTMLElement | null>(null);
+const createHeading = ref<HTMLElement | null>(null);
 const settingsOpen = ref(false);
 const settingsButton = ref<HTMLButtonElement | null>(null);
 const settingsBackButton = ref<HTMLButtonElement | null>(null);
@@ -2552,6 +2553,16 @@ function clearSelectedQueueRender(): void {
   selectedQueueRender.value = null;
 }
 
+function revealRestoredMobileGeneration(): void {
+  tab.value = "generate";
+  void nextTick(() => {
+    if (!mobileContent.value) return;
+    mobileContent.value.scrollTop = 0;
+    mobileContent.value.scrollLeft = 0;
+    createHeading.value?.focus({ preventScroll: true });
+  });
+}
+
 async function selectMobilePrint(job: Job): Promise<void> {
   const epoch = ++mobilePrintSelectionEpoch;
   clearSelectedQueueRender();
@@ -2589,7 +2600,7 @@ async function selectMobilePrint(job: Job): Promise<void> {
   draft.stopEditing();
   draft.output = "single";
   latestResultClientId.value = job.status === "complete" ? job.clientId : null;
-  tab.value = "generate";
+  revealRestoredMobileGeneration();
   if (
     durable &&
     job.id &&
@@ -10474,7 +10485,14 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
         </div>
         <template v-else>
           <div class="mobile-create-head">
-            <h1 class="section-title">Create</h1>
+            <h1
+              ref="createHeading"
+              class="section-title"
+              tabindex="-1"
+              data-test="mobile-create-heading"
+            >
+              Create
+            </h1>
             <button
               class="mobile-settings-reset"
               type="button"


### PR DESCRIPTION
## Summary

- return mobile Create to the top after tapping a queued or recovered print
- move keyboard focus to the Create heading without opening the software keyboard
- retain the selected print settings and host-held queue status

## Validation

- mobile suite: 316 passed
- desktop queue-restore suites: 85 passed
- web queue-restore suites: 163 passed
- mobile, desktop, and web production builds passed
- Prettier and changelog fragment policy passed
- 390x844 in-app browser QA: queue tap restored the original prompt, reset Create scroll to zero, no console warnings/errors or framework overlay

## Review

Independent sub-agent review found one focus issue. It was fixed and the follow-up review approved with no remaining actionable findings.