### PR TITLE
feat(mobile): add refresh and navigation gestures

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -243,6 +243,8 @@ pushed screen opened from the header.
   content-addressed stash, disclosing the miss in the persistent inline status
   line when the stash no longer holds it — saved metadata carries the digest,
   never the face bytes.
+  A downward swipe from the top dismisses Info without affecting the viewer's
+  horizontal previous/next-print swipe.
   Every mutation fans out to each physical copy's exact Keychain-authenticated
   host via the shared `planOrganizationFanout` plan
   (`desktop/src/mobile/libraryOrganization.ts` holds the mobile state
@@ -329,9 +331,15 @@ pushed screen opened from the header.
   `https://utensils.io/mold/privacy` through the native external-browser opener.
 
 The app shell suppresses WebKit focus/double-tap page zoom and rubber-band
-overscroll. The Library viewer keeps its scoped horizontal swipe gesture, and
-the Library grid keeps a scoped two-finger pinch (`touch-action: pan-y`) that
-resizes thumbnails while one-finger scrolling is unaffected.
+overscroll. A horizontal swipe moves through Create → Library → Models →
+Machines, while a right swipe pops Machine Detail or Settings. Editable
+controls, horizontal scrollers, action rows, dialogs, and the full-screen
+Library viewer retain their own gesture authority. Pulling down at the top
+refreshes Library, Models, Machines, and Machine Detail; Create and Settings
+stay on their existing live polling/streaming paths so an in-progress form is
+never disrupted. The Library viewer keeps its scoped horizontal swipe gesture,
+and the Library grid keeps a scoped two-finger pinch (`touch-action: pan-y`)
+that resizes thumbnails while one-finger scrolling is unaffected.
 
 Prepared expansion always snapshots the selected remote host ID, endpoint,
 Keychain-provided key, and server instance. Batch is a directly editable

--- a/changelog.d/mobile-refresh-navigation.md
+++ b/changelog.d/mobile-refresh-navigation.md
@@ -1,5 +1,5 @@
-feat(mobile): add native refresh and navigation gestures
-
-- Dismiss Library Info by swiping its sheet down.
-- Pull to refresh Library, Models, Machines, and Machine Detail.
-- Swipe between primary destinations and swipe back from Machine Detail or Settings without stealing nested gestures.
+- **Mobile navigation and remote-data refresh feel native.** Swipe down to dismiss
+  Library Info, pull to refresh Library, Models, Machines, or Machine Detail,
+  swipe between primary destinations, and swipe back from Machine Detail or
+  Settings without stealing gestures from the gallery viewer, image-tile
+  scrolling on Android tablets, or nested controls.

--- a/changelog.d/mobile-refresh-navigation.md
+++ b/changelog.d/mobile-refresh-navigation.md
@@ -1,0 +1,5 @@
+feat(mobile): add native refresh and navigation gestures
+
+- Dismiss Library Info by swiping its sheet down.
+- Pull to refresh Library, Models, Machines, and Machine Detail.
+- Swipe between primary destinations and swipe back from Machine Detail or Settings without stealing nested gestures.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -516,6 +516,22 @@ function fieldControl(label: string): DOMWrapper<Element> {
   return field.find("input, textarea, select");
 }
 
+function mobileTouch(type: string, x: number, y: number, ended = false): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const point = { identifier: 17, clientX: x, clientY: y };
+  Object.defineProperty(event, "touches", { value: ended ? [] : [point] });
+  Object.defineProperty(event, "changedTouches", { value: [point] });
+  return event;
+}
+
+async function swipeMobileContent(fromX: number, toX: number, y = 180): Promise<void> {
+  const content = wrapper!.get(".mobile-content").element;
+  content.dispatchEvent(mobileTouch("touchstart", fromX, y));
+  content.dispatchEvent(mobileTouch("touchmove", toX, y));
+  content.dispatchEvent(mobileTouch("touchend", toX, y, true));
+  await flushPromises();
+}
+
 function deferred<T>() {
   let resolve!: (value: T) => void;
   let reject!: (reason?: unknown) => void;
@@ -7702,6 +7718,127 @@ describe("MobileApp create settings reset", () => {
 });
 
 describe("MobileApp primary navigation", () => {
+  it("swipes left and right through the four major destinations", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    await swipeMobileContent(280, 100);
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+    await swipeMobileContent(280, 100);
+    expect(wrapper.get("[data-test='mobile-tab-catalog']").attributes("aria-current")).toBe("page");
+    await swipeMobileContent(100, 280);
+    expect(wrapper.get("[data-test='mobile-tab-gallery']").attributes("aria-current")).toBe("page");
+  });
+
+  it("ignores left swipes in Settings and returns to the same underlying tab", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-open-settings']").trigger("click");
+    await swipeMobileContent(280, 100);
+    expect(wrapper.find("[data-test='mobile-settings-back']").exists()).toBe(true);
+
+    await wrapper.get("[data-test='mobile-settings-back']").trigger("click");
+    expect(wrapper.get("[data-test='mobile-tab-generate']").attributes("aria-current")).toBe(
+      "page",
+    );
+  });
+
+  it("swipes right out of Machine Detail without stealing swipe-row gestures", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    await wrapper.get("[data-test='mobile-host-row']").trigger("click");
+    await flushPromises();
+    expect(wrapper.find("[data-test='mobile-host-detail']").exists()).toBe(true);
+
+    await swipeMobileContent(90, 270);
+    expect(wrapper.find("[data-test='mobile-host-detail']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-tab-hosts']").attributes("aria-current")).toBe("page");
+  });
+
+  it("opens Machine Detail at the top and restores the Machines list scroll", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    const content = wrapper.get(".mobile-content").element as HTMLElement;
+    content.scrollTop = 360;
+
+    await wrapper.get("[data-test='mobile-host-row']").trigger("click");
+    await flushPromises();
+    expect(content.scrollTop).toBe(0);
+
+    await wrapper.get("[data-test='host-detail-back']").trigger("click");
+    await flushPromises();
+    expect(content.scrollTop).toBe(360);
+  });
+
+  it("does not switch destinations when a horizontal control owns the gesture", async () => {
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const modelPicker = fieldControl("Model").element;
+    modelPicker.dispatchEvent(mobileTouch("touchstart", 280, 180));
+    modelPicker.dispatchEvent(mobileTouch("touchmove", 100, 180));
+    modelPicker.dispatchEvent(mobileTouch("touchend", 100, 180, true));
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-tab-generate']").attributes("aria-current")).toBe(
+      "page",
+    );
+  });
+
+  it("pulls Models and Machines to refresh their remote snapshots", async () => {
+    invoke.mockImplementation((command: string) => {
+      if (command === "keychain_get_api_key") return Promise.resolve(target.apiKey);
+      if (command === "discover_mold_hosts") return Promise.resolve([]);
+      return Promise.resolve(null);
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const content = wrapper.get(".mobile-content").element;
+
+    await wrapper.get("[data-test='mobile-tab-catalog']").trigger("click");
+    await flushPromises();
+    const catalogBefore = apiJsonTo.mock.calls.filter(([, path]) =>
+      String(path).startsWith("/api/catalog/search"),
+    ).length;
+    content.dispatchEvent(mobileTouch("touchstart", 120, 100));
+    content.dispatchEvent(mobileTouch("touchmove", 120, 230));
+    content.dispatchEvent(mobileTouch("touchend", 120, 230, true));
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => String(path).startsWith("/api/catalog/search"))
+          .length,
+      ).toBeGreaterThan(catalogBefore),
+    );
+
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    await flushPromises();
+    const probesBefore = apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length;
+    content.dispatchEvent(mobileTouch("touchstart", 120, 100));
+    content.dispatchEvent(mobileTouch("touchmove", 120, 230));
+    content.dispatchEvent(mobileTouch("touchend", 120, 230, true));
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => path === "/api/status").length,
+      ).toBeGreaterThan(probesBefore),
+    );
+    expect(invoke).toHaveBeenCalledWith("discover_mold_hosts", { timeoutMs: 2500 });
+
+    await wrapper.get("[data-test='mobile-host-row']").trigger("click");
+    await flushPromises();
+    const detailModelsBefore = apiJsonTo.mock.calls.filter(
+      ([, path]) => path === "/api/models",
+    ).length;
+    content.dispatchEvent(mobileTouch("touchstart", 120, 100));
+    content.dispatchEvent(mobileTouch("touchmove", 120, 230));
+    content.dispatchEvent(mobileTouch("touchend", 120, 230, true));
+    await vi.waitFor(() =>
+      expect(
+        apiJsonTo.mock.calls.filter(([, path]) => path === "/api/models").length,
+      ).toBeGreaterThan(detailModelsBefore),
+    );
+  });
+
   it("starts each tab at the top instead of carrying another tab's scroll position", async () => {
     wrapper = mountMobileApp();
     await flushPromises();
@@ -11240,6 +11377,10 @@ describe("MobileApp Library organization", () => {
       configurable: true,
       value: clientY === undefined ? [] : [{ identifier: 7, clientX: 120, clientY }],
     });
+    Object.defineProperty(event, "changedTouches", {
+      configurable: true,
+      value: clientY === undefined ? [] : [{ identifier: 7, clientX: 120, clientY }],
+    });
     return event;
   }
 
@@ -11254,9 +11395,7 @@ describe("MobileApp Library organization", () => {
     content.dispatchEvent(move);
     await flushPromises();
     expect(move.defaultPrevented).toBe(true);
-    expect(wrapper!.get("[data-test='mobile-library-pull']").text()).toContain(
-      "Release to refresh",
-    );
+    expect(wrapper!.get("[data-test='mobile-view-pull']").text()).toContain("Release to refresh");
     content.dispatchEvent(libraryTouch("touchend"));
 
     await vi.waitFor(() =>
@@ -11277,7 +11416,7 @@ describe("MobileApp Library organization", () => {
     content.dispatchEvent(libraryTouch("touchcancel"));
     await flushPromises();
 
-    expect(wrapper!.get("[data-test='mobile-library-pull']").text()).not.toContain(
+    expect(wrapper!.get("[data-test='mobile-view-pull']").text()).not.toContain(
       "Release to refresh",
     );
     expect(apiJsonTo.mock.calls.filter(([, path]) => path === "/api/gallery")).toHaveLength(before);

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -12911,6 +12911,67 @@ describe("MobileApp identity photo", () => {
     expect(invoke).not.toHaveBeenCalledWith("pick_identity_photo", expect.anything());
   });
 
+  it("keeps Android semantic tile activation and viewer history in sync", async () => {
+    isNativeAndroidRuntime.mockReturnValue(true);
+    const { frames: _frames, fps: _fps, ...stillMetadata } = print.metadata;
+    const androidPrint: GalleryImage = {
+      ...print,
+      filename: "storm.png",
+      format: "png",
+      metadata: {
+        ...stillMetadata,
+        model: identityModel.name,
+        output_format: "png",
+      },
+    };
+    const historyBack = vi.spyOn(window.history, "back").mockImplementation(() => {});
+    serveIdentity([identityModel], [androidPrint]);
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    const semanticTile = wrapper.get("[data-test='gallery-item']");
+    vi.spyOn(semanticTile.element, "getBoundingClientRect").mockReturnValue({
+      left: 100,
+      right: 200,
+      top: 100,
+      bottom: 200,
+      width: 100,
+      height: 100,
+      x: 100,
+      y: 100,
+      toJSON: () => ({}),
+    });
+    await semanticTile.trigger("click", { detail: 0, clientX: 0, clientY: 0 });
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
+
+    await wrapper.get("[data-test='gallery-viewer-reuse']").trigger("click");
+    await vi.waitFor(() =>
+      expect(wrapper?.find("[data-test='gallery-viewer']").exists()).toBe(false),
+    );
+    expect(historyBack).toHaveBeenCalledTimes(1);
+
+    // The real browser removes the marker when history.back() lands.
+    window.history.replaceState(null, "");
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click", {
+      detail: 0,
+      clientX: 0,
+      clientY: 0,
+    });
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(true);
+
+    window.dispatchEvent(new PopStateEvent("popstate"));
+    await flushPromises();
+
+    expect(wrapper.find("[data-test='gallery-viewer']").exists()).toBe(false);
+    expect(historyBack).toHaveBeenCalledTimes(1);
+    window.history.replaceState(null, "");
+    historyBack.mockRestore();
+  });
+
   it("keeps an oversized Android pick inline and never stages its bytes", async () => {
     isNativeAndroidRuntime.mockReturnValue(true);
     serveIdentity([identityModel]);

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -508,6 +508,7 @@ import {
 import { MobileSubmissionAttempts } from "./mobileSubmissionAttempt";
 
 type Tab = "generate" | "gallery" | "catalog" | "hosts";
+type RefreshableMobileView = { refresh(): Promise<void> };
 
 /** Deep-link payload for the Discover shelf; `token` re-fires the intent even
  *  when the (KeepAlive-cached) catalog is asked for the same filters twice. */
@@ -650,6 +651,7 @@ const GALLERY_THUMBNAIL_TIMEOUT_MS = 5_000;
 const GALLERY_THUMBNAIL_PLACEHOLDER = "data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs=";
 const GALLERY_THUMBNAIL_RETRY_MAX_MS = 30_000;
 const MOBILE_LIBRARY_SCROLL_KEY = "mobile:library";
+const MOBILE_MACHINES_SCROLL_KEY = "mobile:machines";
 const REUSE_PRESENTATION_TIMEOUT_MS = 9_000;
 const OUTPUT_OPTIONS = [
   { value: "single" as const, label: "One shot" },
@@ -664,6 +666,8 @@ const draft = useSequenceDraftStore();
 const licenseAcceptance = useLicenseAcceptance();
 draft.hydrate();
 const mobileContent = ref<HTMLElement | null>(null);
+const catalogView = ref<RefreshableMobileView | null>(null);
+const hostDetailView = ref<RefreshableMobileView | null>(null);
 const createHeading = ref<HTMLElement | null>(null);
 const settingsOpen = ref(false);
 const settingsButton = ref<HTMLButtonElement | null>(null);
@@ -1025,13 +1029,19 @@ const gallery = ref<GalleryPrint[]>([]);
 const galleryByThumbnailKey = new Map<string, GalleryPrint>();
 const galleryLoading = ref(false);
 const galleryError = ref("");
-const galleryPullDistance = ref(0);
-const galleryPullRefreshing = ref(false);
-const GALLERY_PULL_THRESHOLD = 72;
-const GALLERY_PULL_MAX = 112;
-let galleryPullTouchId: number | null = null;
-let galleryPullStartX = 0;
-let galleryPullStartY = 0;
+const viewPullDistance = ref(0);
+const viewPullRefreshing = ref(false);
+const VIEW_PULL_THRESHOLD = 72;
+const VIEW_PULL_MAX = 112;
+let viewPullTouchId: number | null = null;
+let viewPullStartX = 0;
+let viewPullStartY = 0;
+const MAJOR_TABS: readonly Tab[] = ["generate", "gallery", "catalog", "hosts"];
+const MAJOR_SWIPE_DISTANCE = 64;
+const MAJOR_SWIPE_INTENT_RATIO = 1.2;
+let majorSwipeTouchId: number | null = null;
+let majorSwipeStartX = 0;
+let majorSwipeStartY = 0;
 const gallerySelectMode = ref(false);
 let nativeGalleryContextKey: string | null = null;
 const gallerySelection = ref<Set<string>>(new Set());
@@ -3709,6 +3719,7 @@ function clearDiscoveredHost() {
 }
 
 async function discoverHosts(): Promise<void> {
+  if (discovering.value) return;
   discovering.value = true;
   hostError.value = "";
   try {
@@ -3810,7 +3821,27 @@ async function selectHost(id: string): Promise<void> {
 }
 
 function showHostDetail(id: string): void {
+  const scroller = mobileContent.value;
+  const showingMachineList = Boolean(scroller?.querySelector("[data-test='mobile-host-row']"));
+  rememberSessionScroll(MOBILE_MACHINES_SCROLL_KEY, {
+    top: showingMachineList ? (scroller?.scrollTop ?? 0) : 0,
+    left: 0,
+  });
   hostDetailId.value = id;
+  void nextTick(() => {
+    if (mobileContent.value) mobileContent.value.scrollTop = 0;
+  });
+}
+
+function closeHostDetail(): void {
+  hostDetailId.value = "";
+  void nextTick(() => {
+    const scroller = mobileContent.value;
+    if (!scroller) return;
+    const position = sessionScrollPosition(MOBILE_MACHINES_SCROLL_KEY);
+    scroller.scrollTop = position.top;
+    scroller.scrollLeft = position.left;
+  });
 }
 
 function renameHost(payload: { id: string; name: string }): void {
@@ -10022,58 +10053,186 @@ function handleForegroundResume(): void {
   }
 }
 
-function beginLibraryPull(event: TouchEvent): void {
+const currentRefreshLabel = computed(() => {
+  if (tab.value === "gallery") return "Library";
+  if (tab.value === "catalog") return "Models";
+  if (tab.value === "hosts") return hostDetail.value ? hostDetail.value.name : "Machines";
+  return "";
+});
+
+const pullRefreshAvailable = computed(
+  () => !settingsOpen.value && ["gallery", "catalog", "hosts"].includes(tab.value),
+);
+
+async function refreshCurrentView(): Promise<void> {
+  if (tab.value === "gallery") {
+    await refreshGallery();
+    return;
+  }
+  if (tab.value === "catalog") {
+    await catalogView.value?.refresh();
+    return;
+  }
+  if (tab.value !== "hosts") return;
+  if (hostDetail.value) {
+    await hostDetailView.value?.refresh();
+    return;
+  }
+  await Promise.all([...connectedHosts.value.map((host) => probeHost(host)), discoverHosts()]);
+}
+
+function beginViewPull(event: TouchEvent): void {
   const scroller = mobileContent.value;
   if (
-    tab.value !== "gallery" ||
-    galleryPullRefreshing.value ||
+    !pullRefreshAvailable.value ||
+    viewPullRefreshing.value ||
     !scroller ||
     scroller.scrollTop > 0 ||
     event.touches.length !== 1
   ) {
-    galleryPullTouchId = null;
+    viewPullTouchId = null;
     return;
   }
   const touch = event.touches[0];
   if (!touch) return;
-  galleryPullTouchId = touch.identifier;
-  galleryPullStartX = touch.clientX;
-  galleryPullStartY = touch.clientY;
+  viewPullTouchId = touch.identifier;
+  viewPullStartX = touch.clientX;
+  viewPullStartY = touch.clientY;
 }
 
-function moveLibraryPull(event: TouchEvent): void {
-  if (galleryPullTouchId === null || event.touches.length !== 1) return;
-  const touch = [...event.touches].find((candidate) => candidate.identifier === galleryPullTouchId);
+function moveViewPull(event: TouchEvent): void {
+  if (viewPullTouchId === null || event.touches.length !== 1) return;
+  const touch = [...event.touches].find((candidate) => candidate.identifier === viewPullTouchId);
   if (!touch) return;
-  const deltaX = touch.clientX - galleryPullStartX;
-  const deltaY = touch.clientY - galleryPullStartY;
+  const deltaX = touch.clientX - viewPullStartX;
+  const deltaY = touch.clientY - viewPullStartY;
   if (deltaY <= 0 || Math.abs(deltaX) >= deltaY) {
-    galleryPullDistance.value = 0;
+    viewPullDistance.value = 0;
     return;
   }
   // Resist the drag like a native refresh control while keeping the threshold
   // reachable with one ordinary thumb pull.
-  galleryPullDistance.value = Math.min(GALLERY_PULL_MAX, deltaY * 0.62);
+  viewPullDistance.value = Math.min(VIEW_PULL_MAX, deltaY * 0.62);
   event.preventDefault();
 }
 
-function finishLibraryPull(): void {
-  if (galleryPullTouchId === null) return;
-  galleryPullTouchId = null;
-  const shouldRefresh = galleryPullDistance.value >= GALLERY_PULL_THRESHOLD;
-  galleryPullDistance.value = 0;
-  if (!shouldRefresh || galleryPullRefreshing.value) return;
-  galleryPullRefreshing.value = true;
-  galleryPullDistance.value = 48;
-  void refreshGallery().finally(() => {
-    galleryPullRefreshing.value = false;
-    galleryPullDistance.value = 0;
+function finishViewPull(): void {
+  if (viewPullTouchId === null) return;
+  viewPullTouchId = null;
+  const shouldRefresh = viewPullDistance.value >= VIEW_PULL_THRESHOLD;
+  viewPullDistance.value = 0;
+  if (!shouldRefresh || viewPullRefreshing.value) return;
+  viewPullRefreshing.value = true;
+  viewPullDistance.value = 48;
+  void refreshCurrentView().finally(() => {
+    viewPullRefreshing.value = false;
+    viewPullDistance.value = 0;
   });
 }
 
-function cancelLibraryPull(): void {
-  galleryPullTouchId = null;
-  galleryPullDistance.value = 0;
+function cancelViewPull(): void {
+  viewPullTouchId = null;
+  viewPullDistance.value = 0;
+}
+
+function horizontalScrollOwnsGesture(target: EventTarget | null): boolean {
+  if (!(target instanceof Element)) return false;
+  if (
+    target.closest(
+      "input, textarea, select, video, audio, [contenteditable='true'], [role='dialog'], .swipe-row, .live-activity-row--has-actions, .mobile-library-sheet, .mobile-catalog-detail, .mobile-catalog-target-sheet",
+    )
+  )
+    return true;
+  let element: Element | null = target;
+  while (element && element !== mobileContent.value) {
+    const style = getComputedStyle(element);
+    if (
+      (style.overflowX === "auto" || style.overflowX === "scroll") &&
+      element.scrollWidth > element.clientWidth
+    )
+      return true;
+    element = element.parentElement;
+  }
+  return false;
+}
+
+function beginMajorSwipe(event: TouchEvent): void {
+  if (
+    pairingScannerOpen.value ||
+    gallerySelectMode.value ||
+    event.touches.length !== 1 ||
+    horizontalScrollOwnsGesture(event.target)
+  ) {
+    majorSwipeTouchId = null;
+    return;
+  }
+  const touch = event.touches[0];
+  if (!touch) return;
+  majorSwipeTouchId = touch.identifier;
+  majorSwipeStartX = touch.clientX;
+  majorSwipeStartY = touch.clientY;
+}
+
+function moveMajorSwipe(event: TouchEvent): void {
+  if (majorSwipeTouchId === null || event.touches.length !== 1) return;
+  const touch = [...event.touches].find((candidate) => candidate.identifier === majorSwipeTouchId);
+  if (!touch) return;
+  const deltaX = touch.clientX - majorSwipeStartX;
+  const deltaY = touch.clientY - majorSwipeStartY;
+  if (Math.abs(deltaX) > 12 && Math.abs(deltaX) >= Math.abs(deltaY) * MAJOR_SWIPE_INTENT_RATIO)
+    event.preventDefault();
+}
+
+function finishMajorSwipe(event: TouchEvent): void {
+  if (majorSwipeTouchId === null) return;
+  const touch = [...(event.changedTouches ?? [])].find(
+    (candidate) => candidate.identifier === majorSwipeTouchId,
+  );
+  majorSwipeTouchId = null;
+  if (!touch) return;
+  const deltaX = touch.clientX - majorSwipeStartX;
+  const deltaY = touch.clientY - majorSwipeStartY;
+  if (
+    Math.abs(deltaX) < MAJOR_SWIPE_DISTANCE ||
+    Math.abs(deltaX) < Math.abs(deltaY) * MAJOR_SWIPE_INTENT_RATIO
+  )
+    return;
+
+  if (settingsOpen.value) {
+    if (deltaX > 0) closeSettings();
+    return;
+  }
+  if (deltaX > 0 && tab.value === "hosts" && hostDetail.value) {
+    closeHostDetail();
+    return;
+  }
+  const current = MAJOR_TABS.indexOf(tab.value);
+  const next = current + (deltaX < 0 ? 1 : -1);
+  if (next >= 0 && next < MAJOR_TABS.length) tab.value = MAJOR_TABS[next]!;
+}
+
+function cancelMajorSwipe(): void {
+  majorSwipeTouchId = null;
+}
+
+function beginMobileTouch(event: TouchEvent): void {
+  beginViewPull(event);
+  beginMajorSwipe(event);
+}
+
+function moveMobileTouch(event: TouchEvent): void {
+  moveViewPull(event);
+  moveMajorSwipe(event);
+}
+
+function finishMobileTouch(event: TouchEvent): void {
+  finishViewPull();
+  finishMajorSwipe(event);
+}
+
+function cancelMobileTouch(): void {
+  cancelViewPull();
+  cancelMajorSwipe();
 }
 
 function usesSoftwareKeyboard(target: EventTarget | null): target is HTMLElement {
@@ -10460,10 +10619,10 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       ref="mobileContent"
       class="mobile-content"
       :class="{ 'is-library': !settingsOpen && tab === 'gallery' }"
-      @touchstart="beginLibraryPull"
-      @touchmove="moveLibraryPull"
-      @touchend="finishLibraryPull"
-      @touchcancel="cancelLibraryPull"
+      @touchstart="beginMobileTouch"
+      @touchmove="moveMobileTouch"
+      @touchend="finishMobileTouch"
+      @touchcancel="cancelMobileTouch"
     >
       <MobileSettingsView
         v-if="settingsOpen"
@@ -10475,7 +10634,20 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
         @update="updateSettings"
         @manage-hosts="manageHostsFromSettings"
       />
-      <template v-else-if="tab === 'generate'">
+      <div
+        v-if="pullRefreshAvailable"
+        class="mobile-library-pull"
+        :class="{ 'is-refreshing': viewPullRefreshing }"
+        :style="{ height: `${viewPullDistance}px` }"
+        role="status"
+        aria-live="polite"
+        data-test="mobile-view-pull"
+      >
+        <span v-if="viewPullRefreshing">Refreshing {{ currentRefreshLabel }}…</span>
+        <span v-else-if="viewPullDistance >= VIEW_PULL_THRESHOLD">Release to refresh</span>
+        <span v-else-if="viewPullDistance > 0">Pull to refresh</span>
+      </div>
+      <template v-if="!settingsOpen && tab === 'generate'">
         <div v-if="!selectedHost" class="empty-state">
           <div>
             <h1 class="section-title">Connect a host</h1>
@@ -11325,18 +11497,6 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       </template>
 
       <template v-else-if="tab === 'gallery'">
-        <div
-          class="mobile-library-pull"
-          :class="{ 'is-refreshing': galleryPullRefreshing }"
-          :style="{ height: `${galleryPullDistance}px` }"
-          role="status"
-          aria-live="polite"
-          data-test="mobile-library-pull"
-        >
-          <span v-if="galleryPullRefreshing">Refreshing…</span>
-          <span v-else-if="galleryPullDistance >= GALLERY_PULL_THRESHOLD">Release to refresh</span>
-          <span v-else-if="galleryPullDistance > 0">Pull to refresh</span>
-        </div>
         <div class="mobile-library-heading">
           <div>
             <h1 class="section-title">Library</h1>
@@ -12078,9 +12238,10 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       <template v-else-if="tab === 'hosts'">
         <MobileHostDetail
           v-if="hostDetail"
+          ref="hostDetailView"
           :host="hostDetail"
           :active="hostDetail.id === selectedHostId"
-          @back="hostDetailId = ''"
+          @back="closeHostDetail"
           @select="useHostForGenerations"
           @rename="renameHost"
           @disconnect="disconnectHost"
@@ -12275,6 +12436,7 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       <KeepAlive>
         <MobileCatalogView
           v-if="!settingsOpen && tab === 'catalog'"
+          ref="catalogView"
           :hosts="connectedHosts"
           :selected-host-id="catalogHostId"
           :filter-intent="catalogFilterIntent"

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -642,6 +642,7 @@ const SEQUENCE_RECOVERY_KEY = "mold.mobile.sequence-job.v1";
 const LIVE_ACTIVITY_KEY = "mold.mobile.live-activity.v1";
 const GALLERY_CAPABILITIES_KEY = "mold.mobile.gallery-capabilities.v1";
 const GALLERY_TAGS_KEY = "mold.mobile.gallery-tags.v1";
+const GALLERY_VIEWER_HISTORY_KEY = "mold.mobile.gallery-viewer";
 const HOST_PROBE_TIMEOUT_MS = 9_000;
 const GALLERY_HOST_TIMEOUT_MS = 9_000;
 /** A broken WebView connection must not hold a thumbnail page forever. Five
@@ -7541,7 +7542,7 @@ async function reusePrint(print: GalleryPrint): Promise<void> {
     // was a gallery image its bytes are still on the print's host — fetch
     // them so the wells fill instead of demanding a reattach.
     void restoreReusedH3BoundaryMedia(print);
-    selectedPrint.value = null;
+    dismissSelectedPrint();
     // The next Gallery visit performs its normal refresh; do not refetch the
     // grid while navigating directly to the restored prompt.
     galleryRefreshDeferred = false;
@@ -7901,7 +7902,7 @@ async function useSelectedPrintAsSource(): Promise<void> {
       form.sourceFit = defaultSourceFitPolicy();
       setGenerationStatus("Gallery print selected as source");
     }
-    selectedPrint.value = null;
+    dismissSelectedPrint();
     galleryRefreshDeferred = false;
     tab.value = "generate";
   } catch (error) {
@@ -7926,6 +7927,12 @@ function galleryImageMimeType(print: GalleryImage, declared: string): string {
 function openPrint(print: GalleryPrint): void {
   reusePrintError.value = "";
   selectedPrint.value = print;
+  if (androidNativeRuntime && !window.history.state?.[GALLERY_VIEWER_HISTORY_KEY]) {
+    window.history.pushState(
+      { ...(window.history.state ?? {}), [GALLERY_VIEWER_HISTORY_KEY]: true },
+      "",
+    );
+  }
 }
 
 const galleryPrintKey = (print: Pick<GalleryPrint, "hostId" | "filename">) =>
@@ -9402,7 +9409,7 @@ async function restoreSelectedPrint(): Promise<void> {
     ...restored.map(({ trashed_at: _trashedAt, purge_at: _purgeAt, ...copy }) => copy),
   ].sort((a, b) => b.timestamp - a.timestamp);
   trashCopies = trashCopies.filter((copy) => !keys.has(galleryPrintKey(copy)));
-  selectedPrint.value = null;
+  dismissSelectedPrint();
   galleryRefreshDeferred = false;
   rebuildGalleryOrganization();
   await requeueGallery();
@@ -9419,7 +9426,7 @@ async function deleteSelectedPrintForever(): Promise<void> {
     copies.filter((copy) => !outcome.failedHostIds.has(copy.hostId)).map(galleryPrintKey),
   );
   if (keys.size === 0) return;
-  selectedPrint.value = null;
+  dismissSelectedPrint();
   galleryRefreshDeferred = false;
   await enqueueGalleryOperation(() => dropCopiesFromLibrary(keys, { purgeThumbnails: true }));
 }
@@ -9496,8 +9503,33 @@ function galleryPrintAtPoint(x: number, y: number): GalleryPrint | null {
   const tile = elements
     .map((element) => element?.closest<HTMLElement>("[data-gallery-print-key]") ?? null)
     .find((element) => element !== null);
-  const key = tile?.dataset.galleryPrintKey;
+  // Android tiles deliberately sit outside pointer hit-testing so Chrome can
+  // hand a vertical drag to the Library scroller. Recover the visual tile by
+  // bounds for delegated taps and select-mode drag painting.
+  const boundedTile =
+    tile ??
+    [
+      ...(galleryGridSurface.value?.querySelectorAll<HTMLElement>("[data-gallery-print-key]") ??
+        []),
+    ].find((element) => {
+      const bounds = element.getBoundingClientRect();
+      return x >= bounds.left && x <= bounds.right && y >= bounds.top && y <= bounds.bottom;
+    });
+  const key = boundedTile?.dataset.galleryPrintKey;
   return key ? (gallery.value.find((print) => galleryPrintKey(print) === key) ?? null) : null;
+}
+
+function beginAndroidGalleryGridSelection(event: PointerEvent): void {
+  if (!androidNativeRuntime) return;
+  const print = galleryPrintAtPoint(event.clientX, event.clientY);
+  if (print) beginGallerySelectionDrag(event, print);
+}
+
+function handleAndroidGalleryGridClick(event: MouseEvent): void {
+  if (!androidNativeRuntime) return;
+  if (event.target instanceof Element && event.target.closest("[data-gallery-print-key]")) return;
+  const print = galleryPrintAtPoint(event.clientX, event.clientY);
+  if (print) handleGalleryTileClick(event, print);
 }
 
 function applyGalleryDragAtPoint(): void {
@@ -9672,7 +9704,7 @@ function selectAllGalleryPrints(): void {
   galleryDeleteConfirming.value = false;
 }
 
-function handleGalleryTileClick(event: MouseEvent, print: GalleryPrint): void {
+function handleGalleryTileClick(event: MouseEvent | KeyboardEvent, print: GalleryPrint): void {
   if (galleryPinchPendingClicks > 0 && event.detail !== 0) {
     galleryPinchPendingClicks -= 1;
     return;
@@ -9793,7 +9825,7 @@ function navigateSelectedPrint(delta: -1 | 1): void {
   selectedPrint.value = next;
 }
 
-function closePrint(): void {
+function closePrint(syncAndroidHistory = true): void {
   reusePrintEpoch += 1;
   reusePrintController?.abort();
   reusePrintController = null;
@@ -9803,7 +9835,7 @@ function closePrint(): void {
   sourceUseController = null;
   usingPrintAsSource.value = false;
   reusePrintError.value = "";
-  selectedPrint.value = null;
+  dismissSelectedPrint(syncAndroidHistory);
   if (galleryRefreshDeferred || galleryRefreshRequested) {
     galleryRefreshDeferred = false;
     // The viewer normally restores focus to its tile. A deferred refresh — or
@@ -9814,6 +9846,21 @@ function closePrint(): void {
       void refreshGallery();
     });
   }
+}
+
+function dismissSelectedPrint(syncAndroidHistory = true): void {
+  selectedPrint.value = null;
+  if (
+    syncAndroidHistory &&
+    androidNativeRuntime &&
+    window.history.state?.[GALLERY_VIEWER_HISTORY_KEY]
+  ) {
+    window.history.back();
+  }
+}
+
+function handleAndroidHistoryPop(): void {
+  if (androidNativeRuntime && selectedPrint.value) closePrint(false);
 }
 
 function reuseSelectedPrint(): void {
@@ -10333,6 +10380,7 @@ onMounted(async () => {
   window.addEventListener("pointerup", finishGallerySelectionDrag);
   window.addEventListener("pointercancel", finishGallerySelectionDrag);
   window.addEventListener("mold:native-gallery-select", selectNativeGalleryContextPrint);
+  window.addEventListener("popstate", handleAndroidHistoryPop);
   mobileContent.value?.addEventListener("scroll", scheduleMobileGalleryWindow, { passive: true });
   // The pinch tracks globally so a finger that slides off the grid mid-gesture
   // still reports, and so a lift outside the grid always ends it.
@@ -10432,6 +10480,7 @@ onBeforeUnmount(() => {
   window.removeEventListener("pointerup", finishGallerySelectionDrag);
   window.removeEventListener("pointercancel", finishGallerySelectionDrag);
   window.removeEventListener("mold:native-gallery-select", selectNativeGalleryContextPrint);
+  window.removeEventListener("popstate", handleAndroidHistoryPop);
   mobileContent.value?.removeEventListener("scroll", scheduleMobileGalleryWindow);
   nativeGalleryContextKey = null;
   finishGallerySelectionDrag();
@@ -11857,11 +11906,16 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
             >
               <div
                 class="gallery-grid gallery-grid-virtual"
-                :class="{ 'is-selecting': gallerySelectMode }"
+                :class="{
+                  'is-selecting': gallerySelectMode,
+                  'is-android-native': androidNativeRuntime,
+                }"
                 :style="{
                   '--mobile-gallery-columns': galleryColumns,
                   transform: `translateY(${mobileGalleryWindow.offset}px)`,
                 }"
+                @pointerdown="beginAndroidGalleryGridSelection"
+                @click="handleAndroidGalleryGridClick"
               >
                 <button
                   v-for="print in visibleGallery"

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -803,6 +803,26 @@ describe("MobileCatalogView", () => {
     expect(wrapper.findAll("[data-test='mobile-catalog-card']")).toHaveLength(3);
   });
 
+  it("keeps installed rows when a manual refresh cannot reach their hosts", async () => {
+    wrapper = mountCatalog();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-catalog-segment-installed']").trigger("click");
+    expect(wrapper.text()).toContain("installed:q8");
+
+    apiFetchTo.mockImplementation((_target: ApiTarget, path: string) =>
+      path === "/api/models" || path === "/api/capabilities"
+        ? Promise.reject(new TypeError("offline"))
+        : Promise.resolve(new Response(null, { status: 204 })),
+    );
+    await (wrapper.vm as unknown as { refresh(): Promise<void> }).refresh();
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("installed:q8");
+    expect(wrapper.get("[data-test='mobile-catalog-action-status']").text()).toContain(
+      "Saved model information is still shown",
+    );
+  });
+
   it("debounces search and ignores a late response from the previous host", async () => {
     vi.useFakeTimers();
     const pending: Array<(response: CatalogSearchResponse) => void> = [];

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -744,10 +744,16 @@ async function loadFamilies(): Promise<void> {
   }
 }
 
-async function refreshModels(): Promise<void> {
+async function refreshModels(): Promise<string[]> {
   const epoch = ++modelsEpoch;
-  const next: Record<string, ModelEntry[]> = {};
-  const nextCapabilities: Record<string, ServerCapabilities> = {};
+  const currentHostIds = new Set(downloadHosts.value.map((host) => host.id));
+  const next = Object.fromEntries(
+    Object.entries(modelsByHost.value).filter(([hostId]) => currentHostIds.has(hostId)),
+  );
+  const nextCapabilities = Object.fromEntries(
+    Object.entries(capabilitiesByHost.value).filter(([hostId]) => currentHostIds.has(hostId)),
+  );
+  const failedHosts = new Set<string>();
   await Promise.all(
     downloadHosts.value.map(async (host) => {
       const target = mobileHostTarget(host);
@@ -763,9 +769,13 @@ async function refreshModels(): Promise<void> {
       if (modelResult.status === "fulfilled") {
         next[host.id] = modelResult.value;
         recordFamilies(modelResult.value.map((model) => model.family));
+      } else {
+        failedHosts.add(host.name);
       }
       if (capabilityResult.status === "fulfilled") {
         nextCapabilities[host.id] = capabilityResult.value;
+      } else {
+        failedHosts.add(host.name);
       }
     }),
   );
@@ -773,7 +783,28 @@ async function refreshModels(): Promise<void> {
     modelsByHost.value = next;
     capabilitiesByHost.value = nextCapabilities;
   }
+  return epoch === modelsEpoch ? [...failedHosts] : [];
 }
+
+/** User-initiated refresh for the whole Models destination. Keep the current
+ * rows mounted while all three independent authorities catch up. */
+async function refreshCatalog(): Promise<void> {
+  announce("Refreshing models…");
+  const [failedHosts] = await Promise.all([refreshModels(), loadFamilies(), runSearch(true)]);
+  if (failedHosts.length > 0) {
+    announce(
+      `Couldn’t refresh ${failedHosts.join(", ")}. Saved model information is still shown.`,
+      true,
+    );
+    return;
+  }
+  announce(
+    error.value ? "Models refreshed with some saved results." : "Models refreshed.",
+    Boolean(error.value),
+  );
+}
+
+defineExpose({ refresh: refreshCatalog });
 
 function handleDownloadEvent({
   host,

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -939,6 +939,31 @@ describe("MobileGalleryViewer info sheet", () => {
     expect(view.get("[data-test='gallery-viewer-print-details']").text()).toContain("1024×1024");
   });
 
+  it("dismisses the Info sheet with a downward swipe from its top", async () => {
+    const view = mountViewer();
+    await flushPromises();
+    await view.get("[data-test='gallery-viewer-info']").trigger("click");
+    const panel = view.get(".mobile-library-sheet-panel").element;
+    const touch = (type: string, y: number, ended = false) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      const point = { identifier: 5, clientX: 120, clientY: y };
+      Object.defineProperty(event, "touches", { value: ended ? [] : [point] });
+      Object.defineProperty(event, "changedTouches", { value: [point] });
+      return event;
+    };
+
+    panel.dispatchEvent(touch("touchstart", 100));
+    const move = touch("touchmove", 240);
+    panel.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(true);
+    await flushPromises();
+    expect(view.get(".mobile-library-sheet-panel").attributes("style")).toContain("translateY");
+    panel.dispatchEvent(touch("touchend", 240, true));
+    await flushPromises();
+
+    expect(view.get("[data-test='gallery-viewer-info-sheet']").classes()).not.toContain("is-open");
+  });
+
   it("matches the desktop print-detail metadata fields", async () => {
     const view = mountViewer({
       ...image,

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -877,6 +877,7 @@ onBeforeUnmount(() => {
       :open="infoOpen"
       :title="viewerTitle"
       :focus-first-control="false"
+      swipe-to-dismiss
       test-id="gallery-viewer-info-sheet"
       @close="closeInfo"
     >

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -658,6 +658,52 @@ async function loadHost(): Promise<void> {
   }
 }
 
+/** Refresh every stale-capable card without clearing the screen or restarting
+ * its live streams. This is the Machine Detail pull-to-refresh authority. */
+async function refreshHostDetail(): Promise<void> {
+  if (props.host.connected === false) return;
+  const epoch = loadEpoch;
+  const requestTarget = target.value;
+  error.value = "";
+  const [statusResult, modelsResult] = await Promise.allSettled([
+    apiJsonTo<ServerStatus>(requestTarget, "/api/status"),
+    apiJsonTo<ModelEntry[]>(requestTarget, "/api/models"),
+  ]);
+  if (
+    epoch !== loadEpoch ||
+    requestTarget.baseUrl !== target.value.baseUrl ||
+    requestTarget.apiKey !== target.value.apiKey
+  )
+    return;
+
+  if (statusResult.status === "fulfilled") {
+    const expectedInstanceId = props.host.instanceId?.trim();
+    const reportedInstanceId = statusResult.value.instance_id?.trim();
+    if (expectedInstanceId && reportedInstanceId && expectedInstanceId !== reportedInstanceId) {
+      emit("status", { id: props.host.id, status: statusResult.value });
+      error.value = "This address now reports a different Mold server identity.";
+      return;
+    }
+    status.value = statusResult.value;
+    emit("status", { id: props.host.id, status: statusResult.value });
+  }
+  if (modelsResult.status === "fulfilled") {
+    installed.value = modelsResult.value.filter((model) => model.downloaded);
+  }
+  if (statusResult.status === "rejected" && modelsResult.status === "rejected") {
+    error.value = describeTransportError(statusResult.reason, props.host.name);
+    emit("status", { id: props.host.id, status: null });
+  }
+
+  await Promise.all([
+    requestQueueRefresh(epoch),
+    refreshDevicesSafely(epoch),
+    refreshLibraryCard(epoch),
+  ]);
+}
+
+defineExpose({ refresh: refreshHostDetail });
+
 async function toggleDevice(device: DeviceInfo): Promise<void> {
   if (!canMutateDevice(device, deviceCapabilities.value)) return;
   const enabled = !device.desired_enabled;

--- a/desktop/src/mobile/MobileLibrarySheet.vue
+++ b/desktop/src/mobile/MobileLibrarySheet.vue
@@ -7,7 +7,7 @@
  * every safe-area inset, with the head row rendered in the body so it can
  * never vanish the way SheetPanel's `full` variant drops its #header slot.
  */
-import { onBeforeUnmount, ref, watch } from "vue";
+import { computed, onBeforeUnmount, ref, watch } from "vue";
 
 const props = withDefaults(
   defineProps<{
@@ -20,19 +20,42 @@ const props = withDefaults(
     testId?: string;
     /** Platform-specific minimum target for the closing control. */
     touchTargetSize?: number;
+    /** Let a downward drag from the top dismiss this read-first sheet. */
+    swipeToDismiss?: boolean;
   }>(),
   {
     focusFirstControl: true,
     doneLabel: "Done",
     testId: "mobile-library-sheet",
     touchTargetSize: 46,
+    swipeToDismiss: false,
   },
 );
 
 const emit = defineEmits<{ close: [] }>();
 
 const panel = ref<HTMLElement | null>(null);
+const body = ref<HTMLElement | null>(null);
+const dragOffset = ref(0);
+const dragging = ref(false);
 let restoreFocus: HTMLElement | null = null;
+let dragTouchId: number | null = null;
+let dragStartX = 0;
+let dragStartY = 0;
+
+const DISMISS_DISTANCE = 96;
+const panelStyle = computed(() => ({
+  transform: dragOffset.value > 0 ? `translateY(${dragOffset.value}px)` : undefined,
+}));
+const backdropStyle = computed(() => ({
+  opacity: dragOffset.value > 0 ? Math.max(0.24, 1 - dragOffset.value / 320) : undefined,
+}));
+
+function resetDrag(): void {
+  dragTouchId = null;
+  dragOffset.value = 0;
+  dragging.value = false;
+}
 
 watch(
   () => props.open,
@@ -52,6 +75,7 @@ watch(
         (first ?? panel.value)?.focus?.();
       });
     } else {
+      resetDrag();
       restoreFocus?.focus?.();
       restoreFocus = null;
     }
@@ -59,8 +83,49 @@ watch(
 );
 
 onBeforeUnmount(() => {
+  resetDrag();
   restoreFocus = null;
 });
+
+function beginDismiss(event: TouchEvent): void {
+  if (
+    !props.swipeToDismiss ||
+    event.touches.length !== 1 ||
+    (body.value?.scrollTop ?? 0) > 0 ||
+    (event.target instanceof Element &&
+      Boolean(event.target.closest("input, textarea, select, button, a, [contenteditable='true']")))
+  ) {
+    resetDrag();
+    return;
+  }
+  const touch = event.touches[0];
+  if (!touch) return;
+  dragTouchId = touch.identifier;
+  dragStartX = touch.clientX;
+  dragStartY = touch.clientY;
+}
+
+function moveDismiss(event: TouchEvent): void {
+  if (dragTouchId === null || event.touches.length !== 1) return;
+  const touch = [...event.touches].find((candidate) => candidate.identifier === dragTouchId);
+  if (!touch) return;
+  const deltaX = touch.clientX - dragStartX;
+  const deltaY = touch.clientY - dragStartY;
+  if (deltaY <= 0 || Math.abs(deltaX) >= deltaY) {
+    dragOffset.value = 0;
+    return;
+  }
+  dragging.value = true;
+  dragOffset.value = Math.min(280, deltaY * 0.82);
+  event.preventDefault();
+}
+
+function finishDismiss(): void {
+  if (dragTouchId === null) return;
+  const dismiss = dragOffset.value >= DISMISS_DISTANCE;
+  resetDrag();
+  if (dismiss) emit("close");
+}
 
 function onKeydown(event: KeyboardEvent): void {
   if (event.key === "Escape") {
@@ -88,11 +153,22 @@ function onKeydown(event: KeyboardEvent): void {
       data-sheet-close
       :aria-label="`Close ${title}`"
       :data-test="`${testId}-backdrop`"
+      :style="backdropStyle"
       @click="emit('close')"
     />
-    <div ref="panel" class="mobile-library-sheet-panel" tabindex="-1">
+    <div
+      ref="panel"
+      class="mobile-library-sheet-panel"
+      :class="{ 'is-dragging': dragging }"
+      :style="panelStyle"
+      tabindex="-1"
+      @touchstart="beginDismiss"
+      @touchmove="moveDismiss"
+      @touchend="finishDismiss"
+      @touchcancel="resetDrag"
+    >
       <span class="mobile-library-sheet-grabber" aria-hidden="true" />
-      <div class="mobile-library-sheet-body">
+      <div ref="body" class="mobile-library-sheet-body">
         <p class="mobile-library-sheet-head" :data-test="`${testId}-head`">{{ title }}</p>
         <slot />
         <button

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2786,6 +2786,16 @@ button:disabled {
   width: 100%;
   height: 100%;
   object-fit: cover;
+  touch-action: pan-y;
+  -webkit-user-drag: none;
+}
+
+/* Chrome WebView cancels the pointer stream on a gallery button but fails to
+   transfer it to the scroll container. Android delegates taps through the
+   grid, leaving the visual tile outside hit-testing so image-origin drags pan
+   the Library natively. iOS keeps the tile hit-testable for its context menu. */
+.gallery-grid.is-android-native .gallery-item {
+  pointer-events: none;
 }
 
 .gallery-item img.is-thumbnail-pending {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -5141,6 +5141,7 @@ button:disabled {
   inset: 0;
   border: 0;
   background: color-mix(in srgb, var(--print) 62%, transparent);
+  transition: opacity 160ms ease-out;
 }
 
 .mobile-library-sheet-panel {
@@ -5154,6 +5155,12 @@ button:disabled {
   background: var(--bath);
   color: var(--rebate);
   animation: mobile-sheet-in 0.2s ease;
+  transition: transform 160ms ease-out;
+  will-change: transform;
+}
+
+.mobile-library-sheet-panel.is-dragging {
+  transition: none;
 }
 
 .mobile-library-sheet-grabber {
@@ -5174,7 +5181,7 @@ button:disabled {
   overflow-x: hidden;
   overflow-y: auto;
   overscroll-behavior: none;
-  touch-action: manipulation;
+  touch-action: pan-y;
   padding: 10px max(18px, env(safe-area-inset-right)) calc(16px + env(safe-area-inset-bottom))
     max(18px, env(safe-area-inset-left));
 }

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 
 const css = readFileSync("src/mobile/mobile.css", "utf8");
 const mobileHtml = readFileSync("index.mobile.html", "utf8");
+const mobileAppComponent = readFileSync("src/mobile/MobileApp.vue", "utf8");
 const preparedComponent = readFileSync("src/mobile/MobilePreparedExpansionBatch.vue", "utf8");
 const pullComponent = readFileSync("src/mobile/MobileExpansionPullStatus.vue", "utf8");
 const composerComponent = readFileSync("src/mobile/MobileSequenceComposer.vue", "utf8");
@@ -63,11 +64,20 @@ describe("mobile Library thumbnail sizing", () => {
   it("reserves the two-finger pinch while one-finger scrolling still works", () => {
     const base = css.match(/\.mobile-gallery-pinch-surface\s*\{([^}]*)\}/s);
     const tile = css.match(/\.gallery-item\s*\{([^}]*)\}/s);
+    const media = css.match(/\.gallery-item img,\s*\.gallery-item video\s*\{([^}]*)\}/s);
 
     expect(base?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
     expect(tile?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
+    expect(media?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
+    expect(media?.[1]).toMatch(/-webkit-user-drag:\s*none\s*;/);
     expect(base?.[1]).toMatch(/flex:\s*1 0 auto\s*;/);
     expect(base?.[1]).toMatch(/min-height:\s*42vh\s*;/);
+    expect(mobileAppComponent).toMatch(
+      /class="gallery-grid gallery-grid-virtual"[\s\S]*?'is-android-native': androidNativeRuntime[\s\S]*?@click="handleAndroidGalleryGridClick"/,
+    );
+    expect(css).toMatch(
+      /\.gallery-grid\.is-android-native\s+\.gallery-item\s*\{[^}]*pointer-events:\s*none\s*;/s,
+    );
   });
 });
 

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -612,7 +612,7 @@ describe("mobile Library organization", () => {
     expect(open?.[1]).toMatch(/display:\s*flex\s*;/);
     expect(body?.[1]).toMatch(/overflow-y:\s*auto\s*;/);
     expect(body?.[1]).toMatch(/overscroll-behavior:\s*none\s*;/);
-    expect(body?.[1]).toMatch(/touch-action:\s*manipulation\s*;/);
+    expect(body?.[1]).toMatch(/touch-action:\s*pan-y\s*;/);
     expect(body?.[1]).toContain("env(safe-area-inset-left)");
     expect(body?.[1]).toContain("env(safe-area-inset-right)");
     expect(body?.[1]).toContain("env(safe-area-inset-bottom)");


### PR DESCRIPTION
## Summary

- dismiss the Library Info sheet with a natural downward swipe
- add pull-to-refresh to Library, Models, Machines, and Machine Detail
- add horizontal swipes across Create, Library, Models, and Machines, plus swipe-back from Settings and Machine Detail
- preserve gallery viewer navigation and interactive-control gesture ownership

## Refresh audit

Refresh is enabled for views whose remote data can become stale: Library, Models, Machines, and Machine Detail. Create and Settings are excluded because their remote state already streams or polls and their primary content is editable or local.

## Validation

- independent agent peer review completed; all initial findings fixed; re-review found no actionable issues
- full desktop suite: 418 files, 5,392 tests passed
- focused mobile suite: 4 files, 464 tests passed
- production mobile build passed
- Prettier and git diff checks passed
- rendered mobile QA at 390x844 passed with no console warnings or errors