### PR TITLE
fix(sdxl): implement Playground v2.5 EDM sampling

### DIFF
--- a/changelog.d/playground-v25-edm.md
+++ b/changelog.d/playground-v25-edm.md
@@ -1,0 +1,3 @@
+- **Fixed Playground v2.5 generation.** Use the model's required EDM DPM++ 2M
+  schedule and latent normalization so renders produce coherent images instead
+  of noise.

--- a/crates/mold-cli/src/main.rs
+++ b/crates/mold-cli/src/main.rs
@@ -1277,7 +1277,8 @@ Examples:
         )]
         qwen2_text_encoder_mode: Option<String>,
 
-        /// Scheduler algorithm for UNet models: ddim, euler-ancestral, uni-pc
+        /// Scheduler algorithm for UNet models: ddim, euler-ancestral, uni-pc,
+        /// or edm-dpm-pp-2m (Playground v2.5 only)
         /// Ignored by flow-matching models (FLUX, SD3, Z-Image, Flux.2, Qwen-Image).
         #[arg(long, env = "MOLD_SCHEDULER", help_heading = "Advanced")]
         scheduler: Option<Scheduler>,

--- a/crates/mold-cli/src/skill/SKILL.md
+++ b/crates/mold-cli/src/skill/SKILL.md
@@ -695,6 +695,7 @@ Default model if none specified: `flux2-klein:q8`
 | `flux-schnell`                 | 4     | 0.0      | 1024x1024                                      |
 | `flux-dev`                     | 25    | 3.5      | 1024x1024                                      |
 | `sdxl-base`                    | 25    | 7.5      | 1024x1024                                      |
+| `playground-v2.5`             | 50    | 3.0      | 1024x1024 (EDM DPM++ 2M)                       |
 | `sdxl-turbo`                   | 4     | 0.0      | 512x512                                        |
 | `sd15`                         | 25    | 7.5      | 512x512                                        |
 | `sd3.5-large`                  | 28    | 4.0      | 1024x1024                                      |

--- a/crates/mold-core/src/config_keys.rs
+++ b/crates/mold-core/src/config_keys.rs
@@ -755,9 +755,10 @@ fn set_model_value(config: &mut Config, key: &str, raw: &str) -> Result<()> {
                 Some("ddim") => Some(Scheduler::Ddim),
                 Some("euler-ancestral") => Some(Scheduler::EulerAncestral),
                 Some("uni-pc") => Some(Scheduler::UniPc),
+                Some("edm-dpm-pp-2m") => Some(Scheduler::EdmDpmPp2m),
                 Some(v) => {
                     bail!(
-                        "invalid value for {key}: '{}'. Valid: none, ddim, euler-ancestral, uni-pc",
+                        "invalid value for {key}: '{}'. Valid: none, ddim, euler-ancestral, uni-pc, edm-dpm-pp-2m",
                         v
                     );
                 }

--- a/crates/mold-core/src/generation_profile.rs
+++ b/crates/mold-core/src/generation_profile.rs
@@ -1423,6 +1423,9 @@ fn recipe(
                     .then(|| "Wan sampler controls apply only to Wan models.".to_string()),
             },
             schedulers: match family {
+                "sdxl" if normalized_model.starts_with("playground-v2.5") => {
+                    vec![Scheduler::EdmDpmPp2m]
+                }
                 "sd15" | "sdxl" => {
                     vec![Scheduler::Ddim, Scheduler::EulerAncestral, Scheduler::UniPc]
                 }

--- a/crates/mold-core/src/manifest.rs
+++ b/crates/mold-core/src/manifest.rs
@@ -1930,12 +1930,12 @@ fn sdxl_manifests() -> Vec<ModelManifest> {
                 files
             },
             defaults: ManifestDefaults {
-                steps: 25,
+                steps: 50,
                 guidance: 3.0,
                 width: 1024,
                 height: 1024,
                 is_schnell: false,
-                scheduler: Some(Scheduler::Ddim),
+                scheduler: Some(Scheduler::EdmDpmPp2m),
                 negative_prompt: None,
                 frames: None,
                 fps: None,
@@ -8888,6 +8888,14 @@ mod tests {
         let manifest = find_manifest("sdxl-base").unwrap();
         assert_eq!(manifest.defaults.scheduler, Some(Scheduler::Ddim));
         assert_eq!(manifest.defaults.steps, 25);
+    }
+
+    #[test]
+    fn playground_v25_uses_its_upstream_edm_contract() {
+        let manifest = find_manifest("playground-v2.5").unwrap();
+        assert_eq!(manifest.defaults.scheduler, Some(Scheduler::EdmDpmPp2m));
+        assert_eq!(manifest.defaults.steps, 50);
+        assert_eq!(manifest.defaults.guidance, 3.0);
     }
 
     #[test]

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -124,8 +124,9 @@ mod base64_required {
 /// Scheduler / solver selection.
 ///
 /// Two disjoint families share this wire slot:
-/// - `Ddim` / `EulerAncestral` / `UniPc` — UNet-based image models (SD1.5,
-///   SDXL). Flow-matching image models (FLUX, SD3, Z-Image, Flux.2,
+/// - `Ddim` / `EulerAncestral` / `UniPc` / `EdmDpmPp2m` — UNet-based image
+///   models (SD1.5, SDXL). `EdmDpmPp2m` is the Playground v2.5 training
+///   contract. Flow-matching image models (FLUX, SD3, Z-Image, Flux.2,
 ///   Qwen-Image) ignore those.
 /// - `Euler` / `DpmPp` — Wan's flow-matching sample solvers (upstream
 ///   `--sample_solver`), alongside `UniPc` which doubles as Wan's default
@@ -139,6 +140,10 @@ pub enum Scheduler {
     Ddim,
     EulerAncestral,
     UniPc,
+    /// EDM DPM++ 2M with the Karras 80 → 0.002 sigma schedule, midpoint
+    /// second-order update, and sigma_data=0.5 (Playground v2.5 only).
+    #[serde(rename = "edm-dpm-pp-2m")]
+    EdmDpmPp2m,
     /// Plain flow Euler over the diffusers/Lightning sigma grid — the solver
     /// the lightx2v 4-step recipe specifies (wan only).
     Euler,
@@ -154,6 +159,7 @@ impl std::fmt::Display for Scheduler {
             Scheduler::Ddim => write!(f, "ddim"),
             Scheduler::EulerAncestral => write!(f, "euler-ancestral"),
             Scheduler::UniPc => write!(f, "uni-pc"),
+            Scheduler::EdmDpmPp2m => write!(f, "edm-dpm-pp-2m"),
             Scheduler::Euler => write!(f, "euler"),
             Scheduler::DpmPp => write!(f, "dpm-pp"),
         }
@@ -174,12 +180,15 @@ impl std::str::FromStr for Scheduler {
                 Ok(Scheduler::EulerAncestral)
             }
             "uni-pc" | "unipc" | "uni_pc" => Ok(Scheduler::UniPc),
+            "edm-dpm-pp-2m" | "edm-dpm++-2m" | "edm_dpm_pp_2m" => {
+                Ok(Scheduler::EdmDpmPp2m)
+            }
             "euler" => Ok(Scheduler::Euler),
             // `dpm++` is upstream Wan's spelling; kebab-case `dpm-pp` is the
             // wire form.
             "dpm-pp" | "dpm++" | "dpmpp" | "dpm_pp" => Ok(Scheduler::DpmPp),
             other => Err(format!(
-                "unknown scheduler: '{other}'. Valid: ddim, euler-ancestral, uni-pc, euler, dpm-pp"
+                "unknown scheduler: '{other}'. Valid: ddim, euler-ancestral, uni-pc, edm-dpm-pp-2m, euler, dpm-pp"
             )),
         }
     }
@@ -5464,11 +5473,15 @@ mod tests {
 
     #[test]
     fn scheduler_serde_roundtrip() {
-        let sched = Scheduler::EulerAncestral;
-        let json = serde_json::to_string(&sched).unwrap();
-        assert_eq!(json, r#""euler-ancestral""#);
-        let back: Scheduler = serde_json::from_str(&json).unwrap();
-        assert_eq!(back, sched);
+        for (sched, expected) in [
+            (Scheduler::EulerAncestral, r#""euler-ancestral""#),
+            (Scheduler::EdmDpmPp2m, r#""edm-dpm-pp-2m""#),
+        ] {
+            let json = serde_json::to_string(&sched).unwrap();
+            assert_eq!(json, expected);
+            let back: Scheduler = serde_json::from_str(&json).unwrap();
+            assert_eq!(back, sched);
+        }
     }
 
     #[test]
@@ -5485,6 +5498,10 @@ mod tests {
         assert_eq!("uni-pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
         assert_eq!("unipc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
         assert_eq!("uni_pc".parse::<Scheduler>().unwrap(), Scheduler::UniPc);
+        assert_eq!(
+            "edm-dpm-pp-2m".parse::<Scheduler>().unwrap(),
+            Scheduler::EdmDpmPp2m
+        );
     }
 
     #[test]
@@ -5497,6 +5514,7 @@ mod tests {
         assert_eq!(Scheduler::Ddim.to_string(), "ddim");
         assert_eq!(Scheduler::EulerAncestral.to_string(), "euler-ancestral");
         assert_eq!(Scheduler::UniPc.to_string(), "uni-pc");
+        assert_eq!(Scheduler::EdmDpmPp2m.to_string(), "edm-dpm-pp-2m");
     }
 
     #[test]

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -2532,15 +2532,33 @@ fn validate_generate_request_after_activation_with(
     // wan's flow solvers are rejected off-family and the UNet schedulers are
     // rejected for wan — at admission, not after the model loads.
     match req.scheduler {
+        Some(crate::Scheduler::EdmDpmPp2m)
+            if family != Some("sdxl") || !req.model.starts_with("playground-v2.5") =>
+        {
+            return Err(
+                "scheduler 'edm-dpm-pp-2m' is the Playground v2.5 sampling contract and is only supported for that model"
+                    .to_string(),
+            );
+        }
+        Some(scheduler)
+            if req.model.starts_with("playground-v2.5")
+                && scheduler != crate::Scheduler::EdmDpmPp2m =>
+        {
+            return Err(format!(
+                "Playground v2.5 requires edm-dpm-pp-2m; scheduler '{scheduler}' would render invalid noise"
+            ));
+        }
         Some(crate::Scheduler::Euler | crate::Scheduler::DpmPp) if family != Some("wan") => {
             return Err(format!(
                 "scheduler '{}' is a Wan sample solver and is only supported for wan models",
                 req.scheduler.expect("matched Some")
             ));
         }
-        Some(crate::Scheduler::Ddim | crate::Scheduler::EulerAncestral)
-            if family == Some("wan") =>
-        {
+        Some(
+            crate::Scheduler::Ddim
+            | crate::Scheduler::EulerAncestral
+            | crate::Scheduler::EdmDpmPp2m,
+        ) if family == Some("wan") => {
             return Err(format!(
                 "Wan supports the uni-pc, euler, and dpm-pp sample solvers; '{}' is a UNet \
                  scheduler",
@@ -5695,6 +5713,26 @@ mod tests {
         // The UNet schedulers keep working off-family.
         flux.scheduler = Some(Scheduler::Ddim);
         assert!(validate_generate_request(&flux).is_ok());
+    }
+
+    #[test]
+    fn playground_v25_requires_its_edm_sampling_contract() {
+        use crate::Scheduler;
+
+        let mut playground = valid_req();
+        playground.model = "playground-v2.5:fp16".to_string();
+        playground.scheduler = Some(Scheduler::EdmDpmPp2m);
+        assert!(validate_generate_request(&playground).is_ok());
+
+        playground.scheduler = Some(Scheduler::Ddim);
+        let error = validate_generate_request(&playground).unwrap_err();
+        assert!(error.contains("would render invalid noise"), "got: {error}");
+
+        let mut generic_sdxl = valid_req();
+        generic_sdxl.model = "sdxl-base:fp16".to_string();
+        generic_sdxl.scheduler = Some(Scheduler::EdmDpmPp2m);
+        let error = validate_generate_request(&generic_sdxl).unwrap_err();
+        assert!(error.contains("only supported"), "got: {error}");
     }
 
     /// #779: wan admits exactly the first/last endpoint keyframe pair, and

--- a/crates/mold-db/src/db.rs
+++ b/crates/mold-db/src/db.rs
@@ -994,6 +994,7 @@ fn scheduler_to_str(s: &Scheduler) -> &'static str {
         Scheduler::Ddim => "ddim",
         Scheduler::EulerAncestral => "euler-ancestral",
         Scheduler::UniPc => "uni-pc",
+        Scheduler::EdmDpmPp2m => "edm-dpm-pp-2m",
         Scheduler::Euler => "euler",
         Scheduler::DpmPp => "dpm-pp",
     }
@@ -1004,6 +1005,7 @@ fn scheduler_from_str(s: &str) -> Option<Scheduler> {
         "ddim" => Scheduler::Ddim,
         "euler-ancestral" => Scheduler::EulerAncestral,
         "uni-pc" | "unipc" => Scheduler::UniPc,
+        "edm-dpm-pp-2m" => Scheduler::EdmDpmPp2m,
         "euler" => Scheduler::Euler,
         "dpm-pp" | "dpm++" | "dpmpp" => Scheduler::DpmPp,
         _ => return None,

--- a/crates/mold-inference/src/lib.rs
+++ b/crates/mold-inference/src/lib.rs
@@ -83,6 +83,7 @@ pub use minimax_h3::private_server::{
 };
 pub mod model_registry;
 pub(crate) mod nvfp4;
+pub(crate) mod playground_edm;
 pub mod progress;
 #[cfg(test)]
 pub(crate) mod pulid_fixtures;

--- a/crates/mold-inference/src/playground_edm.rs
+++ b/crates/mold-inference/src/playground_edm.rs
@@ -1,0 +1,155 @@
+//! Playground v2.5's continuous EDM DPM++ 2M sampler.
+//!
+//! This is a direct, deliberately narrow port of Diffusers'
+//! `EDMDPMSolverMultistepScheduler` configuration shipped by
+//! `playgroundai/playground-v2.5-1024px-aesthetic`: Karras sigmas 80→0.002,
+//! rho 7, sigma_data 0.5, epsilon preconditioning, order 2 / midpoint, and a
+//! terminal zero sigma. Candle's stable-diffusion scheduler trait exposes only
+//! integer timesteps, while this model's UNet requires `0.25 * ln(sigma)`;
+//! keeping the sampler here avoids rounding a continuous training contract.
+
+use candle_core::{Result, Tensor};
+
+const SIGMA_MIN: f64 = 0.002;
+const SIGMA_MAX: f64 = 80.0;
+const SIGMA_DATA: f64 = 0.5;
+const RHO: f64 = 7.0;
+
+pub(crate) struct PlaygroundEdmScheduler {
+    sigmas: Vec<f64>,
+    timesteps: Vec<f64>,
+    previous_denoised: Option<Tensor>,
+    step_index: usize,
+}
+
+impl PlaygroundEdmScheduler {
+    pub(crate) fn new(inference_steps: usize, begin_index: usize) -> Result<Self> {
+        if inference_steps == 0 {
+            return Err(candle_core::Error::Msg(
+                "Playground EDM requires at least one inference step".to_string(),
+            ));
+        }
+        if begin_index >= inference_steps {
+            return Err(candle_core::Error::Msg(format!(
+                "Playground EDM begin index {begin_index} is outside {inference_steps} steps"
+            )));
+        }
+
+        let min_inv_rho = SIGMA_MIN.powf(1.0 / RHO);
+        let max_inv_rho = SIGMA_MAX.powf(1.0 / RHO);
+        let denominator = inference_steps.saturating_sub(1).max(1) as f64;
+        let mut sigmas = (0..inference_steps)
+            .map(|i| {
+                let ramp = i as f64 / denominator;
+                (max_inv_rho + ramp * (min_inv_rho - max_inv_rho)).powf(RHO)
+            })
+            .collect::<Vec<_>>();
+        let timesteps = sigmas.iter().map(|sigma| 0.25 * sigma.ln()).collect();
+        sigmas.push(0.0);
+
+        Ok(Self {
+            sigmas,
+            timesteps,
+            previous_denoised: None,
+            step_index: begin_index,
+        })
+    }
+
+    pub(crate) fn timesteps(&self) -> &[f64] {
+        &self.timesteps
+    }
+
+    pub(crate) fn init_noise_sigma() -> f64 {
+        (SIGMA_MAX * SIGMA_MAX + 1.0).sqrt()
+    }
+
+    pub(crate) fn scale_model_input(&self, sample: &Tensor) -> Result<Tensor> {
+        let sigma = self.sigmas[self.step_index];
+        sample / (sigma * sigma + SIGMA_DATA * SIGMA_DATA).sqrt()
+    }
+
+    pub(crate) fn add_noise_at(
+        &self,
+        original: &Tensor,
+        noise: &Tensor,
+        index: usize,
+    ) -> Result<Tensor> {
+        original + (noise * self.sigmas[index])?
+    }
+
+    pub(crate) fn step(&mut self, model_output: &Tensor, sample: &Tensor) -> Result<Tensor> {
+        let sigma_s0 = self.sigmas[self.step_index];
+        let sigma_t = self.sigmas[self.step_index + 1];
+
+        // Diffusers `precondition_outputs(..., prediction_type="epsilon")`.
+        // Playground's UNet output is not ordinary DDPM epsilon despite that
+        // config spelling: EDM combines it with the current sample first.
+        let denominator = sigma_s0 * sigma_s0 + SIGMA_DATA * SIGMA_DATA;
+        let c_skip = SIGMA_DATA * SIGMA_DATA / denominator;
+        let c_out = sigma_s0 * SIGMA_DATA / denominator.sqrt();
+        let denoised = ((sample * c_skip)? + (model_output * c_out)?)?;
+
+        let terminal = self.step_index + 1 == self.timesteps.len();
+        let prev_sample = match (&self.previous_denoised, terminal) {
+            (None, _) | (_, true) => {
+                // DPM-Solver++ first order. At terminal sigma=0 this reduces
+                // exactly to the current denoised x0 prediction.
+                if sigma_t == 0.0 {
+                    denoised.clone()
+                } else {
+                    let h = sigma_s0.ln() - sigma_t.ln();
+                    let coeff = (-h).exp_m1();
+                    ((sample * (sigma_t / sigma_s0))? - (&denoised * coeff)?)?
+                }
+            }
+            (Some(previous), false) => {
+                // DPM++ 2M midpoint update, matching Diffusers lines 566–592.
+                let sigma_s1 = self.sigmas[self.step_index - 1];
+                let h = sigma_s0.ln() - sigma_t.ln();
+                let h_0 = sigma_s1.ln() - sigma_s0.ln();
+                let r0 = h_0 / h;
+                let d1 = ((&denoised - previous)? / r0)?;
+                let coeff = (-h).exp_m1();
+                let first = (sample * (sigma_t / sigma_s0))?;
+                let first = (first - (&denoised * coeff)?)?;
+                (first - (d1 * (0.5 * coeff))?)?
+            }
+        };
+
+        self.previous_denoised = Some(denoised);
+        self.step_index += 1;
+        Ok(prev_sample)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use candle_core::Device;
+
+    #[test]
+    fn upstream_schedule_endpoints_and_noise_scale_are_exact() {
+        let scheduler = PlaygroundEdmScheduler::new(50, 0).unwrap();
+        assert!((scheduler.sigmas[0] - 80.0).abs() < 1e-12);
+        assert!((scheduler.sigmas[49] - 0.002).abs() < 1e-12);
+        assert_eq!(scheduler.sigmas[50], 0.0);
+        assert!((scheduler.timesteps[0] - 0.25 * 80.0f64.ln()).abs() < 1e-12);
+        assert!((PlaygroundEdmScheduler::init_noise_sigma() - 80.00624975587844).abs() < 1e-12);
+    }
+
+    #[test]
+    fn terminal_step_returns_edm_preconditioned_x0() {
+        let device = Device::Cpu;
+        let mut scheduler = PlaygroundEdmScheduler::new(1, 0).unwrap();
+        let sample = Tensor::new(&[2.0f32], &device).unwrap();
+        let output = Tensor::new(&[3.0f32], &device).unwrap();
+        let actual = scheduler
+            .step(&output, &sample)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()[0];
+        let denominator = 80.0f64.powi(2) + 0.5f64.powi(2);
+        let expected = 2.0 * (0.25 / denominator) + 3.0 * (40.0 / denominator.sqrt());
+        assert!((actual as f64 - expected).abs() < 1e-6);
+    }
+}

--- a/crates/mold-inference/src/playground_edm.rs
+++ b/crates/mold-inference/src/playground_edm.rs
@@ -77,6 +77,17 @@ impl PlaygroundEdmScheduler {
         original + (noise * self.sigmas[index])?
     }
 
+    /// Re-noise preserved inpaint pixels at the scheduler's current sigma.
+    /// Call after `step`: `step_index` has advanced to the destination sigma,
+    /// including the appended terminal zero.
+    pub(crate) fn add_noise_at_current_sigma(
+        &self,
+        original: &Tensor,
+        noise: &Tensor,
+    ) -> Result<Tensor> {
+        original + (noise * self.sigmas[self.step_index])?
+    }
+
     pub(crate) fn step(&mut self, model_output: &Tensor, sample: &Tensor) -> Result<Tensor> {
         let sigma_s0 = self.sigmas[self.step_index];
         let sigma_t = self.sigmas[self.step_index + 1];
@@ -151,5 +162,31 @@ mod tests {
         let denominator = 80.0f64.powi(2) + 0.5f64.powi(2);
         let expected = 2.0 * (0.25 / denominator) + 3.0 * (40.0 / denominator.sqrt());
         assert!((actual as f64 - expected).abs() < 1e-6);
+    }
+
+    #[test]
+    fn inpaint_blend_uses_destination_sigma_and_clean_terminal_latents() {
+        let device = Device::Cpu;
+        let original = Tensor::new(&[2.0f32], &device).unwrap();
+        let noise = Tensor::new(&[3.0f32], &device).unwrap();
+        let model_output = Tensor::zeros(1, candle_core::DType::F32, &device).unwrap();
+        let mut sample = Tensor::zeros(1, candle_core::DType::F32, &device).unwrap();
+        let mut scheduler = PlaygroundEdmScheduler::new(2, 0).unwrap();
+
+        sample = scheduler.step(&model_output, &sample).unwrap();
+        let intermediate = scheduler
+            .add_noise_at_current_sigma(&original, &noise)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()[0];
+        assert!((intermediate - (2.0 + 3.0 * SIGMA_MIN as f32)).abs() < 1e-6);
+
+        scheduler.step(&model_output, &sample).unwrap();
+        let terminal = scheduler
+            .add_noise_at_current_sigma(&original, &noise)
+            .unwrap()
+            .to_vec1::<f32>()
+            .unwrap()[0];
+        assert_eq!(terminal, 2.0);
     }
 }

--- a/crates/mold-inference/src/scheduler.rs
+++ b/crates/mold-inference/src/scheduler.rs
@@ -45,6 +45,11 @@ pub fn build_scheduler(
             };
             config.build(inference_steps)
         }
+        MoldScheduler::EdmDpmPp2m => {
+            anyhow::bail!(
+                "scheduler '{scheduler}' requires Playground EDM's continuous timesteps and is handled by the SDXL pipeline"
+            )
+        }
         // Wan's flow solvers (#795) never reach the UNet scheduler factory:
         // admission rejects them for every non-wan family, and the wan engine
         // consumes the selection itself. Fail loudly rather than silently

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -1184,11 +1184,8 @@ impl SDXLEngine {
             *latents = scheduler.step(&noise_pred, &*latents)?;
 
             if let Some(ctx) = inpaint_ctx {
-                let noised_original = scheduler.add_noise_at(
-                    &ctx.original_latents,
-                    &ctx.noise,
-                    start_step + step_idx,
-                )?;
+                let noised_original =
+                    scheduler.add_noise_at_current_sigma(&ctx.original_latents, &ctx.noise)?;
                 *latents = crate::img2img::blend_inpaint_latents(&*latents, ctx, &noised_original)?;
             }
 

--- a/crates/mold-inference/src/sdxl/pipeline.rs
+++ b/crates/mold-inference/src/sdxl/pipeline.rs
@@ -92,6 +92,35 @@ fn lora_stack_fingerprint(loras: &[mold_core::LoraWeight]) -> Vec<(String, u64)>
 const VAE_SCALE_STANDARD: f64 = 0.18215;
 /// VAE scaling factor for SDXL Turbo models.
 const VAE_SCALE_TURBO: f64 = 0.13025;
+/// Playground v2.5 trains against per-channel normalized SDXL VAE latents.
+const PLAYGROUND_VAE_SCALE: f64 = 0.5;
+const PLAYGROUND_LATENTS_MEAN: [f32; 4] = [-1.6574, 1.886, -1.383, 2.5155];
+const PLAYGROUND_LATENTS_STD: [f32; 4] = [8.4927, 5.9022, 6.5498, 5.2299];
+
+fn playground_latent_stats(device: &Device, dtype: DType) -> Result<(Tensor, Tensor)> {
+    let mean = Tensor::new(&PLAYGROUND_LATENTS_MEAN, device)?
+        .reshape((1, 4, 1, 1))?
+        .to_dtype(dtype)?;
+    let std = Tensor::new(&PLAYGROUND_LATENTS_STD, device)?
+        .reshape((1, 4, 1, 1))?
+        .to_dtype(dtype)?;
+    Ok((mean, std))
+}
+
+fn normalize_playground_latents(latents: &Tensor) -> Result<Tensor> {
+    let (mean, std) = playground_latent_stats(latents.device(), latents.dtype())?;
+    ((latents - mean.broadcast_as(latents.shape())?)? * PLAYGROUND_VAE_SCALE)?
+        .broadcast_div(&std)
+        .map_err(Into::into)
+}
+
+fn denormalize_playground_latents(latents: &Tensor) -> Result<Tensor> {
+    let (mean, std) = playground_latent_stats(latents.device(), latents.dtype())?;
+    (((latents.broadcast_mul(&std)? / PLAYGROUND_VAE_SCALE)?
+        + mean.broadcast_as(latents.shape())?)?)
+    .to_dtype(latents.dtype())
+    .map_err(Into::into)
+}
 
 fn resolve_sdxl_vae_dtype(default_dtype: DType, single_file: bool) -> DType {
     let default = if single_file {
@@ -953,7 +982,6 @@ impl SDXLEngine {
     ///
     /// `start_step` allows starting from a later timestep for img2img (0 = full txt2img).
     #[allow(clippy::too_many_arguments)]
-    #[allow(clippy::too_many_arguments)]
     fn denoise_loop(
         &self,
         unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
@@ -967,6 +995,19 @@ impl SDXLEngine {
         inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
         identity: Option<&super::identity::ResolvedSdxlIdentity>,
     ) -> Result<()> {
+        if matches!(sched, Scheduler::EdmDpmPp2m) {
+            return self.denoise_loop_playground_edm(
+                unet,
+                text_embeddings,
+                latents,
+                guidance,
+                cfg_plus,
+                steps,
+                start_step,
+                inpaint_ctx,
+                identity,
+            );
+        }
         let use_cfg = cfg_active(guidance);
         let mut scheduler = crate::scheduler::build_scheduler(
             sched,
@@ -1080,6 +1121,91 @@ impl SDXLEngine {
         Ok(())
     }
 
+    #[allow(clippy::too_many_arguments)]
+    fn denoise_loop_playground_edm(
+        &self,
+        unet: &stable_diffusion::unet_2d::UNet2DConditionModel,
+        text_embeddings: &Tensor,
+        latents: &mut Tensor,
+        guidance: f64,
+        cfg_plus: bool,
+        steps: u32,
+        start_step: usize,
+        inpaint_ctx: Option<&crate::img_utils::InpaintContext>,
+        identity: Option<&super::identity::ResolvedSdxlIdentity>,
+    ) -> Result<()> {
+        if start_step >= steps as usize {
+            return Ok(());
+        }
+        if cfg_plus {
+            tracing::warn!(
+                "cfg_plus requested for Playground EDM — using the model's required DPM++ 2M integrator without CFG++"
+            );
+        }
+        let use_cfg = cfg_active(guidance);
+        let mut scheduler =
+            crate::playground_edm::PlaygroundEdmScheduler::new(steps as usize, start_step)?;
+        let timesteps = scheduler.timesteps().to_vec();
+        let active_timesteps = &timesteps[start_step..];
+        let identity_runtime = identity.map(super::identity::ResolvedSdxlIdentity::runtime);
+        if let Some(resolved) = identity {
+            self.base.progress.info(&format!(
+                "Face identity: {} cross-attention modules",
+                resolved.module_count()
+            ));
+        }
+
+        let denoise_label = format!("Denoising ({} EDM steps)", active_timesteps.len());
+        self.base.progress.stage_start(&denoise_label);
+        let denoise_start = Instant::now();
+
+        for (step_idx, &t) in active_timesteps.iter().enumerate() {
+            self.base.progress.checkpoint()?;
+            let step_start = Instant::now();
+            let latent_input = if use_cfg {
+                Tensor::cat(&[&*latents, &*latents], 0)?
+            } else {
+                latents.clone()
+            };
+            let latent_input = scheduler.scale_model_input(&latent_input)?;
+            let hook = identity_runtime
+                .as_ref()
+                .and_then(|runtime| runtime.hook_for_step(start_step + step_idx));
+            let noise_pred = match hook.as_ref() {
+                Some(hook) => unet.forward_with_hook(&latent_input, t, text_embeddings, hook)?,
+                None => unet.forward(&latent_input, t, text_embeddings)?,
+            };
+            let noise_pred = if use_cfg {
+                let chunks = noise_pred.chunk(2, 0)?;
+                (&chunks[0] + ((&chunks[1] - &chunks[0])? * guidance)?)?
+            } else {
+                noise_pred
+            };
+            *latents = scheduler.step(&noise_pred, &*latents)?;
+
+            if let Some(ctx) = inpaint_ctx {
+                let noised_original = scheduler.add_noise_at(
+                    &ctx.original_latents,
+                    &ctx.noise,
+                    start_step + step_idx,
+                )?;
+                *latents = crate::img2img::blend_inpaint_latents(&*latents, ctx, &noised_original)?;
+            }
+
+            self.base.progress.emit(ProgressEvent::DenoiseStep {
+                step: step_idx + 1,
+                total: active_timesteps.len(),
+                elapsed: step_start.elapsed(),
+            });
+        }
+
+        self.base.progress.checkpoint()?;
+        self.base
+            .progress
+            .stage_done(&denoise_label, denoise_start.elapsed());
+        Ok(())
+    }
+
     /// Prepare img2img latents: VAE encode source image, add noise at the appropriate timestep.
     /// Returns (noised_latents, start_step, encoded, noise).
     ///
@@ -1128,8 +1254,12 @@ impl SDXLEngine {
                     device,
                     vae_dtype,
                 )?;
-                let encoded = vae.encode(&source_tensor)?;
-                let encoded = (encoded.mode()? * vae_scale)?;
+                let encoded = vae.encode(&source_tensor)?.mode()?;
+                let encoded = if matches!(sched, Scheduler::EdmDpmPp2m) {
+                    normalize_playground_latents(&encoded)?
+                } else {
+                    (encoded * vae_scale)?
+                };
                 // VAE may have been loaded at fp32 (banding fix); cast the
                 // encoded latents back to engine dtype so the rest of the
                 // denoise loop stays at its natural precision.
@@ -1149,21 +1279,24 @@ impl SDXLEngine {
 
         let start_step = crate::img2img::img2img_start_index(steps as usize, strength);
 
-        let scheduler = crate::scheduler::build_scheduler(
-            sched,
-            steps as usize,
-            PredictionType::Epsilon,
-            self.is_turbo,
-        )?;
-        let timesteps = scheduler.timesteps().to_vec();
-
         let latent_h = height as usize / 8;
         let latent_w = width as usize / 8;
         let noise =
             crate::engine::seeded_randn(seed, &[1, 4, latent_h, latent_w], device, DType::F32)?;
         let noise = noise.to_dtype(dtype)?;
 
-        let noised = if start_step < timesteps.len() {
+        let noised = if start_step < steps as usize && matches!(sched, Scheduler::EdmDpmPp2m) {
+            let scheduler =
+                crate::playground_edm::PlaygroundEdmScheduler::new(steps as usize, start_step)?;
+            scheduler.add_noise_at(&encoded, &noise, start_step)?
+        } else if start_step < steps as usize {
+            let scheduler = crate::scheduler::build_scheduler(
+                sched,
+                steps as usize,
+                PredictionType::Epsilon,
+                self.is_turbo,
+            )?;
+            let timesteps = scheduler.timesteps();
             scheduler.add_noise(&encoded, noise.clone(), timesteps[start_step])?
         } else {
             encoded.clone()
@@ -1511,14 +1644,17 @@ impl SDXLEngine {
         } else {
             let latent_h = height / 8;
             let latent_w = width / 8;
-            let init_scheduler = crate::scheduler::build_scheduler(
-                sched,
-                req.steps as usize,
-                PredictionType::Epsilon,
-                self.is_turbo,
-            )?;
-            let init_noise_sigma = init_scheduler.init_noise_sigma();
-            drop(init_scheduler);
+            let init_noise_sigma = if matches!(sched, Scheduler::EdmDpmPp2m) {
+                crate::playground_edm::PlaygroundEdmScheduler::init_noise_sigma()
+            } else {
+                crate::scheduler::build_scheduler(
+                    sched,
+                    req.steps as usize,
+                    PredictionType::Epsilon,
+                    self.is_turbo,
+                )?
+                .init_noise_sigma()
+            };
             let latents = (crate::engine::seeded_randn(
                 seed,
                 &[1, 4, latent_h, latent_w],
@@ -1578,12 +1714,16 @@ impl SDXLEngine {
         self.base.progress.stage_start("VAE decode");
         let vae_decode_start = Instant::now();
 
-        let vae_scale = if self.is_turbo {
-            VAE_SCALE_TURBO
+        let latents = if matches!(sched, Scheduler::EdmDpmPp2m) {
+            denormalize_playground_latents(&latents)?
         } else {
-            VAE_SCALE_STANDARD
+            let vae_scale = if self.is_turbo {
+                VAE_SCALE_TURBO
+            } else {
+                VAE_SCALE_STANDARD
+            };
+            (latents / vae_scale)?
         };
-        let latents = (latents / vae_scale)?;
         let latents_for_vae = latents.to_dtype(vae_dtype)?;
         let device_for_sync = device.clone();
         let img = crate::vae_tiling::decode_with_oom_fallback(
@@ -1746,14 +1886,17 @@ impl SDXLEngine {
             } else {
                 let latent_h = height / 8;
                 let latent_w = width / 8;
-                let init_scheduler = crate::scheduler::build_scheduler(
-                    sched,
-                    req.steps as usize,
-                    PredictionType::Epsilon,
-                    self.is_turbo,
-                )?;
-                let init_noise_sigma = init_scheduler.init_noise_sigma();
-                drop(init_scheduler);
+                let init_noise_sigma = if matches!(sched, Scheduler::EdmDpmPp2m) {
+                    crate::playground_edm::PlaygroundEdmScheduler::init_noise_sigma()
+                } else {
+                    crate::scheduler::build_scheduler(
+                        sched,
+                        req.steps as usize,
+                        PredictionType::Epsilon,
+                        self.is_turbo,
+                    )?
+                    .init_noise_sigma()
+                };
                 let latents = (crate::engine::seeded_randn(
                     seed,
                     &[1, 4, latent_h, latent_w],
@@ -1807,12 +1950,16 @@ impl SDXLEngine {
         self.base.progress.stage_start("VAE decode");
         let vae_start = Instant::now();
 
-        let vae_scale = if self.is_turbo {
-            VAE_SCALE_TURBO
+        let latents = if matches!(sched, Scheduler::EdmDpmPp2m) {
+            denormalize_playground_latents(&latents)?
         } else {
-            VAE_SCALE_STANDARD
+            let vae_scale = if self.is_turbo {
+                VAE_SCALE_TURBO
+            } else {
+                VAE_SCALE_STANDARD
+            };
+            (latents / vae_scale)?
         };
-        let latents = (latents / vae_scale)?;
         let latents_for_vae = latents.to_dtype(loaded.vae_dtype)?;
         let vae = &loaded.vae;
         let device_for_sync = loaded.device.clone();
@@ -1972,6 +2119,26 @@ mod tests {
     use std::collections::HashMap;
     use std::sync::{Arc, Mutex};
     use tokenizers::models::bpe::BPE;
+
+    #[test]
+    fn playground_latent_normalization_round_trips_all_channels() {
+        let device = Device::Cpu;
+        let latents = Tensor::new(&[[[[1.0f32]], [[-2.0]], [[3.5]], [[0.25]]]], &device).unwrap();
+        let normalized = normalize_playground_latents(&latents).unwrap();
+        let restored = denormalize_playground_latents(&normalized).unwrap();
+        let delta = (&restored - &latents)
+            .unwrap()
+            .abs()
+            .unwrap()
+            .max_all()
+            .unwrap()
+            .to_scalar::<f32>()
+            .unwrap();
+        assert!(
+            delta < 1e-5,
+            "Playground latent transform drifted by {delta}"
+        );
+    }
 
     /// Synthesise a minimal SDXL-shaped single-file safetensors with one
     /// representative key per component bucket. Tensor data is one zero

--- a/crates/mold-inference/src/wan/pipeline.rs
+++ b/crates/mold-inference/src/wan/pipeline.rs
@@ -602,7 +602,7 @@ fn resolve_wan_solver(
             Scheduler::UniPc => Ok(WanSolverKind::UniPc),
             Scheduler::Euler => Ok(WanSolverKind::Euler),
             Scheduler::DpmPp => Ok(WanSolverKind::DpmPp),
-            Scheduler::Ddim | Scheduler::EulerAncestral => bail!(
+            Scheduler::Ddim | Scheduler::EulerAncestral | Scheduler::EdmDpmPp2m => bail!(
                 "Wan supports the uni-pc, euler, and dpm-pp sample solvers; '{scheduler}' is a \
                  UNet scheduler"
             ),

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -6441,8 +6441,11 @@ impl App {
                     Some(Scheduler::EulerAncestral) => Some(Scheduler::UniPc),
                     Some(Scheduler::UniPc) => None,
                     // Wan flow solvers are not part of the SD scheduler row's
-                    // cycle; a stale restored value resets to the default.
-                    Some(Scheduler::Euler) | Some(Scheduler::DpmPp) => None,
+                    // cycle; model-specific EDM and stale Wan values reset to
+                    // the manifest default.
+                    Some(Scheduler::EdmDpmPp2m)
+                    | Some(Scheduler::Euler)
+                    | Some(Scheduler::DpmPp) => None,
                 };
             }
             // Enter on the merged Seed row edits the value (◀▶ cycles mode)
@@ -6844,7 +6847,13 @@ impl App {
                 key: SettingsKey::ModelScheduler,
                 label: "Scheduler",
                 field_type: SettingsFieldType::Toggle {
-                    options: vec!["(none)", "ddim", "euler-ancestral", "uni-pc"],
+                    options: vec![
+                        "(none)",
+                        "ddim",
+                        "euler-ancestral",
+                        "uni-pc",
+                        "edm-dpm-pp-2m",
+                    ],
                 },
             });
             rows.push(SettingsRow::Field {
@@ -7304,6 +7313,7 @@ impl App {
                             "ddim" => Some(Scheduler::Ddim),
                             "euler-ancestral" => Some(Scheduler::EulerAncestral),
                             "uni-pc" => Some(Scheduler::UniPc),
+                            "edm-dpm-pp-2m" => Some(Scheduler::EdmDpmPp2m),
                             _ => None,
                         };
                     }

--- a/docs/generated/generation-profiles-v1.json
+++ b/docs/generated/generation-profiles-v1.json
@@ -26907,7 +26907,7 @@
       "profile": {
         "schema_version": 1,
         "profile_id": "sdxl.playground-v2.5",
-        "profile_hash": "040f10f4eaf21b8a73af6eaa9bf8f827998278586b80eda6185af461709e4dbc",
+        "profile_hash": "86e278946573501e9d6955d5c165aa89534322a649fde435fc682282546ebf9d",
         "default_recipe_id": "default",
         "recipes": [
           {
@@ -26917,7 +26917,7 @@
             "defaults": {
               "width": 1024,
               "height": 1024,
-              "steps": 25,
+              "steps": 50,
               "guidance": 3.0
             },
             "resolution": {
@@ -27038,12 +27038,12 @@
               ]
             },
             "steps": {
-              "default": 25,
+              "default": 50,
               "min": 1,
               "max": 100,
               "step": 1,
               "recommended": [
-                25
+                50
               ],
               "mode": "adjustable"
             },
@@ -27113,9 +27113,7 @@
                 "reason": "Wan sampler controls apply only to Wan models."
               },
               "schedulers": [
-                "ddim",
-                "euler-ancestral",
-                "uni-pc"
+                "edm-dpm-pp-2m"
               ]
             },
             "provenance": [

--- a/docs/model-resolution-matrix.md
+++ b/docs/model-resolution-matrix.md
@@ -2457,14 +2457,14 @@ Provenance: MoldPolicy `mold-qualified compatibility profile`, qualified: `true`
 
 ### `playground-v2.5:fp16`
 
-Schema 1 · hash `040f10f4eaf21b8a73af6eaa9bf8f827998278586b80eda6185af461709e4dbc` · default recipe `default`
+Schema 1 · hash `86e278946573501e9d6955d5c165aa89534322a649fde435fc682282546ebf9d` · default recipe `default`
 
 Models: `playground-v2.5:fp16`.
 
 #### Default (`default`)
 
 - Resolution: dynamic; alignment `16`; minimum `64x64`; maximum `1800000` pixels; axis limit `none`; aspect range `unbounded`.
-- Defaults: `1024x1024`, 25 steps, guidance 3.
+- Defaults: `1024x1024`, 50 steps, guidance 3.
 - Steps: 1–100 by 1; guidance: 0–100 by 0.1 (Adjustable).
 
 | Exact ratio | Qualified presets |

--- a/studio/lib/generated/generationProfileV1.ts
+++ b/studio/lib/generated/generationProfileV1.ts
@@ -75,7 +75,7 @@ fixed_scale?: number | null, };
 
 export type SourceImageCapability = "unsupported" | "optional" | "required";
 
-export type Scheduler = "ddim" | "euler-ancestral" | "uni-pc" | "euler" | "dpm-pp";
+export type Scheduler = "ddim" | "euler-ancestral" | "uni-pc" | "edm-dpm-pp-2m" | "euler" | "dpm-pp";
 
 export type GenerationCapabilitiesProfile = { guidance: GuidanceCapabilities, negative_prompt: FeatureControlProfile, source_image?: SourceImageCapability | null, supports_lora: boolean, supports_controlnet: boolean,
 /**

--- a/studio/lib/generationCapabilities.ts
+++ b/studio/lib/generationCapabilities.ts
@@ -21,7 +21,13 @@ export { isMinimaxH3Family } from "./minimaxH3Authoring";
  * wan solver off-family and a UNet scheduler on wan.
  */
 export type GenerationScheduler =
-  "default" | "ddim" | "euler-ancestral" | "uni-pc" | "euler" | "dpm-pp";
+  | "default"
+  | "ddim"
+  | "euler-ancestral"
+  | "uni-pc"
+  | "edm-dpm-pp-2m"
+  | "euler"
+  | "dpm-pp";
 
 export type SourceImageMode =
   | "single"
@@ -127,6 +133,7 @@ const SCHEDULER_LABELS: Record<GenerationScheduler, string> = {
   ddim: "DDIM",
   "euler-ancestral": "Euler ancestral",
   "uni-pc": "UniPC",
+  "edm-dpm-pp-2m": "EDM DPM++ 2M",
   euler: "Euler",
   "dpm-pp": "DPM++",
 };

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -67,7 +67,8 @@ export type Scheduler =
   | GenerationScheduler
   | { ddim: unknown }
   | { "euler-ancestral": unknown }
-  | { "uni-pc": unknown };
+  | { "uni-pc": unknown }
+  | { "edm-dpm-pp-2m": unknown };
 
 export interface OutputMetadata {
   /** User-facing authoring mode; independent of internal auto-chaining. */


### PR DESCRIPTION
## Summary

- implement the official Playground v2.5 EDM DPM++ 2M Karras sampling contract
- apply the model-specific VAE latent mean/std normalization
- expose and validate the scheduler consistently across CLI, API profiles, web, desktop, and TUI
- fix destination-sigma inpaint blending and reject invalid scheduler/model combinations before inference

## Root cause

Playground v2.5 was routed through Mold's standard SDXL DDIM path with the ordinary SDXL VAE scale. Upstream uses continuous EDM timesteps, sigma-data preconditioning, DPM++ 2M midpoint integration, and per-channel latent normalization. The mismatch produced noise-only output.

## Verification

- independent sub-agent review found and verified fixes for the TUI enum gate and inpaint destination sigma; final re-review clean
- `nix develop -c cargo check -p mold-ai-tui -p mold-ai --all-targets`
- `nix develop -c cargo clippy -p mold-ai-core -p mold-ai-db -p mold-ai-inference -p mold-ai-tui --all-targets -- -D warnings`
- focused core manifest, validation, scheduler, latent normalization, and inpaint tests
- focused Studio and web generation-capability tests
- formatting, generated-profile, changelog-policy, and diff checks
- two coherent 1024x1024 Metal renders at 50 steps / guidance 3.0, seeds 42 and 314159, indexed in the external Mold Library
