### PR TITLE
fix(catalog): add SD3 family discovery

### DIFF
--- a/changelog.d/sd3-model-family.md
+++ b/changelog.d/sd3-model-family.md
@@ -1,0 +1,1 @@
+- **Discover SD3.5 models.** Show Stable Diffusion 3.5 in the Models family picker and return matching installable Hugging Face models across desktop, web, and mobile.

--- a/crates/mold-catalog/src/civitai_map.rs
+++ b/crates/mold-catalog/src/civitai_map.rs
@@ -189,7 +189,7 @@ pub fn supported_for(family: Family, bundling: Bundling, kind: Kind) -> bool {
         // don't inherit checkpoint runnability rules.
         Lora => matches!(
             family,
-            Flux | Flux2 | Sd15 | Sdxl | ZImage | Ltx2 | Wan | QwenImage
+            Flux | Flux2 | Sd15 | Sdxl | Sd3 | ZImage | Ltx2 | Wan | QwenImage
         ),
         Vae | TextEncoder | Tokenizer | Clip => true,
         ControlNet => matches!(family, Sd15 | Sdxl),
@@ -197,6 +197,30 @@ pub fn supported_for(family: Family, bundling: Bundling, kind: Kind) -> bool {
     }
 }
 
-fn supported_for_checkpoint(_family: Family, _bundling: Bundling) -> bool {
-    true
+fn supported_for_checkpoint(family: Family, bundling: Bundling) -> bool {
+    // SD3.5 is runnable from a complete separated Diffusers repository. A
+    // bare bundled transformer needs the three text encoders and VAE that the
+    // catalog does not yet synthesize as companions, so do not advertise that
+    // shape as runnable.
+    family != Family::Sd3 || bundling == Bundling::Separated
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sd3_support_requires_a_complete_separated_repository() {
+        assert!(supported_for(
+            Family::Sd3,
+            Bundling::Separated,
+            Kind::Checkpoint
+        ));
+        assert!(!supported_for(
+            Family::Sd3,
+            Bundling::SingleFile,
+            Kind::Checkpoint
+        ));
+        assert!(supported_for(Family::Sd3, Bundling::SingleFile, Kind::Lora));
+    }
 }

--- a/crates/mold-catalog/src/companions.rs
+++ b/crates/mold-catalog/src/companions.rs
@@ -367,6 +367,10 @@ pub fn companions_for(
             push(&mut out, "clip-g");
             push(&mut out, "sdxl-vae");
         }
+        // Live SD3.5 discovery is limited to complete separated Diffusers
+        // repositories. Bundled checkpoints are marked unsupported until a
+        // reviewed SD3 companion graph exists.
+        Family::Sd3 => {}
         Family::ZImage => {
             push(&mut out, "z-image-te");
         }

--- a/crates/mold-catalog/src/defaults.rs
+++ b/crates/mold-catalog/src/defaults.rs
@@ -134,6 +134,15 @@ pub fn runtime_defaults_for_family(
             frames: None,
             fps: None,
         },
+        "sd3" | "sd3.5" => CatalogRuntimeDefaults {
+            width: 1024,
+            height: 1024,
+            steps: 28,
+            guidance: 4.0,
+            is_schnell: None,
+            frames: None,
+            fps: None,
+        },
         "sd15" => CatalogRuntimeDefaults {
             width: 512,
             height: 512,
@@ -192,6 +201,11 @@ mod tests {
         let flux = runtime_defaults_for_family("flux", None);
         assert_eq!(flux.frames, None);
         assert_eq!(flux.fps, None);
+
+        let sd3 = runtime_defaults_for_family("sd3", None);
+        assert_eq!((sd3.width, sd3.height), (1024, 1024));
+        assert_eq!((sd3.steps, sd3.guidance), (28, 4.0));
+        assert_eq!((sd3.frames, sd3.fps), (None, None));
     }
 
     /// Wan's timing splits on VAE generation, and the sub-family name is the

--- a/crates/mold-catalog/src/families.rs
+++ b/crates/mold-catalog/src/families.rs
@@ -12,6 +12,7 @@ pub enum Family {
     Flux2,
     Sd15,
     Sdxl,
+    Sd3,
     ZImage,
     LtxVideo,
     Ltx2,
@@ -26,6 +27,7 @@ pub const ALL_FAMILIES: &[Family] = &[
     Family::Flux2,
     Family::Sd15,
     Family::Sdxl,
+    Family::Sd3,
     Family::ZImage,
     Family::LtxVideo,
     Family::Ltx2,
@@ -62,6 +64,7 @@ impl Family {
             Family::Flux2 => "flux2",
             Family::Sd15 => "sd15",
             Family::Sdxl => "sdxl",
+            Family::Sd3 => "sd3",
             Family::ZImage => "z-image",
             Family::LtxVideo => "ltx-video",
             Family::Ltx2 => "ltx2",
@@ -89,6 +92,7 @@ impl Family {
             | Family::Flux2
             | Family::Sd15
             | Family::Sdxl
+            | Family::Sd3
             | Family::ZImage
             | Family::QwenImage
             | Family::Wuerstchen => false,
@@ -102,6 +106,7 @@ impl Family {
             "flux2" => Family::Flux2,
             "sd15" => Family::Sd15,
             "sdxl" => Family::Sdxl,
+            "sd3" | "sd3.5" | "stable-diffusion-3" | "stable-diffusion-3.5" => Family::Sd3,
             "z-image" => Family::ZImage,
             "ltx-video" => Family::LtxVideo,
             "ltx2" => Family::Ltx2,
@@ -139,5 +144,16 @@ mod tests {
         let families = active_families().collect::<Vec<_>>();
         assert!(families.contains(&Family::MinimaxH3));
         assert!(families.contains(&Family::Flux));
+    }
+
+    #[test]
+    fn sd3_aliases_use_the_manifest_family_slug() {
+        for alias in ["sd3", "sd3.5", "stable-diffusion-3", "stable-diffusion-3.5"] {
+            let family = Family::from_str(alias).unwrap();
+            assert_eq!(family, Family::Sd3);
+            assert_eq!(family.as_str(), "sd3");
+            assert!(!family.is_video());
+        }
+        assert!(active_families().any(|family| family == Family::Sd3));
     }
 }

--- a/crates/mold-catalog/src/hf_seeds.rs
+++ b/crates/mold-catalog/src/hf_seeds.rs
@@ -21,9 +21,14 @@ pub fn seeds_for(family: Family) -> &'static [&'static str] {
             "stable-diffusion-v1-5/stable-diffusion-v1-5",
         ],
         Sdxl => &["stabilityai/stable-diffusion-xl-base-1.0"],
+        Sd3 => &[
+            "stabilityai/stable-diffusion-3.5-large",
+            "stabilityai/stable-diffusion-3.5-large-turbo",
+            "stabilityai/stable-diffusion-3.5-medium",
+        ],
         ZImage => &["Tongyi-MAI/Z-Image-Turbo", "Tongyi-MAI/Z-Image-Base"],
         LtxVideo => &["Lightricks/LTX-Video"],
-        Ltx2 => &["Lightricks/LTX-Video-2", "Lightricks/LTX-Video-2.3"],
+        Ltx2 => &["Lightricks/LTX-2", "Lightricks/LTX-2.3"],
         // Upstream's own releases plus the two repack lines mold's manifests
         // actually pull from — a user searching "wan" should see those ranked
         // as foundations rather than buried under community fine-tunes.

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -1089,6 +1089,30 @@ async fn hf_search_paged(
     Ok(result)
 }
 
+/// Upstream query used when a family filter has no user-entered search text.
+///
+/// Hugging Face has no structured family filter. Fetching its generic
+/// downloads-sorted window and filtering locally leaves less common families
+/// empty even though matching repositories exist beyond that window. Keep the
+/// query terms here exhaustive so every taxonomy addition must choose an
+/// upstream spelling before it can compile.
+fn hf_family_search_term(family: Family) -> &'static str {
+    match family {
+        Family::Flux => "flux.1",
+        Family::Flux2 => "flux.2",
+        Family::Sd15 => "stable-diffusion-v1",
+        Family::Sdxl => "stable-diffusion-xl",
+        Family::Sd3 => "stable-diffusion-3.5",
+        Family::ZImage => "z-image",
+        Family::LtxVideo => "ltx-video",
+        Family::Ltx2 => "ltx-2",
+        Family::Wan => "wan2",
+        Family::MinimaxH3 => "minimax-h3",
+        Family::QwenImage => "qwen-image",
+        Family::Wuerstchen => "wuerstchen",
+    }
+}
+
 /// HF `/api/models?search=…` summary row. Lean compared to the per-repo
 /// detail; `tree` is fetched lazily on download (`fetch_hf_repo`).
 #[derive(Clone, Debug, Deserialize)]
@@ -1118,13 +1142,14 @@ async fn hf_search(base: &str, opts: &LiveSearchOpts) -> Result<LiveSearchResult
     let mut url =
         reqwest::Url::parse(&format!("{base}/api/models")).expect("hf base URL must be valid");
     let trimmed_q = opts.q.as_deref().map(str::trim).filter(|s| !s.is_empty());
+    let upstream_search = trimmed_q.or_else(|| opts.family.map(hf_family_search_term));
     {
         let mut q = url.query_pairs_mut();
         let window = opts.page.saturating_mul(opts.page_size).clamp(1, 1000);
         q.append_pair("limit", &window.to_string());
         q.append_pair("sort", opts.sort.hf_value());
         q.append_pair("direction", "-1");
-        if let Some(query) = trimmed_q {
+        if let Some(query) = upstream_search {
             q.append_pair("search", query);
         }
         // Pin to diffusers / text-to-image / image-to-video so the search
@@ -1390,6 +1415,12 @@ pub fn family_from_hf(
         Family::QwenImage
     } else if id_lower.contains("wuerstchen") {
         Family::Wuerstchen
+    } else if id_lower.contains("stable-diffusion-3.5")
+        || id_lower.contains("stable-diffusion-3-")
+        || id_lower.contains("/sd3.5")
+        || id_lower.contains("/sd3-")
+    {
+        Family::Sd3
     } else if id_lower.contains("stable-diffusion-xl") || id_lower.contains("sdxl") {
         Family::Sdxl
     } else if id_lower.contains("stable-diffusion-v1")
@@ -1402,16 +1433,22 @@ pub fn family_from_hf(
         let mut matched: Option<Family> = None;
         for tag in tags {
             let t = tag.to_ascii_lowercase();
-            matched = match t.as_str() {
-                "flux" => Some(Family::Flux),
-                "flux.2" | "flux2" => Some(Family::Flux2),
-                "stable-diffusion-xl" | "sdxl" => Some(Family::Sdxl),
-                "stable-diffusion" => Some(Family::Sd15),
-                // Safe as an exact tag where it is unsafe as a substring:
-                // a repo that tags itself `wan` is claiming the family.
-                "wan" => Some(Family::Wan),
-                "minimax-h3" | "minimax_h3" | "minimaxh3" => Some(Family::MinimaxH3),
-                _ => continue,
+            matched = if t.starts_with("base_model:stabilityai/stable-diffusion-3")
+                || t == "diffusers:stablediffusion3pipeline"
+            {
+                Some(Family::Sd3)
+            } else {
+                match t.as_str() {
+                    "flux" => Some(Family::Flux),
+                    "flux.2" | "flux2" => Some(Family::Flux2),
+                    "stable-diffusion-xl" | "sdxl" => Some(Family::Sdxl),
+                    "stable-diffusion" => Some(Family::Sd15),
+                    // Safe as an exact tag where it is unsafe as a substring:
+                    // a repo that tags itself `wan` is claiming the family.
+                    "wan" => Some(Family::Wan),
+                    "minimax-h3" | "minimax_h3" | "minimaxh3" => Some(Family::MinimaxH3),
+                    _ => continue,
+                }
             };
             break;
         }
@@ -1788,6 +1825,28 @@ mod tests {
     }
 
     #[test]
+    fn hf_family_search_terms_follow_current_upstream_names() {
+        let cases = [
+            (Family::Flux, "flux.1"),
+            (Family::Flux2, "flux.2"),
+            (Family::Sd15, "stable-diffusion-v1"),
+            (Family::Sdxl, "stable-diffusion-xl"),
+            (Family::Sd3, "stable-diffusion-3.5"),
+            (Family::ZImage, "z-image"),
+            (Family::LtxVideo, "ltx-video"),
+            (Family::Ltx2, "ltx-2"),
+            (Family::Wan, "wan2"),
+            (Family::MinimaxH3, "minimax-h3"),
+            (Family::QwenImage, "qwen-image"),
+            (Family::Wuerstchen, "wuerstchen"),
+        ];
+        assert_eq!(cases.len(), crate::families::ALL_FAMILIES.len());
+        for (family, expected) in cases {
+            assert_eq!(hf_family_search_term(family), expected, "{family}");
+        }
+    }
+
+    #[test]
     fn page_offset_is_safe_for_zero_and_maximum_caller_values() {
         assert_eq!(page_offset(&LiveSearchOpts::default()), 0);
         assert_eq!(
@@ -1845,6 +1904,45 @@ mod tests {
         assert!(result.entries[0].id.0.contains("dev-3"));
         assert!(result.entries[1].id.0.contains("dev-4"));
         assert_eq!(result.total, 5, "a full window must advertise another page");
+    }
+
+    #[tokio::test]
+    async fn hf_family_filter_constrains_the_upstream_window_for_sd3() {
+        let server = MockServer::start().await;
+        let hits = vec![serde_json::json!({
+            "id": "city96/stable-diffusion-3.5-medium-gguf",
+            "tags": [
+                "diffusers",
+                "base_model:stabilityai/stable-diffusion-3.5-medium"
+            ],
+            "pipeline_tag": "text-to-image"
+        })];
+        Mock::given(method("GET"))
+            .and(path("/api/models"))
+            .and(query_param("search", "stable-diffusion-3.5"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(hits))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = hf_search(
+            &server.uri(),
+            &LiveSearchOpts {
+                family: Some(Family::Sd3),
+                source: Some(Source::Hf),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("SD3 family page");
+
+        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.entries[0].family, Family::Sd3);
+        assert_eq!(
+            result.entries[0].source_id,
+            "city96/stable-diffusion-3.5-medium-gguf"
+        );
+        server.verify().await;
     }
 
     /// Real Civitai ignores `page=` entirely — `/api/v1/models` is

--- a/crates/mold-catalog/src/synthesis.rs
+++ b/crates/mold-catalog/src/synthesis.rs
@@ -282,9 +282,12 @@ pub fn family_bundles_vae_unconditionally(family: Family) -> bool {
         // the VAE in its own file, and the GGUF experts could not bundle one
         // even in principle. So there is nothing to probe for and the resolver
         // routes straight to the VAE companion.
-        Family::Flux2 | Family::ZImage | Family::LtxVideo | Family::Wan | Family::MinimaxH3 => {
-            false
-        }
+        Family::Flux2
+        | Family::Sd3
+        | Family::ZImage
+        | Family::LtxVideo
+        | Family::Wan
+        | Family::MinimaxH3 => false,
         Family::QwenImage | Family::Wuerstchen => false,
     }
 }

--- a/crates/mold-catalog/tests/families_roundtrip.rs
+++ b/crates/mold-catalog/tests/families_roundtrip.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeSet;
+
 use mold_catalog::families::{Family, ALL_FAMILIES};
 
 #[test]
@@ -19,6 +21,7 @@ fn manifest_strings_are_stable() {
         (Family::Flux2, "flux2"),
         (Family::Sd15, "sd15"),
         (Family::Sdxl, "sdxl"),
+        (Family::Sd3, "sd3"),
         (Family::ZImage, "z-image"),
         (Family::LtxVideo, "ltx-video"),
         (Family::Ltx2, "ltx2"),
@@ -30,6 +33,40 @@ fn manifest_strings_are_stable() {
         assert_eq!(fam.as_str(), s, "{:?} → {s}", fam);
         assert_eq!(Family::from_str(s).unwrap(), fam, "{s} → {:?}", fam);
     }
+}
+
+/// The manifest registry is the shipped-model authority; the Models taxonomy
+/// must cover every visible generation family in it. Qwen Image Edit is the
+/// one deliberate presentation merge, sharing the Qwen Image catalog shelf.
+/// Utility manifests are not generation families and never belong in the
+/// family picker.
+#[test]
+fn catalog_taxonomy_covers_every_visible_generation_manifest_family() {
+    const UTILITY_FAMILIES: &[&str] = &[
+        "companion",
+        "controlnet",
+        "ltx2-camera-control",
+        "ltx2-control",
+        "qwen3-expand",
+        "upscaler",
+    ];
+
+    let manifest_families = mold_core::manifest::visible_manifests()
+        .filter_map(|manifest| {
+            let family = match manifest.family.as_str() {
+                "qwen-image-edit" => "qwen-image",
+                family if UTILITY_FAMILIES.contains(&family) => return None,
+                family => family,
+            };
+            Some(family.to_string())
+        })
+        .collect::<BTreeSet<_>>();
+    let catalog_families = ALL_FAMILIES
+        .iter()
+        .map(|family| family.as_str().to_string())
+        .collect::<BTreeSet<_>>();
+
+    assert_eq!(catalog_families, manifest_families);
 }
 
 /// `is_video` and the runtime-defaults table are two statements of the same

--- a/crates/mold-catalog/tests/live_search.rs
+++ b/crates/mold-catalog/tests/live_search.rs
@@ -884,10 +884,13 @@ fn family_from_hf_id_substring() {
         ("black-forest-labs/FLUX.1-dev", Family::Flux),
         ("black-forest-labs/FLUX.2-dev", Family::Flux2),
         ("Lightricks/LTX-Video-2.3", Family::Ltx2),
+        ("Lightricks/LTX-2.3", Family::Ltx2),
         ("Lightricks/LTX-Video", Family::LtxVideo),
         ("MiniMaxAI/MiniMax-H3", Family::MinimaxH3),
         ("someone/MiniMax-H3-FL2VA-finetune", Family::MinimaxH3),
         ("stabilityai/stable-diffusion-xl-base-1.0", Family::Sdxl),
+        ("stabilityai/stable-diffusion-3.5-large", Family::Sd3),
+        ("city96/stable-diffusion-3.5-medium-gguf", Family::Sd3),
         ("Tongyi-MAI/Z-Image-Turbo", Family::ZImage),
     ];
     for (id, want) in cases {
@@ -905,6 +908,25 @@ fn family_from_hf_id_substring() {
             "H3 lookalike {id} must not be classified"
         );
     }
+}
+
+#[test]
+fn family_from_hf_recognizes_sd3_metadata_without_misclassifying_sd15() {
+    for tags in [
+        vec!["diffusers:StableDiffusion3Pipeline".to_string()],
+        vec!["base_model:stabilityai/stable-diffusion-3.5-large".to_string()],
+    ] {
+        let (family, _) = family_from_hf("someone/opaque-image-model", &tags, None).unwrap();
+        assert_eq!(family, Family::Sd3);
+    }
+
+    let (family, _) = family_from_hf(
+        "stabilityai/stable-diffusion-v1-5",
+        &["stable-diffusion".to_string()],
+        None,
+    )
+    .unwrap();
+    assert_eq!(family, Family::Sd15);
 }
 
 /// Every spelling of Wan that the ecosystem actually ships must land on the

--- a/crates/mold-server/src/catalog_live_test.rs
+++ b/crates/mold-server/src/catalog_live_test.rs
@@ -747,6 +747,28 @@ fn flux2_dev_hugging_face_checkpoint_is_offered_as_one_builtin_download() {
 }
 
 #[test]
+fn sd3_hugging_face_support_is_limited_to_unambiguous_builtin_repositories() {
+    let mut built_in = hf_checkpoint("city96/stable-diffusion-3.5-medium-gguf");
+    built_in.family = mold_catalog::families::Family::Sd3;
+    let tmp = tempfile::tempdir().expect("tempdir");
+
+    assert!(super::hf_repo_has_one_builtin_model(&built_in.source_id));
+    assert!(super::entry_download_supported(&built_in));
+    assert_eq!(
+        super::live_entry_to_wire(&built_in, tmp.path())["supported"],
+        true
+    );
+
+    let mut arbitrary = hf_checkpoint("someone/arbitrary-sd3.5-diffusers");
+    arbitrary.family = mold_catalog::families::Family::Sd3;
+    assert!(!super::entry_download_supported(&arbitrary));
+    assert_eq!(
+        super::live_entry_to_wire(&arbitrary, tmp.path())["supported"],
+        false
+    );
+}
+
+#[test]
 fn named_ltx23_bf16_manifests_remain_downloadable() {
     for model in ["ltx-2.3-22b-dev:bf16", "ltx-2.3-22b-distilled:bf16"] {
         let entry = hf_checkpoint(model);

--- a/crates/mold-server/tests/catalog_routes.rs
+++ b/crates/mold-server/tests/catalog_routes.rs
@@ -17,6 +17,7 @@ async fn families_endpoint_returns_static_taxonomy() {
         "flux2",
         "sd15",
         "sdxl",
+        "sd3",
         "z-image",
         "ltx-video",
         "ltx2",
@@ -52,6 +53,11 @@ async fn capabilities_includes_catalog_block() {
         .unwrap()
         .iter()
         .any(|family| family == "minimax-h3"));
+    assert!(v["catalog"]["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|family| family == "sd3"));
     // The reviewed compact H3 rows are ordinary model identities. Execution
     // availability is advertised by the task/backend capability instead of a
     // family-wide licensing restriction.


### PR DESCRIPTION
## Summary
- add canonical SD3 and SD3.5 catalog taxonomy and Hugging Face classification
- scope Hugging Face upstream searches by family so every Models surface receives populated shelves
- fail closed for unsupported single-file SD3 checkpoints and pin taxonomy completeness to visible manifests

## Validation
- nix develop -c cargo test -p mold-ai-catalog
- nix develop -c cargo clippy -p mold-ai-catalog --tests -- -D warnings
- nix develop -c cargo test -p mold-ai-server --test catalog_routes
- nix develop -c cargo test -p mold-ai-server catalog_api::catalog_live_test::sd3_hugging_face_support_is_limited_to_unambiguous_builtin_repositories
- independent sub-agent peer review: approved with no remaining findings