### PR TITLE
fix(catalog): handle provider overloads gracefully

### DIFF
--- a/changelog.d/civitai-overload-ux.md
+++ b/changelog.d/civitai-overload-ux.md
@@ -1,0 +1,1 @@
+- **Catalog outages recover without alarming errors.** Mold now respects catalog providers' retry timing and presents temporary Civitai or Hugging Face overloads as a calm, retryable notice while keeping available models visible.

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -150,6 +150,9 @@ pub enum LiveSearchError {
         host: &'static str,
         status: u16,
         body: String,
+        /// Upstream-provided delay from `Retry-After`, when present. Search
+        /// retries honor this instead of immediately adding more load.
+        retry_after: Option<Duration>,
     },
 }
 
@@ -408,9 +411,42 @@ pub struct LiveSearchResult {
 pub struct CatalogProviderError {
     pub source: Source,
     pub message: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub code: Option<&'static str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub retry_after_seconds: Option<u64>,
 }
 
 const SEARCH_RETRY_DELAYS: [Duration; 2] = [Duration::from_millis(100), Duration::from_millis(250)];
+const MAX_SEARCH_RETRY_DELAY: Duration = Duration::from_secs(15);
+
+fn upstream_retry_after(error: &LiveSearchError) -> Option<Duration> {
+    match error {
+        LiveSearchError::Upstream { retry_after, .. } => *retry_after,
+        _ => None,
+    }
+}
+
+fn search_retry_delay(error: &LiveSearchError, fallback: Duration) -> Option<Duration> {
+    match upstream_retry_after(error) {
+        Some(delay) if delay > MAX_SEARCH_RETRY_DELAY => None,
+        Some(delay) => Some(delay.max(fallback)),
+        None => Some(fallback),
+    }
+}
+
+fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
+    let raw = headers
+        .get(reqwest::header::RETRY_AFTER)?
+        .to_str()
+        .ok()?
+        .trim();
+    let seconds = raw.parse::<f64>().ok()?;
+    if !seconds.is_finite() || seconds < 0.0 {
+        return None;
+    }
+    Duration::try_from_secs_f64(seconds).ok()
+}
 
 fn retryable_search_error(error: &LiveSearchError) -> bool {
     match error {
@@ -429,13 +465,22 @@ where
     for (attempt, delay) in SEARCH_RETRY_DELAYS.iter().enumerate() {
         match search().await {
             Err(error) if retryable_search_error(&error) => {
+                let Some(delay) = search_retry_delay(&error, *delay) else {
+                    tracing::warn!(
+                        target: "catalog.live",
+                        attempt = attempt + 1,
+                        error = %error,
+                        "catalog provider requested a retry beyond the request wait budget"
+                    );
+                    return Err(error);
+                };
                 tracing::warn!(
                     target: "catalog.live",
                     attempt = attempt + 1,
                     error = %error,
                     "catalog provider request failed; retrying"
                 );
-                tokio::time::sleep(*delay).await;
+                tokio::time::sleep(delay).await;
             }
             result => return result,
         }
@@ -443,14 +488,39 @@ where
     search().await
 }
 
-fn provider_error(source: Source) -> CatalogProviderError {
+fn provider_error(source: Source, error: &LiveSearchError) -> CatalogProviderError {
     let provider = match source {
         Source::Hf => "Hugging Face",
         Source::Civitai => "Civitai",
     };
+    let (code, message) = match error {
+        LiveSearchError::Upstream { status: 429, .. } => (
+            Some("rate-limited"),
+            format!("{provider} is handling too many requests right now. Try again shortly."),
+        ),
+        LiveSearchError::Upstream { status: 503, .. } if source == Source::Civitai => (
+            Some("overloaded"),
+            "Civitai is busy right now. Try again in a few seconds.".into(),
+        ),
+        _ => (None, format!("{provider} is temporarily unavailable.")),
+    };
     CatalogProviderError {
         source,
-        message: format!("{provider} is temporarily unavailable."),
+        message,
+        code,
+        retry_after_seconds: upstream_retry_after(error).map(|delay| delay.as_secs().max(1)),
+    }
+}
+
+fn transient_provider_result(
+    source: Source,
+    error: &LiveSearchError,
+    opts: &LiveSearchOpts,
+) -> LiveSearchResult {
+    LiveSearchResult {
+        entries: Vec::new(),
+        total: page_offset(opts),
+        provider_errors: vec![provider_error(source, error)],
     }
 }
 
@@ -523,10 +593,16 @@ pub async fn search_page(
                     status: 401 | 403, ..
                 },
             ) => return Err(error),
+            Err(error)
+                if matches!(opts.source, Some(Source::Civitai))
+                    && retryable_search_error(&error) =>
+            {
+                return Ok(transient_provider_result(Source::Civitai, &error, opts));
+            }
             Err(error) if matches!(opts.source, Some(Source::Civitai)) => return Err(error),
             Err(error) => {
                 tracing::warn!(target: "catalog.live", error = %error, "civitai search failed");
-                provider_errors.push(provider_error(Source::Civitai));
+                provider_errors.push(provider_error(Source::Civitai, &error));
             }
         }
     }
@@ -543,10 +619,13 @@ pub async fn search_page(
                     status: 401 | 403, ..
                 },
             ) => return Err(e),
+            Err(e) if matches!(opts.source, Some(Source::Hf)) && retryable_search_error(&e) => {
+                return Ok(transient_provider_result(Source::Hf, &e, opts));
+            }
             Err(e) if matches!(opts.source, Some(Source::Hf)) => return Err(e),
             Err(e) => {
                 tracing::warn!(target: "catalog.live", error = %e, "hf search failed");
-                provider_errors.push(provider_error(Source::Hf));
+                provider_errors.push(provider_error(Source::Hf, &e));
             }
         }
     }
@@ -1015,12 +1094,14 @@ async fn civitai_fetch_window(
     }
     let resp = req.send().await?;
     let status = resp.status();
+    let retry_after = parse_retry_after(resp.headers());
     let body = resp.text().await?;
     if !status.is_success() {
         return Err(LiveSearchError::Upstream {
             host: "civitai.com",
             status: status.as_u16(),
             body: body.chars().take(400).collect(),
+            retry_after,
         });
     }
     let parsed: CivitaiResponse = serde_json::from_str(&body)?;
@@ -1148,12 +1229,14 @@ async fn hf_search(base: &str, opts: &LiveSearchOpts) -> Result<LiveSearchResult
     }
     let resp = req.send().await?;
     let status = resp.status();
+    let retry_after = parse_retry_after(resp.headers());
     let body = resp.text().await?;
     if !status.is_success() {
         return Err(LiveSearchError::Upstream {
             host: "huggingface.co",
             status: status.as_u16(),
             body: body.chars().take(400).collect(),
+            retry_after,
         });
     }
     let hits: Vec<HfSearchHit> = serde_json::from_str(&body)?;
@@ -1480,6 +1563,7 @@ pub async fn fetch_civitai_version(
             host: "civitai.com",
             status: status.as_u16(),
             body: body.chars().take(400).collect(),
+            retry_after: None,
         });
     }
     let detail: CivitaiVersionDetail = serde_json::from_str(&body)?;
@@ -1536,6 +1620,7 @@ pub async fn fetch_civitai_version(
         body: format!(
             "model-version {version_id} did not normalize (unsupported kind, missing safetensors, or unknown baseModel)"
         ),
+        retry_after: None,
     })
 }
 
@@ -1564,6 +1649,7 @@ async fn fetch_civitai_model_item(
             host: "civitai.com",
             status: status.as_u16(),
             body: body.chars().take(400).collect(),
+            retry_after: None,
         });
     }
     Ok(serde_json::from_str(&body)?)
@@ -1593,6 +1679,7 @@ pub async fn fetch_entry_by_id(
             host: "catalog",
             status: 400,
             body: format!("'{id}' is not a catalog id (expected a cv: or hf: prefix)"),
+            retry_after: None,
         })
     }
 }
@@ -1628,6 +1715,7 @@ pub async fn fetch_hf_repo(
             host: "huggingface.co",
             status: detail_status.as_u16(),
             body: detail_body.chars().take(400).collect(),
+            retry_after: None,
         });
     }
     let detail: HfDetail = serde_json::from_str(&detail_body)?;
@@ -1639,6 +1727,7 @@ pub async fn fetch_hf_repo(
             host: "huggingface.co",
             status: tree_status.as_u16(),
             body: tree_body.chars().take(400).collect(),
+            retry_after: None,
         });
     }
     let tree: Vec<HfTreeEntry> = serde_json::from_str(&tree_body)?;
@@ -1649,6 +1738,7 @@ pub async fn fetch_hf_repo(
                 host: "huggingface.co",
                 status: 422,
                 body: format!("repo {repo_id} doesn't map to a supported mold family"),
+                retry_after: None,
             },
         )?;
 
@@ -1656,6 +1746,7 @@ pub async fn fetch_hf_repo(
         host: "huggingface.co",
         status: 422,
         body: e.to_string(),
+        retry_after: None,
     })
 }
 
@@ -2414,6 +2505,8 @@ mod tests {
             [CatalogProviderError {
                 source: Source::Hf,
                 message: "Hugging Face is temporarily unavailable.".into(),
+                code: None,
+                retry_after_seconds: None,
             }]
         );
         let requests = server.received_requests().await.expect("requests");
@@ -2461,6 +2554,8 @@ mod tests {
             [CatalogProviderError {
                 source: Source::Civitai,
                 message: "Civitai is temporarily unavailable.".into(),
+                code: None,
+                retry_after_seconds: None,
             }]
         );
     }
@@ -2475,6 +2570,7 @@ mod tests {
                     host: "huggingface.co",
                     status: 502,
                     body: "bad gateway".into(),
+                    retry_after: None,
                 })
             } else {
                 Ok("recovered")
@@ -2485,6 +2581,78 @@ mod tests {
 
         assert_eq!(result, "recovered");
         assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 2);
+    }
+
+    #[test]
+    fn retry_after_delay_wins_over_the_short_local_backoff() {
+        let error = LiveSearchError::Upstream {
+            host: "civitai.com",
+            status: 503,
+            body: "overloaded".into(),
+            retry_after: Some(Duration::from_secs(2)),
+        };
+
+        assert_eq!(
+            search_retry_delay(&error, Duration::from_millis(100)),
+            Some(Duration::from_secs(2))
+        );
+    }
+
+    #[tokio::test]
+    async fn long_retry_after_stops_in_request_retries_without_truncating_notice() {
+        let attempts = std::sync::atomic::AtomicUsize::new(0);
+        let error = retry_search(|| async {
+            attempts.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            Err::<(), _>(LiveSearchError::Upstream {
+                host: "civitai.com",
+                status: 429,
+                body: "slow down".into(),
+                retry_after: Some(Duration::from_secs(60)),
+            })
+        })
+        .await
+        .expect_err("long Retry-After should leave retry timing to the caller");
+
+        assert_eq!(attempts.load(std::sync::atomic::Ordering::SeqCst), 1);
+        let notice = provider_error(Source::Civitai, &error);
+        assert_eq!(notice.retry_after_seconds, Some(60));
+    }
+
+    #[test]
+    fn retry_after_parser_accepts_civitais_seconds_header() {
+        let mut headers = reqwest::header::HeaderMap::new();
+        headers.insert(reqwest::header::RETRY_AFTER, "2".parse().unwrap());
+        assert_eq!(parse_retry_after(&headers), Some(Duration::from_secs(2)));
+    }
+
+    #[tokio::test]
+    async fn source_only_overload_becomes_a_provider_notice() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/models"))
+            .respond_with(
+                ResponseTemplate::new(503)
+                    .insert_header("Retry-After", "0")
+                    .set_body_string("Model search is temporarily overloaded — please retry."),
+            )
+            .expect(3)
+            .mount(&server)
+            .await;
+        let opts = LiveSearchOpts {
+            source: Some(Source::Civitai),
+            ..Default::default()
+        };
+
+        let result = search_page(&server.uri(), &server.uri(), &test_cache(), &opts)
+            .await
+            .expect("a temporary source-only outage is a normal degraded response");
+
+        assert!(result.entries.is_empty());
+        assert_eq!(result.total, 0);
+        assert_eq!(result.provider_errors.len(), 1);
+        assert_eq!(result.provider_errors[0].source, Source::Civitai);
+        assert_eq!(result.provider_errors[0].code, Some("overloaded"));
+        assert!(result.provider_errors[0].message.contains("busy right now"));
     }
 
     #[tokio::test]

--- a/crates/mold-server/src/catalog_api.rs
+++ b/crates/mold-server/src/catalog_api.rs
@@ -937,6 +937,8 @@ pub async fn live_search_catalog(
                         .push(mold_catalog::live::CatalogProviderError {
                             source: failed_source,
                             message: format!("{provider} is temporarily unavailable."),
+                            code: None,
+                            retry_after_seconds: None,
                         });
                     partial
                 }

--- a/crates/mold-server/src/catalog_live_test.rs
+++ b/crates/mold-server/src/catalog_live_test.rs
@@ -48,11 +48,13 @@ fn combined_search_replaces_each_rejected_server_credential() {
         host: "civitai.com",
         status: 401,
         body: "stale".into(),
+        retry_after: None,
     };
     let hf_error = mold_catalog::live::LiveSearchError::Upstream {
         host: "huggingface.co",
         status: 403,
         body: "stale".into(),
+        retry_after: None,
     };
 
     assert!(super::replace_failed_search_credential(
@@ -85,6 +87,7 @@ fn combined_search_retries_without_auth_when_the_server_credential_is_rejected()
         host: "huggingface.co",
         status: 401,
         body: "stale".into(),
+        retry_after: None,
     };
 
     assert!(super::replace_failed_search_credential(
@@ -204,7 +207,9 @@ async fn h3_search_identity_reaches_the_upstream_catalog() {
         "/api/catalog/search?q=MiniMax-H3&source=civitai",
     ] {
         let (status, body) = get(router.clone(), uri).await;
-        assert_eq!(status, StatusCode::BAD_GATEWAY, "{body}");
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let parsed: serde_json::Value = serde_json::from_str(&body).expect("json response");
+        assert_eq!(parsed["provider_errors"][0]["source"], "civitai");
     }
 
     assert_eq!(
@@ -785,6 +790,40 @@ async fn live_search_returns_normalized_civitai_rows() {
         entries[0]["page_url"], "https://civitai.com/models/9001?modelVersionId=8001",
         "wire rows carry the model page link"
     );
+}
+
+#[tokio::test]
+async fn civitai_overload_returns_a_graceful_provider_notice() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(wm_path("/api/v1/models"))
+        .respond_with(
+            ResponseTemplate::new(503)
+                .insert_header("Retry-After", "0")
+                .set_body_json(serde_json::json!({
+                    "error": "Model search is temporarily overloaded — please retry."
+                })),
+        )
+        .expect(3)
+        .mount(&server)
+        .await;
+
+    let state = AppState::for_tests().with_civitai_base(server.uri());
+    let router = create_router(state);
+    let (status, body) = get(
+        router,
+        "/api/catalog/search?q=alien&kind=lora&source=civitai",
+    )
+    .await;
+
+    assert_eq!(status, StatusCode::OK, "{body}");
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json response");
+    assert_eq!(parsed["entries"], serde_json::json!([]));
+    assert_eq!(parsed["provider_errors"][0]["source"], "civitai");
+    assert_eq!(parsed["provider_errors"][0]["code"], "overloaded");
+    assert!(parsed["provider_errors"][0]["message"]
+        .as_str()
+        .is_some_and(|message| message.contains("busy right now")));
 }
 
 #[tokio::test]

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -5847,6 +5847,7 @@ mod tests {
             host: "civitai.com",
             status: 404,
             body: "{\"error\": \"not found\"}".to_string(),
+            retry_after: None,
         };
         let mapped = live_error_to_install_error("cv:42", &upstream);
         assert!(matches!(mapped, mold_core::InstallError::NotFound(_)));
@@ -5858,6 +5859,7 @@ mod tests {
             host: "civitai.com",
             status: 500,
             body: "internal".into(),
+            retry_after: None,
         };
         let mapped = live_error_to_install_error("cv:42", &upstream);
         assert!(matches!(

--- a/desktop/src/components/models/CatalogTab.test.ts
+++ b/desktop/src/components/models/CatalogTab.test.ts
@@ -228,7 +228,14 @@ describe("CatalogTab media filter under pagination", () => {
       page: 1,
       page_size: PAGE_SIZE,
       total: 1,
-      provider_errors: [{ source: "civitai", message: "Civitai is temporarily unavailable." }],
+      provider_errors: [
+        {
+          source: "civitai",
+          code: "overloaded",
+          retry_after_seconds: 2,
+          message: "Civitai is busy right now. Try again in a few seconds.",
+        },
+      ],
     });
     const wrapper = await mountCatalog({
       installedEntries: [
@@ -242,6 +249,12 @@ describe("CatalogTab media filter under pagination", () => {
     });
 
     expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain("Civitai");
+    expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain(
+      "The catalog is catching up.",
+    );
+    expect(wrapper.get("[data-test='catalog-provider-warning']").classes()).toContain(
+      "text-warning",
+    );
     expect(wrapper.text()).toContain("Healthy HF model");
     expect(wrapper.text()).toContain("qwen-image-edit:q4");
 
@@ -254,6 +267,31 @@ describe("CatalogTab media filter under pagination", () => {
     expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain(
       "still unavailable",
     );
+  });
+
+  it("does not claim an unavailable provider returned no matches", async () => {
+    searchCatalog.mockResolvedValue({
+      entries: [],
+      page: 1,
+      page_size: PAGE_SIZE,
+      total: 0,
+      provider_errors: [
+        {
+          source: "civitai",
+          code: "overloaded",
+          retry_after_seconds: 60,
+          message: "Civitai is busy right now. Try again in a few seconds.",
+        },
+      ],
+    });
+
+    const wrapper = await mountCatalog({ query: "Alien" });
+
+    expect(wrapper.get("[data-test='catalog-provider-warning']").text()).toContain(
+      "The catalog is catching up.",
+    );
+    expect(wrapper.find("[data-test='catalog-empty']").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain('Nothing on the shelf for "Alien"');
   });
 
   it("lists Qwen Image Edit models under the Qwen Image family", async () => {

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -416,7 +416,7 @@ async function runSearch(reset: boolean) {
   loading.value = true;
   error.value = null;
   try {
-    for (let fetched = 0; ; ) {
+    for (let fetched = 0; ;) {
       const { target, forward } = catalogTarget();
       const res = await searchCatalog(
         {

--- a/desktop/src/components/models/CatalogTab.vue
+++ b/desktop/src/components/models/CatalogTab.vue
@@ -416,7 +416,7 @@ async function runSearch(reset: boolean) {
   loading.value = true;
   error.value = null;
   try {
-    for (let fetched = 0; ;) {
+    for (let fetched = 0; ; ) {
       const { target, forward } = catalogTarget();
       const res = await searchCatalog(
         {
@@ -785,17 +785,29 @@ onUnmounted(() => {
     <div
       v-if="error || providerErrors.length"
       data-test="catalog-provider-warning"
-      class="border-stop/30 bg-stop/5 flex items-center gap-3 rounded-control border px-3 py-2 text-caption text-stop"
+      class="flex items-center gap-3 rounded-control border px-3 py-2 text-caption"
+      :class="
+        error
+          ? 'border-stop/30 bg-stop/5 text-stop'
+          : 'border-warning/30 bg-warning/10 text-warning'
+      "
       role="alert"
     >
-      <p class="min-w-0 flex-1">
-        {{ error ?? providerErrors.map((item) => item.message).join(" ") }}
-        <span v-if="providerErrors.length"> Showing available models.</span>
-      </p>
+      <div class="min-w-0 flex-1">
+        <p class="font-medium">
+          {{ error ? "Couldn’t refresh the catalog." : "The catalog is catching up." }}
+        </p>
+        <p class="opacity-80">
+          {{ error ?? providerErrors.map((item) => item.message).join(" ") }}
+          <span v-if="providerErrors.length && displayEntries.length">
+            Showing available models.</span
+          >
+        </p>
+      </div>
       <button
         type="button"
         data-test="catalog-retry"
-        class="border-stop/40 shrink-0 rounded-control border px-2 py-1 font-medium hover:bg-stop/10"
+        class="shrink-0 rounded-control border border-current/40 px-2 py-1 font-medium hover:bg-current/10"
         :disabled="loading"
         @click="retrySearch"
       >
@@ -851,7 +863,7 @@ onUnmounted(() => {
     <!-- Empty state — keyed on the FILTERED list so an all-image page under
          the Video chip explains itself instead of rendering a blank grid. -->
     <div
-      v-if="!loading && displayEntries.length === 0"
+      v-if="!loading && displayEntries.length === 0 && !error && providerErrors.length === 0"
       class="p-8 text-center text-body text-ink-2"
       data-test="catalog-empty"
     >

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -436,13 +436,7 @@ export interface ExpandResponse {
 
 export type RemixSourceKind = "original" | "current" | "direct";
 export type RemixDimension =
-  | "composition"
-  | "camera"
-  | "lighting"
-  | "setting"
-  | "mood"
-  | "movement"
-  | "style";
+  "composition" | "camera" | "lighting" | "setting" | "mood" | "movement" | "style";
 
 export interface RemixRequest {
   source_prompt: string;
@@ -1259,13 +1253,7 @@ export interface ChainLimits {
 }
 
 export type ChainJobState =
-  | "queued"
-  | "running"
-  | "paused"
-  | "interrupted"
-  | "failed"
-  | "completed"
-  | "cancelled";
+  "queued" | "running" | "paused" | "interrupted" | "failed" | "completed" | "cancelled";
 
 export type StageState = "pending" | "running" | "completed" | "failed";
 

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -436,7 +436,13 @@ export interface ExpandResponse {
 
 export type RemixSourceKind = "original" | "current" | "direct";
 export type RemixDimension =
-  "composition" | "camera" | "lighting" | "setting" | "mood" | "movement" | "style";
+  | "composition"
+  | "camera"
+  | "lighting"
+  | "setting"
+  | "mood"
+  | "movement"
+  | "style";
 
 export interface RemixRequest {
   source_prompt: string;
@@ -1023,6 +1029,8 @@ export interface CatalogSearchResponse {
 export interface CatalogProviderError {
   source: "hf" | "civitai";
   message: string;
+  code?: "overloaded" | "rate-limited" | string;
+  retry_after_seconds?: number;
 }
 
 /** One family from `GET /api/catalog/families`. */
@@ -1251,7 +1259,13 @@ export interface ChainLimits {
 }
 
 export type ChainJobState =
-  "queued" | "running" | "paused" | "interrupted" | "failed" | "completed" | "cancelled";
+  | "queued"
+  | "running"
+  | "paused"
+  | "interrupted"
+  | "failed"
+  | "completed"
+  | "cancelled";
 
 export type StageState = "pending" | "running" | "completed" | "failed";
 

--- a/desktop/src/mobile/MobileCatalogView.test.ts
+++ b/desktop/src/mobile/MobileCatalogView.test.ts
@@ -1991,13 +1991,22 @@ describe("MobileCatalogView", () => {
   });
 
   it("keeps partial provider rows when a manual retry still fails", async () => {
-    searchCatalog.mockResolvedValueOnce({
+    searchCatalog.mockResolvedValue({
       ...searchResponse([entry("Healthy HF model")]),
-      provider_errors: [{ source: "civitai", message: "Civitai is temporarily unavailable." }],
+      provider_errors: [
+        {
+          source: "civitai",
+          code: "overloaded",
+          retry_after_seconds: 2,
+          message: "Civitai is busy right now. Try again in a few seconds.",
+        },
+      ],
     });
     wrapper = mountCatalog(studio.id, [studio]);
     await flushPromises();
     expect(wrapper.text()).toContain("Healthy HF model");
+    expect(wrapper.text()).toContain("The catalog is catching up.");
+    expect(wrapper.get(".mobile-catalog-error").classes()).toContain("mobile-catalog-warning");
 
     searchCatalog.mockRejectedValueOnce(new Error("still unavailable"));
     await wrapper.get(".mobile-catalog-retry").trigger("click");
@@ -2005,6 +2014,30 @@ describe("MobileCatalogView", () => {
 
     expect(wrapper.text()).toContain("Healthy HF model");
     expect(wrapper.text()).toContain("still unavailable");
+  });
+
+  it("does not claim an unavailable provider returned no matches", async () => {
+    searchCatalog.mockResolvedValueOnce({
+      ...searchResponse([]),
+      provider_errors: [
+        {
+          source: "civitai",
+          code: "overloaded",
+          retry_after_seconds: 60,
+          message: "Civitai is busy right now. Try again in a few seconds.",
+        },
+      ],
+    });
+
+    wrapper = mountCatalog(studio.id, [studio]);
+    await flushPromises();
+    await wrapper.get('[aria-label="Catalog source"] button:last-child').trigger("click");
+    await flushPromises();
+
+    expect(wrapper.text()).toContain("The catalog is catching up.");
+    expect(wrapper.find("[data-test='mobile-catalog-empty']").exists()).toBe(false);
+    expect(wrapper.find(".mobile-catalog-results").exists()).toBe(false);
+    expect(wrapper.text()).not.toContain("No catalog models found.");
   });
 
   it("falls back to the families seen in results when the taxonomy is unavailable", async () => {

--- a/desktop/src/mobile/MobileCatalogView.vue
+++ b/desktop/src/mobile/MobileCatalogView.vue
@@ -145,6 +145,7 @@ const page = ref(1);
 const hasMore = ref(false);
 const loading = ref(false);
 const error = ref("");
+const providerWarning = ref(false);
 const announcement = ref("");
 const announcementIsError = ref(false);
 const modelsByHost = ref<Record<string, ModelEntry[]>>({});
@@ -654,6 +655,7 @@ function scheduleSearch(): void {
     ++searchEpoch;
     loading.value = false;
     error.value = "";
+    providerWarning.value = false;
     return;
   }
   debounce = setTimeout(() => void runSearch(true), 400);
@@ -669,6 +671,7 @@ async function runSearch(reset: boolean): Promise<void> {
   }
   loading.value = true;
   error.value = "";
+  providerWarning.value = false;
   try {
     for (let fetched = 0; ; fetched += 1) {
       const response = await searchCatalog(
@@ -686,7 +689,9 @@ async function runSearch(reset: boolean): Promise<void> {
         target,
       );
       if (epoch !== searchEpoch) return;
-      error.value = (response.provider_errors ?? []).map((item) => item.message).join(" ");
+      const issues = response.provider_errors ?? [];
+      providerWarning.value = issues.length > 0;
+      error.value = issues.map((item) => item.message).join(" ");
       nextEntries = [...nextEntries, ...response.entries];
       entries.value = nextEntries;
       recordFamilies(response.entries.map((row) => row.family));
@@ -709,6 +714,7 @@ async function runSearch(reset: boolean): Promise<void> {
     }
   } catch (cause) {
     if (epoch !== searchEpoch) return;
+    providerWarning.value = false;
     error.value = errorMessage(cause, selectedHost.value?.name);
     hasMore.value = false;
   } finally {
@@ -1424,10 +1430,22 @@ onBeforeUnmount(() => {
         </label>
       </div>
 
-      <div v-if="error" class="mobile-catalog-error error-text" role="alert">
+      <div
+        v-if="error"
+        class="mobile-catalog-error"
+        :class="providerWarning ? 'mobile-catalog-warning' : 'error-text'"
+        role="alert"
+      >
         <span>
-          {{ error }}
-          <template v-if="combinedEntries.length"> Showing available models.</template>
+          <strong>{{
+            providerWarning ? "The catalog is catching up." : "Couldn’t refresh the catalog."
+          }}</strong>
+          <span class="mobile-catalog-error-detail">
+            {{ error }}
+            <template v-if="providerWarning && combinedEntries.length">
+              Showing available models.</template
+            >
+          </span>
         </span>
         <button
           class="mobile-catalog-retry"
@@ -1442,7 +1460,7 @@ onBeforeUnmount(() => {
         Loading models…
       </div>
       <div
-        v-else-if="combinedEntries.length === 0"
+        v-else-if="combinedEntries.length === 0 && !error"
         class="mobile-catalog-empty empty-state"
         data-test="mobile-catalog-empty"
       >
@@ -1451,7 +1469,11 @@ onBeforeUnmount(() => {
         <template v-else>No catalog models found.</template>
       </div>
 
-      <ul v-else class="mobile-catalog-results" aria-label="Catalog models">
+      <ul
+        v-else-if="combinedEntries.length > 0"
+        class="mobile-catalog-results"
+        aria-label="Catalog models"
+      >
         <li
           v-for="entry in combinedEntries"
           :key="entry.id"

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -3573,6 +3573,19 @@ button:disabled {
   margin: 14px 0;
 }
 
+.mobile-catalog-error > span {
+  display: grid;
+  gap: 3px;
+}
+
+.mobile-catalog-error-detail {
+  opacity: 0.82;
+}
+
+.mobile-catalog-warning {
+  color: var(--warning);
+}
+
 .mobile-catalog-retry {
   min-width: 72px;
   min-height: 44px;

--- a/web/src/components/CatalogCardGrid.test.ts
+++ b/web/src/components/CatalogCardGrid.test.ts
@@ -147,16 +147,50 @@ describe("CatalogCardGrid result count", () => {
 describe("CatalogCardGrid provider resilience", () => {
   it("keeps healthy rows visible beside a provider warning and retries", async () => {
     mockState.providerErrors = ref([
-      { source: "civitai", message: "Civitai is temporarily unavailable." },
+      {
+        source: "civitai",
+        code: "overloaded",
+        retry_after_seconds: 2,
+        message: "Civitai is busy right now. Try again in a few seconds.",
+      },
     ]);
     const w = mount(CatalogCardGrid);
 
     expect(w.get("[data-test='catalog-provider-warning']").text()).toContain(
       "Civitai",
     );
+    expect(w.get("[data-test='catalog-provider-warning']").text()).toContain(
+      "The catalog is catching up.",
+    );
+    expect(w.get("[data-test='catalog-provider-warning']").classes()).toContain(
+      "text-warning",
+    );
+    expect(
+      w.get("[data-test='catalog-provider-warning'] p").classes(),
+    ).not.toContain("text-rose-100");
     expect(w.findAllComponents({ name: "CatalogCard" })).toHaveLength(1);
     await w.get("[data-test='catalog-retry']").trigger("click");
     expect(mockState.refresh).toHaveBeenCalledOnce();
+  });
+
+  it("does not claim an unavailable provider returned no matches", () => {
+    mockState.entries = ref([]);
+    mockState.visibleEntries = ref([]);
+    mockState.resultCount = ref(0);
+    mockState.total = ref(0);
+    mockState.providerErrors = ref([
+      {
+        source: "civitai",
+        code: "overloaded",
+        retry_after_seconds: 60,
+        message: "Civitai is busy right now. Try again in a few seconds.",
+      },
+    ]);
+
+    const w = mount(CatalogCardGrid);
+
+    expect(w.text()).toContain("The catalog is catching up.");
+    expect(w.text()).not.toContain("No models found.");
   });
 });
 

--- a/web/src/components/CatalogCardGrid.vue
+++ b/web/src/components/CatalogCardGrid.vue
@@ -187,24 +187,33 @@ async function startBatch(): Promise<void> {
     <div
       v-if="cat.errorMsg.value || cat.providerErrors.value.length"
       data-test="catalog-provider-warning"
-      class="bg-bench border border-edge flex items-start gap-3 rounded-2xl px-4 py-3 text-sm text-rose-200"
+      class="bg-bench flex items-start gap-3 rounded-2xl border px-4 py-3 text-sm"
+      :class="
+        cat.errorMsg.value
+          ? 'border-rose-200/30 text-rose-200'
+          : 'border-warning/30 text-warning'
+      "
       role="alert"
     >
       <span class="mt-0.5">⚠</span>
       <div class="min-w-0 flex-1">
-        <p class="font-medium text-rose-100">
+        <p class="font-medium">
           {{
             cat.errorMsg.value
               ? "Couldn't refresh the catalog."
-              : "Part of the catalog is unavailable."
+              : "The catalog is catching up."
           }}
         </p>
-        <p class="text-rose-200/80">
+        <p class="opacity-80">
           {{
             cat.errorMsg.value ??
             cat.providerErrors.value.map((item) => item.message).join(" ")
           }}
-          <span v-if="cat.providerErrors.value.length">
+          <span
+            v-if="
+              cat.providerErrors.value.length && cat.visibleEntries.value.length
+            "
+          >
             Showing available models.</span
           >
         </p>
@@ -212,7 +221,7 @@ async function startBatch(): Promise<void> {
       <button
         type="button"
         data-test="catalog-retry"
-        class="border border-rose-200/40 shrink-0 rounded-lg px-3 py-1.5 font-medium text-rose-100 hover:bg-rose-100/10"
+        class="shrink-0 rounded-lg border border-current/40 px-3 py-1.5 font-medium hover:bg-current/10"
         :disabled="cat.loading.value"
         @click="cat.refresh()"
       >
@@ -222,7 +231,12 @@ async function startBatch(): Promise<void> {
 
     <!-- Empty state -->
     <div
-      v-if="!cat.loading.value && cat.visibleEntries.value.length === 0"
+      v-if="
+        !cat.loading.value &&
+        cat.visibleEntries.value.length === 0 &&
+        !cat.errorMsg.value &&
+        cat.providerErrors.value.length === 0
+      "
       class="flex flex-col items-center justify-center gap-2 py-16 text-ink-3"
     >
       <p class="text-sm">No models found.</p>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,13 +29,7 @@ export type {
 
 // Matches `mold_core::OutputFormat` on the wire (lowercase strings).
 export type OutputFormat =
-  | "png"
-  | "jpeg"
-  | "gif"
-  | "apng"
-  | "webp"
-  | "mp4"
-  | "wav";
+  "png" | "jpeg" | "gif" | "apng" | "webp" | "mp4" | "wav";
 
 export type SeedMode = "random" | "static" | "increment";
 
@@ -324,9 +318,7 @@ export interface LoraWeight {
 
 // ── Device placement (Agent C: model-ui-overhaul §3) ──────────────────────
 export type DeviceRef =
-  | { kind: "auto" }
-  | { kind: "cpu" }
-  | { kind: "gpu"; ordinal: number };
+  { kind: "auto" } | { kind: "cpu" } | { kind: "gpu"; ordinal: number };
 
 export interface AdvancedPlacement {
   transformer: DeviceRef;
@@ -1205,11 +1197,7 @@ export interface Ltx2CameraControlInfo {
 // server's serde output.
 
 export type JobStatusWire =
-  | "queued"
-  | "active"
-  | "completed"
-  | "failed"
-  | "cancelled";
+  "queued" | "active" | "completed" | "failed" | "cancelled";
 
 export interface DownloadJobWire {
   id: string;

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -29,7 +29,13 @@ export type {
 
 // Matches `mold_core::OutputFormat` on the wire (lowercase strings).
 export type OutputFormat =
-  "png" | "jpeg" | "gif" | "apng" | "webp" | "mp4" | "wav";
+  | "png"
+  | "jpeg"
+  | "gif"
+  | "apng"
+  | "webp"
+  | "mp4"
+  | "wav";
 
 export type SeedMode = "random" | "static" | "increment";
 
@@ -318,7 +324,9 @@ export interface LoraWeight {
 
 // ── Device placement (Agent C: model-ui-overhaul §3) ──────────────────────
 export type DeviceRef =
-  { kind: "auto" } | { kind: "cpu" } | { kind: "gpu"; ordinal: number };
+  | { kind: "auto" }
+  | { kind: "cpu" }
+  | { kind: "gpu"; ordinal: number };
 
 export interface AdvancedPlacement {
   transformer: DeviceRef;
@@ -1197,7 +1205,11 @@ export interface Ltx2CameraControlInfo {
 // server's serde output.
 
 export type JobStatusWire =
-  "queued" | "active" | "completed" | "failed" | "cancelled";
+  | "queued"
+  | "active"
+  | "completed"
+  | "failed"
+  | "cancelled";
 
 export interface DownloadJobWire {
   id: string;
@@ -1390,6 +1402,8 @@ export interface CatalogListResponse {
 export interface CatalogProviderError {
   source: "hf" | "civitai";
   message: string;
+  code?: "overloaded" | "rate-limited" | string;
+  retry_after_seconds?: number;
 }
 
 export interface CatalogFamilyCount {


### PR DESCRIPTION
## Summary

- honor upstream `Retry-After` for transient catalog failures and stop in-request retries when the requested delay exceeds the 15-second request budget
- return degraded catalog responses with structured provider notices instead of surfacing transient Civitai/Hugging Face overloads as HTTP 502 errors
- show calm amber recovery UI with Retry across desktop, web, and mobile while preserving healthy results and suppressing misleading empty states

## Root cause

Civitai intermittently returns HTTP 503 with `Retry-After: 2` and an overload response. Mold retried after fixed 100 ms and 250 ms delays, ignored the upstream delay, then converted the final provider failure into a generic 502. The clients rendered that as a red `ApiError: Bad Gateway` banner.

## Verification

- `cargo test -p mold-ai-catalog live::tests:: --lib` (33 passed)
- `cargo test -p mold-ai-server catalog_live_test:: --lib` (40 passed)
- desktop targeted Vitest suites (94 passed)
- web targeted Vitest suite (21 passed)
- `cargo clippy -p mold-ai-catalog -p mold-ai-server --all-targets -- -D warnings`
- desktop, mobile, and web production builds
- rendered browser QA of CivitAI + LoRAs + `Alien` with no hard-error banner or console warnings
- independent sub-agent peer review: PASS after all findings were addressed
