### PR TITLE
fix(desktop): bind LoRAs to generation hosts

### DIFF
--- a/changelog.d/desktop-lora-host-routing.md
+++ b/changelog.d/desktop-lora-host-routing.md
@@ -1,0 +1,1 @@
+- **Keep LoRAs on their generation machine.** Mold Studio now loads LoRAs from the selected machine and keeps generation pinned there, preventing remote jobs from receiving an unreadable path from another host.

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -107,6 +107,7 @@ import { AUDIO_ONLY_PIPELINE, isAudioOnlyPipeline } from "@studio/lib/ltx2Pipeli
 import LoraStack from "../generate/LoraStack.vue";
 import ImagePickerModal from "../generate/ImagePickerModal.vue";
 import { attachPickedVideo } from "../../lib/sourceAttachment";
+import type { HostRoute } from "../../stores/hosts";
 
 const props = withDefaults(
   defineProps<{
@@ -119,6 +120,7 @@ const props = withDefaults(
     cameraControls?: Ltx2CameraControlInfo[];
     cameraControlsLoaded?: boolean;
     cameraUnsupportedReason?: string | null;
+    loraRoute?: HostRoute | null;
   }>(),
   {
     selectedModel: null,
@@ -127,6 +129,7 @@ const props = withDefaults(
     cameraControls: () => [],
     cameraControlsLoaded: false,
     cameraUnsupportedReason: null,
+    loraRoute: null,
   },
 );
 
@@ -739,7 +742,12 @@ function reset() {
         :header-interactive="false"
         data-test="section-lora"
       >
-        <LoraStack :form="form" :model="form.model" @append-word="emit('append-word', $event)" />
+        <LoraStack
+          :form="form"
+          :model="form.model"
+          :route="loraRoute"
+          @append-word="emit('append-word', $event)"
+        />
       </AccordionSection>
 
       <!-- 5 · Upscale after generate -->

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -3,6 +3,7 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { reactive } from "vue";
 import InspectorPanel from "./InspectorPanel.vue";
+import AdvancedSettings from "./AdvancedSettings.vue";
 import ModelPicker from "./ModelPicker.vue";
 import ShapePicker from "@ui/components/ShapePicker.vue";
 import ResolutionSelector from "@ui/components/ResolutionSelector.vue";
@@ -570,6 +571,32 @@ describe("InspectorPanel — seed mode", () => {
 });
 
 describe("InspectorPanel — advanced", () => {
+  it("passes the selected generation machine to the one-shot LoRA picker", async () => {
+    const connection = useConnectionStore();
+    connection.info = { mode: "local", baseUrl: "http://127.0.0.1:7680", apiKey: "local" };
+    connection.status = "ready";
+    useHostsStore().extras.push({
+      id: "plato-7680",
+      label: "plato",
+      url: "http://plato:7680",
+      apiKey: null,
+      status: "ready",
+      error: null,
+      instanceId: "plato-instance",
+    });
+    useAppPrefsStore().settings = { generateTargetHost: "plato-7680" } as never;
+    const form = formFor("z-image");
+    form.model = "z-image-turbo:q8";
+    const wrapper = mount(InspectorPanel, { props: { form } });
+
+    await wrapper.get('[data-test="open-advanced"]').trigger("click");
+
+    expect(wrapper.getComponent(AdvancedSettings).props("loraRoute")).toMatchObject({
+      hostId: "plato-7680",
+      target: { baseUrl: "http://plato:7680" },
+    });
+  });
+
   it("never counts the Sequence opening image — it is primary-form media, not Advanced", async () => {
     const draft = useSequenceDraftStore();
     draft.output = "sequence";

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -20,7 +20,13 @@ import {
 } from "@studio/lib/modelRuntimeAvailability";
 import type { ChainLimits } from "@studio/lib/api/chainTypes";
 import type { GenerateForm } from "../../lib/generateForm";
-import { buildRequest, resetFormToModelDefaults, seedMode } from "../../lib/generateForm";
+import {
+  buildRequest,
+  loraBindingMatchesRoute,
+  loraHostBinding,
+  resetFormToModelDefaults,
+  seedMode,
+} from "../../lib/generateForm";
 import type {
   Ltx2CameraControlInfo,
   Ltx2ControlAdapterInfo,
@@ -102,6 +108,16 @@ const hosts = useHostsStore();
 const appPrefs = useAppPrefsStore();
 const gallery = useGalleryStore();
 const libraryPrefs = useLibraryPrefsStore();
+const loraRoute = computed(() => {
+  const binding = loraHostBinding(props.form.loras);
+  const selected =
+    binding.kind === "bound"
+      ? binding.hostId
+      : normalizeTargetHost(appPrefs.settings?.generateTargetHost ?? null, hosts.all);
+  const route = hosts.resolveRoute(selected, props.form.model || null);
+  if (binding.kind === "bound" && (!route || !loraBindingMatchesRoute(binding, route))) return null;
+  return route;
+});
 const controlAdapters = ref<Ltx2ControlAdapterInfo[]>([]);
 const cameraControls = ref<Ltx2CameraControlInfo[]>([]);
 const cameraControlsLoaded = ref(false);
@@ -1020,6 +1036,7 @@ function resetSettings() {
         :camera-controls="cameraControls"
         :camera-controls-loaded="cameraControlsLoaded"
         :camera-unsupported-reason="cameraUnsupportedReason"
+        :lora-route="loraRoute"
         @append-word="emit('append-word', $event)"
         @canvas-intent="emit('canvas-intent', $event)"
       />

--- a/desktop/src/components/generate/LoraStack.test.ts
+++ b/desktop/src/components/generate/LoraStack.test.ts
@@ -1,0 +1,175 @@
+import { flushPromises, mount } from "@vue/test-utils";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { newGenerateForm } from "../../lib/generateForm";
+import { fetchLoras } from "../../lib/api/loras";
+import LoraStack from "./LoraStack.vue";
+
+vi.mock("../../lib/api/loras", () => ({ fetchLoras: vi.fn() }));
+
+const route = {
+  hostId: "plato-7680",
+  label: "plato",
+  kind: "remote" as const,
+  target: { baseUrl: "http://plato:7680", apiKey: null },
+  instanceId: "plato-instance",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => (resolve = done));
+  return { promise, resolve };
+}
+
+describe("LoraStack host routing", () => {
+  beforeEach(() => vi.mocked(fetchLoras).mockReset());
+
+  it("loads and binds LoRAs from the machine that will generate", async () => {
+    const form = newGenerateForm();
+    form.model = "z-image-turbo:q8";
+    form.family = "z-image";
+    vi.mocked(fetchLoras).mockResolvedValue([
+      {
+        id: "alien",
+        name: "Alien Xenomorph",
+        path: "/storage/mold/models/alien.safetensors",
+        family: "z-image",
+        trained_words: ["alien"],
+        added_at: 1,
+      },
+    ]);
+    const wrapper = mount(LoraStack, { props: { form, model: form.model, route } });
+
+    const addButton = wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Add LoRA"));
+    expect(addButton).toBeDefined();
+    await addButton!.trigger("click");
+    await flushPromises();
+
+    expect(fetchLoras).toHaveBeenCalledWith(form.model, route.target);
+    await wrapper.get("[data-test='lora-picker'] button").trigger("click");
+    expect(form.loras).toEqual([
+      {
+        path: "/storage/mold/models/alien.safetensors",
+        name: "Alien Xenomorph",
+        scale: 1,
+        trainedWords: ["alien"],
+        hostId: "plato-7680",
+        hostBaseUrl: "http://plato:7680",
+        hostInstanceId: "plato-instance",
+      },
+    ]);
+  });
+
+  it("discards a stale LoRA listing when the route changes", async () => {
+    const form = newGenerateForm();
+    form.model = "z-image-turbo:q8";
+    form.family = "z-image";
+    const first = deferred<Awaited<ReturnType<typeof fetchLoras>>>();
+    const second = deferred<Awaited<ReturnType<typeof fetchLoras>>>();
+    vi.mocked(fetchLoras).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const wrapper = mount(LoraStack, { props: { form, model: form.model, route } });
+
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Add LoRA"))!
+      .trigger("click");
+    const halRoute = {
+      ...route,
+      hostId: "hal-7680",
+      label: "hal",
+      target: { baseUrl: "http://hal:7680", apiKey: null },
+      instanceId: "hal-instance",
+    };
+    await wrapper.setProps({ route: halRoute });
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Add LoRA"))!
+      .trigger("click");
+    second.resolve([
+      {
+        id: "hal-lora",
+        name: "HAL LoRA",
+        path: "/hal/lora.safetensors",
+        family: "z-image",
+        trained_words: [],
+        added_at: 2,
+      },
+    ]);
+    await flushPromises();
+    first.resolve([
+      {
+        id: "plato-lora",
+        name: "Plato LoRA",
+        path: "/plato/lora.safetensors",
+        family: "z-image",
+        trained_words: [],
+        added_at: 1,
+      },
+    ]);
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='lora-picker']").text()).toContain("HAL LoRA");
+    expect(wrapper.get("[data-test='lora-picker']").text()).not.toContain("Plato LoRA");
+    await wrapper.get("[data-test='lora-picker'] button").trigger("click");
+    expect(form.loras[0]).toMatchObject({
+      path: "/hal/lora.safetensors",
+      hostId: "hal-7680",
+      hostBaseUrl: "http://hal:7680",
+      hostInstanceId: "hal-instance",
+    });
+  });
+
+  it("discards a stale listing when a host ID now points at another server instance", async () => {
+    const form = newGenerateForm();
+    form.model = "z-image-turbo:q8";
+    form.family = "z-image";
+    const first = deferred<Awaited<ReturnType<typeof fetchLoras>>>();
+    const second = deferred<Awaited<ReturnType<typeof fetchLoras>>>();
+    vi.mocked(fetchLoras).mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise);
+    const wrapper = mount(LoraStack, { props: { form, model: form.model, route } });
+
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Add LoRA"))!
+      .trigger("click");
+    const replacementRoute = { ...route, instanceId: "replacement-instance" };
+    await wrapper.setProps({ route: replacementRoute });
+    await wrapper
+      .findAll("button")
+      .find((button) => button.text().includes("Add LoRA"))!
+      .trigger("click");
+    second.resolve([
+      {
+        id: "new-lora",
+        name: "Replacement LoRA",
+        path: "/replacement/lora.safetensors",
+        family: "z-image",
+        trained_words: [],
+        added_at: 2,
+      },
+    ]);
+    await flushPromises();
+    first.resolve([
+      {
+        id: "old-lora",
+        name: "Old Instance LoRA",
+        path: "/old/lora.safetensors",
+        family: "z-image",
+        trained_words: [],
+        added_at: 1,
+      },
+    ]);
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='lora-picker']").text()).toContain("Replacement LoRA");
+    expect(wrapper.get("[data-test='lora-picker']").text()).not.toContain("Old Instance LoRA");
+    await wrapper.get("[data-test='lora-picker'] button").trigger("click");
+    expect(form.loras[0]).toMatchObject({
+      path: "/replacement/lora.safetensors",
+      hostId: "plato-7680",
+      hostBaseUrl: "http://plato:7680",
+      hostInstanceId: "replacement-instance",
+    });
+  });
+});

--- a/desktop/src/components/generate/LoraStack.vue
+++ b/desktop/src/components/generate/LoraStack.vue
@@ -5,27 +5,48 @@ import { MAX_LORA_STACK } from "../../lib/capabilities";
 import { fetchLoras } from "../../lib/api/loras";
 import type { LoraInfo } from "../../lib/api/types";
 import { cameraMotionLoraPath } from "@studio/lib/cameraMotion";
+import type { HostRoute } from "../../stores/hosts";
 
-const props = defineProps<{ form: GenerateForm; model: string }>();
+const props = defineProps<{ form: GenerateForm; model: string; route: HostRoute | null }>();
 const emit = defineEmits<{ (e: "append-word", word: string): void }>();
 
 const pickerOpen = ref(false);
 const available = ref<LoraInfo[]>([]);
 const loading = ref(false);
 const error = ref<string | null>(null);
+let loadEpoch = 0;
 
 async function openPicker() {
   pickerOpen.value = !pickerOpen.value;
-  if (!pickerOpen.value) return;
+  const epoch = ++loadEpoch;
+  if (!pickerOpen.value) {
+    loading.value = false;
+    return;
+  }
   loading.value = true;
   error.value = null;
-  try {
-    available.value = await fetchLoras(props.model);
-  } catch (err) {
-    error.value = String(err);
-    available.value = [];
-  } finally {
+  const route = props.route;
+  if (!route) {
     loading.value = false;
+    error.value = "The selected machine is unavailable.";
+    available.value = [];
+    return;
+  }
+  try {
+    const response = await fetchLoras(props.model, route.target);
+    if (
+      epoch === loadEpoch &&
+      props.route?.hostId === route.hostId &&
+      (props.route?.instanceId ?? null) === (route.instanceId ?? null)
+    )
+      available.value = response;
+  } catch (err) {
+    if (epoch === loadEpoch) {
+      error.value = String(err);
+      available.value = [];
+    }
+  } finally {
+    if (epoch === loadEpoch) loading.value = false;
   }
 }
 
@@ -34,8 +55,16 @@ function alreadyAdded(path: string): boolean {
 }
 
 function addLora(l: LoraInfo) {
-  if (props.form.loras.length >= MAX_LORA_STACK || alreadyAdded(l.path)) return;
-  props.form.loras.push({ path: l.path, name: l.name, scale: 1, trainedWords: l.trained_words });
+  if (!props.route || props.form.loras.length >= MAX_LORA_STACK || alreadyAdded(l.path)) return;
+  props.form.loras.push({
+    path: l.path,
+    name: l.name,
+    scale: 1,
+    trainedWords: l.trained_words,
+    hostId: props.route.hostId,
+    hostBaseUrl: props.route.target.baseUrl,
+    hostInstanceId: props.route.instanceId ?? null,
+  });
   pickerOpen.value = false;
 }
 
@@ -49,8 +78,16 @@ function removeLora(index: number) {
 
 // Close and reset the picker when the model changes — the family may differ.
 watch(
-  () => props.model,
+  () =>
+    [
+      props.model,
+      props.route?.hostId,
+      props.route?.instanceId,
+      props.route?.target.baseUrl,
+    ] as const,
   () => {
+    loadEpoch += 1;
+    loading.value = false;
     pickerOpen.value = false;
     available.value = [];
   },
@@ -61,6 +98,7 @@ watch(
   <div>
     <div class="mt-5 mb-2 flex items-center gap-2">
       <span class="edge-code">LoRAs</span>
+      <span v-if="route" class="text-caption text-ink-3">{{ route.label }}</span>
       <div class="border-edge h-px flex-1 border-t" />
     </div>
 

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -8,6 +8,7 @@ import {
   buildRequest,
   chainFilingFields,
   cloneGenerateForm,
+  loraHostBinding,
   newGenerateForm,
   normalizeLegacyNegativeSnapshot,
   reconcileModelCapabilities,
@@ -22,6 +23,50 @@ import { DEFAULT_EXTEND_OVERLAP_FRAMES } from "@studio/lib/extend";
 import { addTag, emptyFileUnderState, pickCollection } from "@studio/lib/fileUnder";
 import type { ModelEntry, OutputMetadata } from "./api/types";
 import type { GenerationProfileSet, GenerationRecipeProfile } from "@studio/lib/generationProfile";
+
+describe("loraHostBinding", () => {
+  it("binds host-local LoRA paths to one machine and rejects mixed stacks", () => {
+    const row = (hostId?: string, hostInstanceId?: string | null, hostBaseUrl?: string) => ({
+      path: `${hostId ?? "legacy"}.safetensors`,
+      name: "LoRA",
+      scale: 1,
+      trainedWords: [],
+      ...(hostId
+        ? {
+            hostId,
+            hostBaseUrl: hostBaseUrl ?? `http://${hostId}:7680`,
+            hostInstanceId: hostInstanceId === undefined ? `${hostId}-instance` : hostInstanceId,
+          }
+        : {}),
+    });
+
+    expect(loraHostBinding([row()])).toEqual({ kind: "unbound" });
+    expect(loraHostBinding([row("plato"), row("plato")])).toEqual({
+      kind: "bound",
+      hostId: "plato",
+      baseUrl: "http://plato:7680",
+      instanceId: "plato-instance",
+    });
+    expect(loraHostBinding([row("plato"), row("hal")])).toEqual({
+      kind: "conflict",
+      hostIds: ["plato", "hal"],
+    });
+    expect(loraHostBinding([row(), row("plato")])).toEqual({
+      kind: "conflict",
+      hostIds: ["plato"],
+    });
+    expect(loraHostBinding([row("plato", "old"), row("plato", "new")])).toEqual({
+      kind: "conflict",
+      hostIds: ["plato"],
+    });
+    expect(loraHostBinding([row("plato", null), row("plato", "plato-instance")])).toEqual({
+      kind: "bound",
+      hostId: "plato",
+      baseUrl: "http://plato:7680",
+      instanceId: "plato-instance",
+    });
+  });
+});
 
 function ltx2Model(): ModelEntry {
   return {

--- a/desktop/src/lib/generateForm.ts
+++ b/desktop/src/lib/generateForm.ts
@@ -104,6 +104,63 @@ export interface FormLora {
   name: string;
   scale: number;
   trainedWords: string[];
+  /** Machine whose `/api/loras` returned this host-local path. UI-only: the
+   * request builder strips it before the LoRA reaches the wire. */
+  hostId?: string;
+  /** Endpoint that returned the path, used when instance telemetry was not
+   * available yet. */
+  hostBaseUrl?: string;
+  /** Server installation that owned the path. Null means identity telemetry
+   * was unavailable when picked; a later identity may be accepted only at the
+   * same host id and endpoint. */
+  hostInstanceId?: string | null;
+}
+
+export type LoraHostBinding =
+  | { kind: "unbound" }
+  | { kind: "bound"; hostId: string; baseUrl: string | null; instanceId: string | null }
+  | { kind: "conflict"; hostIds: string[] };
+
+/** A LoRA path is host-local, so a picked stack freezes generation to the
+ * machine that supplied it. Legacy/restored rows have no binding and retain
+ * the selected generation policy. */
+export function loraHostBinding(loras: readonly FormLora[]): LoraHostBinding {
+  const hostIds = new Set<string>();
+  const baseUrls = new Set<string>();
+  const instanceIds = new Set<string>();
+  let unboundCount = 0;
+  for (const lora of loras) {
+    if (!lora.hostId) {
+      unboundCount += 1;
+      continue;
+    }
+    hostIds.add(lora.hostId);
+    if (lora.hostBaseUrl) baseUrls.add(lora.hostBaseUrl);
+    if (lora.hostInstanceId) instanceIds.add(lora.hostInstanceId);
+  }
+  if (hostIds.size === 0) return { kind: "unbound" };
+  if (unboundCount > 0 || hostIds.size > 1 || baseUrls.size > 1 || instanceIds.size > 1)
+    return { kind: "conflict", hostIds: [...hostIds] };
+  return {
+    kind: "bound",
+    hostId: hostIds.values().next().value!,
+    baseUrl: baseUrls.values().next().value ?? null,
+    instanceId: instanceIds.values().next().value ?? null,
+  };
+}
+
+/** Whether a concrete route can safely consume a host-local LoRA path. A
+ * missing picked instance may promote to later telemetry only when the host
+ * id and exact endpoint still match. */
+export function loraBindingMatchesRoute(
+  binding: Extract<LoraHostBinding, { kind: "bound" }>,
+  route: { hostId: string; instanceId?: string | null; target: { baseUrl: string } },
+): boolean {
+  return (
+    route.hostId === binding.hostId &&
+    (binding.baseUrl === null || route.target.baseUrl === binding.baseUrl) &&
+    (binding.instanceId === null || (route.instanceId ?? null) === binding.instanceId)
+  );
 }
 
 /** A picked file (base64, no data-URI prefix); `filename` is display metadata. */

--- a/desktop/src/views/GenerateView.missingModel.test.ts
+++ b/desktop/src/views/GenerateView.missingModel.test.ts
@@ -188,6 +188,168 @@ describe("GenerateView missing-model pull before submit", () => {
     expect(toasts.items.some((item) => item.kind === "error")).toBe(false);
   });
 
+  it("routes a picked LoRA back to the machine that supplied its path", async () => {
+    addRemoteHost();
+    const hosts = useHostsStore();
+    const resolveFeasible = vi.spyOn(hosts, "resolveFeasible").mockResolvedValue({
+      kind: "route",
+      route: remoteRoute,
+      preview: null,
+    });
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([]),
+    });
+    const form = useGenerateFormStore().form;
+    form.family = "z-image";
+    form.loras = [
+      {
+        path: "/storage/mold/models/alien.safetensors",
+        name: "Alien Xenomorph",
+        scale: 1,
+        trainedWords: [],
+        hostId: remoteRoute.hostId,
+        hostBaseUrl: remoteRoute.target.baseUrl,
+        hostInstanceId: remoteRoute.instanceId ?? null,
+      },
+    ];
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.get('[data-test="generate-button"]').trigger("click");
+    await flushPromises();
+
+    expect(resolveFeasible).toHaveBeenCalledWith(
+      remoteRoute.hostId,
+      expect.objectContaining({
+        model: model.name,
+        loras: [{ path: "/storage/mold/models/alien.safetensors", scale: 1 }],
+      }),
+      1,
+      expect.objectContaining({ signal: expect.any(AbortSignal) }),
+    );
+    expect(submit).toHaveBeenCalledWith(
+      expect.any(Object),
+      1,
+      expect.objectContaining({ hostId: remoteRoute.hostId }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
+  it("refuses a LoRA whose source machine was forgotten instead of falling back to Auto", async () => {
+    const hosts = useHostsStore();
+    const resolveFeasible = vi.spyOn(hosts, "resolveFeasible");
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([]),
+    });
+    const form = useGenerateFormStore().form;
+    form.family = "z-image";
+    form.loras = [
+      {
+        path: "/forgotten/lora.safetensors",
+        name: "Forgotten LoRA",
+        scale: 1,
+        trainedWords: [],
+        hostId: "forgotten-7680",
+        hostBaseUrl: "http://forgotten:7680",
+        hostInstanceId: "forgotten-instance",
+      },
+    ];
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.get('[data-test="generate-button"]').trigger("click");
+    await flushPromises();
+
+    expect(resolveFeasible).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+    expect(useToastStore().items.at(-1)?.message).toContain(
+      "machine that supplied the selected LoRA is no longer the same server",
+    );
+  });
+
+  it("refuses a LoRA when its host ID has been reused by another server instance", async () => {
+    addRemoteHost();
+    const hosts = useHostsStore();
+    const resolveFeasible = vi.spyOn(hosts, "resolveFeasible");
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([]),
+    });
+    const form = useGenerateFormStore().form;
+    form.family = "z-image";
+    form.loras = [
+      {
+        path: "/retired/lora.safetensors",
+        name: "Retired Server LoRA",
+        scale: 1,
+        trainedWords: [],
+        hostId: remoteRoute.hostId,
+        hostBaseUrl: remoteRoute.target.baseUrl,
+        hostInstanceId: "retired-instance",
+      },
+    ];
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.get('[data-test="generate-button"]').trigger("click");
+    await flushPromises();
+
+    expect(resolveFeasible).not.toHaveBeenCalled();
+    expect(submit).not.toHaveBeenCalled();
+    expect(useToastStore().items.at(-1)?.message).toContain(
+      "machine that supplied the selected LoRA is no longer the same server",
+    );
+  });
+
+  it("accepts later instance telemetry for the same LoRA host and endpoint", async () => {
+    addRemoteHost();
+    const hosts = useHostsStore();
+    const resolveFeasible = vi.spyOn(hosts, "resolveFeasible").mockResolvedValue({
+      kind: "route",
+      route: remoteRoute,
+      preview: null,
+    } as FeasibleRouteResult);
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([]),
+    });
+    const form = useGenerateFormStore().form;
+    form.family = "z-image";
+    form.loras = [
+      {
+        path: "/storage/mold/models/alien.safetensors",
+        name: "Alien LoRA",
+        scale: 1,
+        trainedWords: [],
+        hostId: remoteRoute.hostId,
+        hostBaseUrl: remoteRoute.target.baseUrl,
+        hostInstanceId: null,
+      },
+    ];
+    const wrapper = mountView();
+    await flushPromises();
+
+    await wrapper.get('[data-test="generate-button"]').trigger("click");
+    await flushPromises();
+
+    expect(resolveFeasible).toHaveBeenCalledWith(
+      remoteRoute.hostId,
+      expect.any(Object),
+      1,
+      expect.any(Object),
+    );
+    expect(submit).toHaveBeenCalledWith(
+      expect.any(Object),
+      1,
+      expect.objectContaining({ hostId: remoteRoute.hostId }),
+      expect.any(Object),
+      expect.any(Object),
+    );
+  });
+
   it("asks which machine to pull onto when more than one could run it", async () => {
     addRemoteHost();
     const hosts = useHostsStore();

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -723,6 +723,69 @@ describe("GenerateView prepared expansion batches", () => {
     });
   });
 
+  it.each([
+    ["prepared", 3],
+    ["quick", 1],
+  ])("refuses a %s expansion frozen to a different machine than its LoRA", async (_kind, batch) => {
+    const form = useGenerateFormStore().form;
+    form.batchSize = batch;
+    const hosts = useHostsStore();
+    const localRoute = {
+      hostId: "local",
+      label: "This device",
+      kind: "local" as const,
+      target: { baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" },
+      instanceId: null,
+    };
+    const remoteRoute = {
+      hostId: "remote-one",
+      label: "Studio GPU",
+      kind: "remote" as const,
+      target: { baseUrl: "http://studio:7680", apiKey: "remote-key" },
+      instanceId: "studio-id",
+    };
+    const resolveRoute = vi.spyOn(hosts, "resolveRoute").mockReturnValue(localRoute);
+    vi.mocked(expandPrompt).mockResolvedValue({
+      original: "a lighthouse at dusk",
+      expanded: Array.from({ length: batch }, (_, index) => `variation ${index + 1}`),
+    });
+    const submit = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
+      jobs: [],
+      settled: Promise.resolve([]),
+    });
+    const wrapper = mountView();
+    await flushPromises();
+
+    wrapper.findComponent(ExpandControl).vm.$emit("expand");
+    await flushPromises();
+    resolveRoute.mockImplementation((selection) =>
+      selection === remoteRoute.hostId ? remoteRoute : localRoute,
+    );
+    form.loras = [
+      {
+        path: "/studio/alien.safetensors",
+        name: "Alien LoRA",
+        scale: 1,
+        trainedWords: [],
+        hostId: remoteRoute.hostId,
+        hostBaseUrl: remoteRoute.target.baseUrl,
+        hostInstanceId: remoteRoute.instanceId,
+      },
+    ];
+
+    if (batch > 1) {
+      wrapper.findComponent(PreparedExpansionBatch).vm.$emit("generate");
+    } else {
+      await wrapper.get('[data-test="generate-button"]').trigger("click");
+    }
+    await flushPromises();
+
+    expect(submit).not.toHaveBeenCalled();
+    expect(useToastStore().items.at(-1)?.message).toContain(
+      "prepared print is frozen to a different machine",
+    );
+  });
+
   it("reuses a quick transformed prompt after a host-only selection change", async () => {
     const form = useGenerateFormStore().form;
     form.batchSize = 1;

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -137,6 +137,8 @@ import {
   chainFilingFields,
   cloneGenerateForm,
   keepingPrintIdentity,
+  loraBindingMatchesRoute,
+  loraHostBinding,
   normalizeLegacyNegativeSnapshot,
 } from "../lib/generateForm";
 import { composeStyle, mergeStyleNegative, styleHint } from "../lib/stylePresets";
@@ -3484,6 +3486,35 @@ async function generate() {
       preliminaryRouting.kind === "chain"
         ? buildAutoChainRequest(preliminaryRequest, preliminaryRouting)
         : preliminaryRequest;
+    const loraBinding = loraHostBinding(draft.loras);
+    if (loraBinding.kind === "conflict") {
+      toasts.push(
+        "The selected LoRAs have mixed or missing machine provenance. Remove them and choose the stack again from one machine.",
+        "error",
+      );
+      return;
+    }
+    if (loraBinding.kind === "bound") {
+      const boundRoute = hosts.resolveRoute(loraBinding.hostId, draft.model);
+      if (!boundRoute || !loraBindingMatchesRoute(loraBinding, boundRoute)) {
+        toasts.push(
+          "The machine that supplied the selected LoRA is no longer the same server. Reconnect it or remove the LoRA.",
+          "error",
+        );
+        return;
+      }
+      if (route && !loraBindingMatchesRoute(loraBinding, route)) {
+        toasts.push(
+          "The prepared print is frozen to a different machine than the selected LoRA. Re-expand it or remove the LoRA.",
+          "error",
+        );
+        return;
+      }
+    }
+    const generateTarget =
+      loraBinding.kind === "bound"
+        ? loraBinding.hostId
+        : (appPrefs.settings?.generateTargetHost ?? null);
     if (route) {
       // Prepared work already froze the concrete host. Preserve that
       // authority through source preprocessing and perform exactly one
@@ -3504,12 +3535,9 @@ async function generate() {
       }
       route = feasible;
     } else {
-      const feasibility = await hosts.resolveFeasible(
-        appPrefs.settings?.generateTargetHost ?? null,
-        planningRequest,
-        batch,
-        { signal: submitSignal },
-      );
+      const feasibility = await hosts.resolveFeasible(generateTarget, planningRequest, batch, {
+        signal: submitSignal,
+      });
       if (!submissionGuard.isCurrent(submitToken)) return;
       if (feasibility.kind !== "route") {
         // Nothing can run this print. When the only thing in the way is the


### PR DESCRIPTION
## Summary
- query LoRAs from the concrete machine selected for generation instead of always querying the desktop local server
- bind host-local LoRA paths to host ID, endpoint, and known server instance, then freeze generation to that route
- fail closed for stale, mixed-provenance, cross-host, replaced-server, prepared, and quick-expansion route mismatches
- discard stale asynchronous LoRA listings when the selected route changes

## Root cause
The desktop LoRA picker called the local `/api/loras` endpoint without the selected generation target. It then submitted that local absolute path to Plato. Plato correctly held the durable job because that Mac path was unreadable there; the UI surfaced this as a misleading model/download flow. This was not a Z-Image quantization compatibility guard.

## Verification
- `nix develop -c bash -lc "cd desktop && bun run test && bun run build"` — 5,404 tests passed; production build passed
- `nix develop -c bash -lc "cd desktop && bunx vue-tsc -b && bun run fmt:check"` — passed
- `nix develop -c bash -lc "bun run check:architecture"` — passed
- independent sub-agent peer review — no actionable findings