### PR TITLE
fix(hosts): normalize bare addresses across surfaces

### DIFF
--- a/changelog.d/host-address-defaults.md
+++ b/changelog.d/host-address-defaults.md
@@ -1,0 +1,4 @@
+- **Bare host addresses work on every surface.** iPhone, Android, desktop,
+  web, CLI, and TUI connections now consistently expand a hostname or IP such
+  as `100.123.198.98` to Mold's `http://` and `:7680` defaults while preserving
+  explicit protocols and ports.

--- a/crates/mold-core/src/client.rs
+++ b/crates/mold-core/src/client.rs
@@ -2665,14 +2665,35 @@ fn build_client(api_key: Option<&str>) -> (Client, bool) {
 /// - Host with port: `hal9000:8080` → `http://hal9000:8080`
 /// - Full URL: `http://hal9000:7680` → unchanged
 /// - URL without port: `http://hal9000` → unchanged (uses scheme default 80/443)
+fn has_http_scheme(input: &str) -> bool {
+    input
+        .get(..7)
+        .is_some_and(|prefix| prefix.eq_ignore_ascii_case("http://"))
+        || input
+            .get(..8)
+            .is_some_and(|prefix| prefix.eq_ignore_ascii_case("https://"))
+}
+
 pub fn normalize_host(input: &str) -> String {
     let trimmed = input.trim().trim_end_matches('/');
-    if trimmed.contains("://") {
+    let has_scheme = has_http_scheme(trimmed);
+    let bare_ipv6 = !has_scheme
+        && !trimmed.starts_with('[')
+        && trimmed.bytes().filter(|byte| *byte == b':').count() > 1;
+    let candidate = if has_scheme {
         trimmed.to_string()
-    } else if trimmed.contains(':') {
-        format!("http://{trimmed}")
+    } else if bare_ipv6 {
+        format!("http://[{trimmed}]")
     } else {
-        format!("http://{trimmed}:7680")
+        format!("http://{trimmed}")
+    };
+    if let Ok(mut url) = reqwest::Url::parse(&candidate) {
+        if !has_scheme && url.port().is_none() {
+            let _ = url.set_port(Some(7680));
+        }
+        url.to_string().trim_end_matches('/').to_string()
+    } else {
+        candidate
     }
 }
 
@@ -2895,6 +2916,12 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_scheme_case_insensitively() {
+        let client = MoldClient::new("HTTP://hal9000");
+        assert_eq!(client.host(), "http://hal9000");
+    }
+
+    #[test]
     fn test_normalize_localhost() {
         let client = MoldClient::new("localhost");
         assert_eq!(client.host(), "http://localhost:7680");
@@ -2908,14 +2935,35 @@ mod tests {
 
     #[test]
     fn test_normalize_ip_address() {
-        let client = MoldClient::new("192.168.1.100");
-        assert_eq!(client.host(), "http://192.168.1.100:7680");
+        let client = MoldClient::new("100.123.198.98");
+        assert_eq!(client.host(), "http://100.123.198.98:7680");
     }
 
     #[test]
     fn test_normalize_ip_with_port() {
         let client = MoldClient::new("192.168.1.100:9090");
         assert_eq!(client.host(), "http://192.168.1.100:9090");
+    }
+
+    #[test]
+    fn test_normalize_bare_ipv6() {
+        let client = MoldClient::new("::1");
+        assert_eq!(client.host(), "http://[::1]:7680");
+    }
+
+    #[test]
+    fn test_normalize_host_is_idempotent() {
+        for input in [
+            "100.123.198.98",
+            "100.123.198.98:9000",
+            "http://100.123.198.98",
+            "https://studio.tailnet.ts.net",
+            "https://studio.tailnet.ts.net:443",
+            "::1",
+        ] {
+            let once = normalize_host(input);
+            assert_eq!(normalize_host(&once), once, "{input}");
+        }
     }
 
     #[test]

--- a/desktop/src-tauri/src/connection.rs
+++ b/desktop/src-tauri/src/connection.rs
@@ -69,28 +69,17 @@ pub fn host_id(url: &str) -> String {
     id
 }
 
-/// Normalize a user-entered host: default scheme/port, strip trailing slashes.
+/// Normalize a user-entered host: default omitted scheme/port, strip trailing slashes.
 pub fn normalize_host_url(input: &str) -> Result<String, String> {
-    let trimmed = input.trim().trim_end_matches('/');
-    if trimmed.is_empty() {
+    if input.trim().trim_end_matches('/').is_empty() {
         return Err("Enter a host, like hal9000".into());
     }
-    let has_explicit_scheme = trimmed.starts_with("http://") || trimmed.starts_with("https://");
-    let with_scheme = if has_explicit_scheme {
-        trimmed.to_string()
-    } else {
-        format!("http://{trimmed}")
-    };
-    let mut url =
-        reqwest::Url::parse(&with_scheme).map_err(|_| "Enter a valid host.".to_string())?;
+    let normalized = mold_core::client::normalize_host(input);
+    let url = reqwest::Url::parse(&normalized).map_err(|_| "Enter a valid host.".to_string())?;
     if url.host_str().is_none() {
         return Err("Enter a valid host.".into());
     }
-    if !has_explicit_scheme && url.port().is_none() {
-        url.set_port(Some(7680))
-            .map_err(|_| "Enter a valid host.".to_string())?;
-    }
-    Ok(url.to_string().trim_end_matches('/').to_string())
+    Ok(normalized)
 }
 
 #[cfg(test)]
@@ -129,26 +118,39 @@ mod tests {
 
     #[test]
     fn normalizes_host_urls() {
-        assert_eq!(
-            normalize_host_url("hal9000").unwrap(),
-            "http://hal9000:7680"
-        );
-        assert_eq!(
-            normalize_host_url("studio.local:7680").unwrap(),
-            "http://studio.local:7680"
-        );
+        for (input, expected) in [
+            ("hal9000", "http://hal9000:7680"),
+            ("100.123.198.98", "http://100.123.198.98:7680"),
+            ("100.123.198.98:9000", "http://100.123.198.98:9000"),
+            ("http://100.123.198.98", "http://100.123.198.98"),
+            ("HTTP://100.123.198.98", "http://100.123.198.98"),
+            (
+                "https://studio.tailnet.ts.net",
+                "https://studio.tailnet.ts.net",
+            ),
+            (
+                "https://studio.tailnet.ts.net:443",
+                "https://studio.tailnet.ts.net",
+            ),
+            ("::1", "http://[::1]:7680"),
+        ] {
+            assert_eq!(normalize_host_url(input).unwrap(), expected, "{input}");
+        }
         assert_eq!(
             normalize_host_url("http://studio.local:7680///").unwrap(),
             "http://studio.local:7680"
         );
-        assert_eq!(
-            normalize_host_url("https://mold.example.com/").unwrap(),
-            "https://mold.example.com"
-        );
-        assert_eq!(
-            normalize_host_url("http://mold.example.com/").unwrap(),
-            "http://mold.example.com"
-        );
+        for input in [
+            "100.123.198.98",
+            "100.123.198.98:9000",
+            "http://100.123.198.98",
+            "https://studio.tailnet.ts.net",
+            "https://studio.tailnet.ts.net:443",
+            "::1",
+        ] {
+            let once = normalize_host_url(input).unwrap();
+            assert_eq!(normalize_host_url(&once).unwrap(), once, "{input}");
+        }
         assert!(normalize_host_url("   ").is_err());
     }
 }

--- a/desktop/src/components/machines/ConnectMachineModal.test.ts
+++ b/desktop/src/components/machines/ConnectMachineModal.test.ts
@@ -82,6 +82,17 @@ describe("ConnectMachineModal", () => {
     expect(confirm.text()).toContain("online and ready");
   });
 
+  it("probes a bare IP through the default protocol and port", async () => {
+    const wrapper = await mountModal();
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='connect-address']").setValue("100.123.198.98");
+    await wrapper.get("[data-test='connect-continue']").trigger("click");
+    await flushPromises();
+
+    expect(testRemoteHost).toHaveBeenCalledWith("http://100.123.198.98:7680", null);
+  });
+
   it("hands the RunPod type off to the provisioning view and closes", async () => {
     const wrapper = await mountModal();
     await wrapper.get("[data-test='connect-type-runpod']").trigger("click");

--- a/desktop/src/lib/hosts.test.ts
+++ b/desktop/src/lib/hosts.test.ts
@@ -32,12 +32,32 @@ describe("hostIdFromUrl", () => {
 });
 
 describe("normalizeHostUrl", () => {
-  it("mirrors the Rust normalize_host_url rules", () => {
-    expect(normalizeHostUrl("hal9000")).toBe("http://hal9000:7680");
-    expect(normalizeHostUrl("studio.local:7680")).toBe("http://studio.local:7680");
+  it.each([
+    ["100.123.198.98", "http://100.123.198.98:7680"],
+    ["100.123.198.98:9000", "http://100.123.198.98:9000"],
+    ["http://100.123.198.98", "http://100.123.198.98"],
+    ["https://studio.tailnet.ts.net", "https://studio.tailnet.ts.net"],
+    ["https://studio.tailnet.ts.net:443", "https://studio.tailnet.ts.net"],
+    ["::1", "http://[::1]:7680"],
+  ])("normalizes %s with only the missing defaults", (input, expected) => {
+    expect(normalizeHostUrl(input)).toBe(expected);
+  });
+
+  it("strips trailing slashes and rejects blank input", () => {
     expect(normalizeHostUrl("http://studio.local:7680///")).toBe("http://studio.local:7680");
-    expect(normalizeHostUrl("https://mold.example.com/")).toBe("https://mold.example.com");
     expect(() => normalizeHostUrl("   ")).toThrow();
+  });
+
+  it.each([
+    "100.123.198.98",
+    "100.123.198.98:9000",
+    "http://100.123.198.98",
+    "https://studio.tailnet.ts.net",
+    "https://studio.tailnet.ts.net:443",
+    "::1",
+  ])("is idempotent for %s", (input) => {
+    const once = normalizeHostUrl(input);
+    expect(normalizeHostUrl(once)).toBe(once);
   });
 });
 

--- a/desktop/src/lib/hosts.ts
+++ b/desktop/src/lib/hosts.ts
@@ -97,12 +97,13 @@ export function mergeSavedHostsByInstanceId<T extends SavedHostLike>(
   return { hosts: out, dropped };
 }
 
-/** Default scheme/port, strip trailing slashes. Throws on garbage input. */
+/** Default a bare host to HTTP on Mold's port. Throws on garbage input. */
 export function normalizeHostUrl(input: string): string {
   const trimmed = input.trim().replace(/\/+$/, "");
   if (!trimmed) throw new Error("Enter a host, like hal9000");
-  const hasScheme = trimmed.startsWith("http://") || trimmed.startsWith("https://");
-  const withScheme = hasScheme ? trimmed : `http://${trimmed}`;
+  const hasScheme = /^https?:\/\//i.test(trimmed);
+  const bareIpv6 = !hasScheme && !trimmed.startsWith("[") && (trimmed.match(/:/g)?.length ?? 0) > 1;
+  const withScheme = hasScheme ? trimmed : `http://${bareIpv6 ? `[${trimmed}]` : trimmed}`;
   const url = new URL(withScheme);
   if (!url.hostname) throw new Error("Enter a valid host.");
   if (!hasScheme && !url.port) url.port = "7680";

--- a/desktop/src/mobile/hosts.test.ts
+++ b/desktop/src/mobile/hosts.test.ts
@@ -70,10 +70,13 @@ describe("mobile remote hosts", () => {
     ]);
   });
 
-  it("accepts Tailscale MagicDNS names and applies Mold's default port", () => {
-    expect(normalizeRemoteAddress("studio.tailnet.ts.net")).toBe(
-      "http://studio.tailnet.ts.net:7680",
-    );
+  it.each([
+    ["studio.tailnet.ts.net", "http://studio.tailnet.ts.net:7680"],
+    ["100.123.198.98", "http://100.123.198.98:7680"],
+    ["http://100.123.198.98", "http://100.123.198.98"],
+    ["https://studio.tailnet.ts.net", "https://studio.tailnet.ts.net"],
+  ])("uses iOS and Android connection defaults for %s", (input, expected) => {
+    expect(normalizeRemoteAddress(input)).toBe(expected);
   });
 
   it("preserves explicit HTTPS ports", () => {
@@ -84,6 +87,12 @@ describe("mobile remote hosts", () => {
 
   it("uses the HTTPS scheme default when a complete URL omits a port", () => {
     expect(normalizeRemoteAddress("https://mold.example.com/")).toBe("https://mold.example.com");
+  });
+
+  it("preserves an explicitly selected standard HTTPS port", () => {
+    expect(normalizeRemoteAddress("https://mold.example.com:443/")).toBe(
+      "https://mold.example.com",
+    );
   });
 
   it("creates a stable URL slug for legacy hosts without instance ids", () => {

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -456,10 +456,12 @@ export const useHostsStore = defineStore("hosts", {
     async connect(rawUrl: string, apiKey: string | null, name: string | null): Promise<HostView> {
       const url = normalizeHostUrl(rawUrl);
       const id = hostIdFromUrl(url);
-      // `https://local` slugs to the literal "local", colliding with the
-      // built-in engine's reserved id — refuse it rather than shadow the
-      // primary's secret/routing keys.
-      if (id === "local") throw new Error("That address is reserved for the built-in engine.");
+      // The host name "local" is reserved for the built-in engine. Check the
+      // normalized authority directly: adding Mold's default port must not
+      // turn the same reserved address into a different slug.
+      if (new URL(url).hostname.toLowerCase() === "local") {
+        throw new Error("That address is reserved for the built-in engine.");
+      }
       const existing = this.all.find((h) => h.id === id);
       // A fresh row already validated with this authority needs no work. A
       // stale row (or an explicitly supplied replacement key) must probe:

--- a/web/src/components/machines/ConnectModal.test.ts
+++ b/web/src/components/machines/ConnectModal.test.ts
@@ -286,6 +286,19 @@ describe("ConnectModal", () => {
     expect(w.emitted("close")).toBeTruthy();
   });
 
+  it("probes a bare IP through the default protocol and port", async () => {
+    hostStatus.mockResolvedValue(okStatus());
+    const w = mountModal();
+    await advanceToDetails(w);
+    await w.get('[data-test="connect-address"]').setValue("100.123.198.98");
+    await w.get('[data-test="connect-submit"]').trigger("click");
+    await flushPromises();
+
+    expect(hostStatus.mock.calls[0]?.[0]).toMatchObject({
+      url: "http://100.123.198.98:7680",
+    });
+  });
+
   it("labels an unnamed host with the server's hostname, never the raw URL", async () => {
     hostStatus.mockResolvedValue(okStatus({ hostname: "plato" }));
     const w = mountModal();

--- a/web/src/lib/hostRegistry.test.ts
+++ b/web/src/lib/hostRegistry.test.ts
@@ -30,7 +30,7 @@ describe("normalizeHostAddress", () => {
     );
   });
 
-  it("keeps an explicit https scheme (MagicDNS / TLS host)", () => {
+  it("keeps explicit https on its standard port", () => {
     expect(normalizeHostAddress("https://box.tail1234.ts.net")).toBe(
       "https://box.tail1234.ts.net",
     );
@@ -58,6 +58,29 @@ describe("normalizeHostAddress", () => {
     expect(normalizeHostAddress("http://100.105.134.43")).toBe(
       "http://100.105.134.43",
     );
+  });
+
+  it("preserves an explicitly selected standard HTTPS port", () => {
+    expect(normalizeHostAddress("https://box.tail1234.ts.net:443")).toBe(
+      "https://box.tail1234.ts.net",
+    );
+  });
+
+  it("accepts a bare IPv6 address and supplies both defaults", () => {
+    expect(normalizeHostAddress("::1")).toBe("http://[::1]:7680");
+  });
+
+  it.each([
+    "100.123.198.98",
+    "100.123.198.98:9000",
+    "http://100.123.198.98",
+    "https://box.tail1234.ts.net",
+    "https://box.tail1234.ts.net:443",
+    "::1",
+  ])("is idempotent for %s", (input) => {
+    const once = normalizeHostAddress(input);
+    expect(once).not.toBeNull();
+    expect(normalizeHostAddress(once!)).toBe(once);
   });
 
   it("returns null for empty or unparseable input", () => {

--- a/web/src/lib/hostRegistry.ts
+++ b/web/src/lib/hostRegistry.ts
@@ -49,16 +49,20 @@ export function originHost(): HostEntry {
 
 /**
  * Normalize a user-typed address (host, host:port, http(s)://…) to an origin
- * URL, or null when it is empty / unparseable. Schemeless input defaults to
- * http:// — the common LAN / IP / MagicDNS case — and, with no port given,
- * to mold's :7680 (the same rule as desktop's normalizeHostUrl and iOS).
- * An explicit scheme is taken as typed: its standard port applies.
+ * URL, or null when it is empty / unparseable. A bare host defaults to
+ * http:// on Mold's :7680; an explicit scheme or port is preserved.
  */
 export function normalizeHostAddress(input: string): string | null {
   const trimmed = input.trim();
   if (!trimmed) return null;
   const hasScheme = /^https?:\/\//i.test(trimmed);
-  const candidate = hasScheme ? trimmed : `http://${trimmed}`;
+  const bareIpv6 =
+    !hasScheme &&
+    !trimmed.startsWith("[") &&
+    (trimmed.match(/:/g)?.length ?? 0) > 1;
+  const candidate = hasScheme
+    ? trimmed
+    : `http://${bareIpv6 ? `[${trimmed}]` : trimmed}`;
   try {
     const url = new URL(candidate);
     if (!url.hostname) return null;


### PR DESCRIPTION
## Summary
- normalize bare hostnames, IPv4, and IPv6 consistently across iOS, Android, desktop, web, CLI, and TUI
- preserve explicit schemes and ports while making normalization idempotent
- add exact `100.123.198.98` UI and unit regression guards plus a changelog fragment

## Validation
- `nix develop -c ios-check`
- mobile, desktop, and web production builds
- targeted desktop and web suites (215 tests)
- mold-core normalization tests and full mold-core library suite
- desktop Tauri normalization test
- `cargo clippy -p mold-ai-core --all-targets -- -D warnings`
- three independent agent reviews with no remaining findings