### PR TITLE
fix(hosts): deduplicate machines by server UUID

### DIFF
--- a/apps/mobile/plugins/android/src/main/java/AndroidDiscovery.kt
+++ b/apps/mobile/plugins/android/src/main/java/AndroidDiscovery.kt
@@ -134,6 +134,7 @@ internal class AndroidDiscovery(
                                 address,
                                 port,
                                 resolved.attributes["auth"]?.toString(Charsets.UTF_8) == "1",
+                                resolved.attributes["id"]?.toString(Charsets.UTF_8)?.trim()?.ifBlank { null },
                             )
                         }
                         resolveNext()
@@ -159,6 +160,7 @@ internal class AndroidDiscovery(
                 put("host", host.host)
                 put("port", host.port)
                 put("authRequired", host.authRequired)
+                put("instanceId", host.instanceId)
             })
         }
         invoke.resolve(JSObject().apply { put("hosts", array) })
@@ -202,6 +204,7 @@ internal class AndroidDiscovery(
         val host: String,
         val port: Int,
         val authRequired: Boolean,
+        val instanceId: String?,
     )
 
     companion object {

--- a/apps/mobile/plugins/src/models.rs
+++ b/apps/mobile/plugins/src/models.rs
@@ -32,6 +32,7 @@ pub struct DiscoveredHost {
     pub host: String,
     pub port: u16,
     pub auth_required: bool,
+    pub instance_id: Option<String>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]

--- a/apps/mobile/src-tauri/src/discovery.rs
+++ b/apps/mobile/src-tauri/src/discovery.rs
@@ -12,10 +12,11 @@ pub struct DiscoveredHost {
     pub host: String,
     pub port: u16,
     pub auth_required: bool,
+    pub instance_id: Option<String>,
 }
 
 #[cfg(any(target_vendor = "apple", test))]
-fn auth_required_from_txt(txt: &[u8]) -> bool {
+fn txt_value(txt: &[u8], key: &[u8]) -> Option<String> {
     let mut cursor = 0;
     while cursor < txt.len() {
         let length = usize::from(txt[cursor]);
@@ -23,12 +24,22 @@ fn auth_required_from_txt(txt: &[u8]) -> bool {
         let Some(end) = cursor.checked_add(length).filter(|end| *end <= txt.len()) else {
             break;
         };
-        if txt[cursor..end] == *b"auth=1" {
-            return true;
+        let record = &txt[cursor..end];
+        if record.starts_with(key) && record.get(key.len()) == Some(&b'=') {
+            return std::str::from_utf8(&record[key.len() + 1..])
+                .ok()
+                .map(str::trim)
+                .filter(|value| !value.is_empty())
+                .map(ToOwned::to_owned);
         }
         cursor = end;
     }
-    false
+    None
+}
+
+#[cfg(any(target_vendor = "apple", test))]
+fn auth_required_from_txt(txt: &[u8]) -> bool {
+    txt_value(txt, b"auth").as_deref() == Some("1")
 }
 
 #[tauri::command]
@@ -58,6 +69,7 @@ async fn platform_discover(
                     host: host.host,
                     port: host.port,
                     auth_required: host.auth_required,
+                    instance_id: host.instance_id,
                 })
                 .collect()
         })
@@ -90,7 +102,7 @@ mod apple {
     use std::ffi::{c_char, c_void};
     use std::time::{Duration, Instant};
 
-    use super::{DiscoveredHost, auth_required_from_txt};
+    use super::{DiscoveredHost, auth_required_from_txt, txt_value};
 
     type ServiceRef = *mut c_void;
     type Flags = u32;
@@ -210,16 +222,18 @@ mod apple {
             .to_string();
         let full = unsafe { CStr::from_ptr(fullname) }.to_string_lossy();
         let name = full.split("._mold").next().unwrap_or(&host).to_string();
-        let auth_required = if txt.is_null() || txt_len == 0 {
-            false
+        let txt = if txt.is_null() || txt_len == 0 {
+            &[][..]
         } else {
-            auth_required_from_txt(unsafe { std::slice::from_raw_parts(txt, usize::from(txt_len)) })
+            unsafe { std::slice::from_raw_parts(txt, usize::from(txt_len)) }
         };
+        let auth_required = auth_required_from_txt(txt);
         state.host = Some(DiscoveredHost {
             name,
             host,
             port: u16::from_be(port_be),
             auth_required,
+            instance_id: txt_value(txt, b"id"),
         });
     }
 
@@ -315,7 +329,7 @@ mod apple {
 
 #[cfg(test)]
 mod tests {
-    use super::auth_required_from_txt;
+    use super::{auth_required_from_txt, txt_value};
 
     #[test]
     fn reads_auth_required_from_dns_sd_txt() {
@@ -328,5 +342,14 @@ mod tests {
             6, b'a', b'u', b't', b'h', b'=', b'0'
         ]));
         assert!(!auth_required_from_txt(&[8, b'a', b'u']));
+    }
+
+    #[test]
+    fn reads_instance_id_from_dns_sd_txt() {
+        let txt = [
+            6, b'a', b'u', b't', b'h', b'=', b'1', 9, b'i', b'd', b'=', b'u', b'u', b'i', b'd',
+            b'-', b'1',
+        ];
+        assert_eq!(txt_value(&txt, b"id").as_deref(), Some("uuid-1"));
     }
 }

--- a/changelog.d/host-uuid-address-dedup.md
+++ b/changelog.d/host-uuid-address-dedup.md
@@ -1,0 +1,5 @@
+- **Show each machine once across every Mold client.** Desktop, web, iPhone,
+  and Android now treat the server UUID as the machine identity, collapse IP,
+  hostname, and MagicDNS aliases, keep the most recently verified address on
+  the surviving row, and retain intentionally disconnected machines for later
+  reconnection.

--- a/desktop/src/lib/hosts.test.ts
+++ b/desktop/src/lib/hosts.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from "vitest";
 import {
   backendRank,
   hostIdFromUrl,
-  hostnamesCompatible,
   inferBackendFromGpuName,
   mergeSavedHostsByInstanceId,
   modelAvailabilityTag,
@@ -379,21 +378,18 @@ describe("mergeSavedHostsByInstanceId", () => {
     expect(hosts[0]).toMatchObject({ id: "a", name: "Render box" });
   });
 
-  it("keeps same-uuid entries apart when their hostnames differ (shared MOLD_HOME)", () => {
-    // Two RunPod pods on one network volume share a mold.db and thus one
-    // instance uuid — the reported hostname is what tells them apart.
-    const a = host({ id: "pod-a-7680", instanceId: "u", hostname: "pod-a", lastUsedMs: 2 });
-    const b = host({ id: "pod-b-7680", instanceId: "u", hostname: "pod-b", lastUsedMs: 1 });
+  it("merges same-uuid entries even when their reported hostnames differ", () => {
+    const a = host({ id: "pod-a-7680", instanceId: "u", lastUsedMs: 2 });
+    const b = host({ id: "pod-b-7680", instanceId: "u", lastUsedMs: 1 });
     const { hosts, dropped } = mergeSavedHostsByInstanceId([a, b]);
-    expect(hosts.map((h) => h.id)).toEqual(["pod-a-7680", "pod-b-7680"]);
-    expect(dropped).toEqual([]);
+    expect(hosts.map((h) => h.id)).toEqual(["pod-a-7680"]);
+    expect(dropped).toEqual([{ loser: "pod-b-7680", survivor: "pod-a-7680" }]);
   });
 
-  it("still merges when one side's hostname is unknown (older server / saved entry)", () => {
+  it("merges UUID aliases regardless of which address supplied the UUID", () => {
     const byName = host({
       id: "hal9000-7680",
       instanceId: "u",
-      hostname: "hal9000",
       lastUsedMs: 2,
     });
     const byIp = host({ id: "192-168-1-114-7680", instanceId: "u", lastUsedMs: 1 });
@@ -408,16 +404,6 @@ describe("mergeSavedHostsByInstanceId", () => {
     const { hosts, dropped } = mergeSavedHostsByInstanceId([a, b]);
     expect(hosts.map((h) => h.id)).toEqual(["hal9000-7680", "192-168-1-114-7680"]);
     expect(dropped).toEqual([]);
-  });
-});
-
-describe("hostnamesCompatible", () => {
-  it("treats unknown hostnames as compatible and distinct known ones as not", () => {
-    expect(hostnamesCompatible("hal9000", "hal9000")).toBe(true);
-    expect(hostnamesCompatible(null, "hal9000")).toBe(true);
-    expect(hostnamesCompatible("hal9000", undefined)).toBe(true);
-    expect(hostnamesCompatible(null, null)).toBe(true);
-    expect(hostnamesCompatible("pod-a", "pod-b")).toBe(false);
   });
 });
 

--- a/desktop/src/lib/hosts.ts
+++ b/desktop/src/lib/hosts.ts
@@ -45,24 +45,6 @@ export interface SavedHostLike {
   url: string;
   lastUsedMs?: number | null;
   instanceId?: string | null;
-  /** Last-known server-reported hostname (from telemetry / the connect probe).
-   *  Never persisted — callers thread it in to disambiguate distinct servers
-   *  that share an instance id (shared MOLD_HOME). Absent = unknown. */
-  hostname?: string | null;
-}
-
-/**
- * Whether two server-reported hostnames could belong to the same physical
- * server. Unknown hostnames (older servers, entries never polled) are
- * compatible with anything for back-compat; two distinct known hostnames are
- * proof of two distinct servers even when their instance ids collide (two
- * RunPod pods on one network volume share a mold.db and thus one uuid).
- */
-export function hostnamesCompatible(
-  a: string | null | undefined,
-  b: string | null | undefined,
-): boolean {
-  return !a || !b || a === b;
 }
 
 /**
@@ -72,9 +54,8 @@ export function hostnamesCompatible(
  * `lastUsedMs` (ties broken by input order), keeping its slug (and thus its
  * `remote-api-key.<id>` secret and routing keys); a user-assigned name on any
  * duplicate is preserved. Entries with no `instanceId` are never merged, and
- * a shared `instanceId` only counts when the reported hostnames are
- * compatible — two distinct known hostnames mean two distinct servers
- * sharing a MOLD_HOME, which must never collapse. Returns the deduped list
+ * a shared non-empty `instanceId` is authoritative regardless of which IP,
+ * hostname, or MagicDNS alias answered. Returns the deduped list
  * (input order, losers removed) and the loser→survivor id pairs so callers
  * can re-home secrets, connected ids, and a sticky generation target.
  */
@@ -90,11 +71,6 @@ export function mergeSavedHostsByInstanceId<T extends SavedHostLike>(
   }
   const survivorByInstance = new Map<string, T>();
   for (const [uuid, group] of groups) {
-    const known = new Set(group.map((h) => h.hostname).filter((n): n is string => !!n));
-    // ≥2 distinct hostnames answering under one uuid: distinct servers with a
-    // shared/copied data dir. Leave the whole group untouched — an unknown-
-    // hostname entry can't safely be assigned to either server.
-    if (known.size > 1) continue;
     let survivor = group[0]!;
     for (const host of group) {
       if ((host.lastUsedMs ?? 0) > (survivor.lastUsedMs ?? 0)) survivor = host;

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9763,6 +9763,7 @@ describe("MobileApp gallery", () => {
       if (path === "/api/status") {
         return Promise.resolve({
           ...status,
+          instance_id: baseUrl === remoteTarget.baseUrl ? "remote-instance" : "studio-instance",
           hostname: baseUrl === remoteTarget.baseUrl ? "remote" : "studio",
         });
       }
@@ -10085,7 +10086,8 @@ describe("MobileApp host and catalog coordination", () => {
         (requestTarget: unknown, path: string, init?: { signal?: AbortSignal }) => {
           const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
           if (path === "/api/models") return Promise.resolve([model]);
-          if (path === "/api/status" && baseUrl === target.baseUrl) return Promise.resolve(status);
+          if (path === "/api/status" && baseUrl === target.baseUrl)
+            return Promise.resolve({ ...status, instance_id: "studio-instance" });
           if (path === "/api/status") {
             return new Promise<ServerStatus>((resolve, reject) => {
               remoteProbes.push({ resolve, reject, signal: init?.signal });
@@ -10103,7 +10105,12 @@ describe("MobileApp host and catalog coordination", () => {
       expect(remoteProbes).toHaveLength(2);
       expect(remoteProbes[0]?.signal?.aborted).toBe(true);
 
-      remoteProbes[1]?.resolve({ ...status, version: "0.19.0", hostname: "render" });
+      remoteProbes[1]?.resolve({
+        ...status,
+        instance_id: "render-instance",
+        version: "0.19.0",
+        hostname: "render",
+      });
       await flushPromises();
       remoteProbes[0]?.reject(new Error("stale timeout"));
       await flushPromises();
@@ -10137,6 +10144,7 @@ describe("MobileApp host and catalog coordination", () => {
       if (path === "/api/status") {
         return Promise.resolve({
           ...status,
+          instance_id: baseUrl === remoteTarget.baseUrl ? "render-instance" : "studio-instance",
           hostname: baseUrl === remoteTarget.baseUrl ? "render" : "studio",
         });
       }

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -131,6 +131,7 @@ import { profileConflictMessage, profileHashConflict } from "@studio/lib/profile
 import {
   MOBILE_AUTO_ROUTING_HINT,
   MOBILE_CAPABLE_ROUTING_HINT,
+  MOBILE_GENERATE_TARGET_KEY,
   loadMobileGenerateTarget,
   mobileGenerateTargetLabel,
   mobileAutoRoutingAvailable,
@@ -347,12 +348,14 @@ import {
   mobileHostHealthLabel,
   mobileHostMatchesRoute,
   mobileHostTarget,
+  mergeMobileHostsByInstanceId,
   normalizeRemoteAddress,
   recordMobileHostAuthorityRejection,
   recordMobileHostProbeFailure,
   recordMobileHostStatus,
   remoteHostId,
   type MobileHost,
+  type MobileHostAliasDrop,
 } from "./hosts";
 import { applyMobileGalleryMetadata } from "./reuse";
 import {
@@ -473,6 +476,7 @@ import {
   claimMobileDurableTerminalEffect,
   createMobileDurableGenerationRecovery,
   loadMobileDurableGenerationRecoveries,
+  MOBILE_DURABLE_GENERATIONS_KEY,
   mergeMobileDurableHostStatus,
   mobileDurableAdmissionEffectKey,
   mobileDurableJobs,
@@ -537,6 +541,7 @@ interface DiscoveredHost {
   host: string;
   port: number;
   authRequired: boolean;
+  instanceId?: string;
 }
 
 interface GalleryPrint extends MobileGalleryImage {
@@ -675,6 +680,7 @@ const settingsButton = ref<HTMLButtonElement | null>(null);
 const settingsBackButton = ref<HTMLButtonElement | null>(null);
 const mobileSettings = reactive<MobileSettings>(loadMobileSettings());
 const appVersion = ref(import.meta.env.DEV ? "Development build" : "Current build");
+let pendingMobileHostAliasDrops: MobileHostAliasDrop[] = [];
 const hosts = ref<MobileHost[]>(loadHosts());
 function loadMobileActivity(): Record<string, ActivityHostSnapshot> {
   try {
@@ -1204,6 +1210,35 @@ const durableGenerationRetryConfirmations = new Set<string>();
 let nextDurableGenerationClientId = -1;
 let selectedDurableGenerationClientId: number | null = null;
 const mobileDownloads = useMobileDownloadsStore();
+
+function remapMobileHostAliases(dropped: readonly MobileHostAliasDrop[]): void {
+  for (const { loser, survivor } of dropped) {
+    cancelHostProbe(loser);
+    if (selectedHostId.value === loser) selectedHostId.value = survivor;
+    if (catalogHostId.value === loser) catalogHostId.value = survivor;
+    if (hostDetailId.value === loser) hostDetailId.value = survivor;
+    if (generateTargetPolicy.value === loser) {
+      generateTargetPolicy.value = survivor;
+      saveMobileGenerateTarget(survivor);
+    }
+    durableGenerationRecoveries.value = durableGenerationRecoveries.value.map((recovery) =>
+      recovery.tracker.hostId === loser
+        ? { ...recovery, tracker: { ...recovery.tracker, hostId: survivor } }
+        : recovery,
+    );
+    delete liveActivityHosts.value[loser];
+    delete liveQueues.value[loser];
+    delete liveActivityEpochs[loser];
+    retireMobileHostAuthority(loser);
+    pruneHostOrganization(loser);
+    knownHostReachability.delete(loser);
+    void invoke("keychain_delete_api_key", { hostId: loser }).catch(() => undefined);
+  }
+  if (dropped.length > 0) {
+    persistDurableGenerationRecoveries();
+    syncDurableGenerationJobs();
+  }
+}
 function loadLibrarySeenAt(): Record<string, number> {
   try {
     const parsed = JSON.parse(localStorage.getItem(LIBRARY_SEEN_AT_KEY) ?? "{}");
@@ -3596,7 +3631,8 @@ async function submitMobileDurableGeneration(input: {
 function loadHosts(): MobileHost[] {
   try {
     const raw = JSON.parse(localStorage.getItem(STORAGE_KEY) ?? "[]") as MobileHost[];
-    return raw.map((host) => ({
+    const merged = mergeMobileHostsByInstanceId(raw);
+    const normalized = merged.hosts.map((host) => ({
       ...host,
       connected: host.connected !== false,
       apiKey: "",
@@ -3606,6 +3642,49 @@ function loadHosts(): MobileHost[] {
       authorityRejected: false,
       instanceMismatch: undefined,
     }));
+    pendingMobileHostAliasDrops = merged.dropped;
+    for (const { loser, survivor } of merged.dropped) {
+      if (localStorage.getItem(SELECTED_KEY) === loser) localStorage.setItem(SELECTED_KEY, survivor);
+      if (localStorage.getItem(MOBILE_GENERATE_TARGET_KEY) === loser) {
+        localStorage.setItem(MOBILE_GENERATE_TARGET_KEY, survivor);
+      }
+      try {
+        const durable = JSON.parse(
+          localStorage.getItem(MOBILE_DURABLE_GENERATIONS_KEY) ?? "[]",
+        ) as Array<{ tracker?: { hostId?: string } }>;
+        for (const recovery of durable) {
+          if (recovery.tracker?.hostId === loser) recovery.tracker.hostId = survivor;
+        }
+        localStorage.setItem(MOBILE_DURABLE_GENERATIONS_KEY, JSON.stringify(durable));
+
+        const sequence = JSON.parse(localStorage.getItem(SEQUENCE_RECOVERY_KEY) ?? "null") as {
+          hostId?: string;
+        } | null;
+        if (sequence?.hostId === loser) {
+          sequence.hostId = survivor;
+          localStorage.setItem(SEQUENCE_RECOVERY_KEY, JSON.stringify(sequence));
+        }
+
+        const activity = JSON.parse(localStorage.getItem(LIVE_ACTIVITY_KEY) ?? "{}") as Record<
+          string,
+          unknown
+        >;
+        if (Object.hasOwn(activity, loser)) {
+          activity[survivor] ??= activity[loser];
+          delete activity[loser];
+          localStorage.setItem(LIVE_ACTIVITY_KEY, JSON.stringify(activity));
+        }
+      } catch {
+        // Each loader already rejects malformed recovery state safely.
+      }
+    }
+    if (merged.dropped.length > 0) {
+      localStorage.setItem(
+        STORAGE_KEY,
+        JSON.stringify(normalized.map(({ apiKey: _apiKey, ...host }) => host)),
+      );
+    }
+    return normalized;
   } catch {
     return [];
   }
@@ -3633,13 +3712,34 @@ async function hydrateApiKeys(): Promise<void> {
   await Promise.all(
     hosts.value.map(async (host) => {
       try {
-        host.apiKey =
-          (await invoke<string | null>("keychain_get_api_key", { hostId: host.id })) ?? "";
+        let key = await invoke<string | null>("keychain_get_api_key", { hostId: host.id });
+        let migratedAliasKey = false;
+        if (!key) {
+          for (const alias of pendingMobileHostAliasDrops.filter(
+            ({ survivor }) => survivor === host.id,
+          )) {
+            key = await invoke<string | null>("keychain_get_api_key", { hostId: alias.loser });
+            if (key) {
+              migratedAliasKey = true;
+              break;
+            }
+          }
+        }
+        host.apiKey = key ?? "";
+        if (host.apiKey && migratedAliasKey) {
+          await invoke("keychain_set_api_key", { hostId: host.id, apiKey: host.apiKey });
+        }
       } catch {
         host.apiKey = "";
       }
     }),
   );
+  await Promise.all(
+    pendingMobileHostAliasDrops.map(({ loser }) =>
+      invoke("keychain_delete_api_key", { hostId: loser }).catch(() => undefined),
+    ),
+  );
+  pendingMobileHostAliasDrops = [];
 }
 
 async function connectHost(address?: string, discoveredName?: string): Promise<void> {
@@ -3648,25 +3748,27 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
     const baseUrl = normalizeRemoteAddress(address ?? hostInput.address);
     const target = { baseUrl, apiKey: hostInput.apiKey.trim() || null };
     const status = await apiJsonTo<ServerStatus>(target, "/api/status");
-    const instanceId = status.instance_id ?? undefined;
+    const instanceId = status.instance_id?.trim() || undefined;
     const existing = hosts.value.find(
       (host) =>
-        host.baseUrl === baseUrl ||
-        (instanceId &&
-          (host.instanceId === instanceId || host.id === instanceId) &&
-          (!host.hostname || !status.hostname || host.hostname === status.hostname)),
+        (instanceId && host.instanceId?.trim() === instanceId) ||
+        (host.baseUrl === baseUrl && (!host.instanceId || !instanceId)),
     );
-    // URL identity keeps two machines that copied the same MOLD_HOME distinct;
-    // a compatible saved alias keeps its existing keychain id.
-    const id = existing?.id ?? remoteHostId(baseUrl);
+    const slug = remoteHostId(baseUrl);
+    const conflictingSlug = hosts.value.some(
+      (host) => host.id === slug && host.instanceId?.trim() !== instanceId,
+    );
+    const id = existing?.id ?? (conflictingSlug && instanceId ? instanceId : slug);
+    const successfulApiKey = hostInput.apiKey.trim() || existing?.apiKey || "";
     const saved: MobileHost = {
       id,
       name: hostInput.name.trim() || discoveredName || status.hostname || new URL(baseUrl).hostname,
       baseUrl,
-      apiKey: hostInput.apiKey.trim(),
+      apiKey: successfulApiKey,
       hostname: status.hostname ?? undefined,
       version: status.version,
       instanceId,
+      lastConnectedAtMs: Date.now(),
       connected: true,
       online: true,
       stale: false,
@@ -3674,8 +3776,27 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
       authorityRejected: false,
       instanceMismatch: undefined,
     };
-    if (existing) Object.assign(existing, saved);
-    else hosts.value.push(saved);
+    if (existing) {
+      if (existing.baseUrl !== baseUrl || existing.apiKey !== successfulApiKey) {
+        cancelHostProbe(existing.id);
+        retireMobileHostAuthority(existing.id);
+        pruneHostOrganization(existing.id);
+        knownHostReachability.delete(existing.id);
+      }
+      Object.assign(existing, saved);
+    }
+    else {
+      for (const host of hosts.value) {
+        if (host.baseUrl === baseUrl && host.instanceId?.trim() !== instanceId) {
+          host.connected = false;
+          host.online = false;
+        }
+      }
+      hosts.value.push(saved);
+    }
+    const aliases = mergeMobileHostsByInstanceId(hosts.value);
+    hosts.value = aliases.hosts;
+    remapMobileHostAliases(aliases.dropped);
     knownHostReachability.add(saved.id);
     if (saved.apiKey) {
       await invoke("keychain_set_api_key", { hostId: saved.id, apiKey: saved.apiKey });
@@ -3724,7 +3845,21 @@ async function discoverHosts(): Promise<void> {
   discovering.value = true;
   hostError.value = "";
   try {
-    discovered.value = await invoke<DiscoveredHost[]>("discover_mold_hosts", { timeoutMs: 2500 });
+    const found = await invoke<DiscoveredHost[]>("discover_mold_hosts", { timeoutMs: 2500 });
+    const reachableKnown = new Set(
+      hosts.value
+        .filter((host) => host.connected !== false && host.online && !host.stale)
+        .map((host) => host.instanceId?.trim())
+        .filter(Boolean),
+    );
+    const seen = new Set<string>();
+    discovered.value = found.filter((host) => {
+      const uuid = host.instanceId?.trim();
+      if (!uuid) return true;
+      if (reachableKnown.has(uuid) || seen.has(uuid)) return false;
+      seen.add(uuid);
+      return true;
+    });
   } catch (error) {
     hostError.value = describeTransportError(error);
   } finally {
@@ -3883,6 +4018,7 @@ function updateHostStatus(payload: {
   const host = hosts.value.find((candidate) => candidate.id === payload.id);
   if (!host) return false;
   if (payload.status) {
+    const priorInstanceId = host.instanceId?.trim() || null;
     const priorCacheKey = host.instanceId?.trim() || host.id;
     if (recordMobileHostStatus(host, payload.status) === "instance_mismatch") {
       retireMobileHostAuthority(host.id);
@@ -3893,6 +4029,14 @@ function updateHostStatus(payload: {
     const nextCacheKey = host.instanceId?.trim() || host.id;
     if (priorCacheKey !== nextCacheKey) void clearCachedGalleryHosts([priorCacheKey]);
     captureHostTelemetry(host.id, payload.status);
+    const aliases = mergeMobileHostsByInstanceId(hosts.value);
+    if (aliases.dropped.length > 0) {
+      hosts.value = aliases.hosts;
+      remapMobileHostAliases(aliases.dropped);
+    }
+    if (priorInstanceId !== (host.instanceId?.trim() || null) || aliases.dropped.length > 0) {
+      persistHosts();
+    }
   } else {
     const error = payload.error ?? new Error("Status probe failed");
     if (error instanceof ApiError && (error.status === 401 || error.status === 403)) {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3644,7 +3644,8 @@ function loadHosts(): MobileHost[] {
     }));
     pendingMobileHostAliasDrops = merged.dropped;
     for (const { loser, survivor } of merged.dropped) {
-      if (localStorage.getItem(SELECTED_KEY) === loser) localStorage.setItem(SELECTED_KEY, survivor);
+      if (localStorage.getItem(SELECTED_KEY) === loser)
+        localStorage.setItem(SELECTED_KEY, survivor);
       if (localStorage.getItem(MOBILE_GENERATE_TARGET_KEY) === loser) {
         localStorage.setItem(MOBILE_GENERATE_TARGET_KEY, survivor);
       }
@@ -3784,8 +3785,7 @@ async function connectHost(address?: string, discoveredName?: string): Promise<v
         knownHostReachability.delete(existing.id);
       }
       Object.assign(existing, saved);
-    }
-    else {
+    } else {
       for (const host of hosts.value) {
         if (host.baseUrl === baseUrl && host.instanceId?.trim() !== instanceId) {
           host.connected = false;

--- a/desktop/src/mobile/hosts.test.ts
+++ b/desktop/src/mobile/hosts.test.ts
@@ -83,9 +83,7 @@ describe("mobile remote hosts", () => {
   });
 
   it("uses the HTTPS scheme default when a complete URL omits a port", () => {
-    expect(normalizeRemoteAddress("https://mold.example.com/")).toBe(
-      "https://mold.example.com",
-    );
+    expect(normalizeRemoteAddress("https://mold.example.com/")).toBe("https://mold.example.com");
   });
 
   it("creates a stable URL slug for legacy hosts without instance ids", () => {

--- a/desktop/src/mobile/hosts.test.ts
+++ b/desktop/src/mobile/hosts.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   mobileHostHealthLabel,
   mobileHostMatchesRoute,
+  mergeMobileHostsByInstanceId,
   normalizeRemoteAddress,
   recordMobileHostAuthorityRejection,
   recordMobileHostProbeFailure,
@@ -38,6 +39,37 @@ function verifiedHost(overrides: Partial<MobileHost> = {}): MobileHost {
 }
 
 describe("mobile remote hosts", () => {
+  it("collapses IP and hostname aliases by UUID onto the last successful address", () => {
+    const byName = verifiedHost({
+      id: "hal9000-7680",
+      baseUrl: "http://hal9000:7680",
+      instanceId: "same-uuid",
+      lastConnectedAtMs: 10,
+    });
+    const byIp = verifiedHost({
+      id: "100-123-198-98-7681",
+      baseUrl: "http://100.123.198.98:7681",
+      instanceId: "same-uuid",
+      lastConnectedAtMs: 20,
+    });
+
+    expect(mergeMobileHostsByInstanceId([byName, byIp])).toEqual({
+      hosts: [byIp],
+      dropped: [{ loser: byName.id, survivor: byIp.id }],
+    });
+  });
+
+  it("does not merge missing or different server UUIDs", () => {
+    const unknown = verifiedHost({ id: "unknown", instanceId: " " });
+    const first = verifiedHost({ id: "first", instanceId: "uuid-1" });
+    const second = verifiedHost({ id: "second", instanceId: "uuid-2" });
+    expect(mergeMobileHostsByInstanceId([unknown, first, second]).hosts).toEqual([
+      unknown,
+      first,
+      second,
+    ]);
+  });
+
   it("accepts Tailscale MagicDNS names and applies Mold's default port", () => {
     expect(normalizeRemoteAddress("studio.tailnet.ts.net")).toBe(
       "http://studio.tailnet.ts.net:7680",
@@ -50,8 +82,10 @@ describe("mobile remote hosts", () => {
     );
   });
 
-  it("uses the standard HTTPS port when a complete HTTPS URL is entered", () => {
-    expect(normalizeRemoteAddress("https://mold.example.com/")).toBe("https://mold.example.com");
+  it("uses the HTTPS scheme default when a complete URL omits a port", () => {
+    expect(normalizeRemoteAddress("https://mold.example.com/")).toBe(
+      "https://mold.example.com",
+    );
   });
 
   it("creates a stable URL slug for legacy hosts without instance ids", () => {

--- a/desktop/src/mobile/hosts.ts
+++ b/desktop/src/mobile/hosts.ts
@@ -20,6 +20,8 @@ export interface MobileHost {
   version: string | undefined;
   /** Stable server installation id, kept separate from the URL-based row id. */
   instanceId?: string | undefined;
+  /** Wall-clock time of the successful probe that selected `baseUrl`. */
+  lastConnectedAtMs?: number | undefined;
   /** False only after an explicit disconnect; the address and Keychain key remain. */
   connected?: boolean;
   /** A status read succeeded for this exact host target during this app session. */
@@ -41,9 +43,54 @@ export interface MobileHost {
 
 export type MobileHostStatusOutcome = "verified" | "instance_mismatch";
 
-function normalizedInstanceId(value: string | null | undefined): string | null {
+export function normalizedInstanceId(value: string | null | undefined): string | null {
   const normalized = value?.trim();
   return normalized ? normalized : null;
+}
+
+export interface MobileHostAliasDrop {
+  loser: string;
+  survivor: string;
+}
+
+/**
+ * Collapse persisted URL aliases by the server UUID. The most recently
+ * successful address wins the whole row (including its stable Keychain id);
+ * legacy rows fall back to the one last known online, then input order.
+ * Empty UUIDs never merge.
+ */
+export function mergeMobileHostsByInstanceId<T extends MobileHost>(
+  input: readonly T[],
+): { hosts: T[]; dropped: MobileHostAliasDrop[] } {
+  const winnerByUuid = new Map<string, T>();
+  for (const host of input) {
+    const uuid = normalizedInstanceId(host.instanceId);
+    if (!uuid) continue;
+    const current = winnerByUuid.get(uuid);
+    const hostConnected = host.connected !== false;
+    const currentConnected = current?.connected !== false;
+    if (
+      !current ||
+      (hostConnected && !currentConnected) ||
+      (hostConnected === currentConnected &&
+        (host.lastConnectedAtMs ?? 0) > (current.lastConnectedAtMs ?? 0)) ||
+      (hostConnected === currentConnected &&
+        (host.lastConnectedAtMs ?? 0) === (current.lastConnectedAtMs ?? 0) &&
+        host.online &&
+        !current.online)
+    ) {
+      winnerByUuid.set(uuid, host);
+    }
+  }
+  const hosts: T[] = [];
+  const dropped: MobileHostAliasDrop[] = [];
+  for (const host of input) {
+    const uuid = normalizedInstanceId(host.instanceId);
+    const winner = uuid ? winnerByUuid.get(uuid) : undefined;
+    if (!winner || winner.id === host.id) hosts.push(host);
+    else dropped.push({ loser: host.id, survivor: winner.id });
+  }
+  return { hosts, dropped };
 }
 
 /**
@@ -75,6 +122,7 @@ export function recordMobileHostStatus(
   host.version = status.version;
   host.hostname = status.hostname ?? undefined;
   host.instanceId = reported ?? host.instanceId;
+  host.lastConnectedAtMs = Date.now();
   return "verified";
 }
 

--- a/desktop/src/stores/hostModels.test.ts
+++ b/desktop/src/stores/hostModels.test.ts
@@ -95,6 +95,27 @@ describe("hostModels store", () => {
     expect(store.byHost["local"]?.error).toBeNull();
   });
 
+  it("does not restore an in-flight model snapshot after its authority is retired", async () => {
+    addExtra("hal9000-7680", "http://hal9000:7680");
+    let resolveRemote!: (entries: ModelEntry[]) => void;
+    apiJsonTo.mockImplementation((target: { baseUrl: string }) =>
+      target.baseUrl.includes("hal9000")
+        ? new Promise<ModelEntry[]>((resolve) => {
+            resolveRemote = resolve;
+          })
+        : Promise.resolve([model("local-model")]),
+    );
+    const store = useHostModelsStore();
+    const refresh = store.refresh();
+    await vi.waitFor(() => expect(resolveRemote).toBeTypeOf("function"));
+
+    store.retireAuthority("hal9000-7680");
+    resolveRemote([model("stale-remote-model")]);
+    await refresh;
+
+    expect(store.byHost["hal9000-7680"]).toBeUndefined();
+  });
+
   it("skips hosts fetched under 60s ago unless forced", async () => {
     const store = useHostModelsStore();
     await store.refresh();

--- a/desktop/src/stores/hostModels.ts
+++ b/desktop/src/stores/hostModels.ts
@@ -27,6 +27,7 @@ export type UnionModelEntry = ModelEntry & { hostIds: string[] };
 export const useHostModelsStore = defineStore("hostModels", {
   state: () => ({
     byHost: {} as Record<string, HostModelList>,
+    authorityEpoch: {} as Record<string, number>,
     loading: false,
   }),
   getters: {
@@ -131,6 +132,11 @@ export const useHostModelsStore = defineStore("hostModels", {
     },
   },
   actions: {
+    /** Retire cached and in-flight model inventory read under an old target. */
+    retireAuthority(hostId: string) {
+      this.authorityEpoch[hostId] = (this.authorityEpoch[hostId] ?? 0) + 1;
+      delete this.byHost[hostId];
+    },
     /**
      * Fan out `/api/models` to every ready host. Hosts fetched under 60s ago
      * are skipped unless `force`; a host that fails keeps its last entries
@@ -143,13 +149,24 @@ export const useHostModelsStore = defineStore("hostModels", {
         .filter((h) => h.status === "ready" && h.baseUrl)
         .filter((h) => force || now - (this.byHost[h.id]?.fetchedAt ?? 0) >= STALE_MS)
         .map(async (h) => {
+          const authorityEpoch = this.authorityEpoch[h.id] ?? 0;
+          const isCurrent = () => {
+            const current = useHostsStore().all.find((host) => host.id === h.id);
+            return (
+              (this.authorityEpoch[h.id] ?? 0) === authorityEpoch &&
+              current?.baseUrl === h.baseUrl &&
+              current.apiKey === h.apiKey
+            );
+          };
           try {
             const entries = await apiJsonTo<ModelEntry[]>(
               { baseUrl: h.baseUrl!, apiKey: h.apiKey },
               "/api/models",
             );
+            if (!isCurrent()) return;
             this.byHost[h.id] = { entries, fetchedAt: Date.now(), error: null };
           } catch (err) {
+            if (!isCurrent()) return;
             const prev = this.byHost[h.id];
             this.byHost[h.id] = {
               entries: prev?.entries ?? [],

--- a/desktop/src/stores/hosts.test.ts
+++ b/desktop/src/stores/hosts.test.ts
@@ -2626,9 +2626,7 @@ describe("hosts store", () => {
     const second = await hosts.connect("http://pod-b:7680", null, null);
     expect(second.id).toBe(first.id);
     expect(second.baseUrl).toBe("http://pod-b:7680");
-    expect(hosts.all.filter((h) => h.kind === "remote").map((h) => h.id)).toEqual([
-      "pod-a-7680",
-    ]);
+    expect(hosts.all.filter((h) => h.kind === "remote").map((h) => h.id)).toEqual(["pod-a-7680"]);
   });
 
   it("reconcile does not clobber a settings write that lands during its secret IPC", async () => {

--- a/desktop/src/stores/hosts.test.ts
+++ b/desktop/src/stores/hosts.test.ts
@@ -6,6 +6,7 @@ const appSettingsGet = vi.fn();
 const appSettingsSet = vi.fn().mockResolvedValue(undefined);
 const secretGet = vi.fn().mockResolvedValue(null);
 const secretSet = vi.fn().mockResolvedValue(undefined);
+const secretClear = vi.fn().mockResolvedValue(undefined);
 const testRemoteHost = vi.fn();
 const startLocalEngine = vi.fn();
 const ensureLocalServer = vi.fn();
@@ -17,6 +18,7 @@ vi.mock("../lib/ipc", () => ({
     appSettingsSet: (...a: unknown[]) => appSettingsSet(...a),
     secretGet: (...a: unknown[]) => secretGet(...a),
     secretSet: (...a: unknown[]) => secretSet(...a),
+    secretClear: (...a: unknown[]) => secretClear(...a),
     testRemoteHost: (...a: unknown[]) => testRemoteHost(...a),
     startLocalEngine: (...a: unknown[]) => startLocalEngine(...a),
     ensureLocalServer: (...a: unknown[]) => ensureLocalServer(...a),
@@ -2609,9 +2611,7 @@ describe("hosts store", () => {
     expect(live.status).toBe("ready");
   });
 
-  it("connect() keeps two servers with the same instance id but different hostnames separate", async () => {
-    // Two RunPod pods sharing one network volume (shared MOLD_HOME) report
-    // the SAME instance uuid — the reported hostname tells them apart.
+  it("connect() treats the server UUID as authoritative across different hostnames", async () => {
     testRemoteHost.mockImplementation((url: string) =>
       Promise.resolve({
         ok: true,
@@ -2622,12 +2622,12 @@ describe("hosts store", () => {
       }),
     );
     const hosts = useHostsStore();
-    await hosts.connect("http://pod-a:7680", null, null);
+    const first = await hosts.connect("http://pod-a:7680", null, null);
     const second = await hosts.connect("http://pod-b:7680", null, null);
-    expect(second.id).toBe("pod-b-7680");
+    expect(second.id).toBe(first.id);
+    expect(second.baseUrl).toBe("http://pod-b:7680");
     expect(hosts.all.filter((h) => h.kind === "remote").map((h) => h.id)).toEqual([
       "pod-a-7680",
-      "pod-b-7680",
     ]);
   });
 
@@ -2691,6 +2691,9 @@ describe("hosts store", () => {
         connectedHostIds: [ip.id],
       }),
     );
+    secretGet.mockImplementation((name: string) =>
+      Promise.resolve(name.endsWith(ip.id) ? "working-ip-key" : "stale-hostname-key"),
+    );
     testRemoteHost.mockResolvedValue({ ok: true, version: null, error: null });
     apiJsonTo.mockImplementation((target: { baseUrl: string }) => {
       const remote = !target.baseUrl.includes("127.0.0.1");
@@ -2702,6 +2705,9 @@ describe("hosts store", () => {
         hostname: remote ? "hal9000" : "this-mac",
       });
     });
+    useHostModelsStore().byHost[hal.id] = { entries: [], fetchedAt: 1, error: null };
+    useHostModelsStore().byHost[ip.id] = { entries: [], fetchedAt: 1, error: null };
+    const unsubscribeHost = vi.spyOn(useDownloadsStore(), "unsubscribeHost");
     const hosts = useHostsStore();
     await hosts.init();
     await hosts.refresh();
@@ -2710,6 +2716,13 @@ describe("hosts store", () => {
     expect(hosts.all.some((h) => h.id === ip.id)).toBe(false);
     const persisted = appSettingsSet.mock.lastCall?.[0] as ReturnType<typeof settings>;
     expect(persisted.connectedHostIds).toEqual([hal.id]);
+    expect(secretSet).toHaveBeenCalledWith(`remote-api-key.${hal.id}`, "working-ip-key");
+    expect(useHostModelsStore().byHost[hal.id]).toBeUndefined();
+    expect(useHostModelsStore().byHost[ip.id]).toBeUndefined();
+    expect(useHostModelsStore().authorityEpoch[hal.id]).toBeGreaterThan(0);
+    expect(useHostModelsStore().authorityEpoch[ip.id]).toBeGreaterThan(0);
+    expect(unsubscribeHost).toHaveBeenCalledWith(hal.id);
+    expect(unsubscribeHost).toHaveBeenCalledWith(ip.id);
   });
 
   it("reconcile re-homes in-memory names and the appPrefs snapshot", async () => {
@@ -2785,5 +2798,47 @@ describe("hosts store", () => {
     expect(persisted.savedHosts.map((h: SavedHost) => h.id)).toEqual([hal.id]);
     expect(persisted.connectedHostIds).toEqual([hal.id]);
     expect(persisted.generateTargetHost).toBe(hal.id);
+  });
+
+  it("refresh() removes a remote alias of the built-in local UUID", async () => {
+    installSettings(
+      settings({
+        savedHosts: [{ ...hal, instanceId: "uuid-local" }],
+        connectedHostIds: [hal.id],
+        generateTargetHost: hal.id,
+      }),
+    );
+    testRemoteHost.mockResolvedValue({
+      ok: true,
+      version: null,
+      error: null,
+      instanceId: "uuid-local",
+    });
+    apiJsonTo.mockResolvedValue({
+      queue_depth: 0,
+      queue_capacity: 8,
+      version: "0.18.0",
+      instance_id: "uuid-local",
+      hostname: "this-mac",
+    });
+    useHostModelsStore().byHost.local = { entries: [], fetchedAt: 1, error: null };
+    useHostModelsStore().byHost[hal.id] = { entries: [], fetchedAt: 1, error: null };
+    const unsubscribeHost = vi.spyOn(useDownloadsStore(), "unsubscribeHost");
+    const hosts = useHostsStore();
+    await hosts.init();
+    await hosts.refresh();
+
+    expect(hosts.all.filter((host) => host.kind === "remote")).toEqual([]);
+    expect(hosts.extras).toEqual([]);
+    expect(useHostModelsStore().byHost.local).toBeUndefined();
+    expect(useHostModelsStore().byHost[hal.id]).toBeUndefined();
+    expect(useHostModelsStore().authorityEpoch.local).toBeGreaterThan(0);
+    expect(useHostModelsStore().authorityEpoch[hal.id]).toBeGreaterThan(0);
+    expect(unsubscribeHost).toHaveBeenCalledWith(hal.id);
+    expect(unsubscribeHost).not.toHaveBeenCalledWith("local");
+    const persisted = appSettingsSet.mock.lastCall?.[0] as ReturnType<typeof settings>;
+    expect(persisted.savedHosts).toEqual([]);
+    expect(persisted.connectedHostIds).toEqual([]);
+    expect(persisted.generateTargetHost).toBe("local");
   });
 });

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -1519,9 +1519,7 @@ export const useHostsStore = defineStore("hosts", {
             // current address. Persist it so the next launch does not retry a
             // dead hostname alias before showing the working IP.
             merged = merged.map((host) =>
-              host.id === survivor
-                ? { ...host, url: loserLive.url, lastUsedMs: Date.now() }
-                : host,
+              host.id === survivor ? { ...host, url: loserLive.url, lastUsedMs: Date.now() } : host,
             );
           } else {
             this.extras = this.extras.filter((h) => h.id !== loser);

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -20,7 +20,6 @@ import { ApiError, apiJsonTo, type ApiTarget } from "../lib/api/client";
 import { fetchServerCapabilities } from "../lib/api/serverCapabilities";
 import {
   hostIdFromUrl,
-  hostnamesCompatible,
   mergeSavedHostsByInstanceId,
   normalizeHostUrl,
   pickAutoHost,
@@ -346,8 +345,6 @@ export const useHostsStore = defineStore("hosts", {
     all(state): HostView[] {
       const primary = this.primaryHost;
       const rows: HostView[] = primary ? [primary] : [];
-      const hostnameOf = (id: string): string | null =>
-        state.hostnames[id] ?? state.telemetry[id]?.hostname ?? null;
       for (const extra of state.extras) {
         const t = state.telemetry[extra.id];
         const instanceId = t?.instanceId ?? extra.instanceId ?? null;
@@ -360,9 +357,7 @@ export const useHostsStore = defineStore("hosts", {
             (row) =>
               row.id === extra.id ||
               (row.baseUrl && row.baseUrl === extra.url) ||
-              (instanceId !== null &&
-                row.instanceId === instanceId &&
-                hostnamesCompatible(hostnameOf(row.id), hostnameOf(extra.id))),
+              (instanceId !== null && row.instanceId === instanceId),
           )
         )
           continue;
@@ -370,7 +365,11 @@ export const useHostsStore = defineStore("hosts", {
           id: extra.id,
           // User rename wins; otherwise the last-known server hostname (sticky
           // across failed polls); otherwise the URL.
-          label: this.names[extra.id] ?? hostnameOf(extra.id) ?? extra.label,
+          label:
+            this.names[extra.id] ??
+            state.hostnames[extra.id] ??
+            state.telemetry[extra.id]?.hostname ??
+            extra.label,
           kind: "remote",
           baseUrl: extra.url,
           apiKey: extra.apiKey,
@@ -487,16 +486,7 @@ export const useHostsStore = defineStore("hosts", {
       // instead of returning the dead row untouched. The primary "local" row
       // has no extra, so it is returned as-is.
       if (instanceId !== null) {
-        // Hostname-qualified: a shared uuid with a DIFFERENT reported hostname
-        // is two servers sharing a MOLD_HOME, not one server on two addresses.
-        const twin = this.all.find(
-          (h) =>
-            h.instanceId === instanceId &&
-            hostnamesCompatible(
-              this.hostnames[h.id] ?? this.telemetry[h.id]?.hostname,
-              test.hostname,
-            ),
-        );
+        const twin = this.all.find((h) => h.instanceId === instanceId);
         if (twin) {
           if (test.hostname) this.hostnames[twin.id] = test.hostname;
           if (apiKey) await ipc.secretSet(`remote-api-key.${twin.id}`, apiKey);
@@ -517,7 +507,7 @@ export const useHostsStore = defineStore("hosts", {
               // model, or capability data read under another URL/key current.
               delete this.telemetry[twin.id];
               delete this.capabilities[twin.id];
-              delete useHostModelsStore().byHost[twin.id];
+              useHostModelsStore().retireAuthority(twin.id);
               live.url = url;
               live.status = "connecting";
               live.error = null;
@@ -557,7 +547,7 @@ export const useHostsStore = defineStore("hosts", {
           retiredExistingAuthority = true;
           delete this.telemetry[id];
           delete this.capabilities[id];
-          delete useHostModelsStore().byHost[id];
+          useHostModelsStore().retireAuthority(id);
         }
       }
       this.extras = this.extras.filter((h) => h.id !== id);
@@ -586,7 +576,7 @@ export const useHostsStore = defineStore("hosts", {
       this.extras = this.extras.filter((h) => h.id !== id);
       delete this.telemetry[id];
       delete this.capabilities[id];
-      delete useHostModelsStore().byHost[id];
+      useHostModelsStore().retireAuthority(id);
       let clearedTarget = false;
       await withSettingsLock(async () => {
         const settings = await ipc.appSettingsGet();
@@ -1311,7 +1301,7 @@ export const useHostsStore = defineStore("hosts", {
               return false;
             delete this.telemetry[host.id];
             delete this.capabilities[host.id];
-            delete useHostModelsStore().byHost[host.id];
+            useHostModelsStore().retireAuthority(host.id);
             const extra = this.extras.find((candidate) => candidate.id === host.id);
             if (extra) {
               extra.status = "connecting";
@@ -1361,7 +1351,7 @@ export const useHostsStore = defineStore("hosts", {
             const queue = queueResult.value;
             const nextInstanceId = status.instance_id ?? null;
             const instanceChanged = previousInstanceId !== nextInstanceId;
-            if (instanceChanged) delete useHostModelsStore().byHost[host.id];
+            if (instanceChanged) useHostModelsStore().retireAuthority(host.id);
             const previousPredictedCompletion = previousTelemetry?.predictedCompletionMs ?? null;
             this.telemetry[host.id] = {
               queueDepth: status.queue_depth ?? null,
@@ -1456,59 +1446,83 @@ export const useHostsStore = defineStore("hosts", {
     /**
      * Persist newly-learned instance ids onto their saved entries and collapse
      * saved hosts that turn out to be the same physical server (same instance
-     * id AND a compatible hostname). Writes settings only when something
+     * id). Writes settings only when something
      * actually changed, so the 10 s poll stays quiet in steady state. Re-homes
      * the loser's connected-id, sticky target, per-host secret, user name, and
      * live extra onto the surviving slug — in memory as well as on disk.
      */
     async reconcileSavedInstanceIds(learned: Map<string, string>) {
-      const hostnameOf = (id: string): string | null =>
-        this.hostnames[id] ?? this.telemetry[id]?.hostname ?? null;
       const stamp = (saved: SavedHost[]) =>
         saved.map((h) => {
           const uuid = learned.get(h.id);
-          const next = uuid && h.instanceId !== uuid ? { ...h, instanceId: uuid } : h;
-          const hostname = hostnameOf(h.id);
-          return (hostname ? { ...next, hostname } : next) as SavedHost & {
-            hostname?: string | null;
-          };
+          return uuid && h.instanceId !== uuid ? { ...h, instanceId: uuid } : h;
         });
-      // Carry per-host secrets onto survivors BEFORE the settings
-      // read-modify-write, so the get→set window below contains no slow
-      // secret IPC — writers outside this store's lock (theme toggles, route
-      // memory) must not be clobbered by a stale settings snapshot.
-      const probe = mergeSavedHostsByInstanceId(stamp((await ipc.appSettingsGet()).savedHosts));
-      for (const { loser, survivor } of probe.dropped) {
-        const survivorKey = await ipc.secretGet(`remote-api-key.${survivor}`);
-        if (!survivorKey) {
-          const loserKey = await ipc.secretGet(`remote-api-key.${loser}`);
-          if (loserKey) await ipc.secretSet(`remote-api-key.${survivor}`, loserKey);
-        }
-      }
+      const mergeWithLocal = (saved: SavedHost[]) => {
+        const localInstanceId = learned.get("local") ?? this.telemetry.local?.instanceId ?? null;
+        const local = this.primaryHost;
+        if (!localInstanceId || !local?.baseUrl) return mergeSavedHostsByInstanceId(saved);
+        const syntheticLocal: SavedHost = {
+          id: "local",
+          name: null,
+          url: local.baseUrl,
+          lastUsedMs: Number.MAX_SAFE_INTEGER,
+          instanceId: localInstanceId,
+        };
+        const merged = mergeSavedHostsByInstanceId([syntheticLocal, ...saved]);
+        return { ...merged, hosts: merged.hosts.filter((host) => host.id !== "local") };
+      };
+      let appliedDropped: Array<{ loser: string; survivor: string }> = [];
       await withSettingsLock(async () => {
         const settings = await ipc.appSettingsGet();
         const stamped = stamp(settings.savedHosts);
-        const { hosts: merged, dropped } = mergeSavedHostsByInstanceId(stamped);
+        const { hosts: initiallyMerged, dropped } = mergeWithLocal(stamped);
+        let merged = initiallyMerged;
         const changed =
           dropped.length > 0 ||
           stamped.some((h, i) => h.instanceId !== settings.savedHosts[i]?.instanceId);
         if (!changed) return;
+        appliedDropped = dropped;
 
         let connectedHostIds = settings.connectedHostIds;
         let generateTargetHost = settings.generateTargetHost;
         for (const { loser, survivor } of dropped) {
+          const downloads = useDownloadsStore();
+          downloads.unsubscribeHost(loser);
+          if (survivor !== "local") downloads.unsubscribeHost(survivor);
+          useHostModelsStore().retireAuthority(loser);
+          useHostModelsStore().retireAuthority(survivor);
           connectedHostIds = connectedHostIds.map((id) => (id === loser ? survivor : id));
           if (generateTargetHost === loser) generateTargetHost = survivor;
+          if (survivor === "local") {
+            this.extras = this.extras.filter((host) => host.id !== loser && host.id !== "local");
+            delete this.telemetry[loser];
+            delete this.capabilities[loser];
+            delete this.hostnames[loser];
+            delete this.names[loser];
+            continue;
+          }
           // The loser may hold the only working live connection (the
           // survivor's own address might not answer right now) — re-home it
           // onto the surviving slug instead of deleting it.
           const loserLive = this.extras.find((h) => h.id === loser);
-          if (loserLive && !this.extras.some((h) => h.id === survivor)) {
-            this.extras = this.extras.map((h) => (h.id === loser ? { ...h, id: survivor } : h));
+          const survivorLive = this.extras.find((h) => h.id === survivor);
+          const loserIsOnlySuccessfulAlias = learned.has(loser) && !learned.has(survivor);
+          if (loserLive && (!survivorLive || loserIsOnlySuccessfulAlias)) {
+            this.extras = this.extras
+              .filter((host) => host.id !== survivor)
+              .map((host) => (host.id === loser ? { ...host, id: survivor } : host));
             if (this.telemetry[loser]) this.telemetry[survivor] = this.telemetry[loser];
             if (this.capabilities[loser]) this.capabilities[survivor] = this.capabilities[loser];
             if (this.hostnames[loser] && !this.hostnames[survivor])
               this.hostnames[survivor] = this.hostnames[loser];
+            // The UUID owns the row, while this successful route owns its
+            // current address. Persist it so the next launch does not retry a
+            // dead hostname alias before showing the working IP.
+            merged = merged.map((host) =>
+              host.id === survivor
+                ? { ...host, url: loserLive.url, lastUsedMs: Date.now() }
+                : host,
+            );
           } else {
             this.extras = this.extras.filter((h) => h.id !== loser);
           }
@@ -1520,12 +1534,8 @@ export const useHostsStore = defineStore("hosts", {
           if (this.names[loser] && !this.names[survivor]) this.names[survivor] = this.names[loser];
           delete this.names[loser];
         }
-        // `hostname` is a merge input, never a persisted field.
-        const savedHosts: SavedHost[] = merged.map((h) => {
-          const { hostname: _hostname, ...rest } = h;
-          return rest;
-        });
-        connectedHostIds = [...new Set(connectedHostIds)];
+        const savedHosts: SavedHost[] = merged;
+        connectedHostIds = [...new Set(connectedHostIds)].filter((id) => id !== "local");
         await ipc.appSettingsSet({ ...settings, savedHosts, connectedHostIds, generateTargetHost });
         // Keep the in-memory prefs snapshot coherent the same way disconnect()
         // does — every generateTargetHost reader consumes it.
@@ -1533,6 +1543,20 @@ export const useHostsStore = defineStore("hosts", {
         if (prefs.settings)
           prefs.settings = { ...prefs.settings, savedHosts, connectedHostIds, generateTargetHost };
       });
+      // Migrate only the aliases from the exact settings snapshot committed
+      // above. A stale preflight must never clear a key for a row another
+      // settings writer kept or introduced.
+      for (const { loser, survivor } of appliedDropped) {
+        if (survivor !== "local") {
+          const survivorKey = await ipc.secretGet(`remote-api-key.${survivor}`);
+          const loserKey = await ipc.secretGet(`remote-api-key.${loser}`);
+          const loserIsOnlySuccessfulAlias = learned.has(loser) && !learned.has(survivor);
+          if (loserKey && (loserIsOnlySuccessfulAlias || !survivorKey)) {
+            await ipc.secretSet(`remote-api-key.${survivor}`, loserKey);
+          }
+        }
+        await ipc.secretClear(`remote-api-key.${loser}`);
+      }
     },
     async runPoll(generation: number) {
       try {
@@ -1578,17 +1602,8 @@ export const useHostsStore = defineStore("hosts", {
           },
           ...settings.savedHosts.filter((h) => h.id !== id),
         ].slice(0, MAX_SAVED_HOSTS);
-        // Collapse any saved twin that shares this host's instance id (and a
-        // compatible last-known hostname).
-        const withHostnames = upserted.map((h) => {
-          const hostname = this.hostnames[h.id] ?? this.telemetry[h.id]?.hostname ?? null;
-          return hostname ? { ...h, hostname } : h;
-        });
-        const { hosts: mergedHosts, dropped } = mergeSavedHostsByInstanceId(withHostnames);
-        const savedHosts: SavedHost[] = mergedHosts.map((h) => {
-          const { hostname: _hostname, ...rest } = h as SavedHost & { hostname?: string | null };
-          return rest;
-        });
+        // Collapse any saved twin that shares this host's authoritative UUID.
+        const { hosts: savedHosts, dropped } = mergeSavedHostsByInstanceId(upserted);
         const droppedIds = new Set(dropped.map((d) => d.loser));
         const connectedHostIds = [
           ...new Set(

--- a/desktop/src/views/MachinesView.vue
+++ b/desktop/src/views/MachinesView.vue
@@ -268,19 +268,24 @@ async function connectSaved(host: SavedHost) {
 const discovered = ref<DiscoveredHost[]>([]);
 const scanning = ref(false);
 
-const undiscovered = computed(() =>
-  discovered.value.filter(
-    (d) =>
+const undiscovered = computed(() => {
+  const seenInstanceIds = new Set<string>();
+  return discovered.value.filter((d) => {
+    const instanceId = d.instanceId?.trim() || null;
+    const visible =
       !connectedRemoteIds.value.has(hostIdFromUrl(d.url)) &&
-      !(d.instanceId && connectedRemoteInstanceIds.value.has(d.instanceId)) &&
+      !(instanceId && connectedRemoteInstanceIds.value.has(instanceId)) &&
       // The app's own embedded server is already the This-device card; its
       // mDNS advertisement is noise here. Instance UUID identifies the
       // primary (so a standalone `mold serve` on this machine stays listed),
       // and isThisMachine guards against a copied MOLD_HOME sharing that
       // UUID from another box.
-      !(d.isThisMachine && d.instanceId && d.instanceId === hosts.primaryHost?.instanceId),
-  ),
-);
+      !(d.isThisMachine && instanceId && instanceId === hosts.primaryHost?.instanceId) &&
+      !(instanceId && seenInstanceIds.has(instanceId));
+    if (visible && instanceId) seenInstanceIds.add(instanceId);
+    return visible;
+  });
+});
 
 async function scan() {
   scanning.value = true;

--- a/web/src/components/machines/ConnectModal.vue
+++ b/web/src/components/machines/ConnectModal.vue
@@ -53,12 +53,17 @@ const { onKeydown } = useOverlayFocus(isOpen, host, () => close());
 
 const visiblePeers = computed(() => {
   const storedIds = new Set(listStoredHosts().map((host) => host.id));
-  return discovered.value.filter(
-    (peer) =>
+  const seenInstanceIds = new Set<string>();
+  return discovered.value.filter((peer) => {
+    const instanceId = peer.instance_id?.trim() || null;
+    const visible =
       !peer.is_this_machine &&
-      !(peer.instance_id && dedupeByInstanceId(peer.instance_id)) &&
-      !storedIds.has(hostIdFromUrl(peer.url)),
-  );
+      !(instanceId && dedupeByInstanceId(instanceId)) &&
+      !storedIds.has(hostIdFromUrl(peer.url)) &&
+      !(instanceId && seenInstanceIds.has(instanceId));
+    if (visible && instanceId) seenInstanceIds.add(instanceId);
+    return visible;
+  });
 });
 
 function stopDiscoveryRefresh() {

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -22,6 +22,7 @@ import {
   ORIGIN_HOST_ID,
   getGenerateTargetId,
   listHosts,
+  recordSuccessfulHostInstance,
   setGenerateTargetId,
   type HostEntry,
 } from "../lib/hostRegistry";
@@ -568,6 +569,8 @@ async function pollHost(entry: HostEntry): Promise<void> {
     const previousInstanceId =
       telemetry.value[entry.id]?.instanceId ?? entry.instanceId ?? null;
     const nextInstanceId = status.value.instance_id ?? null;
+    const canonical = recordSuccessfulHostInstance(entry.id, nextInstanceId);
+    if (!canonical) return;
     instanceChanged = previousInstanceId !== nextInstanceId;
     if (instanceChanged) {
       routingAuthorityGeneration += 1;

--- a/web/src/lib/hostRegistry.test.ts
+++ b/web/src/lib/hostRegistry.test.ts
@@ -201,7 +201,11 @@ describe("dedupe by instance id", () => {
   });
 
   it("persists a polled UUID, selects that working address, and remaps recovery state", () => {
-    const hostname = addHost({ url: "hal9000:7680", name: "hal9000", instanceId: "uuid-1" });
+    const hostname = addHost({
+      url: "hal9000:7680",
+      name: "hal9000",
+      instanceId: "uuid-1",
+    });
     const ip = addHost({ url: "100.123.198.98:7681", name: "hal9000 IP" });
     localStorage.setItem(
       "mold.create.tracked-sequences.v1",
@@ -219,16 +223,27 @@ describe("dedupe by instance id", () => {
 
     const canonical = recordSuccessfulHostInstance(ip.id, " uuid-1 ");
 
-    expect(canonical).toMatchObject({ id: ip.id, url: "http://100.123.198.98:7681" });
+    expect(canonical).toMatchObject({
+      id: ip.id,
+      url: "http://100.123.198.98:7681",
+    });
     expect(listStoredHosts()).toHaveLength(1);
     expect(getGenerateTargetId()).toBe(ip.id);
-    expect(localStorage.getItem("mold.create.tracked-sequences.v1")).toContain(ip.id);
+    expect(localStorage.getItem("mold.create.tracked-sequences.v1")).toContain(
+      ip.id,
+    );
     expect(localStorage.getItem("mold.generate.jobs")).toContain(ip.id);
-    expect(localStorage.getItem("mold.generate.jobs.recovery.batch-1")).toContain(ip.id);
+    expect(
+      localStorage.getItem("mold.generate.jobs.recovery.batch-1"),
+    ).toContain(ip.id);
   });
 
   it("keeps different UUIDs separate even when the URL slug is reused", () => {
-    const old = addHost({ url: "render:7680", name: "Old", instanceId: "uuid-old" });
+    const old = addHost({
+      url: "render:7680",
+      name: "Old",
+      instanceId: "uuid-old",
+    });
     const replacement = addHost({
       url: "render:7680",
       name: "Replacement",
@@ -236,7 +251,9 @@ describe("dedupe by instance id", () => {
     });
     expect(replacement.id).not.toBe(old.id);
     expect(listStoredHosts()).toHaveLength(2);
-    expect(listStoredHosts().find((host) => host.id === old.id)?.connected).toBe(false);
+    expect(
+      listStoredHosts().find((host) => host.id === old.id)?.connected,
+    ).toBe(false);
   });
 
   it("removes a stored alias when its UUID is the browser origin", () => {

--- a/web/src/lib/hostRegistry.test.ts
+++ b/web/src/lib/hostRegistry.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it } from "vitest";
 import {
   ORIGIN_HOST_ID,
+  HOSTS_STORAGE_KEY,
   addHost,
   dedupeByInstanceId,
   getGenerateTargetId,
@@ -10,6 +11,8 @@ import {
   listStoredHosts,
   normalizeHostAddress,
   originHost,
+  recordSuccessfulHostInstance,
+  reconcileOriginInstanceId,
   removeHost,
   setGenerateTargetId,
   setHostConnected,
@@ -51,9 +54,7 @@ describe("normalizeHostAddress", () => {
     );
   });
 
-  it("respects an explicit scheme without inventing a port", () => {
-    // Typing the scheme means "I know the port" — http defaults to 80,
-    // matching desktop normalizeHostUrl.
+  it("uses the scheme default when a complete URL omits a port", () => {
     expect(normalizeHostAddress("http://100.105.134.43")).toBe(
       "http://100.105.134.43",
     );
@@ -166,6 +167,90 @@ describe("dedupe by instance id", () => {
     expect(merged.url).toBe("http://studio.local:7680");
     expect(merged.name).toBe("Studio (mDNS)");
     expect(listStoredHosts()).toHaveLength(1);
+  });
+
+  it("migrates stored aliases onto the most recently successful address", () => {
+    localStorage.setItem(
+      HOSTS_STORAGE_KEY,
+      JSON.stringify([
+        {
+          id: "hal9000-7680",
+          name: "hal9000",
+          url: "http://hal9000:7680",
+          instanceId: "uuid-1",
+          lastConnectedAtMs: 10,
+        },
+        {
+          id: "100-123-198-98-7681",
+          name: "hal9000",
+          url: "http://100.123.198.98:7681",
+          instanceId: "uuid-1",
+          lastConnectedAtMs: 20,
+        },
+      ]),
+    );
+    setGenerateTargetId("hal9000-7680");
+
+    expect(listStoredHosts()).toEqual([
+      expect.objectContaining({
+        id: "100-123-198-98-7681",
+        url: "http://100.123.198.98:7681",
+      }),
+    ]);
+    expect(getGenerateTargetId()).toBe("100-123-198-98-7681");
+  });
+
+  it("persists a polled UUID, selects that working address, and remaps recovery state", () => {
+    const hostname = addHost({ url: "hal9000:7680", name: "hal9000", instanceId: "uuid-1" });
+    const ip = addHost({ url: "100.123.198.98:7681", name: "hal9000 IP" });
+    localStorage.setItem(
+      "mold.create.tracked-sequences.v1",
+      JSON.stringify([{ hostId: hostname.id, jobId: "chain-1" }]),
+    );
+    localStorage.setItem(
+      "mold.generate.jobs",
+      JSON.stringify({ version: 1, jobs: [{ hostId: hostname.id }] }),
+    );
+    localStorage.setItem(
+      "mold.generate.jobs.recovery.batch-1",
+      JSON.stringify({ version: 1, jobs: [{ hostId: hostname.id }] }),
+    );
+    setGenerateTargetId(hostname.id);
+
+    const canonical = recordSuccessfulHostInstance(ip.id, " uuid-1 ");
+
+    expect(canonical).toMatchObject({ id: ip.id, url: "http://100.123.198.98:7681" });
+    expect(listStoredHosts()).toHaveLength(1);
+    expect(getGenerateTargetId()).toBe(ip.id);
+    expect(localStorage.getItem("mold.create.tracked-sequences.v1")).toContain(ip.id);
+    expect(localStorage.getItem("mold.generate.jobs")).toContain(ip.id);
+    expect(localStorage.getItem("mold.generate.jobs.recovery.batch-1")).toContain(ip.id);
+  });
+
+  it("keeps different UUIDs separate even when the URL slug is reused", () => {
+    const old = addHost({ url: "render:7680", name: "Old", instanceId: "uuid-old" });
+    const replacement = addHost({
+      url: "render:7680",
+      name: "Replacement",
+      instanceId: "uuid-new",
+    });
+    expect(replacement.id).not.toBe(old.id);
+    expect(listStoredHosts()).toHaveLength(2);
+    expect(listStoredHosts().find((host) => host.id === old.id)?.connected).toBe(false);
+  });
+
+  it("removes a stored alias when its UUID is the browser origin", () => {
+    const alias = addHost({
+      url: "127.0.0.1:7680",
+      name: "Local alias",
+      instanceId: "origin-uuid",
+    });
+    setGenerateTargetId(alias.id);
+
+    reconcileOriginInstanceId(" origin-uuid ");
+
+    expect(listStoredHosts()).toEqual([]);
+    expect(getGenerateTargetId()).toBe(ORIGIN_HOST_ID);
   });
 
   it("merges a re-add of the same address by slug", () => {

--- a/web/src/lib/hostRegistry.ts
+++ b/web/src/lib/hostRegistry.ts
@@ -97,7 +97,8 @@ function isHostEntry(value: unknown): value is HostEntry {
     typeof c.url === "string" &&
     (c.apiKey === undefined || typeof c.apiKey === "string") &&
     (c.instanceId === undefined || typeof c.instanceId === "string") &&
-    (c.lastConnectedAtMs === undefined || typeof c.lastConnectedAtMs === "number") &&
+    (c.lastConnectedAtMs === undefined ||
+      typeof c.lastConnectedAtMs === "number") &&
     (c.connected === undefined || typeof c.connected === "boolean") &&
     c.id !== ORIGIN_HOST_ID
   );
@@ -137,12 +138,14 @@ export function mergeStoredHostsByInstanceId(hosts: readonly HostEntry[]): {
       const fallbackKey = uuid
         ? hosts.find(
             (candidate) =>
-              normalizedInstanceId(candidate.instanceId) === uuid && Boolean(candidate.apiKey),
+              normalizedInstanceId(candidate.instanceId) === uuid &&
+              Boolean(candidate.apiKey),
           )?.apiKey
         : undefined;
-      merged.push(fallbackKey && !host.apiKey ? { ...host, apiKey: fallbackKey } : host);
-    }
-    else dropped.push({ loser: host.id, survivor: winner.id });
+      merged.push(
+        fallbackKey && !host.apiKey ? { ...host, apiKey: fallbackKey } : host,
+      );
+    } else dropped.push({ loser: host.id, survivor: winner.id });
   }
   return { hosts: merged, dropped };
 }
@@ -151,7 +154,9 @@ function remapPersistedHostIds(
   dropped: ReadonlyArray<{ loser: string; survivor: string }>,
 ): void {
   if (dropped.length === 0) return;
-  const remap = new Map(dropped.map(({ loser, survivor }) => [loser, survivor]));
+  const remap = new Map(
+    dropped.map(({ loser, survivor }) => [loser, survivor]),
+  );
   const remapJson = (key: string, arrayRoot: boolean): void => {
     const raw = localStorage.getItem(key);
     if (!raw) return;
@@ -186,14 +191,18 @@ function remapPersistedHostIds(
   }
   const legacyHost = localStorage.getItem(LEGACY_SEQUENCE_HOST_KEY);
   const legacySurvivor = legacyHost ? remap.get(legacyHost) : null;
-  if (legacySurvivor) localStorage.setItem(LEGACY_SEQUENCE_HOST_KEY, legacySurvivor);
+  if (legacySurvivor)
+    localStorage.setItem(LEGACY_SEQUENCE_HOST_KEY, legacySurvivor);
 }
 
-function applyAliasRemap(dropped: ReadonlyArray<{ loser: string; survivor: string }>): void {
+function applyAliasRemap(
+  dropped: ReadonlyArray<{ loser: string; survivor: string }>,
+): void {
   if (dropped.length === 0) return;
   const target = getGenerateTargetId();
   const targetRemap = dropped.find(({ loser }) => loser === target);
-  if (targetRemap) localStorage.setItem(GENERATE_TARGET_STORAGE_KEY, targetRemap.survivor);
+  if (targetRemap)
+    localStorage.setItem(GENERATE_TARGET_STORAGE_KEY, targetRemap.survivor);
   remapPersistedHostIds(dropped);
 }
 
@@ -253,7 +262,9 @@ export function dedupeByInstanceId(instanceId: string): HostEntry | null {
   const normalized = normalizedInstanceId(instanceId);
   if (!normalized) return null;
   return (
-    listStoredHosts().find((host) => normalizedInstanceId(host.instanceId) === normalized) ?? null
+    listStoredHosts().find(
+      (host) => normalizedInstanceId(host.instanceId) === normalized,
+    ) ?? null
   );
 }
 
@@ -279,17 +290,24 @@ export function addHost(input: AddHostInput): HostEntry {
   const stored = listStoredHosts();
   const instanceId = normalizedInstanceId(input.instanceId);
   const byInstance = instanceId
-    ? stored.find((host) => normalizedInstanceId(host.instanceId) === instanceId)
+    ? stored.find(
+        (host) => normalizedInstanceId(host.instanceId) === instanceId,
+      )
     : undefined;
   const slug = hostIdFromUrl(url);
   const bySlug = stored.find((host) => host.id === slug);
   const slugInstanceId = normalizedInstanceId(bySlug?.instanceId);
-  const slugConflict = Boolean(bySlug && instanceId && slugInstanceId && instanceId !== slugInstanceId);
+  const slugConflict = Boolean(
+    bySlug && instanceId && slugInstanceId && instanceId !== slugInstanceId,
+  );
   const existing = byInstance ?? (slugConflict ? undefined : bySlug);
   const id =
     existing?.id ??
     (slugConflict && instanceId
-      ? `${slug}-${instanceId.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 12)}`
+      ? `${slug}-${instanceId
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, "-")
+          .slice(0, 12)}`
       : slug);
 
   const entry: HostEntry = {
@@ -305,7 +323,9 @@ export function addHost(input: AddHostInput): HostEntry {
   else if (existing?.instanceId) entry.instanceId = existing.instanceId;
 
   const retired = slugConflict
-    ? stored.map((host) => (host.id === bySlug?.id ? { ...host, connected: false } : host))
+    ? stored.map((host) =>
+        host.id === bySlug?.id ? { ...host, connected: false } : host,
+      )
     : stored;
   const next = existing
     ? retired.map((h) => (h.id === existing.id ? entry : h))
@@ -325,7 +345,9 @@ export function reconcileOriginInstanceId(instanceId: string): void {
   if (aliases.length === 0) return;
   const aliasIds = new Set(aliases.map((host) => host.id));
   writeStoredHosts(stored.filter((host) => !aliasIds.has(host.id)));
-  applyAliasRemap(aliases.map((host) => ({ loser: host.id, survivor: ORIGIN_HOST_ID })));
+  applyAliasRemap(
+    aliases.map((host) => ({ loser: host.id, survivor: ORIGIN_HOST_ID })),
+  );
 }
 
 /** Persist a UUID learned from a successful exact-authority status poll.
@@ -351,11 +373,17 @@ export function recordSuccessfulHostInstance(
   );
   const stamped = stored.map((host) =>
     host.id === id
-      ? { ...host, instanceId: normalized, connected: true, lastConnectedAtMs: successfulAt }
+      ? {
+          ...host,
+          instanceId: normalized,
+          connected: true,
+          lastConnectedAtMs: successfulAt,
+        }
       : host,
   );
   const merged = mergeStoredHostsByInstanceId(stamped);
-  const survivorId = merged.dropped.find(({ loser }) => loser === id)?.survivor ?? id;
+  const survivorId =
+    merged.dropped.find(({ loser }) => loser === id)?.survivor ?? id;
   writeStoredHosts(merged.hosts);
   applyAliasRemap(merged.dropped);
   return merged.hosts.find((host) => host.id === survivorId) ?? null;

--- a/web/src/lib/hostRegistry.ts
+++ b/web/src/lib/hostRegistry.ts
@@ -16,6 +16,10 @@ export const ORIGIN_HOST_ID = "origin";
 export const HOSTS_STORAGE_KEY = "mold.web.hosts.v1";
 export const HOSTS_CHANGED_EVENT = "mold:hosts-changed";
 export const GENERATE_TARGET_CHANGED_EVENT = "mold:generate-target-changed";
+const TRACKED_SEQUENCES_KEY = "mold.create.tracked-sequences.v1";
+const LEGACY_SEQUENCE_HOST_KEY = "mold.create.chain-job-host";
+const GENERATE_JOBS_KEY = "mold.generate.jobs";
+const GENERATE_RECOVERY_PREFIX = `${GENERATE_JOBS_KEY}.recovery.`;
 
 export interface HostEntry {
   /** Slug of the host URL, or "origin" for the serving host. */
@@ -27,6 +31,8 @@ export interface HostEntry {
   apiKey?: string;
   /** Last-seen `/api/status.instance_id`, used to dedupe re-adds. */
   instanceId?: string;
+  /** Successful connection that selected `url`; failed attempts never update it. */
+  lastConnectedAtMs?: number;
   /** False only after an explicit disconnect. Missing means connected for
    *  compatibility with registries written by older Mold versions. */
   connected?: boolean;
@@ -91,9 +97,104 @@ function isHostEntry(value: unknown): value is HostEntry {
     typeof c.url === "string" &&
     (c.apiKey === undefined || typeof c.apiKey === "string") &&
     (c.instanceId === undefined || typeof c.instanceId === "string") &&
+    (c.lastConnectedAtMs === undefined || typeof c.lastConnectedAtMs === "number") &&
     (c.connected === undefined || typeof c.connected === "boolean") &&
     c.id !== ORIGIN_HOST_ID
   );
+}
+
+function normalizedInstanceId(value: string | null | undefined): string | null {
+  const normalized = value?.trim();
+  return normalized ? normalized : null;
+}
+
+export function mergeStoredHostsByInstanceId(hosts: readonly HostEntry[]): {
+  hosts: HostEntry[];
+  dropped: Array<{ loser: string; survivor: string }>;
+} {
+  const winnerByUuid = new Map<string, HostEntry>();
+  for (const host of hosts) {
+    const uuid = normalizedInstanceId(host.instanceId);
+    if (!uuid) continue;
+    const current = winnerByUuid.get(uuid);
+    const hostConnected = host.connected !== false;
+    const currentConnected = current?.connected !== false;
+    if (
+      !current ||
+      (hostConnected && !currentConnected) ||
+      (hostConnected === currentConnected &&
+        (host.lastConnectedAtMs ?? 0) > (current.lastConnectedAtMs ?? 0))
+    ) {
+      winnerByUuid.set(uuid, host);
+    }
+  }
+  const merged: HostEntry[] = [];
+  const dropped: Array<{ loser: string; survivor: string }> = [];
+  for (const host of hosts) {
+    const uuid = normalizedInstanceId(host.instanceId);
+    const winner = uuid ? winnerByUuid.get(uuid) : undefined;
+    if (!winner || winner.id === host.id) {
+      const fallbackKey = uuid
+        ? hosts.find(
+            (candidate) =>
+              normalizedInstanceId(candidate.instanceId) === uuid && Boolean(candidate.apiKey),
+          )?.apiKey
+        : undefined;
+      merged.push(fallbackKey && !host.apiKey ? { ...host, apiKey: fallbackKey } : host);
+    }
+    else dropped.push({ loser: host.id, survivor: winner.id });
+  }
+  return { hosts: merged, dropped };
+}
+
+function remapPersistedHostIds(
+  dropped: ReadonlyArray<{ loser: string; survivor: string }>,
+): void {
+  if (dropped.length === 0) return;
+  const remap = new Map(dropped.map(({ loser, survivor }) => [loser, survivor]));
+  const remapJson = (key: string, arrayRoot: boolean): void => {
+    const raw = localStorage.getItem(key);
+    if (!raw) return;
+    try {
+      const parsed = JSON.parse(raw) as unknown;
+      const rows = arrayRoot
+        ? parsed
+        : parsed && typeof parsed === "object"
+          ? (parsed as { jobs?: unknown }).jobs
+          : null;
+      if (!Array.isArray(rows)) return;
+      let changed = false;
+      for (const row of rows) {
+        if (!row || typeof row !== "object") continue;
+        const record = row as { hostId?: unknown };
+        if (typeof record.hostId !== "string") continue;
+        const survivor = remap.get(record.hostId);
+        if (!survivor) continue;
+        record.hostId = survivor;
+        changed = true;
+      }
+      if (changed) localStorage.setItem(key, JSON.stringify(parsed));
+    } catch {
+      // Recovery state is best effort; malformed records remain untouched.
+    }
+  };
+  remapJson(TRACKED_SEQUENCES_KEY, true);
+  remapJson(GENERATE_JOBS_KEY, false);
+  for (let index = 0; index < localStorage.length; index += 1) {
+    const key = localStorage.key(index);
+    if (key?.startsWith(GENERATE_RECOVERY_PREFIX)) remapJson(key, false);
+  }
+  const legacyHost = localStorage.getItem(LEGACY_SEQUENCE_HOST_KEY);
+  const legacySurvivor = legacyHost ? remap.get(legacyHost) : null;
+  if (legacySurvivor) localStorage.setItem(LEGACY_SEQUENCE_HOST_KEY, legacySurvivor);
+}
+
+function applyAliasRemap(dropped: ReadonlyArray<{ loser: string; survivor: string }>): void {
+  if (dropped.length === 0) return;
+  const target = getGenerateTargetId();
+  const targetRemap = dropped.find(({ loser }) => loser === target);
+  if (targetRemap) localStorage.setItem(GENERATE_TARGET_STORAGE_KEY, targetRemap.survivor);
+  remapPersistedHostIds(dropped);
 }
 
 /** User-added remote hosts (excludes the primary origin). */
@@ -103,7 +204,13 @@ export function listStoredHosts(): HostEntry[] {
   try {
     const parsed = JSON.parse(raw) as unknown;
     if (!Array.isArray(parsed)) return [];
-    return parsed.filter(isHostEntry);
+    const valid = parsed.filter(isHostEntry);
+    const merged = mergeStoredHostsByInstanceId(valid);
+    if (merged.dropped.length > 0) {
+      localStorage.setItem(HOSTS_STORAGE_KEY, JSON.stringify(merged.hosts));
+      applyAliasRemap(merged.dropped);
+    }
+    return merged.hosts;
   } catch {
     return [];
   }
@@ -143,8 +250,11 @@ export function getKnownHost(id: string): HostEntry | null {
  * A blank instance id never matches — an unknown server must not merge.
  */
 export function dedupeByInstanceId(instanceId: string): HostEntry | null {
-  if (!instanceId) return null;
-  return listStoredHosts().find((h) => h.instanceId === instanceId) ?? null;
+  const normalized = normalizedInstanceId(instanceId);
+  if (!normalized) return null;
+  return (
+    listStoredHosts().find((host) => normalizedInstanceId(host.instanceId) === normalized) ?? null
+  );
 }
 
 export interface AddHostInput {
@@ -167,28 +277,88 @@ export function addHost(input: AddHostInput): HostEntry {
   if (url === originUrl()) return originHost();
 
   const stored = listStoredHosts();
-  const byInstance = input.instanceId
-    ? stored.find((h) => h.instanceId === input.instanceId)
+  const instanceId = normalizedInstanceId(input.instanceId);
+  const byInstance = instanceId
+    ? stored.find((host) => normalizedInstanceId(host.instanceId) === instanceId)
     : undefined;
-  const id = hostIdFromUrl(url);
-  const existing = byInstance ?? stored.find((h) => h.id === id);
+  const slug = hostIdFromUrl(url);
+  const bySlug = stored.find((host) => host.id === slug);
+  const slugInstanceId = normalizedInstanceId(bySlug?.instanceId);
+  const slugConflict = Boolean(bySlug && instanceId && slugInstanceId && instanceId !== slugInstanceId);
+  const existing = byInstance ?? (slugConflict ? undefined : bySlug);
+  const id =
+    existing?.id ??
+    (slugConflict && instanceId
+      ? `${slug}-${instanceId.toLowerCase().replace(/[^a-z0-9]+/g, "-").slice(0, 12)}`
+      : slug);
 
   const entry: HostEntry = {
     id: existing?.id ?? id,
     name,
     url,
     connected: true,
+    lastConnectedAtMs: Date.now(),
   };
   if (input.apiKey) entry.apiKey = input.apiKey;
   else if (existing?.apiKey) entry.apiKey = existing.apiKey;
-  if (input.instanceId) entry.instanceId = input.instanceId;
+  if (instanceId) entry.instanceId = instanceId;
   else if (existing?.instanceId) entry.instanceId = existing.instanceId;
 
+  const retired = slugConflict
+    ? stored.map((host) => (host.id === bySlug?.id ? { ...host, connected: false } : host))
+    : stored;
   const next = existing
-    ? stored.map((h) => (h.id === existing.id ? entry : h))
-    : [...stored, entry];
+    ? retired.map((h) => (h.id === existing.id ? entry : h))
+    : [...retired, entry];
   writeStoredHosts(next);
   return entry;
+}
+
+/** Remove a remembered alias when it proves to be the browser's origin. */
+export function reconcileOriginInstanceId(instanceId: string): void {
+  const normalized = normalizedInstanceId(instanceId);
+  if (!normalized) return;
+  const stored = listStoredHosts();
+  const aliases = stored.filter(
+    (host) => normalizedInstanceId(host.instanceId) === normalized,
+  );
+  if (aliases.length === 0) return;
+  const aliasIds = new Set(aliases.map((host) => host.id));
+  writeStoredHosts(stored.filter((host) => !aliasIds.has(host.id)));
+  applyAliasRemap(aliases.map((host) => ({ loser: host.id, survivor: ORIGIN_HOST_ID })));
+}
+
+/** Persist a UUID learned from a successful exact-authority status poll.
+ * The answering address wins, then every alias-owned recovery record follows
+ * the surviving row id. */
+export function recordSuccessfulHostInstance(
+  id: string,
+  instanceId: string | null | undefined,
+): HostEntry | null {
+  const normalized = normalizedInstanceId(instanceId);
+  if (!normalized) return getKnownHost(id);
+  if (id === ORIGIN_HOST_ID) {
+    reconcileOriginInstanceId(normalized);
+    return originHost();
+  }
+  const stored = listStoredHosts();
+  const current = stored.find((host) => host.id === id);
+  if (!current) return null;
+  if (normalizedInstanceId(current.instanceId) === normalized) return current;
+  const successfulAt = Math.max(
+    Date.now(),
+    ...stored.map((host) => (host.lastConnectedAtMs ?? 0) + 1),
+  );
+  const stamped = stored.map((host) =>
+    host.id === id
+      ? { ...host, instanceId: normalized, connected: true, lastConnectedAtMs: successfulAt }
+      : host,
+  );
+  const merged = mergeStoredHostsByInstanceId(stamped);
+  const survivorId = merged.dropped.find(({ loser }) => loser === id)?.survivor ?? id;
+  writeStoredHosts(merged.hosts);
+  applyAliasRemap(merged.dropped);
+  return merged.hosts.find((host) => host.id === survivorId) ?? null;
 }
 
 /** Patch a stored host. The immutable primary cannot be updated (returns null). */

--- a/web/src/pages/MachinesPage.test.ts
+++ b/web/src/pages/MachinesPage.test.ts
@@ -30,6 +30,7 @@ let poll: {
 
 vi.mock("../components/machines/hostClient", () => ({
   useHostPoll: () => poll,
+  hostStatus: vi.fn().mockResolvedValue({ instance_id: "origin-instance" }),
 }));
 
 vi.mock("vue-router", () => ({

--- a/web/src/pages/MachinesPage.vue
+++ b/web/src/pages/MachinesPage.vue
@@ -19,11 +19,14 @@ import {
   ORIGIN_HOST_ID,
   getGenerateTargetId,
   listKnownHosts,
+  originHost,
+  reconcileOriginInstanceId,
   removeHost,
   setHostConnected,
   setGenerateTargetId,
   type HostEntry,
 } from "../lib/hostRegistry";
+import { hostStatus } from "../components/machines/hostClient";
 import { requestConfirm, toast } from "../lib/toasts";
 
 const router = useRouter();
@@ -66,6 +69,12 @@ onMounted(() => {
   window.addEventListener("storage", onStorage);
   document.addEventListener("pointerdown", onDocumentPointer);
   window.addEventListener("keydown", onWindowKey);
+  void hostStatus(originHost())
+    .then((status) => {
+      reconcileOriginInstanceId(status.instance_id ?? "");
+      refreshHosts();
+    })
+    .catch(() => undefined);
 });
 
 onBeforeUnmount(() => {


### PR DESCRIPTION
## Summary

- treat the server instance UUID as the authoritative machine identity across desktop, web, iPhone, and Android
- collapse IP, hostname, MagicDNS, discovery, and local/origin aliases while retaining the actively verified address and disconnected machine records
- migrate host targets, credentials, sequence/generation recovery state, and fence stale model/download authority during alias reconciliation

## Validation

- independent implementation review: approved with no remaining blockers
- desktop Vitest: 5,408 passed
- web Vitest: 1,743 passed
- focused desktop host/model authority: 107 passed
- mobile integration: 323 passed
- mobile Rust discovery: 2 passed
- desktop and web production builds
- `nix fmt`
- `git diff --check`