### PR TITLE
fix: keep machine details responsive with GGUF models

### DIFF
--- a/changelog.d/mobile-host-detail-loading.md
+++ b/changelog.d/mobile-host-detail-loading.md
@@ -1,0 +1,1 @@
+- **Keep machine details responsive with LTX-2.5 GGUF models installed.** GGUF checkpoints are now rejected immediately by safetensors-only capability probes instead of being read end to end, and iPhone/Android machine telemetry no longer waits for the host's model inventory.

--- a/crates/mold-inference/src/ltx2/single_file.rs
+++ b/crates/mold-inference/src/ltx2/single_file.rs
@@ -34,6 +34,8 @@ use std::path::Path;
 use serde_json::Value;
 use thiserror::Error;
 
+const MAX_SAFETENSORS_HEADER_BYTES: u64 = 512 * 1024 * 1024;
+
 /// Transformer key layout in the checkpoint file.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum LtxKeyFormat {
@@ -225,11 +227,32 @@ fn has_prefix(key: &str, prefix: &str) -> bool {
 /// Read just the safetensors header (the 8-byte length prefix + JSON
 /// payload) and return the parsed map — including `__metadata__`. Does
 /// not mmap or read tensor data.
+fn safetensors_header_len(prefix: [u8; 8], file_len: u64) -> Result<usize, LoadError> {
+    if &prefix[..4] == b"GGUF" {
+        return Err(LoadError::Header(
+            "GGUF checkpoint is not a safetensors bundle".to_string(),
+        ));
+    }
+    let header_len = u64::from_le_bytes(prefix);
+    if header_len == 0 || header_len > MAX_SAFETENSORS_HEADER_BYTES {
+        return Err(LoadError::Header(format!(
+            "implausible safetensors header length {header_len}"
+        )));
+    }
+    if header_len > file_len.saturating_sub(8) {
+        return Err(LoadError::Header(format!(
+            "safetensors header length {header_len} exceeds the file payload"
+        )));
+    }
+    usize::try_from(header_len)
+        .map_err(|_| LoadError::Header(format!("safetensors header length {header_len} overflows")))
+}
+
 fn read_header(path: &Path) -> Result<BTreeMap<String, Value>, LoadError> {
     let mut file = File::open(path)?;
     let mut len_buf = [0u8; 8];
     file.read_exact(&mut len_buf)?;
-    let header_len = u64::from_le_bytes(len_buf) as usize;
+    let header_len = safetensors_header_len(len_buf, file.metadata()?.len())?;
     let mut header_buf = vec![0u8; header_len];
     file.read_exact(&mut header_buf)?;
     serde_json::from_slice(&header_buf).map_err(|e| LoadError::Header(e.to_string()))
@@ -267,6 +290,30 @@ mod tests {
             );
         }
         serialize_to_file(&tensors, &None, path).unwrap();
+    }
+
+    #[test]
+    fn gguf_prefix_is_rejected_before_its_version_becomes_a_header_length() {
+        let mut prefix = [0_u8; 8];
+        prefix[..4].copy_from_slice(b"GGUF");
+        prefix[4..].copy_from_slice(&3_u32.to_le_bytes());
+
+        let error = safetensors_header_len(prefix, u64::MAX).unwrap_err();
+
+        assert!(error.to_string().contains("GGUF checkpoint"));
+    }
+
+    #[test]
+    fn audio_capability_probe_rejects_gguf_without_reading_a_tensor_payload() {
+        let p = temp_path("gguf-audio-probe");
+        let mut prefix = [0_u8; 8];
+        prefix[..4].copy_from_slice(b"GGUF");
+        prefix[4..].copy_from_slice(&3_u32.to_le_bytes());
+        std::fs::write(&p, prefix).unwrap();
+
+        assert!(!crate::ltx2::checkpoint_supports_audio_output(&p));
+
+        let _ = std::fs::remove_file(p);
     }
 
     #[test]

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -256,6 +256,28 @@ afterEach(() => {
 });
 
 describe("MobileHostDetail remote host data", () => {
+  it("renders server information without waiting for model inventory", async () => {
+    const pendingModels = deferred<ModelEntry[]>();
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((target, path) =>
+      path === "/api/models" ? pendingModels.promise : originalApi(target, path),
+    );
+
+    const view = await mountDetail();
+
+    expect(view.text()).not.toContain("Reading host…");
+    expect(view.text()).toContain("NVIDIA GeForce RTX 4090");
+    expect(view.text()).toContain("500.0 GB free");
+    expect(view.text()).toContain("Reading installed models…");
+    expect(stream("/api/resources/stream").options.target).toEqual(studioTarget);
+
+    pendingModels.resolve([model("flux-dev:q8", "flux")]);
+    await flushPromises();
+
+    expect(view.text()).toContain("flux-dev:q8");
+    expect(view.text()).not.toContain("Reading installed models…");
+  });
+
   it("shows active sequence stages instead of calling the machine queue empty", async () => {
     const originalApi = apiJsonTo.getMockImplementation()!;
     apiJsonTo.mockImplementation((target, path) => {

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -86,6 +86,8 @@ const deviceCapabilities = ref<ServerCapabilities | null>(null);
 const deviceMutations = ref(new Set<string>());
 const deviceError = ref("");
 const installed = ref<ModelEntry[]>([]);
+const modelsLoading = ref(false);
+const modelsError = ref("");
 const queue = ref<QueueEntry[]>([]);
 const queuePlan = ref<QueuePlan | null>(null);
 const queueApiAvailable = ref(false);
@@ -604,6 +606,8 @@ async function loadHost(): Promise<void> {
   deviceCapabilities.value = null;
   deviceError.value = "";
   installed.value = [];
+  modelsLoading.value = false;
+  modelsError.value = "";
   queue.value = [];
   queuePlan.value = null;
   queueApiAvailable.value = false;
@@ -631,10 +635,7 @@ async function loadHost(): Promise<void> {
   }
 
   try {
-    const [nextStatus, models] = await Promise.all([
-      apiJsonTo<ServerStatus>(target.value, "/api/status"),
-      apiJsonTo<ModelEntry[]>(target.value, "/api/models"),
-    ]);
+    const nextStatus = await apiJsonTo<ServerStatus>(target.value, "/api/status");
     if (epoch !== loadEpoch) return;
     const expectedInstanceId = props.host.instanceId?.trim();
     const reportedInstanceId = nextStatus.instance_id?.trim();
@@ -643,18 +644,52 @@ async function loadHost(): Promise<void> {
       throw new Error("This address now reports a different Mold server identity.");
     }
     status.value = nextStatus;
-    installed.value = models.filter((model) => model.downloaded);
     emit("status", { id: props.host.id, status: nextStatus });
-    await refreshDevicesSafely(epoch);
-    if (epoch !== loadEpoch) return;
-    void refreshLibraryCard(epoch);
-    startLiveServices(epoch);
+    void refreshModelInventory(epoch);
+    void refreshDevicesSafely(epoch).then(() => {
+      if (epoch !== loadEpoch) return;
+      void refreshLibraryCard(epoch);
+      startLiveServices(epoch);
+    });
   } catch (caught) {
     if (epoch !== loadEpoch) return;
     error.value = describeTransportError(caught, props.host.name);
     emit("status", { id: props.host.id, status: null });
   } finally {
     if (epoch === loadEpoch) loading.value = false;
+  }
+}
+
+async function refreshModelInventory(epoch = loadEpoch): Promise<void> {
+  if (props.host.connected === false || modelsLoading.value) return;
+  const requestTarget = target.value;
+  modelsLoading.value = true;
+  modelsError.value = "";
+  try {
+    const models = await apiJsonTo<ModelEntry[]>(requestTarget, "/api/models");
+    if (
+      epoch !== loadEpoch ||
+      requestTarget.baseUrl !== target.value.baseUrl ||
+      requestTarget.apiKey !== target.value.apiKey
+    )
+      return;
+    installed.value = models.filter((model) => model.downloaded);
+  } catch (caught) {
+    if (
+      epoch === loadEpoch &&
+      requestTarget.baseUrl === target.value.baseUrl &&
+      requestTarget.apiKey === target.value.apiKey
+    ) {
+      modelsError.value = describeTransportError(caught, props.host.name);
+    }
+  } finally {
+    if (
+      epoch === loadEpoch &&
+      requestTarget.baseUrl === target.value.baseUrl &&
+      requestTarget.apiKey === target.value.apiKey
+    ) {
+      modelsLoading.value = false;
+    }
   }
 }
 
@@ -665,10 +700,13 @@ async function refreshHostDetail(): Promise<void> {
   const epoch = loadEpoch;
   const requestTarget = target.value;
   error.value = "";
-  const [statusResult, modelsResult] = await Promise.allSettled([
+  void refreshModelInventory(epoch);
+  const statusResult = await Promise.resolve(
     apiJsonTo<ServerStatus>(requestTarget, "/api/status"),
-    apiJsonTo<ModelEntry[]>(requestTarget, "/api/models"),
-  ]);
+  ).then(
+    (value) => ({ status: "fulfilled" as const, value }),
+    (reason: unknown) => ({ status: "rejected" as const, reason }),
+  );
   if (
     epoch !== loadEpoch ||
     requestTarget.baseUrl !== target.value.baseUrl ||
@@ -687,10 +725,7 @@ async function refreshHostDetail(): Promise<void> {
     status.value = statusResult.value;
     emit("status", { id: props.host.id, status: statusResult.value });
   }
-  if (modelsResult.status === "fulfilled") {
-    installed.value = modelsResult.value.filter((model) => model.downloaded);
-  }
-  if (statusResult.status === "rejected" && modelsResult.status === "rejected") {
+  if (statusResult.status === "rejected") {
     error.value = describeTransportError(statusResult.reason, props.host.name);
     emit("status", { id: props.host.id, status: null });
   }
@@ -1339,7 +1374,16 @@ onBeforeUnmount(() => {
             Catalog ›
           </button>
         </div>
-        <ul v-if="installed.length" class="mobile-data-list" data-test="host-detail-models">
+        <p v-if="modelsLoading && !installed.length" class="mobile-empty-note">
+          Reading installed models…
+        </p>
+        <div v-else-if="modelsError && !installed.length" class="row-actions">
+          <p class="status-line error-text" role="alert">{{ modelsError }}</p>
+          <button class="secondary-button" type="button" @click="refreshModelInventory()">
+            Retry models
+          </button>
+        </div>
+        <ul v-else-if="installed.length" class="mobile-data-list" data-test="host-detail-models">
           <li v-for="model in installed" :key="model.name">
             <div>
               <strong>{{ modelDisplayName(model) }}</strong>


### PR DESCRIPTION
## Summary

- reject GGUF checkpoints before safetensors-only LTX-2 audio capability probes interpret the GGUF version as a multi-gigabyte header length
- render shared iPhone/Android machine status and telemetry without waiting for `/api/models`
- add server-path and mobile regression coverage plus a user-facing changelog fragment

## Production diagnosis

- Plato and hal9000 both served `/api/status`, `/api/devices`, `/api/resources`, `/api/capabilities`, and `/api/queue` promptly while `/api/models` stalled for 90+ seconds
- process I/O showed multi-gigabyte reads from installed LTX-2.5 GGUF files during inventory probes
- the first eight GGUF bytes were being decoded as a safetensors header length, causing each inventory request to read the checkpoint payload before failing

## Surface audit

- iOS and Android share `MobileHostDetail.vue`; both previously coupled all machine information to model inventory and are fixed here
- desktop and web already load host status/telemetry independently; all surfaces benefit from the shared server-side probe fix

## Validation

- `nix develop -c cargo test -p mold-ai-inference ltx2::single_file::tests` (10 passed)
- `nix develop -c cargo clippy -p mold-ai-inference --all-targets -- -D warnings`
- `nix develop -c cargo fmt --all -- --check`
- `nix develop -c bunx vitest run src/mobile/MobileHostDetail.test.ts` from `desktop/` (49 passed)
- `nix develop -c bun run build:mobile` from `desktop/`
- Prettier check for changed mobile files
- changelog fragment policy

## Review

Independent agent peer review found no blocking or high-severity findings. Its requested end-to-end GGUF audio capability probe test was added before commit.