### PR TITLE
fix(desktop): open hidden prints and repair reference layout

### DIFF
--- a/changelog.d/notification-hidden-collection-preview.md
+++ b/changelog.d/notification-hidden-collection-preview.md
@@ -1,0 +1,4 @@
+- **Desktop generation notifications open prints filed in hidden collections.**
+  Clicking a completed-print notification now navigates into the print's hidden
+  collection and opens the full viewer instead of landing on a Prints grid that
+  deliberately excludes it.

--- a/changelog.d/notification-hidden-collection-preview.md
+++ b/changelog.d/notification-hidden-collection-preview.md
@@ -2,3 +2,7 @@
   Clicking a completed-print notification now navigates into the print's hidden
   collection and opens the full viewer instead of landing on a Prints grid that
   deliberately excludes it.
+- **Unavailable MiniMax reference controls no longer cover their file details.**
+  Ordered-reference cards now adapt to the Create inspector's actual width, so
+  Reattach, Crop, reorder, and remove controls sit below the unavailable-media
+  message instead of overlapping it.

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -117,7 +117,7 @@ const base = (filename: string, timestamp: number, seed: number): GalleryImage =
 });
 
 const smurf04: GalleryImage = {
-  ...base("mold-flux-1~smurf-04.png", 40, 4),
+  ...base("mold-ltx-1~smurf-04.mp4", 40, 4),
   title: "smurf 04",
   favorite: true,
   tags: ["smurf", "blue"],
@@ -167,9 +167,19 @@ const historyDrawerStub = { name: "HistoryDrawer", props: ["open"], template: "<
 
 async function mountView(
   route = "/library",
-  options: { organize?: boolean; trash?: boolean; trashItems?: GalleryImage[] } = {},
+  options: {
+    organize?: boolean;
+    trash?: boolean;
+    trashItems?: GalleryImage[];
+    hiddenCollection?: boolean;
+  } = {},
 ) {
-  const { organize = true, trash = true, trashItems = [trashed] } = options;
+  const {
+    organize = true,
+    trash = true,
+    trashItems = [trashed],
+    hiddenCollection = false,
+  } = options;
   const router = createRouter({
     history: createMemoryHistory(),
     routes: [
@@ -220,7 +230,10 @@ async function mountView(
     if (path.startsWith("/api/gallery/collections/")) return { filenames: [] };
     return undefined;
   });
-  org.listCollections.mockResolvedValue([{ ...smurfs }, { ...riverStudies }]);
+  org.listCollections.mockResolvedValue([
+    { ...smurfs, hidden: hiddenCollection },
+    { ...riverStudies },
+  ]);
   org.listTags.mockResolvedValue([
     { name: "smurf", count: 2 },
     { name: "blue", count: 1 },
@@ -993,6 +1006,23 @@ describe("Lightbox wiring", () => {
     expect(gallery.scope).toBe("prints");
     expect(gallery.favoritesOnly).toBe(false);
     expect(wrapper.getComponent({ name: "Lightbox" }).props("item").filename).toBe(plain.filename);
+    wrapper.unmount();
+  });
+
+  it("a notification deep link opens a video inside its hidden collection", async () => {
+    const { wrapper, gallery, router } = await mountView(
+      `/library?print=${encodeURIComponent(smurf04.filename)}`,
+      { hiddenCollection: true },
+    );
+
+    expect(gallery.scope).toBe("collections");
+    expect(gallery.collectionSlug).toBe("smurfs");
+    expect(wrapper.getComponent({ name: "Lightbox" }).props("item").filename).toBe(
+      smurf04.filename,
+    );
+    await vi.waitFor(() =>
+      expect(router.currentRoute.value.query).toEqual({ scope: "collections", c: "smurfs" }),
+    );
     wrapper.unmount();
   });
 });

--- a/desktop/src/views/LibraryView.shelf.test.ts
+++ b/desktop/src/views/LibraryView.shelf.test.ts
@@ -172,6 +172,7 @@ async function mountView(
     trash?: boolean;
     trashItems?: GalleryImage[];
     hiddenCollection?: boolean;
+    deferCapabilities?: boolean;
   } = {},
 ) {
   const {
@@ -179,6 +180,7 @@ async function mountView(
     trash = true,
     trashItems = [trashed],
     hiddenCollection = false,
+    deferCapabilities = false,
   } = options;
   const router = createRouter({
     history: createMemoryHistory(),
@@ -208,13 +210,15 @@ async function mountView(
     error: null,
     instanceId: null,
   });
-  hosts.capabilities["plato-7680"] = {
-    gallery: {
-      can_delete: true,
-      organize,
-      trash: trash ? { enabled: true, retention_days: 30 } : null,
-    },
-  };
+  if (!deferCapabilities) {
+    hosts.capabilities["plato-7680"] = {
+      gallery: {
+        can_delete: true,
+        organize,
+        trash: trash ? { enabled: true, retention_days: 30 } : null,
+      },
+    };
+  }
 
   const gallery = useGalleryStore();
   gallery.buckets["plato-7680"] = {
@@ -1023,6 +1027,43 @@ describe("Lightbox wiring", () => {
     await vi.waitFor(() =>
       expect(router.currentRoute.value.query).toEqual({ scope: "collections", c: "smurfs" }),
     );
+    wrapper.unmount();
+  });
+
+  it("retains a hidden-video notification until late capabilities and collections settle", async () => {
+    const { wrapper, gallery, router, hosts } = await mountView(
+      `/library?print=${encodeURIComponent(smurf04.filename)}`,
+      { hiddenCollection: true, deferCapabilities: true },
+    );
+
+    expect(router.currentRoute.value.query.print).toBe(smurf04.filename);
+    expect(wrapper.findComponent({ name: "Lightbox" }).exists()).toBe(false);
+
+    hosts.capabilities["plato-7680"] = {
+      gallery: { can_delete: true, organize: true, trash: null },
+    };
+    await vi.waitFor(() => expect(gallery.collectionsByHost["plato-7680"]?.loaded).toBe(true));
+    await vi.waitFor(() => expect(gallery.collectionSlug).toBe("smurfs"));
+    expect(wrapper.getComponent({ name: "Lightbox" }).props("item").filename).toBe(
+      smurf04.filename,
+    );
+    wrapper.unmount();
+  });
+
+  it("opens a delayed notification target when a same-count refresh adds it", async () => {
+    const late = { ...plain, filename: "late-h3-video.mp4", timestamp: 50 };
+    const { wrapper, gallery, router } = await mountView(
+      `/library?print=${encodeURIComponent(late.filename)}`,
+    );
+
+    expect(router.currentRoute.value.query.print).toBe(late.filename);
+    expect(wrapper.findComponent({ name: "Lightbox" }).exists()).toBe(false);
+    gallery.buckets["plato-7680"]!.items.splice(0, 1, late);
+
+    await vi.waitFor(() =>
+      expect(wrapper.getComponent({ name: "Lightbox" }).props("item").filename).toBe(late.filename),
+    );
+    expect(gallery.buckets["plato-7680"]!.items).toHaveLength(live.length);
     wrapper.unmount();
   });
 });

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -2151,7 +2151,16 @@ watch(
 watch(
   [
     () => route.query.print,
-    () => gallery.merged.length,
+    () => {
+      const print = route.query.print;
+      return typeof print === "string"
+        ? gallery.merged.some((entry) => entry.item.filename === print)
+        : false;
+    },
+    () =>
+      gallery.sources
+        .map((source) => `${source.key}:${gallery.organizeCapable(source.key)}`)
+        .join("|"),
     () =>
       Object.entries(gallery.collectionsByHost)
         .map(([key, bucket]) => `${key}:${bucket.loading}:${bucket.loaded}:${bucket.error ?? ""}`)
@@ -2165,7 +2174,11 @@ watch(
     const unsettledCollectionCopy = (
       entry.copies ?? [{ sourceKey: entry.sourceKey, item: entry.item }]
     ).some((copy) => {
-      if (!copy.item.collections?.length || !gallery.organizeCapable(copy.sourceKey)) return false;
+      // A non-empty collection id is itself evidence that this host supports
+      // organization. Its capability snapshot may still be in flight after
+      // the host becomes ready, so do not consume the one-shot route until
+      // the listing resolves those ids to slugs and hidden state.
+      if (!copy.item.collections?.length) return false;
       const bucket = gallery.collectionsByHost[copy.sourceKey];
       return !bucket || bucket.loading || (!bucket.loaded && bucket.error === null);
     });

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -2075,6 +2075,7 @@ const asString = (value: unknown): string | null =>
   typeof value === "string" && value.length > 0 ? value : null;
 
 let syncingFromRoute = false;
+let openingPrintDeepLink = false;
 watch(
   () => [route.query.scope, route.query.c, route.query.tag, route.query.fav] as const,
   ([scopeParam, c, tag, fav]) => {
@@ -2108,7 +2109,7 @@ watch(
       gallery.favoritesOnly,
     ] as const,
   ([scopeValue, slug, tags, fav]) => {
-    if (syncingFromRoute || route.path !== "/library") return;
+    if (syncingFromRoute || openingPrintDeepLink || route.path !== "/library") return;
     const query: Record<string, string | undefined> = {
       ...(route.query as Record<string, string | undefined>),
     };
@@ -2142,17 +2143,41 @@ watch(
 );
 
 // Deep link: /library?print=<filename> (a ⌘K result or native notification)
-// reveals that print — filters reset so it can't be hidden, then selection +
-// lightbox open once the buckets deliver it. One-shot: the param drops after
-// use so closing the lightbox doesn't re-open it.
+// reveals that print. A print filed only in a hidden collection must open in
+// that collection: the Prints scope deliberately excludes it, and selection
+// is resolved from the current grid. Wait for the relevant collection listing
+// before consuming the one-shot param so a fast gallery response cannot race
+// the slower organization response.
 watch(
-  [() => route.query.print, () => gallery.merged.length],
+  [
+    () => route.query.print,
+    () => gallery.merged.length,
+    () =>
+      Object.entries(gallery.collectionsByHost)
+        .map(([key, bucket]) => `${key}:${bucket.loading}:${bucket.loaded}:${bucket.error ?? ""}`)
+        .join("|"),
+  ],
   ([print]) => {
     if (typeof print !== "string" || !print) return;
     const entry = gallery.merged.find((e) => e.item.filename === print);
     if (!entry) return;
-    gallery.scope = "prints";
-    gallery.collectionSlug = null;
+
+    const unsettledCollectionCopy = (
+      entry.copies ?? [{ sourceKey: entry.sourceKey, item: entry.item }]
+    ).some((copy) => {
+      if (!copy.item.collections?.length || !gallery.organizeCapable(copy.sourceKey)) return false;
+      const bucket = gallery.collectionsByHost[copy.sourceKey];
+      return !bucket || bucket.loading || (!bucket.loaded && bucket.error === null);
+    });
+    if (unsettledCollectionCopy) return;
+
+    const memberships = new Set(gallery.organizationOf(entry).collections);
+    const hiddenCollection = gallery.mergedCollections.find(
+      (collection) => collection.hidden && memberships.has(collection.slug),
+    );
+    openingPrintDeepLink = true;
+    gallery.scope = hiddenCollection ? "collections" : "prints";
+    gallery.collectionSlug = hiddenCollection?.slug ?? null;
     gallery.favoritesOnly = false;
     gallery.tagFilter = [];
     gallery.filter = "all";
@@ -2161,7 +2186,19 @@ watch(
     searchInput.value = "";
     select(entry);
     lightboxOpen.value = true;
-    void router.replace({ query: { ...route.query, print: undefined } });
+    const query = { ...route.query };
+    delete query.print;
+    delete query.host;
+    delete query.tag;
+    delete query.fav;
+    if (hiddenCollection) {
+      query.scope = "collections";
+      query.c = hiddenCollection.slug;
+    } else {
+      delete query.scope;
+      delete query.c;
+    }
+    void router.replace({ path: "/library", query }).finally(() => (openingPrintDeepLink = false));
   },
   { immediate: true },
 );

--- a/studio/components/MinimaxH3AuthoringPanel.test.ts
+++ b/studio/components/MinimaxH3AuthoringPanel.test.ts
@@ -132,6 +132,36 @@ describe("MinimaxH3AuthoringPanel", () => {
     );
   });
 
+  it("keeps unavailable image copy and its complete action row as separate layout regions", () => {
+    const value = state();
+    value.references = [
+      {
+        reference: {
+          kind: "image",
+          media: { authority: "descriptor" },
+          provenance: { name: "missing-subject.png", sha256: "d".repeat(64) },
+          mime_type: "image/png",
+          width: 1_024,
+          height: 768,
+        },
+      },
+    ];
+    const wrapper = mount(MinimaxH3AuthoringPanel, {
+      props: { modelValue: value },
+    });
+
+    const row = wrapper.get('[data-test="h3-reference-0"]');
+    expect(row.get(".h3-authoring__reference-copy").text()).toContain(
+      "Reattach original media before generating.",
+    );
+    expect(row.get('[aria-label="Reference 1 controls"]')).toBeTruthy();
+    expect(row.get('[data-test="h3-reference-reattach-0"]')).toBeTruthy();
+    expect(
+      row.get('[data-test="h3-reference-crop-0"]').attributes("disabled"),
+    ).toBeDefined();
+    expect(row.get('[data-test="h3-reference-remove-0"]')).toBeTruthy();
+  });
+
   it("offers accessible 44pt reorder alternatives without regrouping kinds", async () => {
     const wrapper = mount(MinimaxH3AuthoringPanel, {
       props: { modelValue: state(), touchFriendly: true },

--- a/studio/components/MinimaxH3AuthoringPanel.vue
+++ b/studio/components/MinimaxH3AuthoringPanel.vue
@@ -586,6 +586,7 @@ function imagePreview(
 
 <style scoped>
 .h3-authoring {
+  container-type: inline-size;
   display: grid;
   min-width: 0;
   max-width: 100%;
@@ -743,6 +744,7 @@ function imagePreview(
 .h3-authoring__actions {
   display: flex;
   flex-wrap: wrap;
+  min-width: 0;
   gap: 4px;
 }
 .h3-authoring__errors {
@@ -755,13 +757,16 @@ function imagePreview(
 .h3-authoring--touch input {
   min-height: 44px;
 }
-@media (max-width: 520px) {
+/* The desktop Create inspector is narrow even when the app window is wide, so
+ * this must follow the component's own width rather than the viewport. */
+@container (max-width: 520px) {
   .h3-authoring__reference {
     grid-template-columns: 28px 56px minmax(0, 1fr);
   }
   .h3-authoring__actions {
     grid-column: 2 / -1;
-    justify-content: flex-end;
+    grid-row: 2;
+    justify-content: flex-start;
   }
 }
 </style>


### PR DESCRIPTION
## Summary

- make desktop notification deep links wait for gallery, capability, and collection authorities before selecting the exact print
- enter a hidden collection automatically and open its generated video in the lightbox
- make unavailable MiniMax reference cards respond to the inspector container width so controls never cover file details

## Validation

- `nix develop -c bun run test:studio` — 1,489 tests passed
- `nix develop -c bun run --cwd desktop test -- src/views/LibraryView.test.ts src/views/LibraryView.shelf.test.ts` — 60 tests passed
- `nix develop -c bun run --cwd desktop build`
- rendered shared MiniMax component at the 340px desktop inspector width: zero overlap, zero console errors, and reorder interaction verified
- `bash scripts/release/check-changelog-fragments.sh <base> HEAD`

## Peer review

Independent sub-agent review found late-capability and same-count-refresh notification races. Both are fixed and covered by regression tests.