### PR TITLE
fix(ui): show newest queue items first

### DIFF
--- a/changelog.d/newest-queue-items-first.md
+++ b/changelog.d/newest-queue-items-first.md
@@ -1,0 +1,1 @@
+- **Newest queue work first.** Desktop, web, and mobile now show the latest submitted activity at the top while preserving sending order for simultaneous submissions.

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -35,7 +35,7 @@ function baseJob(): Job {
 }
 
 describe("ActivityStrip", () => {
-  it("keeps queued and recovered running work in chronological order", () => {
+  it("keeps queued and recovered running work newest-first", () => {
     useGenerationStore().jobs = [
       {
         ...baseJob(),
@@ -69,7 +69,7 @@ describe("ActivityStrip", () => {
     };
 
     const text = mount(ActivityStrip).get("[data-test='activity-list-scroll']").text();
-    expect(text.indexOf("older queued print")).toBeLessThan(text.indexOf("newer developing print"));
+    expect(text.indexOf("newer developing print")).toBeLessThan(text.indexOf("older queued print"));
   });
 
   it("keeps recovered shared work visible and actionable", async () => {
@@ -265,7 +265,7 @@ describe("ActivityStrip — unknown outcomes", () => {
 });
 
 describe("ActivityStrip — sequences", () => {
-  it("renders in-flight sequence rows from every host, running work first", () => {
+  it("renders in-flight sequence rows from every host, newest first", () => {
     const chains = useChainJobsStore();
     chains.byHost.local = { jobs: [seqJob({ state: "queued", current_stage: 0 })], error: null };
     chains.byHost["hal9000-7680"] = {
@@ -282,11 +282,10 @@ describe("ActivityStrip — sequences", () => {
     const wrapper = mount(ActivityStrip);
     const rows = wrapper.findAll("[data-test='activity-sequence']");
     expect(rows).toHaveLength(2);
-    // The shared merge puts active work first even when it is older.
-    expect(rows[0]!.text()).toContain("running");
-    expect(rows[0]!.text()).toContain("2/3");
+    expect(rows[0]!.text()).toContain("queued");
+    expect(rows[1]!.text()).toContain("running");
+    expect(rows[1]!.text()).toContain("2/3");
     expect(rows[0]!.text()).toContain("3 clips");
-    expect(rows[1]!.text()).toContain("queued");
   });
 
   it("routes row actions to the owning host", async () => {

--- a/desktop/src/components/create/ActivityStrip.vue
+++ b/desktop/src/components/create/ActivityStrip.vue
@@ -32,6 +32,7 @@ import { useComposerStore } from "../../stores/composer";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { useLiveActivityStore } from "../../stores/liveActivity";
 import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
+import { compareNewestSubmitted } from "@studio/lib/activityOrder";
 
 /**
  * Create activity strip (Mold Studio) — present tense only.
@@ -113,7 +114,16 @@ watch(() => queued.value.length > 0, retainQueuePoll, { immediate: true });
 onBeforeUnmount(() => retainQueuePoll(false));
 
 const MAX_QUEUED_PILLS = 4;
-const visibleQueued = computed(() => queued.value.slice(0, MAX_QUEUED_PILLS));
+const visibleQueued = computed(() =>
+  [...queued.value]
+    .sort((a, b) =>
+      compareNewestSubmitted(
+        { createdAtMs: a.submittedAtUnixMs },
+        { createdAtMs: b.submittedAtUnixMs },
+      ),
+    )
+    .slice(0, MAX_QUEUED_PILLS),
+);
 const hiddenQueuedCount = computed(() =>
   Math.max(0, queued.value.length - visibleQueued.value.length),
 );
@@ -273,8 +283,8 @@ type DesktopActivityRow =
       sequence: ActivityJobVM & { kind: "sequence" };
     };
 
-/** One visual queue across local prints, sequences, and recovered fleet work.
- * A phase transition changes only the row contents, never its position. */
+/** One newest-first visual queue across local prints, sequences, and recovered
+ * fleet work. A phase transition changes only the row contents. */
 const activeRows = computed<DesktopActivityRow[]>(() =>
   [
     ...sharedRows.value.map((shared): DesktopActivityRow => ({
@@ -305,7 +315,7 @@ const activeRows = computed<DesktopActivityRow[]>(() =>
       kind: "sequence",
       sequence,
     })),
-  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+  ].sort(compareNewestSubmitted),
 );
 const attentionSequences = computed(() =>
   partition.value.attention.filter(

--- a/desktop/src/components/machines/QueueColumn.test.ts
+++ b/desktop/src/components/machines/QueueColumn.test.ts
@@ -172,9 +172,9 @@ describe("QueueColumn", () => {
     jobs.queues.local = {
       hostId: "local",
       entries: [
-        { id: "run", model: "m", state: "running", started_at_unix_ms: 1, position: 0 },
-        { id: "A", model: "m", state: "queued", started_at_unix_ms: 2, position: 1 },
-        { id: "B", model: "m", state: "queued", started_at_unix_ms: 3, position: 2 },
+        { id: "run", model: "old-running", state: "running", started_at_unix_ms: 1, position: 0 },
+        { id: "A", model: "middle-queued", state: "queued", started_at_unix_ms: 2, position: 1 },
+        { id: "B", model: "new-queued", state: "queued", started_at_unix_ms: 3, position: 2 },
       ],
       paused: null,
       caps: { canPause: true, canCancelAll: true, canReorder: true },
@@ -185,15 +185,21 @@ describe("QueueColumn", () => {
     const wrapper = mount(QueueColumn);
     await flushPromises();
 
-    // Only the two queued rows expose reorder buttons: index 0 = A, 1 = B.
+    expect(
+      wrapper
+        .findAll("[data-test='queue-surface-row']")
+        .map((row) => row.find(".text-body").text()),
+    ).toEqual(["new-queued", "middle-queued", "old-running"]);
+    // Display is newest-first: B, A, running. Reorder still uses the server's
+    // queued subset: A index 0, B index 1.
     const ups = wrapper.findAll("[data-test='queue-reorder-up']");
     const downs = wrapper.findAll("[data-test='queue-reorder-down']");
     expect(ups).toHaveLength(2);
 
-    await ups[1]!.trigger("click"); // move B up
+    await ups[0]!.trigger("click"); // move B up
     expect(reorder).toHaveBeenLastCalledWith("local", "B", 0);
 
-    await downs[0]!.trigger("click"); // move A down
+    await downs[1]!.trigger("click"); // move A down
     expect(reorder).toHaveBeenLastCalledWith("local", "A", 1);
   });
 

--- a/desktop/src/components/machines/QueueColumn.vue
+++ b/desktop/src/components/machines/QueueColumn.vue
@@ -84,9 +84,11 @@ async function cancel(row: QueueSurfaceRow) {
  *  PATCH uses. `entry.position` counts running jobs too, so nudging against it
  *  is off-by-N (or a no-op) the moment anything on the host is running. */
 function queuedIndexOf(row: QueueSurfaceRow): number {
-  return rows.value
-    .filter((r) => r.hostId === row.hostId && r.entry.state === "queued")
-    .findIndex((r) => r.entry.id === row.entry.id);
+  return (
+    jobs.queues[row.hostId]?.entries
+      .filter((entry) => entry.state === "queued")
+      .findIndex((entry) => entry.id === row.entry.id) ?? -1
+  );
 }
 
 /** Nudge a queued job earlier/later; the server clamps out-of-range indices. */

--- a/desktop/src/components/shell/NavRail.test.ts
+++ b/desktop/src/components/shell/NavRail.test.ts
@@ -121,7 +121,7 @@ describe("NavRail developing jobs", () => {
     };
   }
 
-  it("keeps recovered and local work in chronological order across phase changes", async () => {
+  it("keeps recovered and local work newest-first across phase changes", async () => {
     const wrapper = await mountAt("/create");
     useGenerationStore().jobs = [
       {
@@ -160,7 +160,7 @@ describe("NavRail developing jobs", () => {
     await flushPromises();
 
     const text = wrapper.get("[data-test='developing-jobs']").text();
-    expect(text.indexOf("flux-dev")).toBeLessThan(text.indexOf("flux-schnell"));
+    expect(text.indexOf("flux-schnell")).toBeLessThan(text.indexOf("flux-dev"));
   });
 
   it("shows cancellation progress, then offers to remove the cancelled row", async () => {

--- a/desktop/src/components/shell/NavRail.vue
+++ b/desktop/src/components/shell/NavRail.vue
@@ -41,6 +41,7 @@ import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { useOpenLiveWork } from "../../composables/useOpenLiveWork";
 import { thumbnailPath } from "../../lib/gallery/media";
 import type { FleetActiveWork } from "@studio/api/activity";
+import { compareNewestSubmitted } from "@studio/lib/activityOrder";
 
 const route = useRoute();
 const router = useRouter();
@@ -117,9 +118,9 @@ function isActive(path: string): boolean {
   return route.path === path;
 }
 
-/** Queue order: every live job first (submission order), then enough recent
- * finished prints to use the rail's available height. The flex child scrolls,
- * so a tall window becomes useful history without displacing status/settings. */
+/** Queue inputs: every live job newest-first, then enough recent finished
+ * prints to use the rail's available height. The merged rail re-applies the
+ * same newest-first policy across recovered work and sequences. */
 const railJobs = computed<Job[]>(() => {
   const live = railOrder(
     generation.jobs.filter((j) => j.status !== "complete" && j.status !== "error"),
@@ -175,9 +176,8 @@ type RailRow =
     }
   | { key: string; createdAtMs: number; kind: "print"; print: Job };
 
-/** One visual timeline across recovered work, sequences, prints, and retained
- * print history. Status transitions update rows in place instead of promoting
- * developing work above older queued work. */
+/** One newest-first timeline across recovered work, sequences, prints, and
+ * retained print history. Status transitions update rows in place. */
 const railRows = computed<RailRow[]>(() =>
   [
     ...sharedRows.value.map((shared): RailRow => ({
@@ -198,7 +198,7 @@ const railRows = computed<RailRow[]>(() =>
       kind: "print",
       print,
     })),
-  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+  ].sort(compareNewestSubmitted),
 );
 
 const developingCount = computed(

--- a/desktop/src/lib/queueLanes.test.ts
+++ b/desktop/src/lib/queueLanes.test.ts
@@ -7,7 +7,7 @@ import {
 } from "./queueLanes";
 
 function entry(over: Partial<LaneEntryLike> & { id: string }): LaneEntryLike {
-  return { state: "queued", position: 0, ...over };
+  return { state: "queued", position: 0, started_at_unix_ms: 0, ...over };
 }
 
 describe("laneForEntry", () => {
@@ -23,19 +23,16 @@ describe("laneForEntry", () => {
 });
 
 describe("held rows", () => {
-  it("orders held last instead of comparing an unknown state", () => {
-    // `STATE_RANK` is indexed by the row's state: an unrecognised one yields
-    // `undefined`, and `undefined - n` is NaN, so the comparator silently
-    // stops ordering rather than failing loudly.
+  it("keeps held work visible in newest-first display order", () => {
     const rows = [
-      entry({ id: "held", state: "held", position: 0 }),
-      entry({ id: "run", state: "running", position: 1 }),
-      entry({ id: "queued", state: "queued", position: 2 }),
+      entry({ id: "queued", state: "queued", position: 2, started_at_unix_ms: 1 }),
+      entry({ id: "run", state: "running", position: 1, started_at_unix_ms: 2 }),
+      entry({ id: "held", state: "held", position: 0, started_at_unix_ms: 3 }),
     ];
 
     const lanes = computeQueueLanes(rows, []);
 
-    expect(lanes[0]!.entries.map((row) => row.id)).toEqual(["run", "queued", "held"]);
+    expect(lanes[0]!.entries.map((row) => row.id)).toEqual(["held", "run", "queued"]);
   });
 
   it("puts a held row in the Auto lane rather than claiming a GPU", () => {
@@ -85,14 +82,14 @@ describe("computeQueueLanes", () => {
     expect(lanes[1]!.entries.map((e) => e.id)).toEqual(["q1"]);
   });
 
-  it("orders each lane running-first, then by queue position", () => {
+  it("orders each lane newest-first without changing queue positions", () => {
     const rows = [
-      entry({ id: "q-late", target_gpu: 0, position: 5 }),
-      entry({ id: "run", state: "running", gpu: 0, position: 9 }),
-      entry({ id: "q-early", target_gpu: 0, position: 1 }),
+      entry({ id: "q-late", target_gpu: 0, position: 5, started_at_unix_ms: 3 }),
+      entry({ id: "run", state: "running", gpu: 0, position: 9, started_at_unix_ms: 1 }),
+      entry({ id: "q-early", target_gpu: 0, position: 1, started_at_unix_ms: 2 }),
     ];
     const lanes = computeQueueLanes(rows, [0, 1]);
-    expect(lanes[0]!.entries.map((e) => e.id)).toEqual(["run", "q-early", "q-late"]);
+    expect(lanes[0]!.entries.map((e) => e.id)).toEqual(["q-late", "q-early", "run"]);
   });
 });
 

--- a/desktop/src/lib/queueLanes.ts
+++ b/desktop/src/lib/queueLanes.ts
@@ -4,6 +4,8 @@
  * Pure functions so lane grouping and the drag/drop policy are unit-testable.
  */
 
+import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
+
 export type LaneKey = number | "queue";
 
 /** The subset of a queue row the lane computation needs. */
@@ -13,6 +15,7 @@ export interface LaneEntryLike {
    * replay or dispatch budget. It occupies no lane and waits for no turn. */
   state: "queued" | "running" | "paused" | "held";
   position: number;
+  started_at_unix_ms: number;
   /** GPU ordinal currently running this row (running rows only). */
   gpu?: number;
   /** Requested GPU ordinal for queued rows; absent = Auto. */
@@ -31,12 +34,8 @@ export function laneForEntry(entry: LaneEntryLike): number | null {
   return entry.target_gpu ?? null;
 }
 
-/** Every state this comparator can see. A missing key yields `undefined`, and
- *  `undefined - n` is NaN, which silently stops the sort rather than failing. */
-const STATE_RANK = { running: 0, queued: 1, paused: 2, held: 3 } as const;
-
 function laneOrder<T extends LaneEntryLike>(a: T, b: T): number {
-  return STATE_RANK[a.state] - STATE_RANK[b.state] || a.position - b.position;
+  return compareNewestQueueEntry(a, b);
 }
 
 /**

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -1118,7 +1118,7 @@ describe("MobileApp sequence generation", () => {
     expect(localStorage.getItem("mold.mobile.live-activity.v1")).not.toContain(target.apiKey);
   });
 
-  it("interleaves local and recovered work by submission time", async () => {
+  it("interleaves local and recovered work newest-first", async () => {
     apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
       if (path === "/api/status") return Promise.resolve(status);
       if (path === "/api/models") return Promise.resolve([model]);
@@ -1160,7 +1160,7 @@ describe("MobileApp sequence generation", () => {
     await flushPromises();
 
     const text = wrapper.get(".mobile-generation-queue-list").text();
-    expect(text.indexOf("older queued print")).toBeLessThan(text.indexOf("newer developing print"));
+    expect(text.indexOf("newer developing print")).toBeLessThan(text.indexOf("older queued print"));
   });
 
   it("swipes a queued item from another client to exact-host pause and resume", async () => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -150,6 +150,7 @@ import {
   type ActivityJobVM,
   type PrintActivityVM,
 } from "@studio/lib/activity";
+import { compareNewestSubmitted } from "@studio/lib/activityOrder";
 import {
   buildQueueStatusIndex,
   queueStatusFor,
@@ -2575,8 +2576,8 @@ type MobileActivityDisplayRow =
   | { key: string; createdAtMs: number; kind: "local"; local: ActivityRow }
   | { key: string; createdAtMs: number; kind: "shared"; shared: FleetActiveWork };
 
-/** One chronological queue across this session and server-owned/recovered
- * work. Ownership and phase change row contents, never visual position. */
+/** One newest-first queue across this session and server-owned/recovered work.
+ * Ownership and phase change row contents without changing submission order. */
 const mobileActivityRows = computed<MobileActivityDisplayRow[]>(() =>
   [
     ...activityRows.value.map((local): MobileActivityDisplayRow => ({
@@ -2591,7 +2592,7 @@ const mobileActivityRows = computed<MobileActivityDisplayRow[]>(() =>
       kind: "shared",
       shared,
     })),
-  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+  ].sort(compareNewestSubmitted),
 );
 const expandedQueueFailures = ref(new Set<string>());
 

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -447,8 +447,8 @@ describe("MobileHostDetail remote host data", () => {
 
     const queueRows = view.get("[data-test='host-detail-queue']").findAll("li");
     expect(queueRows).toHaveLength(2);
-    expect(queueRows[0]!.text()).toContain("flux-dev:q8RUNNING · GPU 0");
-    expect(queueRows[1]!.text()).toContain("z-image:q8QUEUED #2");
+    expect(queueRows[0]!.text()).toContain("z-image:q8QUEUED #2");
+    expect(queueRows[1]!.text()).toContain("flux-dev:q8RUNNING · GPU 0");
 
     const modelRows = view.get("[data-test='host-detail-models']").findAll("li");
     expect(modelRows).toHaveLength(2);
@@ -556,6 +556,13 @@ describe("MobileHostDetail remote host data", () => {
     expect(view.text()).toContain("Verifying file [1/19]");
     expect(view.text()).not.toContain("0/0 files");
     expect(view.emitted("status")).toEqual([[{ id: studio.id, status: serverStatus() }]]);
+  });
+
+  it("renders the machine queue newest-first", async () => {
+    const view = await mountDetail();
+    expect(
+      view.findAll("[data-test^='host-detail-queue-row-']").map((row) => row.find("strong").text()),
+    ).toEqual(["z-image:q8", "flux-dev:q8"]);
   });
 
   it("confirms and cancels only a queued job on the exact authenticated host", async () => {

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -23,6 +23,7 @@ import MinimaxH3InventoryPanel from "@studio/components/MinimaxH3InventoryPanel.
 import { canMutateDevice } from "@studio/lib/deviceLifecycle";
 import { queueWaitCode, resolveQueueWait } from "@studio/lib/queuePosition";
 import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
+import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
 import { hostMemoryLevel, hostMemoryScheduleLabel } from "@studio/lib/hostMemory";
 import { apiJsonTo } from "../lib/api/client";
 import { describeTransportError } from "../lib/api/errors";
@@ -147,6 +148,7 @@ const runtimeWindow = computed(() => {
     : null;
 });
 const queueEntryIds = computed(() => queue.value.map((entry) => entry.id));
+const displayQueue = computed(() => [...queue.value].sort(compareNewestQueueEntry));
 const planOnlyWork = computed(() => queuePlanOnlyWork(queuePlan.value, queueEntryIds.value));
 const queueSummary = computed(() => {
   const visibleWork = queue.value.length + planOnlyWork.value.length;
@@ -1269,8 +1271,8 @@ onBeforeUnmount(() => {
             {{ deviceError }}
           </p>
         </div>
-        <ul v-if="queue.length" class="mobile-data-list" data-test="host-detail-queue">
-          <li v-for="entry in queue" :key="entry.id" class="mobile-queue-item">
+        <ul v-if="displayQueue.length" class="mobile-data-list" data-test="host-detail-queue">
+          <li v-for="entry in displayQueue" :key="entry.id" class="mobile-queue-item">
             <SwipeActionRow
               :actions="queueRowActions(entry)"
               :label="`${modelLabel(entry.model)} job`"

--- a/desktop/src/stores/generation.test.ts
+++ b/desktop/src/stores/generation.test.ts
@@ -240,7 +240,7 @@ describe("railOrder", () => {
     submittedAtUnixMs,
   });
 
-  it("keeps submission order when a newer job starts developing", async () => {
+  it("keeps newest submissions first when a newer job starts developing", async () => {
     const { railOrder } = await import("./generation");
     const jobs = [
       job(1, "queued", 3),
@@ -248,13 +248,13 @@ describe("railOrder", () => {
       job(3, "queued", 1),
       job(4, "denoising", null),
     ];
-    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([1, 2, 3, 4]);
+    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([4, 3, 2, 1]);
   });
 
-  it("uses client identity only to break equal submission timestamps", async () => {
+  it("preserves sending order for equal submission timestamps", async () => {
     const { railOrder } = await import("./generation");
     const jobs = [job(7, "loading", null, 10), job(5, "queued", null, 10), job(6, "queued", 1, 10)];
-    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([5, 6, 7]);
+    expect(railOrder(jobs).map((j) => j.clientId)).toEqual([7, 5, 6]);
   });
 });
 

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -1,5 +1,6 @@
 import { reactive } from "vue";
 import { defineStore } from "pinia";
+import { compareNewestSubmitted } from "@studio/lib/activityOrder";
 import { apiFetchTo, currentTarget, type ApiTarget, apiJsonTo } from "../lib/api/client";
 import { sseStream } from "../lib/api/sse";
 import {
@@ -243,13 +244,15 @@ export function planBatchRequests(
 }
 
 /**
- * Stable chronological display order for the jobs rail. A transition from
- * queued to loading/developing must update a row in place, never move it to
- * the top of the visual queue.
+ * Stable newest-first display order for the jobs rail. Equal timestamps retain
+ * sending order, and phase transitions never affect placement.
  */
 export function railOrder(jobs: Job[]): Job[] {
-  return [...jobs].sort(
-    (a, b) => a.submittedAtUnixMs - b.submittedAtUnixMs || a.clientId - b.clientId,
+  return [...jobs].sort((a, b) =>
+    compareNewestSubmitted(
+      { createdAtMs: a.submittedAtUnixMs },
+      { createdAtMs: b.submittedAtUnixMs },
+    ),
   );
 }
 

--- a/desktop/src/stores/jobs.test.ts
+++ b/desktop/src/stores/jobs.test.ts
@@ -122,7 +122,7 @@ beforeEach(() => {
 });
 
 describe("held rows", () => {
-  it("keeps a held row in the listing and sorts it after live work", async () => {
+  it("keeps a held row in the newest-first listing", async () => {
     // A held job exceeded its replay or dispatch cap: it exists only in the
     // journal and will never start on its own. Dropping it here is the one
     // outcome the held-row visibility contract forbids — nothing reports it,
@@ -164,10 +164,8 @@ describe("held rows", () => {
 
     const states = (jobs.queues[host.id]?.entries ?? []).map((entry) => entry.state);
     expect(states).toContain("held");
-    // The shared surface both Machines and Create render puts running work
-    // first and parked work last — held is not competing for a lane.
-    const surface = jobs.queueSurface.map((row) => row.entry.state);
-    expect(surface.indexOf("running")).toBeLessThan(surface.indexOf("held"));
+    const surface = jobs.queueSurface.map((row) => row.entry.id);
+    expect(surface).toEqual(["srv-run", "srv-held"]);
     const held = jobs.queues[host.id]?.entries.find((entry) => entry.state === "held");
     expect(held?.held_reason).toBe("dispatch attempts exhausted");
   });

--- a/desktop/src/stores/jobs.ts
+++ b/desktop/src/stores/jobs.ts
@@ -14,6 +14,7 @@ import { useGenerationStore } from "./generation";
 import { useHostsStore, type HostView } from "./hosts";
 import { useToastStore } from "./toasts";
 import type { Job } from "./generation";
+import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
 
 const POLL_INTERVAL_MS = 5_000;
 
@@ -94,14 +95,6 @@ export interface QueueSurfaceRow {
   canCancelRunning: boolean;
 }
 
-/** Running first, then queued, then held — held work is parked, not in line,
- *  so it must never sort among rows that are actually waiting for a lane. */
-function queueSurfaceRank(entry: EnrichedQueueEntry): number {
-  if (entry.state === "running") return 0;
-  if (entry.state === "queued") return 1;
-  return entry.state === "paused" ? 2 : 3;
-}
-
 function visibleQueueEntries(entries: readonly import("@studio/api/queuePlan").QueueEntry[]) {
   return entries
     .filter(
@@ -166,7 +159,8 @@ export const useJobsStore = defineStore("jobs", {
   getters: {
     /**
      * Unified running+queued rows across every connected host, joined with
-     * this app's own jobs. Running rows first, then by queue position. The
+     * this app's own jobs. Newest submissions render first while scheduler
+     * position remains untouched for queue actions. The
      * single source both the Machines queue column and the Create activity
      * strip render, so the two surfaces show identical state (G2).
      */
@@ -190,11 +184,7 @@ export const useJobsStore = defineStore("jobs", {
           });
         }
       }
-      return rows.sort(
-        (a, b) =>
-          queueSurfaceRank(a.entry) - queueSurfaceRank(b.entry) ||
-          a.entry.position - b.entry.position,
-      );
+      return rows.sort((a, b) => compareNewestQueueEntry(a.entry, b.entry));
     },
   },
   actions: {

--- a/desktop/src/views/HostDetailView.test.ts
+++ b/desktop/src/views/HostDetailView.test.ts
@@ -665,12 +665,12 @@ describe("HostDetailView storage and queue", () => {
     const wrapper = await mountView();
     const rows = wrapper.findAll("[data-test='host-queue-row']");
     expect(rows).toHaveLength(2);
-    expect(rows[0]!.text()).toContain("RUNNING · GPU 0");
-    expect(rows[0]!.text()).toContain("flux-dev:q8");
+    expect(rows[0]!.text()).toContain("QUEUED #1");
+    expect(rows[0]!.text()).toContain("z-image:q8");
+    expect(rows[1]!.text()).toContain("RUNNING · GPU 0");
+    expect(rows[1]!.text()).toContain("flux-dev:q8");
     // Elapsed wall-clock for the running row (~90s → "1m 30s").
-    expect(rows[0]!.text()).toMatch(/1m \d+s/);
-    expect(rows[1]!.text()).toContain("QUEUED #1");
-    expect(rows[1]!.text()).toContain("z-image:q8");
+    expect(rows[1]!.text()).toMatch(/1m \d+s/);
     // Neither entry belongs to this app's generation store.
     expect(rows[0]!.text()).toContain("OTHER CLIENT");
     expect(wrapper.find("[data-test='queue-empty']").exists()).toBe(false);

--- a/studio/api/activity.test.ts
+++ b/studio/api/activity.test.ts
@@ -249,7 +249,7 @@ describe("active work reconciliation", () => {
     ]);
   });
 
-  it("keeps fleet work chronological instead of promoting running phases", () => {
+  it("keeps fleet work newest-first instead of promoting running phases", () => {
     const snapshot = reconcileActivityHost(route, undefined, {
       instance_id: "instance-a",
       observed_at_unix_ms: 10,
@@ -274,8 +274,8 @@ describe("active work reconciliation", () => {
     });
 
     expect(mergeFleetActivity([snapshot]).map((row) => row.id)).toEqual([
-      "older-queued",
       "newer-running",
+      "older-queued",
     ]);
   });
 });

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -1,4 +1,5 @@
 import { apiJsonTo, type ApiTarget } from "./client";
+import { compareNewestSubmitted } from "../lib/activityOrder";
 
 export interface ActiveWorkItem {
   id: string;
@@ -176,8 +177,11 @@ export function mergeFleetActivity(
   // still be queued on one machine while a newer job is already running on
   // another, so grouping by phase makes "developing" work jump to the top.
   // Submission time is the only ordering shared by every work kind and host.
-  return rows.sort(
-    (a, b) =>
-      a.created_at_unix_ms - b.created_at_unix_ms || a.key.localeCompare(b.key),
+  // Equal timestamps retain the server's sending order.
+  return rows.sort((a, b) =>
+    compareNewestSubmitted(
+      { createdAtMs: a.created_at_unix_ms },
+      { createdAtMs: b.created_at_unix_ms },
+    ),
   );
 }

--- a/studio/lib/activity.test.ts
+++ b/studio/lib/activity.test.ts
@@ -15,6 +15,10 @@ import {
   type ActivityJobVM,
   type PrintActivityVM,
 } from "./activity";
+import {
+  compareNewestQueueEntry,
+  compareNewestSubmitted,
+} from "./activityOrder";
 import { buildQueueStatusIndex } from "./queuePosition";
 import type { ChainJobSummary } from "./api/chainTypes";
 
@@ -51,6 +55,38 @@ function summary(extra: Partial<ChainJobSummary> = {}): ChainJobSummary {
     ...extra,
   };
 }
+
+describe("compareNewestSubmitted", () => {
+  it("sorts newest-first and preserves sending order for equal timestamps", () => {
+    const rows = [
+      { id: "equal-first", createdAtMs: 20 },
+      { id: "oldest", createdAtMs: 10 },
+      { id: "equal-second", createdAtMs: 20 },
+      { id: "newest", createdAtMs: 30 },
+    ];
+    expect(rows.sort(compareNewestSubmitted).map(({ id }) => id)).toEqual([
+      "newest",
+      "equal-first",
+      "equal-second",
+      "oldest",
+    ]);
+  });
+
+  it("sorts queue entries newest-first without using scheduler position", () => {
+    const entries = [
+      { id: "sent-first", started_at_unix_ms: 20, position: 9 },
+      { id: "oldest", started_at_unix_ms: 10, position: 0 },
+      { id: "sent-second", started_at_unix_ms: 20, position: 1 },
+      { id: "newest", started_at_unix_ms: 30, position: 7 },
+    ];
+    expect(entries.sort(compareNewestQueueEntry).map(({ id }) => id)).toEqual([
+      "newest",
+      "sent-first",
+      "sent-second",
+      "oldest",
+    ]);
+  });
+});
 
 describe("sequenceActions", () => {
   it("gives running jobs cancel + watch, settled jobs edit paths", () => {
@@ -115,7 +151,7 @@ describe("sequenceToVM", () => {
 });
 
 describe("mergeActivity", () => {
-  it("keeps active work chronological regardless of phase, then settled by recency", () => {
+  it("keeps active work newest-first regardless of phase, then settled by recency", () => {
     const settledPrint = print({
       key: "print:1",
       phase: "done",
@@ -140,8 +176,8 @@ describe("mergeActivity", () => {
       [queuedSeq, settledSeq],
     );
     expect(merged.map((vm) => vm.key)).toEqual([
-      "print:2", // older running work stays where it was submitted
-      "seq:plato:c1", // newer queued work follows it
+      "seq:plato:c1", // newer queued work stays above older running work
+      "print:2",
       "seq:plato:c2", // then settled, newest first
       "print:1",
     ]);

--- a/studio/lib/activity.ts
+++ b/studio/lib/activity.ts
@@ -19,6 +19,7 @@ import {
   type QueueStatusIndex,
 } from "./queuePosition";
 import { friendlySequenceError } from "./sequence";
+import { compareNewestSubmitted } from "./activityOrder";
 
 export type ActivityAction =
   "cancel" | "watch" | "retake" | "edit" | "resume" | "delete";
@@ -241,9 +242,9 @@ export function needsAttention(vm: ActivityJobVM): boolean {
         vm.state === "paused";
 }
 
-/** Merge prints and sequences into one list. Active work stays in chronological
- * submission order, regardless of whether a row is queued or running; settled
- * work follows by recency and is partitioned into attention/history below. */
+/** Merge prints and sequences into one list. Active work stays newest-first,
+ * regardless of whether a row is queued or running; settled work follows by
+ * recency and is partitioned into attention/history below. */
 export function mergeActivity(
   prints: readonly ActivityJobVM[],
   sequences: readonly ActivityJobVM[],
@@ -251,7 +252,7 @@ export function mergeActivity(
   return [...prints, ...sequences].sort((a, b) => {
     const activeDelta = Number(isActive(b)) - Number(isActive(a));
     if (activeDelta !== 0) return activeDelta;
-    if (isActive(a)) return a.createdAtMs - b.createdAtMs;
+    if (isActive(a)) return compareNewestSubmitted(a, b);
     return b.createdAtMs - a.createdAtMs;
   });
 }

--- a/studio/lib/activityOrder.ts
+++ b/studio/lib/activityOrder.ts
@@ -1,0 +1,25 @@
+export interface SubmittedActivityRow {
+  createdAtMs: number;
+}
+
+export interface SubmittedQueueEntry {
+  started_at_unix_ms: number;
+}
+
+/** Newest submissions render first. Returning zero for equal timestamps keeps
+ * the source's stable sending order instead of inventing an ID-based order. */
+export function compareNewestSubmitted(
+  left: SubmittedActivityRow,
+  right: SubmittedActivityRow,
+): number {
+  return right.createdAtMs - left.createdAtMs;
+}
+
+/** Queue display order only. Scheduler position remains authoritative for
+ * dispatch and mutations; equal stamps retain the response's sending order. */
+export function compareNewestQueueEntry(
+  left: SubmittedQueueEntry,
+  right: SubmittedQueueEntry,
+): number {
+  return right.started_at_unix_ms - left.started_at_unix_ms;
+}

--- a/web/src/components/create/ActivityStrip.test.ts
+++ b/web/src/components/create/ActivityStrip.test.ts
@@ -66,7 +66,7 @@ function makeSequenceVM(
 }
 
 describe("ActivityStrip", () => {
-  it("keeps an older queued print above newer running fleet work", () => {
+  it("keeps newer fleet work above an older queued print", () => {
     const olderQueued = makeJob({
       id: "older-queued",
       startedAt: 1_000,
@@ -100,8 +100,8 @@ describe("ActivityStrip", () => {
     const text = mount(ActivityStrip, {
       props: { jobs: [olderQueued], shared: [newerShared] },
     }).text();
-    expect(text.indexOf("a cat")).toBeLessThan(
-      text.indexOf("newer developing print"),
+    expect(text.indexOf("newer developing print")).toBeLessThan(
+      text.indexOf("a cat"),
     );
   });
 
@@ -263,7 +263,7 @@ describe("ActivityStrip", () => {
     ).toContain("9999 other queued prints");
   });
 
-  it("does not promote a newer held print above an older queued print", () => {
+  it("shows a newer held print above an older queued print", () => {
     const wrapper = mount(ActivityStrip, {
       props: {
         jobs: [
@@ -279,10 +279,10 @@ describe("ActivityStrip", () => {
     });
 
     expect(
-      wrapper.find("[data-test='activity-queued-older-queued']").exists(),
+      wrapper.find("[data-test='activity-queued-newer-held']").exists(),
     ).toBe(true);
     expect(
-      wrapper.find("[data-test='activity-queued-newer-held']").exists(),
+      wrapper.find("[data-test='activity-queued-older-queued']").exists(),
     ).toBe(false);
     expect(wrapper.text()).toContain("1 other queued print");
   });

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -29,6 +29,7 @@ import {
 } from "@studio/lib/queuePosition";
 import type { Job } from "../../composables/useGenerateStream";
 import { ORIGIN_HOST_ID } from "../../lib/hostRegistry";
+import { compareNewestSubmitted } from "@studio/lib/activityOrder";
 
 const props = withDefaults(
   defineProps<{
@@ -211,19 +212,22 @@ const running = computed(() =>
 const queued = computed(() =>
   props.jobs.filter((j) => j.state === "running" && !j.workStarted),
 );
-/** Render exactly the oldest submitted queued print, then summarize the rest.
- * Cancellation reveals the following row, so every job remains reachable
- * without producing one interactive DOM subtree per backlog item. */
-const nextQueued = computed(() => {
+/** Render exactly the newest submitted queued print, then summarize the rest.
+ * Cancellation reveals the preceding submission without producing one
+ * interactive DOM subtree per backlog item. */
+const newestQueued = computed(() => {
   const actionable = queued.value.filter((job) => !job.cancelling);
   return (
-    [...(actionable.length > 0 ? actionable : queued.value)].sort(
-      (a, b) => a.startedAt - b.startedAt || a.id.localeCompare(b.id),
+    [...(actionable.length > 0 ? actionable : queued.value)].sort((a, b) =>
+      compareNewestSubmitted(
+        { createdAtMs: a.startedAt },
+        { createdAtMs: b.startedAt },
+      ),
     )[0] ?? null
   );
 });
 const summarizedQueuedCount = computed(() =>
-  Math.max(0, queued.value.length - (nextQueued.value ? 1 : 0)),
+  Math.max(0, queued.value.length - (newestQueued.value ? 1 : 0)),
 );
 
 type WebActivityRow =
@@ -241,8 +245,8 @@ type WebActivityRow =
       sequence: ActivityJobVM & { kind: "sequence" };
     };
 
-/** One visual queue across local prints, sequences, and recovered fleet work.
- * A phase transition changes only the row contents, never its position. */
+/** One newest-first visual queue across local prints, sequences, and recovered
+ * fleet work. A phase transition changes only the row contents. */
 const activeRows = computed<WebActivityRow[]>(() =>
   [
     ...props.shared.map((shared): WebActivityRow => ({
@@ -257,13 +261,13 @@ const activeRows = computed<WebActivityRow[]>(() =>
       kind: "print",
       print,
     })),
-    ...(nextQueued.value
+    ...(newestQueued.value
       ? [
           {
-            key: `print:${nextQueued.value.id}`,
-            createdAtMs: nextQueued.value.startedAt,
+            key: `print:${newestQueued.value.id}`,
+            createdAtMs: newestQueued.value.startedAt,
             kind: "print" as const,
-            print: nextQueued.value,
+            print: newestQueued.value,
           },
         ]
       : []),
@@ -273,7 +277,7 @@ const activeRows = computed<WebActivityRow[]>(() =>
       kind: "sequence",
       sequence,
     })),
-  ].sort((a, b) => a.createdAtMs - b.createdAtMs || a.key.localeCompare(b.key)),
+  ].sort(compareNewestSubmitted),
 );
 const active = computed(
   () =>

--- a/web/src/components/machines/QueueCard.test.ts
+++ b/web/src/components/machines/QueueCard.test.ts
@@ -10,21 +10,21 @@ function listing(): QueueEntry[] {
   return [
     {
       id: "run",
-      model: "m",
+      model: "old-running",
       state: "running",
       started_at_unix_ms: 1,
       position: 0,
     },
     {
       id: "A",
-      model: "m",
+      model: "middle-queued",
       state: "queued",
       started_at_unix_ms: 2,
       position: 1,
     },
     {
       id: "B",
-      model: "m",
+      model: "new-queued",
       state: "queued",
       started_at_unix_ms: 3,
       position: 2,
@@ -57,10 +57,13 @@ describe("QueueCard reorder index", () => {
     expect(wrapper.emitted("cancelAll")).toHaveLength(1);
     expect(
       wrapper.findAll("[data-test='queue-lane']")[0]!.attributes("disabled"),
+    ).toBeUndefined();
+    expect(
+      wrapper.findAll("[data-test='queue-lane']")[2]!.attributes("disabled"),
     ).toBeDefined();
     expect(
-      wrapper.findAll("[data-test='queue-lane']")[1]!.attributes("disabled"),
-    ).toBeUndefined();
+      wrapper.findAll("[data-test='queue-inspect']").map((row) => row.text()),
+    ).toEqual(["new-queued", "middle-queued", "old-running"]);
   });
 
   it("offers running cancellation only when the host advertises cooperative support", () => {
@@ -100,10 +103,11 @@ describe("QueueCard reorder index", () => {
 
   it("moves the last queued job up to queued index 0, not its listing position", async () => {
     const wrapper = mountCard();
-    // Only the two queued rows expose reorder buttons: index 0 = A, 1 = B.
+    // Display is B, A, running; queued mutation indices remain A=0, B=1.
     const upButtons = wrapper.findAll("[data-test='queue-up']");
     expect(upButtons).toHaveLength(2);
-    await upButtons[1]!.trigger("click"); // move B up
+    expect(upButtons[0]!.attributes("aria-label")).toBe("Run earlier");
+    await upButtons[0]!.trigger("click"); // move B up
 
     expect(wrapper.emitted("move")).toEqual([["B", 0]]);
   });
@@ -112,7 +116,8 @@ describe("QueueCard reorder index", () => {
     const wrapper = mountCard();
     const downButtons = wrapper.findAll("[data-test='queue-down']");
     expect(downButtons).toHaveLength(2);
-    await downButtons[0]!.trigger("click"); // move A down
+    expect(downButtons[1]!.attributes("aria-label")).toBe("Run later");
+    await downButtons[1]!.trigger("click"); // move A down
 
     expect(wrapper.emitted("move")).toEqual([["A", 1]]);
   });
@@ -165,8 +170,8 @@ describe("host-wide pause presentation", () => {
     });
 
     const rows = wrapper.findAll("[data-test='queue-row']");
-    expect(rows[0]!.text()).toContain("Queue paused");
-    expect(rows[1]!.text()).toContain("Held");
+    expect(rows[0]!.text()).toContain("Held");
+    expect(rows[1]!.text()).toContain("Queue paused");
   });
 });
 
@@ -233,9 +238,9 @@ describe("restart-paused rows", () => {
     });
 
     const rows = wrapper.findAll("[data-test='queue-row']");
-    expect(rows[0]!.text()).toContain("Paused");
-    expect(rows[1]!.text()).toContain("#1 in line");
-    expect(rows[1]!.text()).not.toContain("Queue paused");
+    expect(rows[0]!.text()).toContain("#1 in line");
+    expect(rows[0]!.text()).not.toContain("Queue paused");
+    expect(rows[1]!.text()).toContain("Paused");
     expect(wrapper.get("[data-test='pause-toggle']").text()).toBe("Resume");
   });
 });

--- a/web/src/components/machines/QueueCard.vue
+++ b/web/src/components/machines/QueueCard.vue
@@ -18,6 +18,7 @@ import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import type { QueuePlan } from "@studio/api/queuePlan";
 import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 import { queueWaitLabel, resolveQueueWait } from "@studio/lib/queuePosition";
+import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
 
 const props = withDefaults(
   defineProps<{
@@ -59,6 +60,9 @@ const emit = defineEmits<{
 
 const queuedIds = computed(() =>
   props.entries.filter((e) => e.state === "queued").map((e) => e.id),
+);
+const displayEntries = computed(() =>
+  [...props.entries].sort(compareNewestQueueEntry),
 );
 const cancellableIds = computed(() =>
   props.entries
@@ -170,9 +174,9 @@ function queuedIndexOf(id: string): number {
         Nothing queued.
       </p>
 
-      <ul v-if="entries.length" class="qc__list">
+      <ul v-if="displayEntries.length" class="qc__list">
         <li
-          v-for="entry in entries"
+          v-for="entry in displayEntries"
           :key="entry.id"
           class="qc__row"
           data-test="queue-row"
@@ -228,7 +232,8 @@ function queuedIndexOf(id: string): number {
               class="qc__icon"
               data-test="queue-up"
               :disabled="dimmed || isFirstQueued(entry.id)"
-              aria-label="Move up"
+              aria-label="Run earlier"
+              title="Run earlier in the dispatch queue"
               @click="emit('move', entry.id, queuedIndexOf(entry.id) - 1)"
             >
               <Icon name="chevron-up" :size="14" />
@@ -238,7 +243,8 @@ function queuedIndexOf(id: string): number {
               class="qc__icon"
               data-test="queue-down"
               :disabled="dimmed || isLastQueued(entry.id)"
-              aria-label="Move down"
+              aria-label="Run later"
+              title="Run later in the dispatch queue"
               @click="emit('move', entry.id, queuedIndexOf(entry.id) + 1)"
             >
               <Icon name="chevron-down" :size="14" />


### PR DESCRIPTION
## Summary

- Show newest submitted work first across desktop, web, and mobile activity and Machines queue surfaces.
- Preserve stable sending order for equal submission timestamps.
- Keep scheduler positions and queue mutation indices in their original server order.
- Clarify web queue controls as dispatch-priority actions.

## Validation

- Full Studio suite: 1,490 tests passed.
- Full web suite: 1,752 tests passed.
- Relevant desktop queue, activity, and mobile regression suites passed.
- Web, desktop, and mobile production builds passed.
- Frontend architecture, Prettier, rendered browser QA, and shipped-source changelog checks passed.

## Review

- Independent agent peer review approved with no remaining findings.
- Findings about Machines coverage and dispatch-priority labels were addressed.
