### PR TITLE
fix(desktop): restore queue actions after restart

### DIFF
--- a/changelog.d/desktop-queue-context-actions.md
+++ b/changelog.d/desktop-queue-context-actions.md
@@ -1,0 +1,1 @@
+- **Restore desktop queue actions after restart.** Selecting a row now loads its durable settings, Retry uses server-held authority, ownership remains recognizable, and right-click menus expose pause/resume, retry, cancel, and GPU placement actions.

--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -14,10 +14,13 @@ vi.mock("../../lib/notify", () => ({ notifyGenerated: vi.fn(), notifyGenerationF
 vi.mock("../../lib/ipc", () => ({ inTauri: () => false, ipc: {} }));
 
 import HostQueuePanel from "./HostQueuePanel.vue";
+import { apiJsonTo } from "../../lib/api/client";
 import { useConnectionStore } from "../../stores/connection";
 import { useHostsStore } from "../../stores/hosts";
 import { useGenerationStore } from "../../stores/generation";
 import { useJobsStore, type QueueEntry } from "../../stores/jobs";
+import { useContextMenuStore } from "../../stores/contextMenu";
+import { useToastStore } from "../../stores/toasts";
 import type { QueuePlan } from "@studio/api/queuePlan";
 
 const stub = { template: "<div />" };
@@ -34,11 +37,46 @@ function queued(id: string, position: number, targetGpu: number): QueueEntry {
   };
 }
 
+function queueMetadata(prompt: string): NonNullable<QueueEntry["metadata"]> {
+  return {
+    prompt,
+    model: "flux2-klein",
+    seed: 7,
+    steps: 4,
+    guidance: 3,
+    width: 512,
+    height: 512,
+  };
+}
+
 async function mountPanel(
   gpuOrdinals: number[],
   entries: QueueEntry[],
   plan: QueuePlan | null = null,
 ) {
+  vi.mocked(apiJsonTo).mockImplementation((_target, path) => {
+    const match = path.match(/^\/api\/queue\/([^/?]+)$/);
+    if (match) {
+      const id = decodeURIComponent(match[1]!);
+      const entry = entries.find((candidate) => candidate.id === id);
+      return entry
+        ? Promise.resolve({ job: entry, work_item: null })
+        : Promise.reject(new Error(`missing queue fixture ${id}`));
+    }
+    return Promise.resolve({ queue_depth: 0 });
+  });
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(async (input: RequestInfo | URL) => {
+      const path = new URL(String(input)).pathname;
+      const match = path.match(/^\/api\/queue\/([^/]+)$/);
+      const id = match ? decodeURIComponent(match[1]!) : "";
+      const entry = entries.find((candidate) => candidate.id === id);
+      return entry
+        ? Response.json({ job: entry, work_item: null })
+        : Response.json({ error: `missing queue fixture ${id}` }, { status: 404 });
+    }),
+  );
   router = createRouter({
     history: createMemoryHistory(),
     routes: [
@@ -75,6 +113,7 @@ async function mountPanel(
 
 beforeEach(() => {
   vi.clearAllMocks();
+  vi.unstubAllGlobals();
 });
 
 describe("HostQueuePanel", () => {
@@ -138,6 +177,51 @@ describe("HostQueuePanel", () => {
     await wrapper.get("[data-test='queue-row']").trigger("click");
     await flushPromises();
     expect(wrapper.find("[data-test='queue-entry-drawer']").exists()).toBe(true);
+  });
+
+  it("does not reopen a closed drawer when hydration finishes", async () => {
+    const { wrapper, jobs } = await mountPanel([], [queued("srv-0", 1, 0)]);
+    let resolveDetail!: (entry: QueueEntry) => void;
+    vi.spyOn(jobs, "queueJob").mockReturnValue(
+      new Promise<QueueEntry>((resolve) => {
+        resolveDetail = resolve;
+      }),
+    );
+
+    await wrapper.get("[data-test='queue-row']").trigger("click");
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await flushPromises();
+    expect(wrapper.find("[data-test='queue-entry-drawer']").exists()).toBe(false);
+
+    resolveDetail({ ...queued("srv-0", 1, 0), metadata: queueMetadata("too late") });
+    await flushPromises();
+    expect(wrapper.find("[data-test='queue-entry-drawer']").exists()).toBe(false);
+  });
+
+  it("does not replace a newer drawer selection with stale hydration", async () => {
+    const first = queued("srv-0", 1, 0);
+    const second = { ...queued("srv-1", 2, 0), model: "z-image" };
+    const { wrapper, jobs } = await mountPanel([], [first, second]);
+    const resolvers = new Map<string, (entry: QueueEntry) => void>();
+    vi.spyOn(jobs, "queueJob").mockImplementation(
+      (_hostId, jobId) =>
+        new Promise<QueueEntry>((resolve) => {
+          resolvers.set(jobId, resolve);
+        }),
+    );
+
+    const rows = wrapper.findAll("[data-test='queue-row']");
+    await rows[0]!.trigger("click");
+    await rows[1]!.trigger("click");
+    resolvers.get("srv-0")?.({ ...first, metadata: queueMetadata("stale first") });
+    await flushPromises();
+    expect(wrapper.get("[data-test='queue-entry-drawer']").attributes("aria-label")).toContain(
+      "z-image",
+    );
+
+    resolvers.get("srv-1")?.({ ...second, metadata: queueMetadata("current second") });
+    await flushPromises();
+    expect(wrapper.get("[data-test='queue-detail-prompt']").text()).toBe("current second");
   });
 
   it("shows this app's own submitted request when the durable listing has none", async () => {
@@ -265,5 +349,148 @@ describe("held rows", () => {
     );
 
     expect(wrapper.find("[data-test='cancel-entry']").exists()).toBe(true);
+  });
+
+  it("hydrates restart-held settings and enables Retry from server authority", async () => {
+    const listing: QueueEntry = {
+      id: "srv-held",
+      model: "flux2-klein",
+      state: "held",
+      started_at_unix_ms: 1,
+      position: 0,
+      held_reason: "no enabled GPU",
+      retryable: true,
+      batch_id: "batch-1",
+      client_batch_id: "client-1",
+    };
+    const { wrapper, jobs } = await mountPanel([], [listing]);
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({
+        job: {
+          ...listing,
+          metadata: {
+            prompt: "a recovered lighthouse",
+            model: "flux2-klein",
+            width: 1024,
+            height: 1024,
+          },
+        },
+        work_item: null,
+      }),
+    );
+    const retry = vi.spyOn(jobs, "retryJob").mockResolvedValue(undefined);
+
+    await wrapper.get("[data-test='queue-row']").trigger("click");
+    await flushPromises();
+
+    const drawer = wrapper.get("[data-test='queue-entry-drawer']");
+    expect(drawer.get("[data-test='queue-detail-prompt']").text()).toBe("a recovered lighthouse");
+    expect(drawer.get("[data-test='queue-detail-reuse']").attributes("disabled")).toBeUndefined();
+    expect(drawer.get("[data-test='queue-detail-retry']").attributes("disabled")).toBeUndefined();
+
+    // The next payload-free queue poll updates state without erasing the
+    // explicitly hydrated request or disabling its actions again.
+    jobs.queues.local!.entries = [{ ...listing, held_reason: "still waiting for a GPU" }];
+    await flushPromises();
+    expect(drawer.get("[data-test='queue-detail-prompt']").text()).toBe("a recovered lighthouse");
+    expect(drawer.get("[data-test='queue-detail-reuse']").attributes("disabled")).toBeUndefined();
+
+    await drawer.get("[data-test='queue-detail-retry']").trigger("click");
+    await flushPromises();
+    expect(retry).toHaveBeenCalledWith(
+      "local",
+      expect.objectContaining({ id: "srv-held", client_batch_id: "client-1" }),
+    );
+  });
+
+  it("opens a row context menu with queue controls and no disabled retry", async () => {
+    const entry: QueueEntry = {
+      id: "srv-held",
+      model: "flux2-klein",
+      state: "held",
+      started_at_unix_ms: 1,
+      position: 0,
+      retryable: true,
+      batch_id: "batch-1",
+      client_batch_id: "client-1",
+    };
+    const { wrapper } = await mountPanel([], [entry]);
+    await wrapper.get("[data-test='queue-row']").trigger("contextmenu", {
+      clientX: 10,
+      clientY: 10,
+    });
+    const items = useContextMenuStore().entries.filter((item) => "label" in item);
+    expect(items.map((item) => item.label)).toEqual([
+      "Show details",
+      "Reuse settings",
+      "Pause queue",
+      "Retry job",
+      "Cancel job",
+    ]);
+    expect(items.find((item) => item.label === "Retry job")?.disabled).not.toBe(true);
+  });
+
+  it("falls back to local settings and retry authority on older hosts", async () => {
+    const listing: QueueEntry = {
+      id: "srv-held",
+      model: "flux2-klein",
+      state: "held",
+      started_at_unix_ms: 1,
+      position: 0,
+      retryable: true,
+    };
+    const { wrapper } = await mountPanel([], [listing]);
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json({ error: "not found" }, { status: 404 }));
+    const generation = useGenerationStore();
+    generation.jobs.push({
+      clientId: 42,
+      id: "srv-held",
+      retryable: true,
+      retrying: false,
+      request: { prompt: "local recovered prompt", model: "flux2-klein" },
+    } as never);
+    const retry = vi.spyOn(generation, "retryHeld").mockResolvedValue(undefined);
+    await flushPromises();
+
+    await wrapper.get("[data-test='queue-row']").trigger("click");
+    await flushPromises();
+    const drawer = wrapper.get("[data-test='queue-entry-drawer']");
+    expect(drawer.get("[data-test='queue-detail-prompt']").text()).toBe("local recovered prompt");
+    expect(drawer.get("[data-test='queue-detail-reuse']").attributes("disabled")).toBeUndefined();
+    expect(drawer.get("[data-test='queue-detail-retry']").attributes("disabled")).toBeUndefined();
+
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json({ error: "not found" }, { status: 404 }));
+    await drawer.get("[data-test='queue-detail-retry']").trigger("click");
+    await flushPromises();
+    expect(retry).toHaveBeenCalledWith(42);
+  });
+
+  it("reports a context-menu retry failure instead of rejecting globally", async () => {
+    const entry: QueueEntry = {
+      id: "srv-held",
+      model: "flux2-klein",
+      state: "held",
+      started_at_unix_ms: 1,
+      position: 0,
+      retryable: true,
+      batch_id: "batch-1",
+      client_batch_id: "client-1",
+    };
+    const { wrapper, jobs } = await mountPanel([], [entry]);
+    vi.spyOn(jobs, "queueJob").mockRejectedValue(new Error("retry authority changed"));
+    await wrapper.get("[data-test='queue-row']").trigger("contextmenu", {
+      clientX: 10,
+      clientY: 10,
+    });
+    const retry = useContextMenuStore().entries.find(
+      (item) => "label" in item && item.label === "Retry job",
+    );
+    if (retry && "action" in retry) retry.action?.();
+    await flushPromises();
+
+    expect(useToastStore().items.at(-1)).toMatchObject({
+      message: "retry authority changed",
+      kind: "error",
+    });
   });
 });

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -63,6 +63,7 @@ const hosts = useHostsStore();
 const hostModels = useHostModelsStore();
 const jobs = useJobsStore();
 const cancellingIds = ref<string[]>([]);
+const retryingIds = ref<string[]>([]);
 const composer = useComposerStore();
 const toasts = useToastStore();
 const contextMenu = useContextMenuStore();
@@ -79,7 +80,13 @@ const caps = computed(() => snapshot.value?.caps ?? null);
 const lanes = computed(() => {
   const snap = snapshot.value;
   const entries = snap
-    ? enrichQueueEntries(snap.entries, props.host.id, generation.jobs, primaryId.value)
+    ? enrichQueueEntries(
+        snap.entries,
+        props.host.id,
+        generation.jobs,
+        primaryId.value,
+        (clientBatchId) => generation.ownsDurableBatch(clientBatchId),
+      )
     : [];
   return computeQueueLanes(entries, snap?.gpuOrdinals ?? []);
 });
@@ -158,16 +165,43 @@ function onLaneDrop(laneKey: LaneKey) {
   }
 }
 
-/** Accessible non-drag fallback: right-click → Move to GPU N. */
+/** Queue actions live on every row. GPU reassignment is appended when the
+ * selected queued row has real device lanes. */
 function openEntryMenu(entry: EnrichedQueueEntry, event: MouseEvent) {
   const ordinals = laneOrdinals();
-  if (entry.state !== "queued" || ordinals.length === 0) return;
-  const current = laneForEntry(entry);
-  const items: MenuEntry[] = ordinals.map((ordinal) => ({
-    label: `Move to GPU ${ordinal}`,
-    disabled: ordinal === current,
-    action: () => void jobs.reassignGpu(props.host.id, entry.id, ordinal),
-  }));
+  const items: MenuEntry[] = [
+    { label: "Show details", action: () => void openQueueDetail(entry) },
+    { label: "Reuse settings", action: () => void reuseEntry(entry) },
+    { separator: true },
+  ];
+  if (caps.value?.canPause || resumeNeeded.value) {
+    items.push({
+      label: resumeNeeded.value ? "Resume queue" : "Pause queue",
+      action: () => void togglePause(),
+    });
+  }
+  if (entry.state === "held" && entry.retryable === true) {
+    items.push({ label: "Retry job", action: () => void retryFromMenu(entry) });
+  }
+  items.push({
+    label: entry.state === "running" ? "Stop job" : "Cancel job",
+    danger: true,
+    disabled: entry.state === "running" && caps.value?.canCancelRunning !== true,
+    action: () => {
+      confirmCancel.value = entry;
+    },
+  });
+  if (entry.state === "queued" && ordinals.length > 0) {
+    const current = laneForEntry(entry);
+    items.push(
+      { separator: true },
+      ...ordinals.map((ordinal) => ({
+        label: `Move to GPU ${ordinal}`,
+        disabled: ordinal === current,
+        action: () => void jobs.reassignGpu(props.host.id, entry.id, ordinal),
+      })),
+    );
+  }
   contextMenu.open(event, items);
 }
 
@@ -230,6 +264,7 @@ async function togglePause() {
 // ── Row info drawer (everything the host says about one queued job) ───────
 const queueDetail = ref<EnrichedQueueEntry | null>(null);
 const detailError = ref<string | null>(null);
+let detailRequestVersion = 0;
 const detailPreview = ref<QueueJobProgress | null>(null);
 const detailNowMs = ref(Date.now());
 let stopPreview: (() => void) | null = null;
@@ -242,11 +277,73 @@ watch(flatEntries, (entries) => {
   const open = queueDetail.value;
   if (!open) return;
   const updated = entries.find((entry) => entry.id === open.id);
-  queueDetail.value = updated ?? null;
+  queueDetail.value = updated
+    ? {
+        ...open,
+        ...updated,
+        // Hot queue polling is intentionally payload-free. Once an explicit
+        // row read hydrates settings, keep them while merging live state.
+        ...(updated.metadata !== undefined
+          ? { metadata: updated.metadata }
+          : open.metadata !== undefined
+            ? { metadata: open.metadata }
+            : {}),
+        ...(updated.batch_id !== undefined
+          ? { batch_id: updated.batch_id }
+          : open.batch_id !== undefined
+            ? { batch_id: open.batch_id }
+            : {}),
+        ...(updated.client_batch_id !== undefined
+          ? { client_batch_id: updated.client_batch_id }
+          : open.client_batch_id !== undefined
+            ? { client_batch_id: open.client_batch_id }
+            : {}),
+        ...(updated.batch_index !== undefined
+          ? { batch_index: updated.batch_index }
+          : open.batch_index !== undefined
+            ? { batch_index: open.batch_index }
+            : {}),
+      }
+    : null;
 });
 
 function closeDetail(): void {
+  detailRequestVersion += 1;
   queueDetail.value = null;
+}
+
+async function hydratedEntry(entry: EnrichedQueueEntry): Promise<EnrichedQueueEntry> {
+  try {
+    const job = await jobs.queueJob(props.host.id, entry.id);
+    return {
+      ...entry,
+      ...job,
+      mine: entry.mine || generation.ownsDurableBatch(job.client_batch_id),
+    };
+  } catch (error) {
+    // Older hosts have no single-job detail route. A row already owned by
+    // this app still has its request and retry authority in local recovery.
+    if (ownJob(entry)) return entry;
+    throw error;
+  }
+}
+
+async function openQueueDetail(entry: EnrichedQueueEntry): Promise<void> {
+  const requestVersion = ++detailRequestVersion;
+  detailError.value = null;
+  // Open synchronously so keyboard/click activation preserves the existing
+  // desktop interaction even while the authoritative row is fetched.
+  queueDetail.value = entry;
+  try {
+    const hydrated = await hydratedEntry(entry);
+    if (requestVersion === detailRequestVersion && queueDetail.value?.id === entry.id) {
+      queueDetail.value = hydrated;
+    }
+  } catch (error) {
+    if (requestVersion === detailRequestVersion && queueDetail.value?.id === entry.id) {
+      detailError.value = error instanceof Error ? error.message : String(error);
+    }
+  }
 }
 
 /** A row this app submitted carries its exact request here, which is the one
@@ -255,9 +352,17 @@ function localMetadataFor(entry: EnrichedQueueEntry): QueueDetailMetadata | null
   return (ownJob(entry)?.request as QueueDetailMetadata | undefined) ?? null;
 }
 
-/** Retry needs the durable batch authority, which lives with the client that
- *  submitted the job — the generation store owns it, keyed by clientId. */
-function retryAuthorityFor(entry: EnrichedQueueEntry): number | null {
+/** Current servers expose durable retry authority on the selected row. Keep
+ * this app's in-memory authority as a compatibility path for older listings. */
+function retryAuthorityFor(entry: EnrichedQueueEntry): unknown | null {
+  if (
+    entry.state === "held" &&
+    entry.retryable === true &&
+    entry.batch_id &&
+    entry.client_batch_id
+  ) {
+    return entry;
+  }
   const job = ownJob(entry);
   return job && job.retryable && !job.retrying ? job.clientId : null;
 }
@@ -346,6 +451,20 @@ function reuseFromDrawer(): void {
   loadQueueSettings(metadata);
 }
 
+async function reuseEntry(entry: EnrichedQueueEntry): Promise<void> {
+  try {
+    const hydrated = await hydratedEntry(entry);
+    const metadata =
+      (hydrated.metadata as OutputMetadata | null | undefined) ??
+      (localMetadataFor(hydrated) as OutputMetadata | null);
+    if (!metadata) throw new Error("The machine did not return settings for this job.");
+    queueDetail.value = hydrated;
+    loadQueueSettings(metadata);
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
+  }
+}
+
 // Cancelling from the drawer is destructive and names the job, so it takes the
 // shared plain ConfirmDialog rather than the row's inline two-step.
 const confirmCancel = ref<EnrichedQueueEntry | null>(null);
@@ -372,13 +491,38 @@ async function cancelConfirmed(): Promise<void> {
 async function retryFromDrawer(): Promise<void> {
   const entry = queueDetail.value;
   if (!entry) return;
-  const clientId = retryAuthorityFor(entry);
-  if (clientId === null) return;
   detailError.value = null;
   try {
-    await generation.retryHeld(clientId);
+    await retryEntry(entry);
   } catch (error) {
     detailError.value = error instanceof Error ? error.message : String(error);
+  }
+}
+
+async function retryEntry(entry: EnrichedQueueEntry): Promise<void> {
+  if (retryingIds.value.includes(entry.id)) return;
+  retryingIds.value = [...retryingIds.value, entry.id];
+  try {
+    const hydrated = await hydratedEntry(entry);
+    if (hydrated.batch_id && hydrated.client_batch_id) {
+      await jobs.retryJob(props.host.id, hydrated);
+    } else {
+      const clientId = ownJob(hydrated)?.clientId ?? null;
+      if (clientId === null) throw new Error("This held generation is not retryable.");
+      await generation.retryHeld(clientId);
+    }
+    toasts.push("Retry queued");
+    if (queueDetail.value?.id === entry.id) queueDetail.value = null;
+  } finally {
+    retryingIds.value = retryingIds.value.filter((id) => id !== entry.id);
+  }
+}
+
+async function retryFromMenu(entry: EnrichedQueueEntry): Promise<void> {
+  try {
+    await retryEntry(entry);
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
   }
 }
 </script>
@@ -447,8 +591,8 @@ async function retryFromDrawer(): Promise<void> {
             @dragstart="onDragStart(entry, $event)"
             @dragend="dragged = null"
             @contextmenu="openEntryMenu(entry, $event)"
-            @click="queueDetail = entry"
-            @keydown.enter="queueDetail = entry"
+            @click="openQueueDetail(entry)"
+            @keydown.enter="openQueueDetail(entry)"
           >
             <div
               v-if="thumbnails"
@@ -556,7 +700,7 @@ async function retryFromDrawer(): Promise<void> {
       :model="queueDetailModel"
       :preview="detailPreview"
       :cancelling="queueDetail ? cancellingIds.includes(queueDetail.id) : false"
-      :retrying="queueDetail ? ownJob(queueDetail)?.retrying === true : false"
+      :retrying="queueDetail ? retryingIds.includes(queueDetail.id) : false"
       :error="detailError"
       @close="closeDetail"
       @reuse="reuseFromDrawer"

--- a/desktop/src/components/machines/QueueColumn.test.ts
+++ b/desktop/src/components/machines/QueueColumn.test.ts
@@ -16,6 +16,7 @@ import QueueColumn from "./QueueColumn.vue";
 import { useConnectionStore } from "../../stores/connection";
 import { useGenerationStore, type Job } from "../../stores/generation";
 import { useJobsStore, type HostQueueCaps, type QueueEntry } from "../../stores/jobs";
+import { useContextMenuStore } from "../../stores/contextMenu";
 
 function entry(over: Partial<QueueEntry> = {}): QueueEntry {
   return {
@@ -142,6 +143,27 @@ describe("QueueColumn", () => {
     const text = wrapper.get("[data-test='queue-surface-row']").text();
     expect(text).toContain("held");
     expect(text).not.toContain("queued");
+  });
+
+  it("opens row controls on right-click and keeps retry actionable", async () => {
+    const { wrapper, jobs } = await mountColumn();
+    jobs.queues.local!.entries = [
+      entry({
+        state: "held",
+        retryable: true,
+        batch_id: "batch-1",
+        client_batch_id: "client-1",
+      }),
+    ];
+    await flushPromises();
+
+    await wrapper.get("[data-test='queue-surface-row']").trigger("contextmenu", {
+      clientX: 10,
+      clientY: 10,
+    });
+    const items = useContextMenuStore().entries.filter((item) => "label" in item);
+    expect(items.map((item) => item.label)).toEqual(["Pause queue", "Retry job", "Cancel job"]);
+    expect(items.find((item) => item.label === "Retry job")?.disabled).not.toBe(true);
   });
 
   it("cancels a queued row against its owning host", async () => {

--- a/desktop/src/components/machines/QueueColumn.vue
+++ b/desktop/src/components/machines/QueueColumn.vue
@@ -13,11 +13,14 @@ import { useGenerationStore, jobProgress } from "../../stores/generation";
 import { useJobsStore, type QueueSurfaceRow } from "../../stores/jobs";
 import { useHostsStore } from "../../stores/hosts";
 import { useToastStore } from "../../stores/toasts";
+import { useContextMenuStore, type MenuEntry } from "../../stores/contextMenu";
 
 const generation = useGenerationStore();
 const jobs = useJobsStore();
 const toasts = useToastStore();
+const contextMenu = useContextMenuStore();
 const cancellingIds = ref<string[]>([]);
+const retryingIds = ref<string[]>([]);
 
 const rows = computed(() => jobs.queueSurface);
 const hostsWithMore = computed(() => {
@@ -80,6 +83,58 @@ async function cancel(row: QueueSurfaceRow) {
   }
 }
 
+async function togglePause(row: QueueSurfaceRow) {
+  const snapshot = jobs.queues[row.hostId];
+  try {
+    if (snapshot?.paused || snapshot?.entries.some((entry) => entry.state === "paused")) {
+      await jobs.resume(row.hostId);
+      toasts.push(`Queue resumed on ${row.hostLabel}`);
+    } else {
+      await jobs.pause(row.hostId);
+      toasts.push(`Queue paused on ${row.hostLabel} — running job finishes`);
+    }
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
+  }
+}
+
+async function retry(row: QueueSurfaceRow) {
+  if (retryingIds.value.includes(row.entry.id)) return;
+  retryingIds.value = [...retryingIds.value, row.entry.id];
+  try {
+    const entry = await jobs.queueJob(row.hostId, row.entry.id);
+    await jobs.retryJob(row.hostId, entry);
+    toasts.push("Retry queued");
+  } catch (error) {
+    toasts.push(error instanceof Error ? error.message : String(error), "error");
+  } finally {
+    retryingIds.value = retryingIds.value.filter((id) => id !== row.entry.id);
+  }
+}
+
+function openQueueMenu(row: QueueSurfaceRow, event: MouseEvent) {
+  const snapshot = jobs.queues[row.hostId];
+  const paused =
+    snapshot?.paused === true || snapshot?.entries.some((entry) => entry.state === "paused");
+  const items: MenuEntry[] = [];
+  if (snapshot?.caps?.canPause || paused) {
+    items.push({
+      label: paused ? "Resume queue" : "Pause queue",
+      action: () => void togglePause(row),
+    });
+  }
+  if (row.entry.state === "held" && row.entry.retryable === true) {
+    items.push({ label: "Retry job", action: () => void retry(row) });
+  }
+  items.push({
+    label: row.entry.state === "running" ? "Stop job" : "Cancel job",
+    danger: true,
+    disabled: row.entry.state === "running" && !row.canCancelRunning,
+    action: () => void cancel(row),
+  });
+  contextMenu.open(event, items);
+}
+
 /** This job's slot among its host's QUEUED rows — the index space the reorder
  *  PATCH uses. `entry.position` counts running jobs too, so nudging against it
  *  is off-by-N (or a no-op) the moment anything on the host is running. */
@@ -107,6 +162,7 @@ async function reorder(row: QueueSurfaceRow, delta: number) {
         :key="`${row.hostId}:${row.entry.id}`"
         data-test="queue-surface-row"
         class="border-edge rounded-chrome border bg-bench p-3.5 shadow-[inset_0_1px_0_var(--card-hi)]"
+        @contextmenu="openQueueMenu(row, $event)"
       >
         <div class="flex items-center gap-3">
           <span

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -561,6 +561,11 @@ export const useGenerationStore = defineStore("generation", {
     },
   },
   actions: {
+    /** Durable client ownership survives a WebView/app restart even when the
+     * reconstructed visual Job has not reconciled its server id yet. */
+    ownsDurableBatch(clientBatchId: string | null | undefined): boolean {
+      return typeof clientBatchId === "string" && durableRecords.has(clientBatchId);
+    },
     /** Restore secret/media-free durable authority after a desktop reload. */
     resumeDurableGenerations(): void {
       if (!durableRecoveryLoaded) {

--- a/desktop/src/stores/jobs.test.ts
+++ b/desktop/src/stores/jobs.test.ts
@@ -537,4 +537,25 @@ describe("enrichQueueEntries", () => {
     const enriched = enrichQueueEntries(entries, "local", [mine], "local");
     expect(enriched[0]?.mine).toBe(false);
   });
+
+  it("recognizes a durable client batch after the app restarts", () => {
+    const entries = [
+      {
+        id: "srv-held",
+        model: "m",
+        state: "held" as const,
+        started_at_unix_ms: 1,
+        position: 0,
+        client_batch_id: "client-recovered",
+      },
+    ];
+    const enriched = enrichQueueEntries(
+      entries,
+      "local",
+      [],
+      "local",
+      (clientBatchId) => clientBatchId === "client-recovered",
+    );
+    expect(enriched[0]).toMatchObject({ mine: true, clientId: null });
+  });
 });

--- a/desktop/src/stores/jobs.ts
+++ b/desktop/src/stores/jobs.ts
@@ -1,12 +1,15 @@
 import { defineStore } from "pinia";
 import { listDevices, type DeviceInfo } from "@studio/api/devices";
 import {
+  getQueueJob,
   mergeQueueEntries,
   parseQueueListing,
   predictedCompletionUnixMs,
   queueListingPath,
   queuePageRequestForCapacity,
   type QueuePlan,
+  type QueueJobAuthority,
+  retryQueueJobRecoveringAmbiguity,
 } from "@studio/api/queuePlan";
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "../lib/api/client";
 import type { OutputMetadata, ServerStatus } from "../lib/api/types";
@@ -38,6 +41,14 @@ export interface QueueEntry {
   metadata?: OutputMetadata | null;
   /** Why the host parked this job. Present only for `state: "held"`. */
   held_reason?: string | null;
+  error?: string | null;
+  retryable?: boolean | null;
+  batch_id?: string | null;
+  client_batch_id?: string | null;
+  batch_index?: number | null;
+  durable?: boolean | null;
+  replayed?: boolean | null;
+  dispatch_attempts?: number | null;
 }
 
 /** Queue controls a host supports (from `GET /api/capabilities`). */
@@ -131,12 +142,17 @@ export function enrichQueueEntries(
   hostId: string,
   localJobs: Job[],
   primaryHostId: string | null,
+  ownsDurableBatch: (clientBatchId: string | null | undefined) => boolean = () => false,
 ): EnrichedQueueEntry[] {
   return entries.map((entry) => {
     const owner = localJobs.find(
       (j) => j.id === entry.id && (j.hostId ?? primaryHostId) === hostId,
     );
-    return { ...entry, mine: !!owner, clientId: owner?.clientId ?? null };
+    return {
+      ...entry,
+      mine: !!owner || ownsDurableBatch(entry.client_batch_id),
+      clientId: owner?.clientId ?? null,
+    };
   });
 }
 
@@ -174,7 +190,13 @@ export const useJobsStore = defineStore("jobs", {
         if (!snap) continue;
         const canReorder = snap.caps?.canReorder ?? false;
         const canCancelRunning = snap.caps?.canCancelRunning ?? false;
-        for (const entry of enrichQueueEntries(snap.entries, host.id, generation.jobs, primaryId)) {
+        for (const entry of enrichQueueEntries(
+          snap.entries,
+          host.id,
+          generation.jobs,
+          primaryId,
+          (clientBatchId) => generation.ownsDurableBatch(clientBatchId),
+        )) {
           rows.push({
             hostId: host.id,
             hostLabel: host.label,
@@ -397,6 +419,50 @@ export const useJobsStore = defineStore("jobs", {
         snapshot.tailEntries = snapshot.tailEntries?.filter(({ id }) => id !== jobId) ?? [];
       }
       void this.refresh();
+    },
+    /** Read the selected row's persisted request. Queue polling stays
+     * payload-free; this explicit path powers details and Reuse settings. */
+    async queueJob(hostId: string, jobId: string): Promise<QueueEntry> {
+      const hosts = useHostsStore();
+      const host = hosts.all.find((candidate) => candidate.id === hostId);
+      const target = host ? this.targetFor(host) : null;
+      if (!host || !target || host.status !== "ready") {
+        throw new Error("The selected machine is not connected.");
+      }
+      return (await getQueueJob(target, jobId)).job as QueueEntry;
+    },
+    /** Retry a server-authorized durable hold even after this app restarted.
+     * Authority lives on the row and host, not in an ephemeral clientId. */
+    async retryJob(hostId: string, entry: QueueEntry): Promise<void> {
+      const hosts = useHostsStore();
+      const host = hosts.all.find((candidate) => candidate.id === hostId);
+      const target = host ? this.targetFor(host) : null;
+      if (!host || !target || host.status !== "ready") {
+        throw new Error("The selected machine identity is unavailable.");
+      }
+      if (
+        entry.state !== "held" ||
+        entry.retryable !== true ||
+        !entry.batch_id ||
+        !entry.client_batch_id
+      ) {
+        throw new Error("This held generation is not retryable.");
+      }
+      const instanceId =
+        host.instanceId ??
+        (await apiJsonTo<{ instance_id?: string }>(target, "/api/status")).instance_id ??
+        null;
+      if (!instanceId) throw new Error("The selected machine identity is unavailable.");
+      const authority: QueueJobAuthority = {
+        instanceId,
+        batchId: entry.batch_id,
+        clientBatchId: entry.client_batch_id,
+        jobId: entry.id,
+      };
+      const outcome = await retryQueueJobRecoveringAmbiguity(target, authority);
+      if (outcome.kind === "uncertain") throw new Error(outcome.error);
+      await this.refreshHost(host);
+      void useGenerationStore().reconcileDurableHost(hostId);
     },
     /**
      * Move a queued job to another GPU lane on its OWNING host via

--- a/studio/api/queuePlan.test.ts
+++ b/studio/api/queuePlan.test.ts
@@ -3,6 +3,7 @@ import { IncompatibleHostError } from "./client";
 import {
   cancelQueueJob,
   findQueueEntryById,
+  getQueueJob,
   listQueue,
   mergeQueueEntries,
   mutateQueueJobOnExpectedInstance,
@@ -302,6 +303,44 @@ describe("queue plan contract", () => {
       "https://gpu.example/api/queue?limit=1",
       "https://gpu.example/api/queue?limit=1&cursor=next",
     ]);
+  });
+
+  it("reads one queue job with persisted settings and retry authority", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(
+      Response.json({
+        job: {
+          id: "held/1",
+          model: "flux-dev:q8",
+          state: "held",
+          started_at_unix_ms: 1,
+          position: 0,
+          retryable: true,
+          batch_id: "batch-1",
+          client_batch_id: "client-1",
+          metadata: { prompt: "a lighthouse" },
+        },
+        work_item: null,
+      }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(
+      getQueueJob(
+        { baseUrl: "https://gpu.example", apiKey: "secret" },
+        "held/1",
+      ),
+    ).resolves.toMatchObject({
+      job: {
+        id: "held/1",
+        retryable: true,
+        batch_id: "batch-1",
+        client_batch_id: "client-1",
+        metadata: { prompt: "a lighthouse" },
+      },
+    });
+    expect(fetchMock.mock.calls[0]?.[0]).toBe(
+      "https://gpu.example/api/queue/held%2F1",
+    );
   });
 
   it("preserves typed host lanes without treating them as device identities", () => {

--- a/studio/api/queuePlan.ts
+++ b/studio/api/queuePlan.ts
@@ -39,6 +39,15 @@ export interface QueueEntry {
   error?: string | null;
   /** Exact opt-in fence for POST /api/queue/{id}/retry. */
   retryable?: boolean | null;
+  /** Durable retry authority exposed by current servers. */
+  batch_id?: string | null;
+  client_batch_id?: string | null;
+  batch_index?: number | null;
+}
+
+export interface QueueJobEntry {
+  job: QueueEntry;
+  work_item?: QueueWorkItem | null;
 }
 
 export interface QueueWorkItem {
@@ -340,6 +349,29 @@ export async function findQueueEntryById(
     seenCursors.add(cursor);
     listing = await listQueue(target, { limit, cursor }, signal);
   }
+}
+
+/** Read one queue row with its persisted request settings and retry authority.
+ * The paginated listing deliberately omits durable request bodies; explicit
+ * inspection is the bounded path that makes Reuse settings work after a
+ * desktop restart and before the worker has hydrated the row. */
+export async function getQueueJob(
+  target: ApiTarget,
+  id: string,
+): Promise<QueueJobEntry> {
+  const value = await apiJsonTo<unknown>(
+    target,
+    `/api/queue/${encodeURIComponent(id)}`,
+  );
+  const root = record(value);
+  if (!root) throw new IncompatibleHostError(["job"]);
+  const [job] = queueEntries([root.job], "job");
+  return {
+    job: job!,
+    ...(root.work_item === undefined
+      ? {}
+      : { work_item: root.work_item as QueueWorkItem | null }),
+  };
 }
 
 /** Cancel work that is still waiting in the explicit host's generation queue. */


### PR DESCRIPTION
## Summary

- add queue-row context menus for pause/resume, retry, cancel/stop, reuse, details, and GPU placement
- hydrate durable queue settings after desktop restart so same-client work remains reusable and retryable
- preserve hydrated details across polling and guard against stale async drawer responses
- retain compatibility with older hosts through local recovery authority

## Validation

- nix develop -c desktop-check
- nix develop -c desktop-test (420 files, 5,450 tests)
- focused queue and host-detail tests (87 queue tests; 66 host-detail tests)
- bash scripts/release/check-changelog-fragments.sh 4e4c0eb5041df53b11bf308e5677aab34e1780ef HEAD
- independent sub-agent peer review completed; all findings addressed, final verification found no issues

## Manual QA

- rendered the Machines workspace through the desktop Vite surface with no console warnings or errors
- exact held-row interaction is covered by component tests because the browser session had no authenticated held queue fixture