### PR TITLE
fix(mobile): keep swipe actions hidden while scrolling

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -293,9 +293,10 @@ pushed screen opened from the header.
   takes two deliberate moves, and the tray is
   equally reachable from the row's **Actions** button so VoiceOver and hardware
   keyboards never depend on the gesture. The horizontal pan is scoped to the
-  row (`touch-action: pan-y`), leaving the list scroll, the Library grid's
-  column pinch, and the gallery viewer's swipe untouched, and the settle
-  animation honours `prefers-reduced-motion`. A host advertising
+  row (`touch-action: pan-y`) and stays visually closed until horizontal travel
+  clearly dominates early diagonal scroll jitter, leaving the list scroll, the
+  Library grid's column pinch, and the gallery viewer's swipe untouched. The
+  settle animation honours `prefers-reduced-motion`. A host advertising
   `capabilities.queue.can_reorder` adds a non-destructive **To back**, which
   sends `PATCH /api/queue/:id {position}` — the server clamps a large index to
   the tail, so the phone never has to read a queue depth its bounded page

--- a/changelog.d/mobile-swipe-scroll.md
+++ b/changelog.d/mobile-swipe-scroll.md
@@ -1,0 +1,2 @@
+- **Mobile queue scrolling.** Fixed action buttons briefly appearing during
+  vertical scrolling in Create and Machine Detail.

--- a/studio/components/SwipeActionRow.test.ts
+++ b/studio/components/SwipeActionRow.test.ts
@@ -130,6 +130,21 @@ describe("SwipeActionRow", () => {
     ).toContain("translateX(0px)");
   });
 
+  it("never exposes the tray during ambiguous diagonal scroll startup", async () => {
+    const wrapper = mountRow();
+    const surface = wrapper.get(
+      '[data-test="swipe-action-row"] > div:last-child',
+    );
+    await pointer(wrapper, "pointerdown", 300, 100);
+    await pointer(wrapper, "pointermove", 287, 111);
+    expect(surface.attributes("style")).toContain("translateX(0px)");
+
+    await pointer(wrapper, "pointermove", 280, 160);
+    await pointer(wrapper, "pointerup", 280, 160);
+    expect(surface.attributes("style")).toContain("translateX(0px)");
+    expect(wrapper.emitted("act")).toBeUndefined();
+  });
+
   it("restores rather than acting when the gesture is cancelled", async () => {
     const wrapper = mountRow();
     vi.spyOn(

--- a/studio/lib/swipeAction.test.ts
+++ b/studio/lib/swipeAction.test.ts
@@ -1,11 +1,13 @@
 import { describe, expect, it } from "vitest";
 import {
   SWIPE_AXIS_LOCK_PX,
+  SWIPE_AXIS_INTENT_RATIO,
   SWIPE_COMMIT_FRACTION,
   beginSwipe,
   createSwipeState,
   endSwipe,
   moveSwipe,
+  resolveSwipeAxis,
   swipeIsOpen,
   type SwipeGestureConfig,
 } from "./swipeAction";
@@ -38,6 +40,26 @@ describe("swipe gesture math", () => {
     const state = drag(-20, -60);
     expect(state.phase).toBe("vertical");
     expect(state.offset).toBe(0);
+  });
+
+  it("keeps early diagonal scroll jitter inert until vertical intent wins", () => {
+    let state = beginSwipe(createSwipeState(), { x: 300, y: 100 });
+    state = moveSwipe(state, { x: 287, y: 111 }, config);
+    expect(state.phase).toBe("undecided");
+    expect(state.offset).toBe(0);
+    expect(state.captured).toBe(false);
+
+    state = moveSwipe(state, { x: 280, y: 160 }, config);
+    expect(state.phase).toBe("vertical");
+    expect(state.offset).toBe(0);
+    expect(state.captured).toBe(false);
+  });
+
+  it("requires clear axis dominance after crossing the travel threshold", () => {
+    expect(resolveSwipeAxis(-20, 18)).toBe("undecided");
+    expect(resolveSwipeAxis(-30, 20)).toBe("horizontal");
+    expect(resolveSwipeAxis(-20, 30)).toBe("vertical");
+    expect(SWIPE_AXIS_INTENT_RATIO).toBeGreaterThan(1);
   });
 
   it("stays vertical for the rest of the gesture once the scroll wins", () => {

--- a/studio/lib/swipeAction.ts
+++ b/studio/lib/swipeAction.ts
@@ -12,6 +12,8 @@
 
 /** Pointer travel before the gesture picks an axis. */
 export const SWIPE_AXIS_LOCK_PX = 12;
+/** Required dominance before a row claims horizontal or vertical intent. */
+export const SWIPE_AXIS_INTENT_RATIO = 1.5;
 /** Fraction of the row width at which a full swipe commits. */
 export const SWIPE_COMMIT_FRACTION = 0.6;
 /** Resistance applied past the tray so the row never tracks the finger 1:1. */
@@ -80,6 +82,25 @@ export function swipeIsOpen(state: SwipeGestureState): boolean {
   return state.offset < 0;
 }
 
+/**
+ * Resolve a pan only after one axis clearly dominates. Mobile scroll events
+ * commonly report a few diagonal samples before the browser commits to its
+ * native vertical pan; treating the first one-pixel lead as horizontal makes
+ * the action tray flash under an otherwise vertical scroll.
+ */
+export function resolveSwipeAxis(
+  dx: number,
+  dy: number,
+): Exclude<SwipePhase, "idle"> {
+  const absX = Math.abs(dx);
+  const absY = Math.abs(dy);
+  if (absX < SWIPE_AXIS_LOCK_PX && absY < SWIPE_AXIS_LOCK_PX)
+    return "undecided";
+  if (absX >= absY * SWIPE_AXIS_INTENT_RATIO) return "horizontal";
+  if (absY >= absX * SWIPE_AXIS_INTENT_RATIO) return "vertical";
+  return "undecided";
+}
+
 export function beginSwipe(
   state: SwipeGestureState,
   point: { x: number; y: number },
@@ -112,11 +133,10 @@ export function moveSwipe(
   const dy = point.y - state.startY;
   let phase: SwipePhase = state.phase;
   if (phase === "undecided") {
-    if (Math.abs(dx) < SWIPE_AXIS_LOCK_PX && Math.abs(dy) < SWIPE_AXIS_LOCK_PX)
-      return { ...state, phase, captured: false };
-    // The list scroll wins a tie: a row that stole an ambiguous drag would
-    // make the queue impossible to scroll past.
-    phase = Math.abs(dx) > Math.abs(dy) ? "horizontal" : "vertical";
+    phase = resolveSwipeAxis(dx, dy);
+    // Keep ambiguous diagonal travel visually inert. The browser can continue
+    // deciding its native pan without a red action tray flashing underneath.
+    if (phase === "undecided") return { ...state, phase, captured: false };
     if (phase === "vertical")
       return {
         ...state,

--- a/ui/components/LiveActivityList.test.ts
+++ b/ui/components/LiveActivityList.test.ts
@@ -1,0 +1,65 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import type { FleetActiveWork } from "@studio/api/activity";
+import LiveActivityList from "./LiveActivityList.vue";
+
+const row: FleetActiveWork = {
+  id: "job-1",
+  key: "host-1:generation:job-1",
+  kind: "generation",
+  phase: "queued",
+  model: "FLUX",
+  created_at_unix_ms: 1,
+  updated_at_unix_ms: 2,
+  can_cancel: true,
+  hostId: "host-1",
+  hostLabel: "hal9000",
+  routeUrl: "http://hal9000:7680",
+  instanceId: "instance-1",
+  stale: false,
+  hostError: null,
+};
+
+function touch(type: string, x: number, y: number, ended = false): Event {
+  const event = new Event(type, { bubbles: true, cancelable: true });
+  const point = { clientX: x, clientY: y };
+  Object.defineProperty(event, "touches", { value: ended ? [] : [point] });
+  Object.defineProperty(event, "changedTouches", { value: [point] });
+  return event;
+}
+
+function mountList() {
+  return mount(LiveActivityList, {
+    props: { rows: [row], interactive: true, swipeActions: true },
+    slots: { actions: '<button type="button">Cancel</button>' },
+  });
+}
+
+describe("LiveActivityList swipe actions", () => {
+  it("opens actions for a clearly horizontal swipe", async () => {
+    const wrapper = mountList();
+    const item = wrapper.get(".live-activity-row");
+    item.element.dispatchEvent(touch("touchstart", 260, 100));
+    item.element.dispatchEvent(touch("touchmove", 160, 102));
+    item.element.dispatchEvent(touch("touchend", 160, 102, true));
+    await wrapper.vm.$nextTick();
+    expect(item.classes()).toContain("live-activity-row--actions-open");
+  });
+
+  it("keeps actions closed when diagonal startup becomes a vertical scroll", async () => {
+    const wrapper = mountList();
+    const item = wrapper.get(".live-activity-row");
+    item.element.dispatchEvent(touch("touchstart", 300, 100));
+    const ambiguous = touch("touchmove", 287, 111);
+    item.element.dispatchEvent(ambiguous);
+    expect(ambiguous.defaultPrevented).toBe(false);
+    expect(item.classes()).not.toContain("live-activity-row--actions-open");
+
+    const vertical = touch("touchmove", 280, 160);
+    item.element.dispatchEvent(vertical);
+    item.element.dispatchEvent(touch("touchend", 280, 160, true));
+    await wrapper.vm.$nextTick();
+    expect(vertical.defaultPrevented).toBe(false);
+    expect(item.classes()).not.toContain("live-activity-row--actions-open");
+  });
+});

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref } from "vue";
 import type { FleetActiveWork } from "@studio/api/activity";
+import { resolveSwipeAxis, type SwipePhase } from "@studio/lib/swipeAction";
 
 const props = withDefaults(
   defineProps<{
@@ -26,8 +27,12 @@ const emit = defineEmits<{
 }>();
 
 const openActionKey = ref<string | null>(null);
-let swipe: { key: string; x: number; y: number; horizontal: boolean } | null =
-  null;
+let swipe: {
+  key: string;
+  x: number;
+  y: number;
+  phase: Exclude<SwipePhase, "idle">;
+} | null = null;
 
 function beginSwipe(row: FleetActiveWork, event: TouchEvent): void {
   if (!props.swipeActions || !props.canSwipe(row) || event.touches.length !== 1)
@@ -38,7 +43,7 @@ function beginSwipe(row: FleetActiveWork, event: TouchEvent): void {
       key: row.key,
       x: touch.clientX,
       y: touch.clientY,
-      horizontal: false,
+      phase: "undecided",
     };
 }
 
@@ -47,17 +52,15 @@ function moveSwipe(event: TouchEvent): void {
   if (!swipe || !touch) return;
   const dx = touch.clientX - swipe.x;
   const dy = touch.clientY - swipe.y;
-  if (!swipe.horizontal && Math.abs(dx) > 10 && Math.abs(dx) > Math.abs(dy)) {
-    swipe.horizontal = true;
-  }
-  if (swipe.horizontal) event.preventDefault();
+  if (swipe.phase === "undecided") swipe.phase = resolveSwipeAxis(dx, dy);
+  if (swipe.phase === "horizontal") event.preventDefault();
 }
 
 function finishSwipe(event: TouchEvent): void {
   const gesture = swipe;
   swipe = null;
   const touch = event.changedTouches[0];
-  if (!gesture || !gesture.horizontal || !touch) return;
+  if (!gesture || gesture.phase !== "horizontal" || !touch) return;
   const dx = touch.clientX - gesture.x;
   if (dx <= -36) openActionKey.value = gesture.key;
   else if (dx >= 36) openActionKey.value = null;


### PR DESCRIPTION
## Summary
- keep swipe action trays closed while diagonal touch movement is still ambiguous
- share the stricter axis-intent resolver across Create, Machine Detail, and fleet activity rows
- add regression coverage for vertical-scroll startup while preserving horizontal swipe actions

## Validation
- `nix develop -c bun run --cwd desktop test` (5,450 tests)
- `nix develop -c bun run --cwd desktop build:mobile`
- `nix develop -c bun run --cwd desktop fmt:check`
- `bash scripts/release/check-changelog-fragments.sh <base> <head>`
- independent subagent peer review: no actionable findings