### PR TITLE
fix(ui): default image-to-video to one generation

### DIFF
--- a/changelog.d/fix-image-to-video-one-shot-duration.md
+++ b/changelog.d/fix-image-to-video-one-shot-duration.md
@@ -1,0 +1,1 @@
+- **One-shot image-to-video duration.** Fixed image-to-video models opening above their one-generation duration across web, desktop, iPhone, and Android.

--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -242,7 +242,7 @@ watch(
 const generationRequest = computed(() => buildRequest(props.form));
 const chainDecision = computed<ChainRoutingDecision>(() =>
   caps.value.supportsVideo
-    ? decideGenerateRequestRouting(generationRequest.value, props.form.family)
+    ? decideGenerateRequestRouting(generationRequest.value, props.form.family, props.selectedModel)
     : { kind: "single" },
 );
 const singleShotPreservationNote = computed(() => {

--- a/desktop/src/lib/chainRouting.ts
+++ b/desktop/src/lib/chainRouting.ts
@@ -3,7 +3,11 @@
  * chain-routing authority.
  */
 
-import { decideGenerateRequestRouting, type ChainRoutingDecision } from "@studio/lib/chainRouting";
+import {
+  decideGenerateRequestRouting,
+  type ChainRoutingDecision,
+  type GenerateRoutingModel,
+} from "@studio/lib/chainRouting";
 import type { AutoChainRequest, GenerateRequest } from "./api/types";
 
 export {
@@ -61,8 +65,9 @@ export function buildAutoChainRequest(
 export function buildGenerationEstimateRequest(
   req: GenerateRequest,
   family: string | null | undefined,
+  model: GenerateRoutingModel | null = null,
 ): GenerateRequest {
-  const decision = decideGenerateRequestRouting(req, family);
+  const decision = decideGenerateRequestRouting(req, family, model);
   const estimate = { ...req };
   // Optional properties must be absent, not merely `undefined`: aside from
   // satisfying the exact wire type, omission guarantees JSON serializers do

--- a/desktop/src/lib/generateForm.test.ts
+++ b/desktop/src/lib/generateForm.test.ts
@@ -288,6 +288,22 @@ describe("model-specific audio capability", () => {
     expect(form.fps).toBe(24);
     expect(form.outputFormat).toBe("mp4");
   });
+
+  it("resets a carried duration to an image-to-video model's one-generation default", () => {
+    const form = newGenerateForm();
+    form.frames = 97;
+    applyModelDefaults(form, {
+      ...ltx2Model(),
+      name: "wan22-i2v-a14b:q5",
+      family: "wan",
+      source_image: "required",
+      default_frames: 81,
+      default_fps: 16,
+      frame_step: 4,
+    });
+
+    expect(form.frames).toBe(81);
+  });
 });
 
 describe("advertised default negative prompt (#787)", () => {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -4091,12 +4091,18 @@ describe("MobileApp generation queue", () => {
   it("snapshots form and host before asynchronous source preprocessing", async () => {
     const studioModel: ModelEntry = {
       ...model,
-      name: "flux:studio",
-      family: "flux",
-      default_width: 1024,
-      default_height: 1024,
+      name: "wan22-i2v-a14b:q5",
+      family: "wan",
+      source_image: "required",
+      default_frames: 81,
+      default_fps: 16,
+      frame_step: 4,
     };
-    const renderModel: ModelEntry = { ...studioModel, name: "flux:render" };
+    const renderModel: ModelEntry = {
+      ...studioModel,
+      name: "wan22-i2v-a14b:q8",
+      default_frames: 73,
+    };
     const renderTarget = { baseUrl: "http://render.tailnet.ts.net:7680", apiKey: "secret" };
     localStorage.setItem(
       "mold.mobile.hosts.v1",
@@ -4172,6 +4178,7 @@ describe("MobileApp generation queue", () => {
     expect(admittedRequests()[0]).toMatchObject({
       prompt: "first prompt",
       model: studioModel.name,
+      frames: 81,
     });
     expect(admittedRequests()[0]?.source_image).toMatch(/^fitted:/);
   });

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -2097,7 +2097,11 @@ const developBlockerReason = computed<string | null>(() => {
 const developDisabled = computed(() => promptMissing.value || developBlockerReason.value !== null);
 const estimateRequest = computed(() => {
   if (!form.model) return null;
-  return buildGenerationEstimateRequest(buildRequest(form), form.family);
+  return buildGenerationEstimateRequest(
+    buildRequest(form),
+    form.family,
+    selectedGenerationModel.value,
+  );
 });
 
 function durableGenerationKey(clientBatchId: string, childIndex: number): string {
@@ -6545,6 +6549,12 @@ async function generate(): Promise<void> {
   // on for every other path.
   let route: HostRoute = initialRoute;
   const draft = applyFileUnderPolicy(cloneGenerateForm(form));
+  const routingModel = selectedGenerationModel.value
+    ? {
+        default_frames: selectedGenerationModel.value.default_frames,
+        source_image: selectedGenerationModel.value.source_image,
+      }
+    : null;
   const originalSource = draft.sourceImage
     ? {
         base64: draft.sourceImage,
@@ -6697,7 +6707,7 @@ async function generate(): Promise<void> {
     }
   }
 
-  const chainRouting = decideGenerateRequestRouting(request, draft.family);
+  const chainRouting = decideGenerateRequestRouting(request, draft.family, routingModel);
   if (chainRouting.kind === "reject") {
     setGenerationStatus(chainRouting.reason);
     generationAnnouncement.value = chainRouting.reason;

--- a/desktop/src/mobile/MobileGenerateParameters.vue
+++ b/desktop/src/mobile/MobileGenerateParameters.vue
@@ -151,7 +151,7 @@ const fpsError = computed(() =>
 );
 const chainDecision = computed<ChainRoutingDecision>(() =>
   caps.value.supportsVideo
-    ? decideGenerateRequestRouting(generationRequest.value, props.form.family)
+    ? decideGenerateRequestRouting(generationRequest.value, props.form.family, props.selectedModel)
     : { kind: "single" },
 );
 

--- a/desktop/src/mobile/MobileSharedParams.test.ts
+++ b/desktop/src/mobile/MobileSharedParams.test.ts
@@ -100,6 +100,40 @@ describe("MobileSharedParams video duration", () => {
     expect(form.frames).toBe(241);
   });
 
+  it("shows an image-to-video tier default at one generation", () => {
+    const form = reactive({
+      ...newGenerateForm(),
+      model: "wan22-i2v-a14b:q5",
+      family: "wan",
+      frames: 81,
+      fps: 16,
+    });
+    const model = {
+      name: form.model,
+      family: form.family,
+      source_image: "required",
+      default_frames: 81,
+      default_fps: 16,
+      max_frames: 257,
+      frame_step: 4,
+    } as ModelEntry;
+    const wrapper = mount(MobileSharedParams, {
+      props: { form, durationModel: model, lastSeed: null },
+      global: {
+        stubs: { MobileResolutionPicker: true, MobileSeedPicker: true },
+      },
+    });
+
+    expect(wrapper.get("[data-test='mobile-duration']").text()).toContain(
+      "81 frames · 16 fps · 5.1s · 1 generation",
+    );
+    expect(
+      wrapper
+        .findAll("[data-test='mobile-duration'] .ms-slider__mark b")
+        .map((mark) => mark.text())[0],
+    ).toBe("1×");
+  });
+
   it("keeps sequence FPS visible without duplicating the duration control", () => {
     const form = reactive({
       ...newGenerateForm(),

--- a/desktop/src/views/GenerateView.sourcefit.test.ts
+++ b/desktop/src/views/GenerateView.sourcefit.test.ts
@@ -484,6 +484,22 @@ describe("GenerateView source-fit submit path", () => {
   });
 
   it("submits the tapped form snapshot when preprocessing is still running", async () => {
+    const firstModel = {
+      ...model,
+      name: "wan22-i2v-a14b:q5",
+      family: "wan",
+      source_image: "required",
+      default_frames: 81,
+      default_fps: 16,
+      frame_step: 4,
+    } as ModelEntry;
+    const nextModel = {
+      ...firstModel,
+      name: "wan22-i2v-a14b:q8",
+      default_frames: 73,
+    } as ModelEntry;
+    apiJsonTo.mockResolvedValue([firstModel, nextModel]);
+    useModelStore().all = [firstModel, nextModel];
     setupMultiHost();
     const submitBatch = vi.spyOn(useGenerationStore(), "submitBatch").mockReturnValue({
       jobs: [],
@@ -500,6 +516,11 @@ describe("GenerateView source-fit submit path", () => {
     mount(GenerateView, { shallow: true, attachTo: document.body });
     await flushPromises();
     const form = primeForm();
+    form.model = firstModel.name;
+    form.family = firstModel.family;
+    form.frames = 81;
+    form.fps = 16;
+    form.sourceFit = { mode: "crop-fill", alignX: "center", alignY: "center" };
     // Batch N now requires a reviewed prepared expansion set. This regression
     // isolates the ordinary Batch 1 source-preprocess snapshot boundary.
     form.batchSize = 1;
@@ -509,12 +530,18 @@ describe("GenerateView source-fit submit path", () => {
 
     form.prompt = "a different live prompt";
     form.batchSize = 3;
+    form.model = nextModel.name;
     finishPreprocess();
     await flushPromises();
 
     expect(submitBatch).toHaveBeenCalledTimes(1);
     const [request, batch] = submitBatch.mock.calls[0]!;
-    expect(request).toMatchObject({ prompt: "a lighthouse", source_image: "FIT" });
+    expect(request).toMatchObject({
+      prompt: "a lighthouse",
+      model: firstModel.name,
+      frames: 81,
+      source_image: "FIT",
+    });
     expect(batch).toBe(1);
   });
 

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -962,7 +962,7 @@ const chainValidationError = computed<string | null>(() => {
   if (formValidationError.value) return formValidationError.value;
   if (!caps.value.supportsVideo) return null;
   const request = buildRequest(form);
-  const decision = decideGenerateRequestRouting(request, form.family);
+  const decision = decideGenerateRequestRouting(request, form.family, selectedEntry.value);
   if (decision.kind === "reject") return decision.reason;
   const unsupported = decision.kind === "chain" ? unsupportedAutoChainFields(request) : [];
   return unsupported.length
@@ -998,7 +998,7 @@ const showStarterCards = computed(() =>
 /** The request the estimate badge previews — null until a model is chosen. */
 const estimateRequest = computed(() => {
   if (!form.model) return null;
-  return buildGenerationEstimateRequest(buildRequest(form), form.family);
+  return buildGenerationEstimateRequest(buildRequest(form), form.family, selectedEntry.value);
 });
 
 /** True when submits (and the estimate preflight) must resolve a route:
@@ -3413,6 +3413,12 @@ async function generate() {
   submissionPlanning.value = true;
   try {
     const draft = cloneGenerateForm(form);
+    const routingModel = selectedEntry.value
+      ? {
+          default_frames: selectedEntry.value.default_frames,
+          source_image: selectedEntry.value.source_image,
+        }
+      : null;
     const originalSource = draft.sourceImage
       ? {
           base64: draft.sourceImage,
@@ -3467,7 +3473,11 @@ async function generate() {
       sourcePreprocessed = true;
     }
     const preliminaryRequest = buildRequest(draft);
-    const preliminaryRouting = decideGenerateRequestRouting(preliminaryRequest, draft.family);
+    const preliminaryRouting = decideGenerateRequestRouting(
+      preliminaryRequest,
+      draft.family,
+      routingModel,
+    );
     if (preliminaryRouting.kind === "reject") {
       toasts.push(preliminaryRouting.reason, "error");
       return;
@@ -3612,7 +3622,7 @@ async function generate() {
         height: decoded?.height ?? null,
       });
     }
-    const chainRouting = decideGenerateRequestRouting(request, draft.family);
+    const chainRouting = decideGenerateRequestRouting(request, draft.family, routingModel);
     if (chainRouting.kind === "reject") {
       toasts.push(chainRouting.reason, "error");
       return;

--- a/studio/lib/chainRouting.ts
+++ b/studio/lib/chainRouting.ts
@@ -57,6 +57,12 @@ export type GenerateRoutingRequest = {
   guidance_overrides?: object | null;
 };
 
+/** Model-row fields that refine routing beyond the request wire itself. */
+export type GenerateRoutingModel = {
+  default_frames?: number | null | undefined;
+  source_image?: string | null | undefined;
+};
+
 export type AutoChainUnsupportedField =
   | "negative_prompt"
   | "loras"
@@ -223,6 +229,7 @@ function canonicalizeFamily(family: string | null | undefined): string {
 export function decideGenerateRequestRouting(
   req: GenerateRoutingRequest,
   family: string | null | undefined,
+  model: GenerateRoutingModel | null = null,
   motionTail: number = DEFAULT_MOTION_TAIL,
 ): ChainRoutingDecision {
   const frames = req.frames;
@@ -248,6 +255,8 @@ export function decideGenerateRequestRouting(
     req.model,
     motionTail,
     req.fps,
+    model?.source_image,
+    model?.default_frames,
   );
   if (decision.kind !== "chain") return decision;
 
@@ -285,6 +294,9 @@ export function decideChainRouting(
    * older server that does not advertise the field gets.
    */
   sourceImage: string | null | undefined = undefined,
+  /** `/api/models.default_frames`; wan tiers may raise their one-generation
+   * routing size above the family floor. */
+  tierDefault: number | null | undefined = undefined,
 ): ChainRoutingDecision {
   if (!frames || frames <= 0) return { kind: "single" };
 
@@ -311,7 +323,7 @@ export function decideChainRouting(
 
   const isWan = normalizedFamily === "wan";
   const clipFrames = isWan
-    ? wanDefaultClipFrames(model)
+    ? wanRoutingClipFrames(model, tierDefault)
     : LTX2_DEFAULT_CLIP_FRAMES;
   if (frames <= clipFrames) return { kind: "single" };
 

--- a/studio/lib/chainRouting.wan.test.ts
+++ b/studio/lib/chainRouting.wan.test.ts
@@ -80,6 +80,22 @@ describe("wan chain routing", () => {
     );
   });
 
+  it("treats a tier's advertised default as one generation", () => {
+    const model = "wan22-i2v-a14b:q5";
+    expect(
+      decideChainRouting(81, "wan", model, undefined, 16, "required", 81),
+    ).toEqual({ kind: "single" });
+
+    expect(
+      decideChainRouting(85, "wan", model, undefined, 16, "required", 81),
+    ).toMatchObject({
+      kind: "chain",
+      clipFrames: 81,
+      motionTail: WAN_HANDOFF_DUPLICATED_FRAMES,
+      stageCount: 2,
+    });
+  });
+
   it("keeps every clip length on wan's 4k+1 grid", () => {
     for (const model of ["wan22-t2v-a14b:q5", "wan22-ti2v-5b:fp16"]) {
       const decision = decideChainRouting(

--- a/studio/lib/videoDuration.test.ts
+++ b/studio/lib/videoDuration.test.ts
@@ -79,6 +79,27 @@ describe("video duration controls", () => {
     expect(videoFramesForModelSelection(125, wan)).toBe(125);
   });
 
+  it("enters an image-to-video model at its one-generation default", () => {
+    const wanI2v = {
+      name: "wan22-i2v-a14b:q5",
+      family: "wan",
+      source_image: "required",
+      default_frames: 81,
+      default_fps: 16,
+      max_frames: 257,
+      frame_step: 4,
+    };
+
+    expect(videoFramesForModelSelection(97, wanI2v)).toBe(81);
+    expect(videoGenerationCount(81, 16, wanI2v)).toBe(1);
+    expect(videoGenerationCount(85, 16, wanI2v)).toBe(2);
+    expect(videoGenerationMarks(16, wanI2v)[0]).toEqual({
+      frames: 81,
+      generations: 1,
+      label: "1×",
+    });
+  });
+
   it("validates frame counts against the selected model grid", () => {
     expect(videoFramesError(45, { family: "wan" })).toBeNull();
     expect(videoFramesError(45, { family: "ltx2" })).toBe(

--- a/studio/lib/videoDuration.ts
+++ b/studio/lib/videoDuration.ts
@@ -212,6 +212,12 @@ export function videoFramesForModelSelection(
   const rate = fixedVideoFps(model) ?? model?.default_fps ?? 24;
   const normalizedDefault = clampVideoFrames(fallback, rate, model);
 
+  // Required-source checkpoints are image-to-video models. Selecting one is
+  // a fresh default boundary: carrying a longer duration from the previous
+  // checkpoint can silently enter automatic sequencing instead of the model's
+  // advertised one-generation clip.
+  if (model?.source_image === "required") return normalizedDefault;
+
   if (frames == null || videoFrameGridError(frames, model)) {
     return normalizedDefault;
   }
@@ -267,6 +273,7 @@ export function videoGenerationCount(
       model: model?.name ?? routingRequest.model ?? "",
     },
     model?.family,
+    model,
   );
   return decision.kind === "chain" ? decision.stageCount : 1;
 }

--- a/web/src/composables/useGenerateForm.test.ts
+++ b/web/src/composables/useGenerateForm.test.ts
@@ -82,6 +82,23 @@ describe("useGenerateForm", () => {
     expect(form.state.value.sourceFitPolicy).toEqual({ mode: "crop-fill" });
   });
 
+  it("resets a carried duration to an image-to-video model's one-generation default", () => {
+    const form = useGenerateForm();
+    form.state.value.frames = 97;
+    form.applyModelDefaults(
+      makeModel({
+        name: "wan22-i2v-a14b:q5",
+        family: "wan",
+        source_image: "required",
+        default_frames: 81,
+        default_fps: 16,
+        frame_step: 4,
+      }),
+    );
+
+    expect(form.state.value.frames).toBe(81);
+  });
+
   it("serializes a host-provided IC-LoRA control without replacing custom LoRAs", () => {
     const form = useGenerateForm();
     form.state.value.model = "ltx-2.3-22b-distilled:fp8";

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -1753,6 +1753,7 @@ const chainDecision = computed(() =>
   decideGenerateRequestRouting(
     form.toRequest(currentModel.value),
     currentModel.value?.family ?? null,
+    currentModel.value,
   ),
 );
 const singleShotPreservationNote = computed(() => {


### PR DESCRIPTION
## Summary

- reset required-source video models to their advertised one-generation frame default on selection
- use per-tier WAN defaults for duration marks, estimates, and submit routing across web, desktop, iPhone, and Android
- freeze routing metadata with async form snapshots so live model changes cannot reroute an in-flight submission

## Root cause

Studio preserved a valid duration from the previously selected model and its shared WAN routing mirror still used the old family floor instead of the selected tier default. That made an 81-frame image-to-video default appear or submit as multiple generations.

## Validation

- frontend architecture check
- 1,493 shared Studio tests
- 1,753 web tests
- 5,447 desktop/mobile tests
- web, desktop, and shared iPhone/Android mobile production builds
- independent agent peer review; one async snapshot race found, fixed, regression-tested, and re-reviewed with no remaining findings
- shipped-source changelog fragment policy