### PR TITLE
fix(queue): surface generation lifecycle progress

### DIFF
--- a/changelog.d/generation-lifecycle-feedback.md
+++ b/changelog.d/generation-lifecycle-feedback.md
@@ -1,0 +1,5 @@
+- **Generation now reports what it is actually doing.** Desktop, web, mobile,
+  CLI, TUI, Discord, and activity views distinguish dependency preparation,
+  model loading, and generation instead of leaving active work labeled as
+  queued; large-model verification also publishes live byte progress and reuses
+  durable attestations after restart.

--- a/crates/mold-cli/src/commands/mcp.rs
+++ b/crates/mold-cli/src/commands/mcp.rs
@@ -312,10 +312,18 @@ fn append_queue_plan_status_lines(lines: &mut Vec<String>, queue: &mold_core::Qu
                 .clone()
                 .unwrap_or_else(|| "unassigned".into()),
         };
+        let preparation = item
+            .preparation_label()
+            .map(|label| format!(" preparation={label}"))
+            .unwrap_or_default();
+        let runtime = item
+            .runtime_label()
+            .map(|label| format!(" stage={label}"))
+            .unwrap_or_default();
         lines.push(format!(
-            "work {}: phase={} lane={}/{} blocked={} finish={} confidence={}",
+            "work {}: phase={} lane={}/{} blocked={} finish={} confidence={}{}{}",
             item.work_id,
-            item.activity_phase,
+            item.presentation_phase(),
             lane,
             item.lane_order
                 .map(|value| value.to_string())
@@ -328,6 +336,8 @@ fn append_queue_plan_status_lines(lines: &mut Vec<String>, queue: &mold_core::Qu
                 .map(|value| value.to_string())
                 .unwrap_or_else(|| "unknown".into()),
             item.estimate_confidence,
+            preparation,
+            runtime,
         ));
     }
 }

--- a/crates/mold-cli/src/commands/ps.rs
+++ b/crates/mold-cli/src/commands/ps.rs
@@ -265,15 +265,25 @@ fn format_work_item(item: &QueueWorkItem) -> String {
         .estimated_finish_unix_ms
         .map(|finish| format!(" finish={finish}"))
         .unwrap_or_default();
+    let preparation = item
+        .preparation_label()
+        .map(|label| format!(" preparation={label}"))
+        .unwrap_or_default();
+    let runtime = item
+        .runtime_label()
+        .map(|label| format!(" stage={label}"))
+        .unwrap_or_default();
     format!(
-        "{} {} phase={} lane={} confidence={}{}{}",
+        "{} {} phase={} lane={} confidence={}{}{}{}{}",
         item.work_id,
         item.work_kind,
-        item.activity_phase,
+        item.presentation_phase(),
         lane,
         item.estimate_confidence,
         blocked,
-        eta
+        eta,
+        preparation,
+        runtime
     )
 }
 
@@ -332,6 +342,25 @@ mod tests {
         let formatted = format_work_item(&item);
         assert!(formatted.contains("host-utility/1"));
         assert!(!formatted.contains("cpu:utility:0"));
+    }
+
+    #[test]
+    fn preparation_formats_as_active_work_with_component_progress() {
+        let formatted = format_work_item(&QueueWorkItem {
+            work_id: "print-1".into(),
+            activity_phase: mold_core::QueueActivityPhase::Blocked,
+            blocked_reason: Some(mold_core::QueueBlockedReason::Preparing),
+            preparation_progress: Some(mold_core::QueuePreparationProgress {
+                component: "Verifying model files".into(),
+                bytes_done: 27,
+                bytes_total: 100,
+                phase_elapsed_ms: Some(10),
+            }),
+            ..Default::default()
+        });
+
+        assert!(formatted.contains("phase=preparing"));
+        assert!(formatted.contains("preparation=Verifying model files 27%"));
     }
 
     #[test]

--- a/crates/mold-cli/src/commands/queue.rs
+++ b/crates/mold-cli/src/commands/queue.rs
@@ -601,7 +601,13 @@ pub(crate) fn render_detail(
         );
     }
     if let Some(item) = work_item {
-        line("Planned phase", item.activity_phase.to_string());
+        line("Planned phase", item.presentation_phase().to_string());
+        if let Some(label) = item.preparation_label() {
+            line("Preparing", label);
+        }
+        if let Some(label) = item.runtime_label() {
+            line("Current stage", label.to_string());
+        }
         if let Some(device) = item.planned_device_id.as_deref() {
             line("Planned device", device.to_string());
         }

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -3944,6 +3944,18 @@ pub struct QueueWorkItem {
     /// What that preparation is working through, when it reports it.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub preparation_progress: Option<QueuePreparationProgress>,
+    /// Live execution phase joined from the queue progress registry when a
+    /// client reads the queue (`loading` or `running`). The scheduler's plan
+    /// remains payload-free and older servers omit this enrichment.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_phase: Option<String>,
+    /// Latest model-load or inference stage for this live work item.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_stage: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_current: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub runtime_total: Option<u64>,
     #[serde(default)]
     #[schema(value_type = String)]
     pub activity_phase: QueueActivityPhase,
@@ -3956,6 +3968,43 @@ pub struct QueueWorkItem {
 }
 
 impl QueueWorkItem {
+    /// User-facing phase for clients that render the scheduler plan directly.
+    ///
+    /// Preparation remains encoded as a typed blocked reason on the wire for
+    /// compatibility, but presenting it as "blocked" contradicts the work the
+    /// server is actively performing.
+    pub fn presentation_phase(&self) -> &str {
+        if self.blocked_reason == Some(QueueBlockedReason::Preparing) {
+            "preparing"
+        } else if let Some(phase) = self.runtime_phase.as_deref() {
+            phase
+        } else {
+            self.activity_phase.as_str()
+        }
+    }
+
+    /// Current dependency-preparation component, including a bounded percent
+    /// when the preparer reports a byte total.
+    pub fn preparation_label(&self) -> Option<String> {
+        let progress = self.preparation_progress.as_ref()?;
+        if progress.bytes_total == 0 {
+            return Some(progress.component.clone());
+        }
+        let percent = progress
+            .bytes_done
+            .saturating_mul(100)
+            .checked_div(progress.bytes_total)
+            .unwrap_or(0)
+            .min(100);
+        Some(format!("{} {percent}%", progress.component))
+    }
+
+    pub fn runtime_label(&self) -> Option<&str> {
+        self.runtime_stage.as_deref().or_else(|| {
+            (self.runtime_phase.as_deref() == Some("loading")).then_some("Loading model")
+        })
+    }
+
     /// Whether this work belongs to the host utility lane.
     ///
     /// Current servers provide the typed lane class. The exact legacy
@@ -4092,6 +4141,13 @@ pub struct ActiveWorkItem {
     pub current: Option<u64>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub total: Option<u64>,
+    /// Latest human-facing model-load or inference stage.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stage: Option<String>,
+    /// Scheduler-owned dependency preparation detail. Additive so older hosts
+    /// and non-generation work retain the existing activity wire shape.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub preparation_progress: Option<QueuePreparationProgress>,
     /// Server-confirmed cancellation support for this exact item. Clients may
     /// narrow this further when the item is not part of their local session.
     #[serde(default)]

--- a/crates/mold-discord/src/format.rs
+++ b/crates/mold-discord/src/format.rs
@@ -508,10 +508,20 @@ pub fn format_server_status_pages(
                         .map(mold_core::QueueBlockedReason::as_str)
                         .or(work.assignment_reason.as_deref())
                         .unwrap_or("none");
+                    let preparation = work
+                        .preparation_label()
+                        .map(|label| format!(" · {label}"))
+                        .unwrap_or_default();
+                    let runtime = work
+                        .runtime_label()
+                        .map(|label| format!(" · {label}"))
+                        .unwrap_or_default();
                     truncate_chars(
                         &format!(
-                            "`{}` · {} · lane {lane} · finish {finish} · {} confidence · {reason}",
-                            work.work_id, work.activity_phase, work.estimate_confidence
+                            "`{}` · {}{preparation}{runtime} · lane {lane} · finish {finish} · {} confidence · {reason}",
+                            work.work_id,
+                            work.presentation_phase(),
+                            work.estimate_confidence
                         ),
                         360,
                     )

--- a/crates/mold-server/src/execution_plan.rs
+++ b/crates/mold-server/src/execution_plan.rs
@@ -12,6 +12,7 @@ use mold_scheduler::ExecutionEquivalenceFingerprint;
 use serde::Serialize;
 use sha2::{Digest, Sha256};
 use std::collections::{BTreeMap, BTreeSet};
+#[cfg(not(any(unix, windows)))]
 use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex, OnceLock};
@@ -2070,6 +2071,7 @@ pub(crate) fn warm_execution_equivalence_cache(
     config: &Config,
     request: &GenerateRequest,
     prepared: &PreparedExecutionInputs,
+    preparation_progress: Option<&crate::variant_dependencies::PreparationProgressSink>,
 ) {
     let family = config
         .resolved_model_config(&request.model)
@@ -2092,8 +2094,39 @@ pub(crate) fn warm_execution_equivalence_cache(
             .into_values(),
         );
     }
+    let total_bytes = paths
+        .iter()
+        .filter_map(|path| std::fs::metadata(path).ok().map(|metadata| metadata.len()))
+        .fold(0_u64, u64::saturating_add);
+    let mut completed_bytes = 0_u64;
+    crate::variant_dependencies::publish_preparation_progress(
+        preparation_progress,
+        "Verifying model files",
+        completed_bytes,
+        total_bytes,
+    );
     for path in paths {
-        let _ = artifact_facts_path_with_policy(&path, false);
+        let artifact_bytes = std::fs::metadata(&path)
+            .ok()
+            .map(|metadata| metadata.len())
+            .unwrap_or_default();
+        let mut progress = |done: u64, _total: u64| {
+            crate::variant_dependencies::publish_preparation_progress(
+                preparation_progress,
+                "Verifying model files",
+                completed_bytes.saturating_add(done.min(artifact_bytes)),
+                total_bytes,
+            );
+            Ok(())
+        };
+        let _ = artifact_facts_path_with_policy_and_progress(&path, false, Some(&mut progress));
+        completed_bytes = completed_bytes.saturating_add(artifact_bytes);
+        crate::variant_dependencies::publish_preparation_progress(
+            preparation_progress,
+            "Verifying model files",
+            completed_bytes,
+            total_bytes,
+        );
     }
     // LTX-2 admission needs the checkpoint's per-block weight layout. Reading
     // the safetensors header is blocking work, so it is warmed here (already
@@ -4197,6 +4230,14 @@ impl Drop for ArtifactFactOwnerGuard {
 }
 
 fn artifact_facts_path_with_policy(path: &Path, cache_only: bool) -> ArtifactFacts {
+    artifact_facts_path_with_policy_and_progress(path, cache_only, None)
+}
+
+fn artifact_facts_path_with_policy_and_progress(
+    path: &Path,
+    cache_only: bool,
+    mut progress: Option<&mut dyn FnMut(u64, u64) -> anyhow::Result<()>>,
+) -> ArtifactFacts {
     let Ok(before_metadata) = std::fs::metadata(path) else {
         return ArtifactFacts {
             content: unknown_equivalence_content(path, None),
@@ -4282,8 +4323,12 @@ fn artifact_facts_path_with_policy(path: &Path, cache_only: bool) -> ArtifactFac
     let facts = {
         let _permit = artifact_read_limiter().acquire();
         note_artifact_physical_read(path);
-        let content = hash_equivalence_artifact_contents(path)
-            .unwrap_or_else(|_| unknown_equivalence_content(path, Some(&before)));
+        let content = hash_equivalence_artifact_contents_with_progress(path, |done, total| {
+            progress
+                .as_mut()
+                .map_or(Ok(()), |callback| callback(done, total))
+        })
+        .unwrap_or_else(|_| unknown_equivalence_content(path, Some(&before)));
         let format = match mold_inference::artifact_format::probe(path) {
             Ok(format) => ArtifactFormatFact::Known(format),
             Err(error) => ArtifactFormatFact::ProbeFailure(error),
@@ -4309,37 +4354,22 @@ fn artifact_facts_path_with_policy(path: &Path, cache_only: bool) -> ArtifactFac
     owner.finish(published, stable, before)
 }
 
+#[cfg(test)]
 fn hash_equivalence_artifact_contents(path: &Path) -> std::io::Result<EquivalenceContentIdentity> {
-    // Pull completion writes this marker only after hashing the complete
-    // artifact, and model discovery already treats it as the installed-byte
-    // authority. Reusing it keeps an authoritative placement preview from
-    // synchronously rereading tens of gigabytes before the job can queue.
-    if let Some(digest) = verified_sha256_marker_digest(path) {
-        return Ok(EquivalenceContentIdentity::Sha256(digest));
-    }
-    let mut file = std::fs::File::open(path)?;
-    let mut hash = Sha256::new();
-    let mut buffer = vec![0_u8; 1024 * 1024];
-    loop {
-        let read = file.read(&mut buffer)?;
-        if read == 0 {
-            break;
-        }
-        hash.update(&buffer[..read]);
-    }
-    Ok(EquivalenceContentIdentity::Sha256(format!(
-        "{:x}",
-        hash.finalize()
-    )))
+    hash_equivalence_artifact_contents_with_progress(path, |_, _| Ok(()))
+        .map_err(std::io::Error::other)
 }
 
-fn verified_sha256_marker_digest(path: &Path) -> Option<String> {
-    // The marker's first line is the digest; a second `len=` line (added so
-    // `Config::file_is_complete` can tell a marker that still describes the
-    // file from a stale one) is read and discarded by the shared helper.
-    let digest = mold_core::download::recorded_sha256_marker(path)?;
-    (digest.len() == 64 && digest.bytes().all(|byte| byte.is_ascii_hexdigit()))
-        .then(|| digest.to_ascii_lowercase())
+fn hash_equivalence_artifact_contents_with_progress(
+    path: &Path,
+    progress: impl FnMut(u64, u64) -> anyhow::Result<()>,
+) -> anyhow::Result<EquivalenceContentIdentity> {
+    // Use the retained-descriptor verifier shared with downloads. It refuses
+    // symlinks and path replacement, single-flights concurrent callers, and
+    // persists an owner-private identity-bound attestation so an unchanged
+    // legacy artifact is read only once across process restarts.
+    mold_core::download::pinned_file_digest_with_progress(path, progress)
+        .map(EquivalenceContentIdentity::Sha256)
 }
 
 fn unknown_equivalence_content(
@@ -6996,17 +7026,19 @@ mod tests {
     }
 
     #[test]
-    fn verified_digest_marker_is_the_artifact_content_identity() {
+    fn legacy_verified_digest_marker_cannot_override_current_artifact_bytes() {
         let root = TempDir::new().unwrap();
         let path = root.path().join("weights.safetensors");
         std::fs::write(&path, b"already verified model bytes").unwrap();
-        let digest = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
-        mold_core::download::write_sha256_marker(&path, digest).unwrap();
+        let forged = "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef";
+        mold_core::download::write_sha256_marker(&path, forged).unwrap();
+        let file = mold_core::secure_file::open_regular_file_no_follow(&path).unwrap();
+        let expected = mold_core::secure_file::sha256_open_file(&file).unwrap();
 
         assert_eq!(
             hash_equivalence_artifact_contents(&path).unwrap(),
-            EquivalenceContentIdentity::Sha256(digest.to_string()),
-            "placement preparation should trust the digest attested by the download verifier"
+            EquivalenceContentIdentity::Sha256(expected),
+            "placement preparation must authenticate current bytes through the durable pinned-digest authority"
         );
     }
 
@@ -7360,7 +7392,14 @@ mod tests {
             #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
             h3_private_admission_by_device: BTreeMap::new(),
         };
-        warm_execution_equivalence_cache(&config, &request, &prepared);
+        let progress = crate::variant_dependencies::PreparationProgressSink::default();
+        warm_execution_equivalence_cache(&config, &request, &prepared, Some(&progress));
+        let progress = progress
+            .snapshot()
+            .expect("warm pass reports its byte progress");
+        assert_eq!(progress.component, "Verifying model files");
+        assert!(progress.bytes_total > 0);
+        assert_eq!(progress.bytes_done, progress.bytes_total);
 
         let reads = Arc::new(AtomicUsize::new(0));
         let _guards = concrete_artifacts_for_family(

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -5927,6 +5927,42 @@ async fn health(State(state): State<AppState>) -> impl IntoResponse {
 
 // ── /api/queue ───────────────────────────────────────────────────────────────
 
+fn enrich_queue_plan_runtime(
+    plan: &mut Option<mold_core::QueuePlan>,
+    registry: &crate::job_registry::JobRegistry,
+) {
+    let Some(plan) = plan else { return };
+    for work in &mut plan.work_items {
+        if work.activity_phase != mold_core::QueueActivityPhase::Active {
+            continue;
+        }
+        let Some(progress) = registry.progress_snapshot(&work.work_id) else {
+            continue;
+        };
+        let progress = progress.unwrap_or_default();
+        let running = progress.step.is_some();
+        work.runtime_phase = Some(if running { "running" } else { "loading" }.to_string());
+        work.runtime_stage = progress.stage.clone().or_else(|| {
+            progress
+                .weight_load
+                .as_ref()
+                .map(|load| format!("Loading {}", load.component))
+        });
+        let (current, total) = if running {
+            (
+                progress.step.map(|value| value as u64),
+                progress.total.map(|value| value as u64),
+            )
+        } else {
+            progress.weight_load.as_ref().map_or((None, None), |load| {
+                (Some(load.bytes_loaded), Some(load.bytes_total))
+            })
+        };
+        work.runtime_current = current;
+        work.runtime_total = total;
+    }
+}
+
 /// Bounded snapshot of jobs currently queued or running on the server. Clients
 /// (notably the web SPA) poll this to reconcile their local card list — any
 /// "running" card whose server id isn't here is a zombie left over from a
@@ -5952,6 +5988,7 @@ async fn list_queue(
 ) -> Result<Json<QueueListingResponse>, ApiError> {
     let mut listing = state.job_registry.snapshot();
     listing.plan = state.scheduled_work.latest_plan();
+    enrich_queue_plan_runtime(&mut listing.plan, &state.job_registry);
     let requested_page = QueuePageRequest::parse(query, state.queue_capacity)?;
     let explicit_page = requested_page.explicit;
 
@@ -6096,7 +6133,9 @@ async fn get_queue_job(
     // plan entries are its children — the first child that names it as parent.
     // Matching only `work_id` would answer `null` for exactly the batch parent
     // whose phase a client is asking about.
-    let work_item = state.scheduled_work.latest_plan().and_then(|plan| {
+    let mut plan = state.scheduled_work.latest_plan();
+    enrich_queue_plan_runtime(&mut plan, &state.job_registry);
+    let work_item = plan.and_then(|plan| {
         let items = plan.work_items;
         items
             .iter()

--- a/crates/mold-server/src/routes_activity.rs
+++ b/crates/mold-server/src/routes_activity.rs
@@ -18,14 +18,29 @@ fn nonnegative_ms(value: i64) -> u64 {
     value.try_into().unwrap_or_default()
 }
 
-fn scheduler_phase(phase: &QueueActivityPhase) -> &'static str {
-    match phase {
-        QueueActivityPhase::Active | QueueActivityPhase::Cpu => "running",
+fn scheduler_phase(
+    work: &mold_core::QueueWorkItem,
+    progress: Option<&mold_core::queue_progress::QueueJobProgress>,
+) -> &'static str {
+    match work.activity_phase {
+        QueueActivityPhase::Cpu => "running",
+        QueueActivityPhase::Active if progress.and_then(|value| value.step).is_some() => "running",
+        // Only registry-backed generations have a model-loading progress
+        // record. Scheduler-owned GPU work (chain stages, upscales, utilities)
+        // is already executing once its lease is Active and must not inherit
+        // the generation fallback label indefinitely.
+        QueueActivityPhase::Active if progress.is_some() => "loading",
+        QueueActivityPhase::Active => "running",
         QueueActivityPhase::Dispatching => "loading",
+        QueueActivityPhase::Blocked
+            if work.blocked_reason == Some(mold_core::QueueBlockedReason::Preparing) =>
+        {
+            "preparing"
+        }
         QueueActivityPhase::Blocked
         | QueueActivityPhase::WarmWait
         | QueueActivityPhase::Queued
-        | QueueActivityPhase::Unknown(_) => "preparing",
+        | QueueActivityPhase::Unknown(_) => "queued",
     }
 }
 
@@ -45,15 +60,47 @@ struct SchedulerActivity {
     phase: &'static str,
     current: Option<u64>,
     total: Option<u64>,
+    stage: Option<String>,
+    preparation_progress: Option<mold_core::QueuePreparationProgress>,
 }
 
-fn scheduler_activity(state: &AppState) -> HashMap<String, SchedulerActivity> {
-    let mut by_parent: HashMap<String, SchedulerActivity> = HashMap::new();
+#[derive(Default)]
+struct SchedulerActivityIndex {
+    by_work: HashMap<String, SchedulerActivity>,
+    by_parent: HashMap<String, SchedulerActivity>,
+}
+
+fn merge_scheduler_activity(current: &mut SchedulerActivity, candidate: &SchedulerActivity) {
+    let candidate_rank = phase_rank(candidate.phase);
+    let current_rank = phase_rank(current.phase);
+    if candidate_rank > current_rank {
+        *current = candidate.clone();
+    } else if candidate_rank == current_rank {
+        if candidate.stage.is_some() {
+            current.stage = candidate.stage.clone();
+        }
+        if candidate.preparation_progress.is_some() {
+            current.preparation_progress = candidate.preparation_progress.clone();
+            current.current = candidate.current;
+            current.total = candidate.total;
+        } else {
+            current.current = current.current.max(candidate.current);
+            current.total = current.total.max(candidate.total);
+        }
+    }
+}
+
+fn scheduler_activity(state: &AppState) -> SchedulerActivityIndex {
+    let mut index = SchedulerActivityIndex::default();
     let Some(plan) = state.scheduled_work.latest_plan() else {
-        return by_parent;
+        return index;
     };
     for work in plan.work_items {
-        let phase = scheduler_phase(&work.activity_phase);
+        let runtime_progress = state
+            .job_registry
+            .progress_snapshot(&work.work_id)
+            .flatten();
+        let phase = scheduler_phase(&work, runtime_progress.as_ref());
         let kind = match work.work_kind.as_str() {
             "chain_stage" => "sequence",
             "generation" | "prepared_sibling" => "generation",
@@ -64,26 +111,56 @@ fn scheduler_activity(state: &AppState) -> HashMap<String, SchedulerActivity> {
         // monotonic submission counter, not a place in line; the registry
         // ordering below is the one authority for that, and it is what
         // `GET /api/queue` reports.
+        let preparation_progress = work.preparation_progress.clone();
+        let stage = runtime_progress.as_ref().and_then(|progress| {
+            progress.stage.clone().or_else(|| {
+                progress
+                    .weight_load
+                    .as_ref()
+                    .map(|load| format!("Loading {}", load.component))
+            })
+        });
+        let runtime_current = runtime_progress.as_ref().and_then(|progress| {
+            progress
+                .step
+                .map(|value| value.try_into().unwrap_or(u64::MAX))
+                .or_else(|| progress.weight_load.as_ref().map(|load| load.bytes_loaded))
+        });
+        let runtime_total = runtime_progress.as_ref().and_then(|progress| {
+            progress
+                .total
+                .map(|value| value.try_into().unwrap_or(u64::MAX))
+                .or_else(|| progress.weight_load.as_ref().map(|load| load.bytes_total))
+        });
         let candidate = SchedulerActivity {
             kind,
             phase,
-            current: work.chain_stage.map(u64::from),
-            total: work
-                .batch_partition
-                .map(|partition| u64::from(partition.count)),
+            current: preparation_progress
+                .as_ref()
+                .map(|progress| progress.bytes_done)
+                .or(runtime_current)
+                .or_else(|| work.chain_stage.map(u64::from)),
+            total: preparation_progress
+                .as_ref()
+                .map(|progress| progress.bytes_total)
+                .or(runtime_total)
+                .or_else(|| {
+                    work.batch_partition
+                        .map(|partition| u64::from(partition.count))
+                }),
+            stage: stage.or_else(|| (phase == "loading").then(|| "Loading model".to_string())),
+            preparation_progress,
         };
-        by_parent
+        index
+            .by_work
+            .insert(work.work_id.clone(), candidate.clone());
+        index
+            .by_parent
             .entry(work.parent_id)
-            .and_modify(|current| {
-                if phase_rank(candidate.phase) > phase_rank(current.phase) {
-                    current.phase = candidate.phase;
-                }
-                current.current = current.current.max(candidate.current);
-                current.total = current.total.max(candidate.total);
-            })
+            .and_modify(|current| merge_scheduler_activity(current, &candidate))
             .or_insert(candidate);
     }
-    by_parent
+    index
 }
 
 /// Return the host-owned, nonterminal work snapshot used to reconcile Now
@@ -104,7 +181,10 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
 
     for entry in queue.entries {
         represented.insert(entry.id.clone());
-        let scheduled = scheduler.get(&entry.id);
+        let scheduled = scheduler
+            .by_work
+            .get(&entry.id)
+            .or_else(|| scheduler.by_parent.get(&entry.id));
         let phase = scheduled.map_or_else(
             || match entry.state {
                 crate::job_registry::JobLifecycle::Queued => "queued",
@@ -126,8 +206,11 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
             created_at_unix_ms: entry.started_at_unix_ms,
             updated_at_unix_ms: observed_at_unix_ms,
             position: Some(entry.position),
-            current: None,
-            total: None,
+            current: scheduled.and_then(|activity| activity.current),
+            total: scheduled.and_then(|activity| activity.total),
+            stage: scheduled.and_then(|activity| activity.stage.clone()),
+            preparation_progress: scheduled
+                .and_then(|activity| activity.preparation_progress.clone()),
             can_cancel: !cancelling
                 && matches!(
                     entry.state,
@@ -161,6 +244,8 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
                             position: None,
                             current: None,
                             total: None,
+                            stage: None,
+                            preparation_progress: None,
                             can_cancel: true,
                         });
                     }
@@ -193,9 +278,10 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
                     .chain_jobs
                     .as_ref()
                     .is_some_and(|runner| runner.is_cancelling(&row.id));
+            let scheduled = scheduler.by_parent.get(&row.id);
             let phase = if cancelling {
                 "cancelling"
-            } else if let Some(activity) = scheduler.get(&row.id) {
+            } else if let Some(activity) = scheduled {
                 activity.phase
             } else if row.state == mold_core::chain_job::ChainJobState::Queued {
                 "queued"
@@ -214,6 +300,9 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
                 position: None,
                 current: Some(u64::from(row.current_stage)),
                 total: Some(u64::from(row.stage_count)),
+                stage: scheduled.and_then(|activity| activity.stage.clone()),
+                preparation_progress: scheduled
+                    .and_then(|activity| activity.preparation_progress.clone()),
                 can_cancel: true,
             });
         }
@@ -227,7 +316,7 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
     // Scheduler-only work includes preparation/utility phases that never
     // enter either durable registry. Collapse partitions/stages to one parent
     // row so a batch or chain never double-renders.
-    for (parent_id, activity) in &scheduler {
+    for (parent_id, activity) in &scheduler.by_parent {
         // Generation and sequence registries own their terminal boundary. A
         // separately published scheduler plan may lag completion briefly and
         // is enrichment only for those work kinds, never resurrection.
@@ -249,6 +338,8 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
             position: None,
             current: activity.current,
             total: activity.total,
+            stage: activity.stage.clone(),
+            preparation_progress: activity.preparation_progress.clone(),
             can_cancel: false,
         });
     }
@@ -274,6 +365,8 @@ pub async fn list_active_work(State(state): State<AppState>) -> Json<ActiveWorkS
             position: Some(position),
             current: Some(job.bytes_done),
             total: Some(job.bytes_total),
+            stage: None,
+            preparation_progress: None,
             can_cancel: true,
         });
     }

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -3417,14 +3417,93 @@ mod tests {
             .await
             .unwrap();
         state.job_registry.register("queued-a", "flux-dev:q4");
+        state
+            .job_registry
+            .register("preparing-d", "flux2-klein-9b:bf16");
+        state
+            .job_registry
+            .register("batch-child", "flux2-klein-9b:bf16");
         state.job_registry.register("running-b", "sdxl:q8");
         state.job_registry.mark_running("running-b", Some(1));
+        state.job_registry.record_progress(
+            "running-b",
+            &mold_core::types::SseProgressEvent::StageStart {
+                name: "Loading Flux.2 transformer".into(),
+            },
+        );
+        state.job_registry.register("denoising-e", "sdxl:q8");
+        state.job_registry.mark_running("denoising-e", Some(0));
+        state.job_registry.record_progress(
+            "denoising-e",
+            &mold_core::types::SseProgressEvent::DenoiseStep {
+                step: 2,
+                total: 4,
+                elapsed_ms: 1_000,
+            },
+        );
         state.scheduled_work.set_queue_work_items_for_tests(vec![
             mold_core::QueueWorkItem {
-                work_id: "running-b:child".into(),
+                work_id: "queued-a".into(),
+                parent_id: "queued-a".into(),
+                work_kind: "generation".into(),
+                activity_phase: mold_core::QueueActivityPhase::Queued,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "preparing-d".into(),
+                parent_id: "preparing-d".into(),
+                work_kind: "generation".into(),
+                blocked_reason: Some(mold_core::QueueBlockedReason::Preparing),
+                preparation_progress: Some(mold_core::QueuePreparationProgress {
+                    component: "Verifying model files".into(),
+                    bytes_done: 27,
+                    bytes_total: 100,
+                    phase_elapsed_ms: Some(4_200),
+                }),
+                activity_phase: mold_core::QueueActivityPhase::Blocked,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "batch-child".into(),
+                parent_id: "batch-parent".into(),
+                work_kind: "prepared_sibling".into(),
+                blocked_reason: Some(mold_core::QueueBlockedReason::Preparing),
+                preparation_progress: Some(mold_core::QueuePreparationProgress {
+                    component: "Loading reference images".into(),
+                    bytes_done: 41,
+                    bytes_total: 100,
+                    phase_elapsed_ms: Some(900),
+                }),
+                activity_phase: mold_core::QueueActivityPhase::Blocked,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "running-b".into(),
                 parent_id: "running-b".into(),
                 work_kind: "generation".into(),
-                activity_phase: mold_core::QueueActivityPhase::Dispatching,
+                activity_phase: mold_core::QueueActivityPhase::Active,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "denoising-e".into(),
+                parent_id: "denoising-e".into(),
+                work_kind: "generation".into(),
+                activity_phase: mold_core::QueueActivityPhase::Active,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "sequence-c:stage:0".into(),
+                parent_id: "sequence-c".into(),
+                work_kind: "chain_stage".into(),
+                chain_stage: Some(0),
+                activity_phase: mold_core::QueueActivityPhase::Active,
+                ..Default::default()
+            },
+            mold_core::QueueWorkItem {
+                work_id: "upscale-f".into(),
+                parent_id: "upscale-f".into(),
+                work_kind: "standalone_upscale".into(),
+                activity_phase: mold_core::QueueActivityPhase::Active,
                 ..Default::default()
             },
             mold_core::QueueWorkItem {
@@ -3454,17 +3533,35 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
         let body = json_body(response).await;
         let items = body["items"].as_array().unwrap();
-        assert_eq!(items.len(), 5);
+        assert_eq!(items.len(), 9);
         let item = |id: &str| items.iter().find(|item| item["id"] == id).unwrap();
         assert_eq!(item("queued-a")["kind"], "generation");
         assert_eq!(item("queued-a")["phase"], "queued");
         assert_eq!(item("queued-a")["can_cancel"], true);
         assert_eq!(item("running-b")["phase"], "loading");
+        assert_eq!(item("running-b")["stage"], "Loading Flux.2 transformer");
         assert_eq!(item("running-b")["can_cancel"], true);
+        assert_eq!(item("denoising-e")["phase"], "running");
+        assert_eq!(item("denoising-e")["current"], 2);
+        assert_eq!(item("denoising-e")["total"], 4);
+        assert_eq!(item("preparing-d")["phase"], "preparing");
+        assert_eq!(
+            item("preparing-d")["preparation_progress"]["component"],
+            "Verifying model files"
+        );
+        assert_eq!(item("preparing-d")["current"], 27);
+        assert_eq!(item("preparing-d")["total"], 100);
+        assert_eq!(item("batch-child")["phase"], "preparing");
+        assert_eq!(item("batch-child")["current"], 41);
+        assert_eq!(item("batch-child")["total"], 100);
         assert_eq!(item("expand-parent")["kind"], "prompt_expand");
         assert_eq!(item("expand-parent")["phase"], "running");
         assert_eq!(item("sequence-c")["kind"], "sequence");
         assert_eq!(item("sequence-c")["phase"], "running");
+        assert!(item("sequence-c").get("stage").is_none());
+        assert_eq!(item("upscale-f")["kind"], "standalone_upscale");
+        assert_eq!(item("upscale-f")["phase"], "running");
+        assert!(item("upscale-f").get("stage").is_none());
         assert!(
             items.iter().all(|item| item["id"] != "one-shot-chain"),
             "an auto-chained one-shot is represented by its generation row, not a second sequence"
@@ -3473,6 +3570,23 @@ mod tests {
         assert_eq!(item(&download_id)["phase"], "queued");
         assert_eq!(body["instance_id"], instance_id);
         assert!(body["observed_at_unix_ms"].as_u64().unwrap() > 0);
+
+        let queue_body = json_body(
+            app.clone()
+                .oneshot(
+                    Request::get("/api/queue/running-b")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap(),
+        )
+        .await;
+        assert_eq!(queue_body["work_item"]["runtime_phase"], "loading");
+        assert_eq!(
+            queue_body["work_item"]["runtime_stage"],
+            "Loading Flux.2 transformer"
+        );
 
         registry.remove("queued-a");
         registry.remove("running-b");

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -895,6 +895,9 @@ enum PreparationState {
 }
 
 enum PreparationEvent {
+    Progress {
+        work_id: String,
+    },
     Ready {
         work_id: String,
         prepared: Box<PreparedGeneration>,
@@ -1560,6 +1563,9 @@ fn queue_plan_semantically_equal(
             // Another live clock reading. The progress BYTES stay, because a
             // preparation that has moved is a real change worth publishing.
             work.preparation_elapsed_ms = None;
+            if let Some(progress) = &mut work.preparation_progress {
+                progress.phase_elapsed_ms = None;
+            }
             let duration = work
                 .estimated_start_unix_ms
                 .zip(work.estimated_finish_unix_ms)
@@ -2048,17 +2054,14 @@ impl Coordinator {
                         // The sink holds a phase clock the wire does not; the
                         // wire gets the phase's own age, which is what a queue
                         // row can act on.
-                        progress: pending
-                            .preparation_progress
-                            .lock()
-                            .unwrap_or_else(|poisoned| poisoned.into_inner())
-                            .as_ref()
-                            .map(|state| mold_core::QueuePreparationProgress {
+                        progress: pending.preparation_progress.snapshot().map(|state| {
+                            mold_core::QueuePreparationProgress {
                                 component: state.component.clone(),
                                 bytes_done: state.bytes_done,
                                 bytes_total: state.bytes_total,
                                 phase_elapsed_ms: Some(now_ms.saturating_sub(state.started_ms)),
-                            }),
+                            }
+                        }),
                     },
                 )
             })
@@ -2078,11 +2081,15 @@ impl Coordinator {
             };
             pending.preparation = PreparationState::Preparing;
             pending.preparation_started_ms = Some(monotonic_ms());
-            *pending
-                .preparation_progress
-                .lock()
-                .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+            pending.preparation_progress.clear();
             let preparation_progress = pending.preparation_progress.clone();
+            let progress_tx = self.preparation_tx.clone();
+            let progress_id = id.clone();
+            preparation_progress.set_notifier(Arc::new(move || {
+                let _ = progress_tx.send(PreparationEvent::Progress {
+                    work_id: progress_id.clone(),
+                });
+            }));
             tracing::info!(
                 job_id = %id,
                 model = %pending.job.request.model,
@@ -2210,6 +2217,19 @@ impl Coordinator {
 
     fn handle_preparation_event(&mut self, event: PreparationEvent, immediate: &mut bool) {
         match event {
+            PreparationEvent::Progress { work_id } => {
+                if self
+                    .pending
+                    .get(&work_id)
+                    .is_some_and(|pending| pending.preparation == PreparationState::Preparing)
+                {
+                    // Preparation is observable scheduler state. Advancing the
+                    // state authority makes GET /api/queue and the emitted
+                    // queue-plan event agree without fabricating a worker
+                    // lease or bypassing the normal planner projection.
+                    self.mutate(immediate);
+                }
+            }
             PreparationEvent::Ready { work_id, prepared } => {
                 let Some(pending) = self.pending.get_mut(&work_id) else {
                     return;
@@ -7022,6 +7042,10 @@ fn queue_plan_projection_at_unix(
                 warm_wait_deadline_unix_ms: None,
                 preparation_elapsed_ms: None,
                 preparation_progress: None,
+                runtime_phase: None,
+                runtime_stage: None,
+                runtime_current: None,
+                runtime_total: None,
                 activity_phase: if lease.accepted && host_utility {
                     mold_core::QueueActivityPhase::Cpu
                 } else if lease.accepted {
@@ -7155,6 +7179,10 @@ fn queue_plan_projection_at_unix(
                     warm_wait_deadline_unix_ms: warm_wait.map(|wait| to_unix(wait.deadline_ms)),
                     preparation_elapsed_ms: preparing.map(|view| view.elapsed_ms),
                     preparation_progress: preparing.and_then(|view| view.progress.clone()),
+                    runtime_phase: None,
+                    runtime_stage: None,
+                    runtime_current: None,
+                    runtime_total: None,
                     activity_phase: if warm_wait.is_some() {
                         mold_core::QueueActivityPhase::WarmWait
                     } else if blocked.is_some() {
@@ -10857,6 +10885,13 @@ mod tests {
             lane_order: Some(0),
             estimated_start_unix_ms: Some(10_000),
             estimated_finish_unix_ms: Some(15_000),
+            blocked_reason: Some(mold_core::QueueBlockedReason::Preparing),
+            preparation_progress: Some(mold_core::QueuePreparationProgress {
+                component: "Verifying model files".into(),
+                bytes_done: 27,
+                bytes_total: 100,
+                phase_elapsed_ms: Some(4_200),
+            }),
             ..Default::default()
         };
         let first = mold_core::QueuePlan {
@@ -10876,11 +10911,25 @@ mod tests {
             work_items: vec![mold_core::QueueWorkItem {
                 estimated_start_unix_ms: Some(11_000),
                 estimated_finish_unix_ms: Some(16_000),
+                preparation_progress: Some(mold_core::QueuePreparationProgress {
+                    component: "Verifying model files".into(),
+                    bytes_done: 27,
+                    bytes_total: 100,
+                    phase_elapsed_ms: Some(9_900),
+                }),
                 ..work
             }],
             ..first.clone()
         };
         assert!(queue_plan_semantically_equal(&first, &shifted));
+
+        let mut progressed = shifted.clone();
+        progressed.work_items[0]
+            .preparation_progress
+            .as_mut()
+            .unwrap()
+            .bytes_done = 28;
+        assert!(!queue_plan_semantically_equal(&first, &progressed));
 
         let mut slower = shifted;
         slower.work_items[0].estimated_finish_unix_ms = Some(17_000);
@@ -15709,6 +15758,45 @@ mod tests {
             wire["preparation_progress"]["bytes_total"],
             37_000_000_000_u64
         );
+    }
+
+    #[tokio::test]
+    async fn preparation_progress_invalidates_the_published_plan_authority() {
+        let (worker, _worker_rx) = test_worker(0);
+        let pool = Arc::new(GpuPool {
+            workers: vec![worker].into(),
+        });
+        let (ingress_tx, mut ingress_rx) = tokio::sync::mpsc::channel(1);
+        let queue = QueueHandle::new(ingress_tx);
+        let state = AppState::empty(mold_core::Config::default(), queue.clone(), pool, 1);
+        state.job_registry.register("progressing", "flux-dev:q4");
+        let (job, _result) = fake_generation("progressing");
+        queue.submit(job, 1).await.unwrap();
+        let mut coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+        let mut immediate = false;
+        coordinator.enqueue(ingress_rx.recv().await.unwrap(), &mut immediate);
+        coordinator
+            .pending
+            .get_mut("progressing")
+            .unwrap()
+            .preparation = PreparationState::Preparing;
+
+        let before = coordinator.state_version;
+        immediate = false;
+        coordinator.handle_preparation_event(
+            PreparationEvent::Progress {
+                work_id: "progressing".into(),
+            },
+            &mut immediate,
+        );
+
+        assert!(immediate, "a progress update must wake publication now");
+        assert!(coordinator.state_version > before);
+        assert!(coordinator.dirty.dirty_since.is_some());
     }
 
     struct SelectiveBlockingPreparer {

--- a/crates/mold-server/src/variant_dependencies.rs
+++ b/crates/mold-server/src/variant_dependencies.rs
@@ -1716,11 +1716,13 @@ pub(crate) async fn prepare_inputs_for_devices(
     let warm_config = config.clone();
     let warm_request = request.clone();
     let warm_prepared = prepared.clone();
+    let warm_progress = context.preparation_progress.clone();
     tokio::task::spawn_blocking(move || {
         crate::execution_plan::warm_execution_equivalence_cache(
             &warm_config,
             &warm_request,
             &warm_prepared,
+            warm_progress.as_ref(),
         );
     })
     .await
@@ -2530,11 +2532,63 @@ pub struct PreparationProgressState {
 
 /// What a running dependency preparation is currently working through.
 ///
-/// A shared cell rather than a channel: the scheduler reads the LATEST value
-/// when it projects the queue, and a pass that emits a progress event per
-/// megabyte of a ~37 GB artifact set must not queue thirty-seven thousand
-/// messages nobody is going to read.
-pub type PreparationProgressSink = Arc<std::sync::Mutex<Option<PreparationProgressState>>>;
+/// The latest observation stays in one shared cell. A throttled callback only
+/// wakes the scheduler when enough time passed (or the component changed), so
+/// a multi-gigabyte artifact does not turn one-megabyte reads into an unbounded
+/// queue of plan events.
+pub struct PreparationProgressCell {
+    latest: std::sync::Mutex<Option<PreparationProgressState>>,
+    notifier: std::sync::Mutex<Option<Arc<dyn Fn() + Send + Sync>>>,
+    last_notification_ms: std::sync::atomic::AtomicU64,
+}
+
+impl Default for PreparationProgressCell {
+    fn default() -> Self {
+        Self {
+            latest: Default::default(),
+            notifier: Default::default(),
+            last_notification_ms: std::sync::atomic::AtomicU64::new(u64::MAX),
+        }
+    }
+}
+
+impl std::fmt::Debug for PreparationProgressCell {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("PreparationProgressCell")
+            .field("latest", &self.snapshot())
+            .finish_non_exhaustive()
+    }
+}
+
+impl PreparationProgressCell {
+    pub(crate) fn clear(&self) {
+        *self
+            .latest
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = None;
+        self.last_notification_ms
+            .store(u64::MAX, std::sync::atomic::Ordering::Relaxed);
+    }
+
+    pub(crate) fn snapshot(&self) -> Option<PreparationProgressState> {
+        self.latest
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .clone()
+    }
+
+    pub(crate) fn set_notifier(&self, notifier: Arc<dyn Fn() + Send + Sync>) {
+        *self
+            .notifier
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = Some(notifier);
+    }
+}
+
+pub type PreparationProgressSink = Arc<PreparationProgressCell>;
+
+const PREPARATION_PROGRESS_NOTIFY_INTERVAL_MS: u64 = 250;
 
 /// Advance the published observation, keeping a phase's own start time.
 ///
@@ -2569,14 +2623,50 @@ pub(crate) fn publish_preparation_progress(
     bytes_total: u64,
 ) {
     let Some(sink) = sink else { return };
-    let mut slot = sink.lock().unwrap_or_else(|poisoned| poisoned.into_inner());
-    *slot = Some(advance_preparation_progress(
-        slot.take(),
-        component,
-        bytes_done,
-        bytes_total,
-        crate::scheduler::monotonic_ms(),
-    ));
+    let now_ms = crate::scheduler::monotonic_ms();
+    let should_notify = {
+        let mut slot = sink
+            .latest
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        if slot.as_ref().is_some_and(|current| {
+            current.component == component
+                && current.bytes_done == bytes_done
+                && current.bytes_total == bytes_total
+        }) {
+            return;
+        }
+        let component_changed = slot
+            .as_ref()
+            .is_none_or(|current| current.component != component);
+        *slot = Some(advance_preparation_progress(
+            slot.take(),
+            component,
+            bytes_done,
+            bytes_total,
+            now_ms,
+        ));
+        let previous = sink
+            .last_notification_ms
+            .load(std::sync::atomic::Ordering::Relaxed);
+        component_changed
+            || (bytes_total > 0 && bytes_done >= bytes_total)
+            || previous == u64::MAX
+            || now_ms.saturating_sub(previous) >= PREPARATION_PROGRESS_NOTIFY_INTERVAL_MS
+    };
+    if !should_notify {
+        return;
+    }
+    sink.last_notification_ms
+        .store(now_ms, std::sync::atomic::Ordering::Relaxed);
+    let notify = sink
+        .notifier
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+        .clone();
+    if let Some(notify) = notify {
+        notify();
+    }
 }
 
 #[derive(Clone, Debug, Default)]
@@ -2747,6 +2837,35 @@ mod tests {
         assert_eq!(
             next_phase.started_ms, 9_500,
             "a new phase must not inherit the previous phase's age"
+        );
+    }
+
+    #[test]
+    fn preparation_progress_notifies_on_open_component_change_and_completion() {
+        use std::sync::atomic::{AtomicUsize, Ordering};
+
+        let sink = PreparationProgressSink::default();
+        let notifications = Arc::new(AtomicUsize::new(0));
+        let observed = Arc::clone(&notifications);
+        sink.set_notifier(Arc::new(move || {
+            observed.fetch_add(1, Ordering::SeqCst);
+        }));
+
+        publish_preparation_progress(Some(&sink), "Verifying model files", 0, 100);
+        publish_preparation_progress(Some(&sink), "Verifying model files", 1, 100);
+        assert_eq!(
+            notifications.load(Ordering::SeqCst),
+            1,
+            "byte-level updates inside the throttle window must coalesce"
+        );
+
+        publish_preparation_progress(Some(&sink), "Loading references", 0, 10);
+        publish_preparation_progress(Some(&sink), "Loading references", 10, 10);
+        assert_eq!(notifications.load(Ordering::SeqCst), 3);
+        assert_eq!(
+            sink.snapshot()
+                .map(|state| (state.component, state.bytes_done)),
+            Some(("Loading references".to_string(), 10))
         );
     }
 

--- a/crates/mold-tui/src/ui/machines.rs
+++ b/crates/mold-tui/src/ui/machines.rs
@@ -702,7 +702,12 @@ fn short_device_id(id: &str) -> String {
 }
 
 fn queue_plan_detail(work: &mold_core::QueueWorkItem) -> String {
-    let mut parts = vec![work.activity_phase.to_string().replace('_', " ")];
+    let mut parts = vec![work.presentation_phase().replace('_', " ")];
+    if let Some(label) = work.preparation_label() {
+        parts.push(label);
+    } else if let Some(label) = work.runtime_label() {
+        parts.push(label.to_string());
+    }
     let order = work
         .lane_order
         .map(|order| order.to_string())
@@ -1239,6 +1244,24 @@ mod tests {
         });
         assert!(detail.contains("host utility lane 0"));
         assert!(!detail.contains("internal-id-must-not-render"));
+    }
+
+    #[test]
+    fn queue_plan_detail_surfaces_dependency_preparation_progress() {
+        let detail = queue_plan_detail(&mold_core::QueueWorkItem {
+            activity_phase: mold_core::QueueActivityPhase::Blocked,
+            blocked_reason: Some(mold_core::QueueBlockedReason::Preparing),
+            preparation_progress: Some(mold_core::QueuePreparationProgress {
+                component: "Verifying model files".into(),
+                bytes_done: 27,
+                bytes_total: 100,
+                phase_elapsed_ms: Some(10),
+            }),
+            ..Default::default()
+        });
+
+        assert!(detail.starts_with("preparing · Verifying model files 27%"));
+        assert!(!detail.starts_with("blocked"));
     }
 
     #[test]

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -106,6 +106,45 @@ describe("ActivityStrip", () => {
     expect(routerPush).toHaveBeenCalledWith("/models");
   });
 
+  it("names server-side preparation instead of presenting it as queued", () => {
+    useLiveActivityStore().hosts = {
+      render: {
+        hostId: "render",
+        hostLabel: "HAL 9000",
+        target: { baseUrl: "http://render", apiKey: null },
+        routeUrl: "http://render",
+        instanceId: "render-instance",
+        observedAtUnixMs: 2,
+        stale: false,
+        error: null,
+        items: [
+          {
+            id: "print-1",
+            kind: "generation",
+            phase: "preparing",
+            model: "flux2-klein-9b:bf16",
+            created_at_unix_ms: 1,
+            updated_at_unix_ms: 2,
+            current: 27,
+            total: 100,
+            preparation_progress: {
+              component: "Verifying model files",
+              bytes_done: 27,
+              bytes_total: 100,
+            },
+            can_cancel: true,
+          },
+        ],
+        unavailableKinds: [],
+      },
+    };
+
+    const text = mount(ActivityStrip).get("[data-test='shared-live-activity']").text();
+    expect(text).toMatch(
+      /HAL 9000 · Preparing · Verifying model files\s+· 27%/,
+    );
+  });
+
   it("is hidden when nothing is in flight", () => {
     const wrapper = mount(ActivityStrip);
     expect(wrapper.find("[data-test='activity-strip']").exists()).toBe(false);

--- a/desktop/src/components/create/ActivityStrip.test.ts
+++ b/desktop/src/components/create/ActivityStrip.test.ts
@@ -140,9 +140,7 @@ describe("ActivityStrip", () => {
     };
 
     const text = mount(ActivityStrip).get("[data-test='shared-live-activity']").text();
-    expect(text).toMatch(
-      /HAL 9000 · Preparing · Verifying model files\s+· 27%/,
-    );
+    expect(text).toMatch(/HAL 9000 · Preparing · Verifying model files\s+· 27%/);
   });
 
   it("is hidden when nothing is in flight", () => {

--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -125,6 +125,68 @@ describe("HostQueuePanel", () => {
     expect(wrapper.get("[data-test='queue-row']").text()).toContain("PAUSED");
   });
 
+  it("shows dependency preparation component and progress on a queued row", async () => {
+    const entry = queued("preparing", 0, 0);
+    const { wrapper } = await mountPanel([], [entry], {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "settled",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: entry.id,
+          parent_id: entry.id,
+          work_kind: "generation",
+          priority_class: "user",
+          queue_rank: 0,
+          bypass_count: 0,
+          estimate_confidence: "low",
+          blocked_reason: "preparing",
+          preparation_progress: {
+            component: "Verifying model files",
+            bytes_done: 27,
+            bytes_total: 100,
+          },
+        },
+      ],
+    });
+
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain(
+      "PREPARING · VERIFYING MODEL FILES 27%",
+    );
+  });
+
+  it("shows the host's model-loading stage for a running row", async () => {
+    const entry = { ...queued("loading", 0, 0), state: "running" as const };
+    const { wrapper } = await mountPanel([], [entry], {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "settled",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: entry.id,
+          parent_id: entry.id,
+          work_kind: "generation",
+          priority_class: "user",
+          queue_rank: 0,
+          bypass_count: 0,
+          estimate_confidence: "low",
+          activity_phase: "active",
+          runtime_phase: "loading",
+          runtime_stage: "Loading Flux.2 transformer",
+        },
+      ],
+    });
+
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain(
+      "LOADING FLUX.2 TRANSFORMER",
+    );
+    expect(wrapper.get("[data-test='queue-row']").text()).not.toContain("NEXT UP");
+  });
+
   it("offers Resume for restart-paused work while the global gate is open", async () => {
     const entry = { ...queued("srv-paused", 0, 0), state: "paused" as const };
     const { wrapper, jobs } = await mountPanel([], [entry]);

--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -181,9 +181,7 @@ describe("HostQueuePanel", () => {
       ],
     });
 
-    expect(wrapper.get("[data-test='queue-row']").text()).toContain(
-      "LOADING FLUX.2 TRANSFORMER",
-    );
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain("LOADING FLUX.2 TRANSFORMER");
     expect(wrapper.get("[data-test='queue-row']").text()).not.toContain("NEXT UP");
   });
 

--- a/desktop/src/components/machines/HostQueuePanel.vue
+++ b/desktop/src/components/machines/HostQueuePanel.vue
@@ -14,7 +14,13 @@ import QueueEntryDrawer from "../jobs/QueueEntryDrawer.vue";
 import ConfirmDialog from "../shell/ConfirmDialog.vue";
 import { useGenerationStore, jobPhase, jobProgress, type Job } from "../../stores/generation";
 import { type HostView } from "../../stores/hosts";
-import { queueWaitCode, resolveQueueWait } from "@studio/lib/queuePosition";
+import {
+  buildQueueStatusIndex,
+  queueRuntimeCode,
+  queueStatusFor,
+  queueWaitCode,
+  resolveQueueWait,
+} from "@studio/lib/queuePosition";
 import { queueEntryDetailModel, type QueueDetailMetadata } from "@studio/lib/queueEntryDetail";
 import { watchSelectedQueuePreview, type QueueJobProgress } from "@studio/api/generationSelection";
 import { enrichQueueEntries, useJobsStore, type EnrichedQueueEntry } from "../../stores/jobs";
@@ -76,6 +82,17 @@ const restartPaused = computed(
 const dispatchPaused = computed(() => snapshot.value?.paused === true);
 const resumeNeeded = computed(() => dispatchPaused.value || restartPaused.value);
 const caps = computed(() => snapshot.value?.caps ?? null);
+const queueStatus = computed(() => {
+  const current = snapshot.value;
+  return buildQueueStatusIndex([
+    {
+      hostId: props.host.id,
+      entries: current?.entries ?? [],
+      plan: current?.plan ?? null,
+      paused: current?.paused,
+    },
+  ]);
+});
 
 const lanes = computed(() => {
   const snap = snapshot.value;
@@ -111,12 +128,21 @@ function entryCode(entry: EnrichedQueueEntry): string {
   if (entry.state === "running") {
     const job = ownJob(entry);
     if (job && job.total > 0 && job.status === "denoising") return `${job.step}/${job.total}`;
+    const runtime = queueRuntimeCode(snapshot.value?.plan, entry.id);
+    if (runtime) return runtime;
     return entry.gpu !== undefined ? `RUNNING · GPU ${entry.gpu}` : "RUNNING";
   }
   if (dispatchPaused.value && entry.state === "queued") return "PAUSED";
   // Same waiting vocabulary as Create and iPhone, resolved once in studio —
   // including "held", which is parked rather than in line.
-  return queueWaitCode(resolveQueueWait({ state: entry.state, position: entry.position }));
+  return queueWaitCode(
+    resolveQueueWait(
+      queueStatusFor(queueStatus.value, props.host.id, entry.id) ?? {
+        state: entry.state,
+        position: entry.position,
+      },
+    ),
+  );
 }
 
 /** The host's own words for why a job is parked, shown beside the row so the

--- a/desktop/src/lib/durableGenerationPresentation.test.ts
+++ b/desktop/src/lib/durableGenerationPresentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { newJob } from "./generationJob";
+import { applyDurablePresentation } from "./durableGenerationPresentation";
+
+const request = {
+  model: "flux2-klein-9b:bf16",
+  prompt: "a frog",
+  width: 1024,
+  height: 1024,
+  steps: 4,
+};
+
+describe("desktop durable generation presentation", () => {
+  it("keeps the host's running sub-stage across lifecycle reconciliation", () => {
+    const job = newJob(request);
+    job.status = "loading";
+    job.stage = "Loading model";
+
+    applyDurablePresentation(job, { kind: "running", label: "Developing" });
+
+    expect(job.stage).toBe("Loading model");
+  });
+
+  it("sets the generic running stage on the first worker lease", () => {
+    const job = newJob(request);
+
+    applyDurablePresentation(job, { kind: "running", label: "Developing" });
+
+    expect(job.status).toBe("loading");
+    expect(job.stage).toBe("Developing");
+  });
+});

--- a/desktop/src/lib/durableGenerationPresentation.ts
+++ b/desktop/src/lib/durableGenerationPresentation.ts
@@ -54,8 +54,9 @@ export function applyDurablePresentation(job: Job, p: GenerationChildPresentatio
       return;
     case "running":
       // A retry can move a held child straight to running; the hold is over.
+      const alreadyRunning = job.status === "loading";
       job.status = "loading";
-      job.stage = p.label;
+      if (!alreadyRunning || !job.stage) job.stage = p.label;
       clearHold(job);
       return;
     case "complete":

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -545,6 +545,7 @@ type ActivityRow =
       /** Effective lifecycle after applying the host-wide queue pause. */
       queueState: string | null;
       blockedReason: string | null;
+      preparation: Extract<ActivityJobVM, { kind: "print" }>["preparation"];
       sequence: null;
     }
   | { key: string; print: null; sequence: Extract<ActivityJobVM, { kind: "sequence" }> };
@@ -2291,6 +2292,7 @@ function syncDurableGenerationJobs(): void {
               if (url) job.previewUrl = url;
               if (progress.step !== null) job.step = progress.step;
               if (progress.total !== null) job.total = progress.total;
+              if (progress.stage) job.stage = progress.stage;
             },
           );
         }
@@ -2417,6 +2419,7 @@ const activityRows = computed<ActivityRow[]>(() =>
             queuePosition: vm.queuePosition ?? null,
             queueState: vm.queueState ?? null,
             blockedReason: vm.blockedReason ?? null,
+            preparation: vm.preparation ?? null,
           },
         ]
       : [];
@@ -2555,6 +2558,7 @@ function activityRowStatus(row: ActivityRow): string {
       state: row.queueState,
       position: row.queuePosition ?? row.print.queuePosition,
       blockedReason: row.blockedReason,
+      preparation: row.preparation,
     }),
   );
 }
@@ -3105,6 +3109,7 @@ const generationStatus = computed(() => {
           state: live?.state,
           position: live?.position ?? active.queuePosition,
           blockedReason: live?.blockedReason,
+          preparation: live?.preparation,
         }),
       );
     }

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -256,6 +256,87 @@ afterEach(() => {
 });
 
 describe("MobileHostDetail remote host data", () => {
+  it("shows dependency preparation component and progress on a queued row", async () => {
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((target, path) => {
+      if (path === "/api/queue?limit=8") {
+        return Promise.resolve({
+          entries: [queueEntries[1]],
+          plan: {
+            plan_version: 1,
+            state_version: 1,
+            optimizer_state: "settled",
+            dirty_since_unix_ms: null,
+            next_replan_at_unix_ms: null,
+            work_items: [
+              {
+                work_id: "job-queued",
+                parent_id: "job-queued",
+                work_kind: "generation",
+                priority_class: "user",
+                queue_rank: 0,
+                bypass_count: 0,
+                estimate_confidence: "low",
+                blocked_reason: "preparing",
+                preparation_progress: {
+                  component: "Verifying model files",
+                  bytes_done: 27,
+                  bytes_total: 100,
+                },
+              },
+            ],
+          },
+        });
+      }
+      return originalApi(target, path);
+    });
+
+    const view = await mountDetail();
+
+    expect(view.get("[data-test='host-detail-queue-row-job-queued']").text()).toContain(
+      "PREPARING · VERIFYING MODEL FILES 27%",
+    );
+  });
+
+  it("shows the host's runtime loading stage on a running queue row", async () => {
+    const running = { ...queueEntries[1]!, state: "running" };
+    const originalApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((target, path) => {
+      if (path === "/api/queue?limit=8") {
+        return Promise.resolve({
+          entries: [running],
+          plan: {
+            plan_version: 1,
+            state_version: 1,
+            optimizer_state: "settled",
+            dirty_since_unix_ms: null,
+            next_replan_at_unix_ms: null,
+            work_items: [
+              {
+                work_id: running.id,
+                parent_id: running.id,
+                work_kind: "generation",
+                priority_class: "user",
+                queue_rank: 0,
+                bypass_count: 0,
+                estimate_confidence: "low",
+                activity_phase: "active",
+                runtime_phase: "loading",
+                runtime_stage: "Loading Flux.2 transformer",
+              },
+            ],
+          },
+        });
+      }
+      return originalApi(target, path);
+    });
+
+    const view = await mountDetail();
+    const row = view.get("[data-test='host-detail-queue-row-job-queued']");
+    expect(row.text()).toContain("LOADING FLUX.2 TRANSFORMER");
+    expect(row.text()).not.toContain("NEXT UP");
+  });
+
   it("renders server information without waiting for model inventory", async () => {
     const pendingModels = deferred<ModelEntry[]>();
     const originalApi = apiJsonTo.getMockImplementation()!;

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -21,7 +21,13 @@ import { queueEntryDetailModel, type QueueDetailMetadata } from "@studio/lib/que
 import type { SwipeRowAction } from "@studio/lib/swipeAction";
 import MinimaxH3InventoryPanel from "@studio/components/MinimaxH3InventoryPanel.vue";
 import { canMutateDevice } from "@studio/lib/deviceLifecycle";
-import { queueWaitCode, resolveQueueWait } from "@studio/lib/queuePosition";
+import {
+  buildQueueStatusIndex,
+  queueRuntimeCode,
+  queueStatusFor,
+  queueWaitCode,
+  resolveQueueWait,
+} from "@studio/lib/queuePosition";
 import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
 import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
 import { hostMemoryLevel, hostMemoryScheduleLabel } from "@studio/lib/hostMemory";
@@ -148,6 +154,16 @@ const runtimeWindow = computed(() => {
     : null;
 });
 const queueEntryIds = computed(() => queue.value.map((entry) => entry.id));
+const queueStatus = computed(() =>
+  buildQueueStatusIndex([
+    {
+      hostId: props.host.id,
+      entries: queue.value,
+      plan: queuePlan.value,
+      paused: status.value?.queue_paused === true,
+    },
+  ]),
+);
 const displayQueue = computed(() => [...queue.value].sort(compareNewestQueueEntry));
 const planOnlyWork = computed(() => queuePlanOnlyWork(queuePlan.value, queueEntryIds.value));
 const queueSummary = computed(() => {
@@ -1014,12 +1030,22 @@ async function unload(name: string): Promise<void> {
 }
 
 function queueCode(entry: QueueEntry): string {
-  if (entry.state === "running")
+  if (entry.state === "running") {
+    const runtime = queueRuntimeCode(queuePlan.value, entry.id);
+    if (runtime) return runtime;
     return entry.gpu == null ? "RUNNING" : `RUNNING · GPU ${entry.gpu}`;
+  }
   if (dispatchPaused.value && entry.state === "queued") return "PAUSED";
   // Same waiting vocabulary as the Create queue, resolved once in studio —
   // a held row reads HELD, never a place in line.
-  return queueWaitCode(resolveQueueWait({ state: entry.state, position: entry.position }));
+  return queueWaitCode(
+    resolveQueueWait(
+      queueStatusFor(queueStatus.value, props.host.id, entry.id) ?? {
+        state: entry.state,
+        position: entry.position,
+      },
+    ),
+  );
 }
 
 function downloadPercent(done: number, total: number): number {

--- a/desktop/src/stores/generation.ts
+++ b/desktop/src/stores/generation.ts
@@ -890,6 +890,7 @@ export const useGenerationStore = defineStore("generation", {
               if (url) job.previewUrl = url;
               if (progress.step !== null) job.step = progress.step;
               if (progress.total !== null) job.total = progress.total;
+              if (progress.stage) job.stage = progress.stage;
             },
           );
         } else {

--- a/desktop/src/views/GenerateView.prepared.test.ts
+++ b/desktop/src/views/GenerateView.prepared.test.ts
@@ -17,6 +17,7 @@ import { useToastStore } from "../stores/toasts";
 import { useDownloadsStore } from "../stores/downloads";
 import { useUiStore } from "../stores/ui";
 import { useAppPrefsStore } from "../stores/appPrefs";
+import { useJobsStore } from "../stores/jobs";
 import { useComposerStore } from "../stores/composer";
 import { expandPrompt } from "../lib/api/expand";
 import { remixPrompt } from "../lib/api/remix";
@@ -256,6 +257,73 @@ describe("GenerateView prepared expansion batches", () => {
       "data:image/png;base64,UFJFVklFVw==",
     );
     expect(wrapper.get('[data-test="generation-live-status"]').text()).toBe("Developing 8/20");
+  });
+
+  it("shows active dependency preparation instead of plain Queued", async () => {
+    const generation = useGenerationStore();
+    const queued = newJob({
+      model: model.name,
+      prompt: "queue lighthouse",
+      width: 1024,
+      height: 1024,
+      steps: 20,
+    });
+    Object.assign(queued, {
+      clientId: 1,
+      batchId: 1,
+      id: "preparing-print",
+      hostId: "local",
+      hostLabel: "This device",
+    });
+    generation.jobs.push(queued);
+    generation.selectedClientId = queued.clientId;
+    useJobsStore().queues.local = {
+      hostId: "local",
+      entries: [
+        {
+          id: queued.id,
+          model: queued.model,
+          state: "queued",
+          started_at_unix_ms: 1,
+          position: 0,
+        },
+      ],
+      paused: false,
+      error: null,
+      caps: null,
+      gpuOrdinals: [0],
+      plan: {
+        plan_version: 1,
+        state_version: 1,
+        optimizer_state: "settled",
+        dirty_since_unix_ms: null,
+        next_replan_at_unix_ms: null,
+        work_items: [
+          {
+            work_id: queued.id,
+            parent_id: queued.id,
+            work_kind: "generation",
+            priority_class: "user",
+            queue_rank: 0,
+            bypass_count: 0,
+            estimate_confidence: "low",
+            blocked_reason: "preparing",
+            preparation_progress: {
+              component: "Verifying model files",
+              bytes_done: 27,
+              bytes_total: 100,
+            },
+          },
+        ],
+      },
+    };
+
+    const wrapper = mountView();
+    await flushPromises();
+
+    expect(wrapper.get('[data-test="generation-live-status"]').text()).toBe(
+      "Preparing · Verifying model files 27%",
+    );
   });
 
   it("expands in Auto when model owners differ only by patch version", async () => {

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -2235,13 +2235,7 @@ const liveGenerationStatus = computed(() => {
   if (!j || j.status === "complete" || j.status === "error") return "";
   if (j.status === "queued") {
     return queueWaitLabel(
-      resolveQueueWait(
-        queueStatusFor(
-          queueStatus.value,
-          j.hostId ?? hosts.primaryHost?.id,
-          j.id,
-        ),
-      ),
+      resolveQueueWait(queueStatusFor(queueStatus.value, j.hostId ?? hosts.primaryHost?.id, j.id)),
     );
   }
   if (j.status === "loading") return `${j.stage ?? "Preparing"}…`;

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -42,6 +42,13 @@ import { filterRestrictedModels } from "@studio/lib/modelAccess";
 import { effectiveGenerationRecipe } from "@studio/lib/generationProfile";
 import { profileConflictMessage } from "@studio/lib/profileFleet";
 import { useLiveActivityStore } from "../stores/liveActivity";
+import { useJobsStore } from "../stores/jobs";
+import {
+  buildQueueStatusIndex,
+  queueStatusFor,
+  queueWaitLabel,
+  resolveQueueWait,
+} from "@studio/lib/queuePosition";
 import { imageDimensionsFromBase64 } from "@studio/lib/imageDimensions";
 import { attachPickedImage } from "../lib/sourceAttachment";
 import {
@@ -275,6 +282,7 @@ const downloads = useDownloadsStore();
 const pullResume = usePullResumeStore();
 const licenseAcceptance = useLicenseAcceptance();
 const liveActivity = useLiveActivityStore();
+const jobsStore = useJobsStore();
 
 function placementFailureMessage(result: Exclude<FeasibleRouteResult, { kind: "route" }>): string {
   if (result.kind === "profile_mismatch") {
@@ -2203,6 +2211,17 @@ const selectedQueuePreviewSrc = computed(() =>
     : null,
 );
 
+const queueStatus = computed(() =>
+  buildQueueStatusIndex(
+    Object.values(jobsStore.queues).map((snapshot) => ({
+      hostId: snapshot.hostId,
+      entries: snapshot.entries,
+      plan: snapshot.plan,
+      paused: snapshot.paused,
+    })),
+  ),
+);
+
 const liveGenerationStatus = computed(() => {
   const selected = selectedQueueRender.value;
   if (selected) {
@@ -2214,7 +2233,17 @@ const liveGenerationStatus = computed(() => {
   }
   const j = job.value;
   if (!j || j.status === "complete" || j.status === "error") return "";
-  if (j.status === "queued") return "Queued";
+  if (j.status === "queued") {
+    return queueWaitLabel(
+      resolveQueueWait(
+        queueStatusFor(
+          queueStatus.value,
+          j.hostId ?? hosts.primaryHost?.id,
+          j.id,
+        ),
+      ),
+    );
+  }
   if (j.status === "loading") return `${j.stage ?? "Preparing"}…`;
   const copy = jobProgressCopy(j);
   return j.status === "finishing" ? `${copy}…` : copy;

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -11,6 +11,13 @@ export interface ActiveWorkItem {
   position?: number | null;
   current?: number | null;
   total?: number | null;
+  stage?: string | null;
+  preparation_progress?: {
+    component: string;
+    bytes_done: number;
+    bytes_total: number;
+    phase_elapsed_ms?: number | null;
+  } | null;
   can_cancel: boolean;
 }
 

--- a/studio/api/queuePlan.ts
+++ b/studio/api/queuePlan.ts
@@ -85,6 +85,10 @@ export interface QueueWorkItem {
     /** Age of the current phase alone, reset when the phase changes. */
     phase_elapsed_ms?: number | null;
   } | null;
+  runtime_phase?: "loading" | "running" | (string & {}) | null;
+  runtime_stage?: string | null;
+  runtime_current?: number | null;
+  runtime_total?: number | null;
   warm_wait_deadline_unix_ms?: number | null;
   activity_phase?:
     | "queued"

--- a/studio/components/QueuePlanWorkList.test.ts
+++ b/studio/components/QueuePlanWorkList.test.ts
@@ -71,4 +71,18 @@ describe("QueuePlanWorkList", () => {
       false,
     );
   });
+
+  it("shows live preparation detail for plan-only work", () => {
+    const preparing = plan();
+    preparing.work_items[0]!.activity_phase = "blocked";
+    preparing.work_items[0]!.blocked_reason = "preparing";
+    preparing.work_items[0]!.preparation_progress = {
+      component: "Verifying model files",
+      bytes_done: 27,
+      bytes_total: 100,
+    };
+    const wrapper = mount(QueuePlanWorkList, { props: { plan: preparing } });
+
+    expect(wrapper.text()).toContain("Preparing · Verifying model files 27%");
+  });
 });

--- a/studio/components/QueuePlanWorkList.vue
+++ b/studio/components/QueuePlanWorkList.vue
@@ -2,10 +2,7 @@
 import { computed } from "vue";
 import type { QueuePlan, QueueWorkItem } from "../api/queuePlan";
 import { queuePlanOnlyWork } from "../lib/queuePlanPresentation";
-import {
-  preparationForWorkItem,
-  preparationLabel,
-} from "../lib/queuePosition";
+import { preparationForWorkItem, preparationLabel } from "../lib/queuePosition";
 
 const props = withDefaults(
   defineProps<{

--- a/studio/components/QueuePlanWorkList.vue
+++ b/studio/components/QueuePlanWorkList.vue
@@ -2,6 +2,10 @@
 import { computed } from "vue";
 import type { QueuePlan, QueueWorkItem } from "../api/queuePlan";
 import { queuePlanOnlyWork } from "../lib/queuePlanPresentation";
+import {
+  preparationForWorkItem,
+  preparationLabel,
+} from "../lib/queuePosition";
 
 const props = withDefaults(
   defineProps<{
@@ -33,6 +37,8 @@ function kindLabel(item: QueueWorkItem): string {
 }
 
 function phaseLabel(item: QueueWorkItem): string {
+  const preparation = preparationForWorkItem(item);
+  if (preparation) return preparationLabel(preparation);
   return words(item.activity_phase ?? "scheduled");
 }
 

--- a/studio/lib/activity.test.ts
+++ b/studio/lib/activity.test.ts
@@ -386,6 +386,13 @@ describe("withLiveQueueStatus", () => {
       hostId: "local",
       entries: [
         {
+          id: "srv-prep",
+          model: "m",
+          state: "queued",
+          started_at_unix_ms: 2,
+          position: 1,
+        },
+        {
           id: "srv-run",
           model: "m",
           state: "running",
@@ -414,6 +421,22 @@ describe("withLiveQueueStatus", () => {
         dirty_since_unix_ms: null,
         next_replan_at_unix_ms: null,
         work_items: [
+          {
+            work_id: "w-prep",
+            parent_id: "srv-prep",
+            work_kind: "generation",
+            priority_class: "normal",
+            queue_rank: 2,
+            bypass_count: 0,
+            estimate_confidence: "low",
+            blocked_reason: "preparing",
+            preparation_elapsed_ms: 4_200,
+            preparation_progress: {
+              component: "Verifying model files",
+              bytes_done: 27,
+              bytes_total: 100,
+            },
+          },
           {
             work_id: "w3",
             parent_id: "srv-3",
@@ -477,6 +500,20 @@ describe("withLiveQueueStatus", () => {
     const vm = withLiveQueueStatus(print() as PrintActivityVM, index, "srv-3");
     expect(vm.blockedReason).toBe("insufficient_host_ram");
     expect(queueStatusLabel(vm)).toBe("Waiting for memory");
+  });
+
+  it("carries live preparation detail into the shared activity label", () => {
+    const vm = withLiveQueueStatus(
+      print() as PrintActivityVM,
+      index,
+      "srv-prep",
+    );
+    expect(vm.preparation).toEqual({
+      component: "Verifying model files",
+      fraction: 0.27,
+      elapsedMs: 4_200,
+    });
+    expect(queueStatusLabel(vm)).toBe("Preparing · Verifying model files 27%");
   });
 
   it("names the job at the head of the queue", () => {

--- a/studio/lib/activity.ts
+++ b/studio/lib/activity.ts
@@ -16,6 +16,7 @@ import {
   queueStatusFor,
   queueWaitLabel,
   resolveQueueWait,
+  type QueuePreparation,
   type QueueStatusIndex,
 } from "./queuePosition";
 import { friendlySequenceError } from "./sequence";
@@ -54,6 +55,8 @@ export type ActivityJobVM =
       queueState?: string | null;
       /** Raw scheduler `blocked_reason` for this job, when the plan named one. */
       blockedReason?: string | null;
+      /** Live dependency preparation detail from the scheduler plan. */
+      preparation?: QueuePreparation | null;
     }
   | {
       kind: "sequence";
@@ -175,6 +178,7 @@ export function withLiveQueueStatus(
   if (status.state !== null) next.queueState = status.state;
   if (status.position !== null) next.queuePosition = status.position;
   if (status.blockedReason !== null) next.blockedReason = status.blockedReason;
+  if (status.preparation !== null) next.preparation = status.preparation;
   return next;
 }
 
@@ -192,6 +196,7 @@ export function queueStatusLabel(vm: ActivityJobVM): string | null {
       state: vm.queueState,
       position: vm.queuePosition,
       blockedReason: vm.blockedReason,
+      preparation: vm.preparation,
     }),
   );
 }

--- a/studio/lib/queueEntryDetail.test.ts
+++ b/studio/lib/queueEntryDetail.test.ts
@@ -98,6 +98,36 @@ describe("queueEntryDetailModel", () => {
     expect(model({ plan }).waitLabel).toBe("#3 in line");
   });
 
+  it("shows dependency preparation instead of leaving the row queued", () => {
+    const plan: QueuePlan = {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "clean",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: "job-1",
+          parent_id: "batch-parent",
+          work_kind: "prepared_sibling",
+          priority_class: "normal",
+          queue_rank: 0,
+          bypass_count: 0,
+          estimate_confidence: "high",
+          blocked_reason: "preparing",
+          preparation_progress: {
+            component: "Verifying model files",
+            bytes_done: 27,
+            bytes_total: 100,
+          },
+        },
+      ],
+    };
+    const detail = model({ plan });
+    expect(detail.stateCode).toBe("PREPARING · VERIFYING MODEL FILES 27%");
+    expect(detail.waitLabel).toBe("Preparing · Verifying model files 27%");
+  });
+
   it("groups host-supplied settings the way the Create inspector does", () => {
     const detail = model({ metadata });
     expect(detail.metadataSource).toBe("host");

--- a/studio/lib/queueEntryDetail.ts
+++ b/studio/lib/queueEntryDetail.ts
@@ -22,6 +22,8 @@
 import type { QueueEntry, QueuePlan, QueueWorkItem } from "../api/queuePlan";
 import {
   normalizeBlockedReason,
+  preparationForWorkItem,
+  queueWorkItemFor,
   queueWaitCode,
   queueWaitLabel,
   resolveQueueWait,
@@ -218,16 +220,6 @@ function loraFields(
   ];
 }
 
-function workItemFor(
-  plan: QueuePlan | null | undefined,
-  jobId: string,
-): QueueWorkItem | null {
-  for (const item of plan?.work_items ?? []) {
-    if (item.parent_id === jobId || item.work_id === jobId) return item;
-  }
-  return null;
-}
-
 function laneLabel(item: QueueWorkItem): string | null {
   if (item.gpu != null) return `GPU ${item.gpu}`;
   if (item.planned_lane_kind === "host_utility") return "CPU";
@@ -368,10 +360,11 @@ export function queueEntryDetailModel(
   const { entry, hostLabel, modelLabel, nowMs } = input;
   const running = entry.state === "running";
   const held = entry.state === "held";
-  const item = workItemFor(input.plan, entry.id);
+  const item = queueWorkItemFor(input.plan, entry.id);
   const wait = resolveQueueWait({
     position: entry.position,
     blockedReason: item?.blocked_reason ?? item?.reason,
+    preparation: item ? preparationForWorkItem(item) : null,
   });
 
   const hostMetadata =

--- a/studio/lib/queuePlanPresentation.ts
+++ b/studio/lib/queuePlanPresentation.ts
@@ -8,13 +8,17 @@ export function queuePlanOnlyWork(
 ): QueueWorkItem[] {
   const excluded = new Set(excludeIds);
   return [...(plan?.work_items ?? [])]
-    .filter(
-      (item) =>
+    .filter((item) => {
+      const rawReason = item.blocked_reason ?? item.reason;
+      const reason = normalizeBlockedReason(rawReason);
+      const preparing = rawReason === "preparing";
+      return (
         !excluded.has(item.work_id) &&
         !excluded.has(item.parent_id) &&
-        item.activity_phase !== "blocked" &&
-        normalizeBlockedReason(item.blocked_reason ?? item.reason) === null,
-    )
+        (item.activity_phase !== "blocked" || preparing) &&
+        (reason === null || preparing)
+      );
+    })
     .sort(
       (a, b) =>
         a.queue_rank - b.queue_rank ||

--- a/studio/lib/queuePosition.test.ts
+++ b/studio/lib/queuePosition.test.ts
@@ -43,6 +43,55 @@ function plan(blocked: Record<string, string>): QueuePlan {
 }
 
 describe("buildQueueStatusIndex", () => {
+  it("prefers an exact batch child over an earlier parent aggregate", () => {
+    const exactPlan: QueuePlan = {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "settled",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: "job-1:sibling",
+          parent_id: "job-1",
+          work_kind: "prepared_sibling",
+          priority_class: "normal",
+          queue_rank: 0,
+          bypass_count: 0,
+          estimate_confidence: "medium",
+          blocked_reason: "model_not_installed",
+        },
+        {
+          work_id: "job-1",
+          parent_id: "batch-parent",
+          work_kind: "prepared_sibling",
+          priority_class: "normal",
+          queue_rank: 1,
+          bypass_count: 0,
+          estimate_confidence: "medium",
+          blocked_reason: "preparing",
+          preparation_progress: {
+            component: "Exact child files",
+            bytes_done: 41,
+            bytes_total: 100,
+          },
+        },
+      ],
+    };
+    const index = buildQueueStatusIndex([
+      {
+        hostId: "alpha",
+        entries: [entry("job-1", 2)],
+        plan: exactPlan,
+      },
+    ]);
+
+    expect(queueStatusFor(index, "alpha", "job-1")).toMatchObject({
+      blockedReason: "preparing",
+      preparation: { component: "Exact child files", fraction: 0.41 },
+    });
+  });
+
   it("projects a host-wide pause onto queued rows without hiding held work", () => {
     const index = buildQueueStatusIndex([
       {

--- a/studio/lib/queuePosition.ts
+++ b/studio/lib/queuePosition.ts
@@ -31,31 +31,73 @@ export interface QueuePreparation {
 }
 
 /** The plan's preparation report for a job's work item, if it carries one. */
+export function preparationForWorkItem(
+  item: QueueWorkItem,
+): QueuePreparation | null {
+  if (item.blocked_reason !== "preparing") return null;
+  const progress = item.preparation_progress ?? null;
+  const total = progress?.bytes_total ?? 0;
+  return {
+    component: progress?.component || null,
+    fraction:
+      progress && total > 0
+        ? Math.min(1, Math.max(0, progress.bytes_done / total))
+        : null,
+    elapsedMs:
+      typeof item.preparation_elapsed_ms === "number" &&
+      Number.isFinite(item.preparation_elapsed_ms)
+        ? item.preparation_elapsed_ms
+        : null,
+  };
+}
+
+/** Exact queue work for a job, falling back to a parent aggregate only after
+ * checking batch-child identity. */
+export function queueWorkItemFor(
+  plan: QueuePlan | null | undefined,
+  jobId: string,
+): QueueWorkItem | null {
+  const items = plan?.work_items ?? [];
+  return (
+    items.find((item) => item.work_id === jobId) ??
+    items.find((item) => item.parent_id === jobId) ??
+    null
+  );
+}
+
+/** Live worker copy added to queue-plan rows by current hosts. */
+export function queueRuntimeLabel(
+  plan: QueuePlan | null | undefined,
+  jobId: string,
+): string | null {
+  const item = queueWorkItemFor(plan, jobId);
+  if (!item?.runtime_phase) return null;
+  const stage =
+    item.runtime_stage?.trim() ||
+    (item.runtime_phase === "loading" ? "Loading model" : "Running");
+  if (
+    item.runtime_current != null &&
+    item.runtime_total != null &&
+    item.runtime_total > 0
+  ) {
+    return `${stage} · ${item.runtime_current}/${item.runtime_total}`;
+  }
+  return stage;
+}
+
+export function queueRuntimeCode(
+  plan: QueuePlan | null | undefined,
+  jobId: string,
+): string | null {
+  return queueRuntimeLabel(plan, jobId)?.toLocaleUpperCase() ?? null;
+}
+
 function planPreparation(
   plan: QueuePlan | null | undefined,
   jobId: string,
 ): QueuePreparation | null {
-  if (!plan) return null;
-  const items: readonly QueueWorkItem[] = plan.work_items ?? [];
-  for (const item of items) {
-    if (item.parent_id !== jobId && item.work_id !== jobId) continue;
-    if (item.blocked_reason !== "preparing") continue;
-    const progress = item.preparation_progress ?? null;
-    const total = progress?.bytes_total ?? 0;
-    return {
-      component: progress?.component || null,
-      fraction:
-        progress && total > 0
-          ? Math.min(1, Math.max(0, progress.bytes_done / total))
-          : null,
-      elapsedMs:
-        typeof item.preparation_elapsed_ms === "number" &&
-        Number.isFinite(item.preparation_elapsed_ms)
-          ? item.preparation_elapsed_ms
-          : null,
-    };
-  }
-  return null;
+  const item = queueWorkItemFor(plan, jobId);
+  return item ? preparationForWorkItem(item) : null;
 }
 
 /** "Preparing", or "Preparing · Verifying MiniMax H3 artifacts 41%". */
@@ -225,14 +267,9 @@ function planBlockedReason(
   plan: QueuePlan | null | undefined,
   jobId: string,
 ): string | null {
-  if (!plan) return null;
-  const items: readonly QueueWorkItem[] = plan.work_items ?? [];
-  for (const item of items) {
-    if (item.parent_id !== jobId && item.work_id !== jobId) continue;
-    const label = normalizeBlockedReason(item.blocked_reason ?? item.reason);
-    if (label !== null) return item.blocked_reason ?? item.reason ?? null;
-  }
-  return null;
+  const item = queueWorkItemFor(plan, jobId);
+  const reason = item?.blocked_reason ?? item?.reason;
+  return normalizeBlockedReason(reason) === null ? null : (reason ?? null);
 }
 
 /**

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -144,7 +144,9 @@ function phase(row: FleetActiveWork): string {
           <strong>{{ title(row) }}</strong>
           <span>
             {{ row.hostLabel }} · {{ phase(row) }}
-            <template v-if="progress(row) !== null"> · {{ progress(row) }}%</template>
+            <template v-if="progress(row) !== null">
+              · {{ progress(row) }}%</template
+            >
             <template v-if="row.stale">
               · Last seen active ·
               {{ row.hostError ?? "Waiting to reconnect" }}</template

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -91,6 +91,14 @@ function progress(row: FleetActiveWork): number | null {
     Math.min(100, Math.round((row.current / row.total) * 100)),
   );
 }
+
+function phase(row: FleetActiveWork): string {
+  if (row.phase === "preparing" && row.preparation_progress?.component) {
+    return `Preparing · ${row.preparation_progress.component}`;
+  }
+  if (row.stage) return row.stage;
+  return row.phase.replaceAll("_", " ");
+}
 </script>
 
 <template>
@@ -135,10 +143,8 @@ function progress(row: FleetActiveWork): number | null {
         <span class="live-activity-copy">
           <strong>{{ title(row) }}</strong>
           <span>
-            {{ row.hostLabel }} · {{ row.phase.replaceAll("_", " ") }}
-            <template v-if="progress(row) !== null">
-              · {{ progress(row) }}%</template
-            >
+            {{ row.hostLabel }} · {{ phase(row) }}
+            <template v-if="progress(row) !== null"> · {{ progress(row) }}%</template>
             <template v-if="row.stale">
               · Last seen active ·
               {{ row.hostError ?? "Waiting to reconnect" }}</template

--- a/web/src/components/machines/QueueCard.test.ts
+++ b/web/src/components/machines/QueueCard.test.ts
@@ -112,7 +112,9 @@ describe("QueueCard reorder index", () => {
     expect(wrapper.get("[data-test='queue-row']").text()).toContain(
       "Denoising · 2/4",
     );
-    expect(wrapper.get("[data-test='queue-row']").text()).not.toContain("Next up");
+    expect(wrapper.get("[data-test='queue-row']").text()).not.toContain(
+      "Next up",
+    );
   });
 
   it("exposes advertised queue controls and disables lane changes for running jobs", async () => {

--- a/web/src/components/machines/QueueCard.test.ts
+++ b/web/src/components/machines/QueueCard.test.ts
@@ -39,6 +39,82 @@ function mountCard() {
 }
 
 describe("QueueCard reorder index", () => {
+  it("shows dependency preparation component and progress on a queued row", () => {
+    const entry = listing()[1]!;
+    const wrapper = mount(QueueCard, {
+      props: {
+        entries: [entry],
+        gpuOrdinals: [0],
+        plan: {
+          plan_version: 1,
+          state_version: 1,
+          optimizer_state: "settled",
+          dirty_since_unix_ms: null,
+          next_replan_at_unix_ms: null,
+          work_items: [
+            {
+              work_id: entry.id,
+              parent_id: entry.id,
+              work_kind: "generation",
+              priority_class: "user",
+              queue_rank: 0,
+              bypass_count: 0,
+              estimate_confidence: "low",
+              blocked_reason: "preparing",
+              preparation_progress: {
+                component: "Verifying model files",
+                bytes_done: 27,
+                bytes_total: 100,
+              },
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain(
+      "Preparing · Verifying model files 27%",
+    );
+  });
+
+  it("shows runtime stage and step for a running row", () => {
+    const entry = listing()[0]!;
+    const wrapper = mount(QueueCard, {
+      props: {
+        entries: [entry],
+        gpuOrdinals: [0],
+        plan: {
+          plan_version: 1,
+          state_version: 1,
+          optimizer_state: "settled",
+          dirty_since_unix_ms: null,
+          next_replan_at_unix_ms: null,
+          work_items: [
+            {
+              work_id: entry.id,
+              parent_id: entry.id,
+              work_kind: "generation",
+              priority_class: "user",
+              queue_rank: 0,
+              bypass_count: 0,
+              estimate_confidence: "low",
+              activity_phase: "active",
+              runtime_phase: "running",
+              runtime_stage: "Denoising",
+              runtime_current: 2,
+              runtime_total: 4,
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.get("[data-test='queue-row']").text()).toContain(
+      "Denoising · 2/4",
+    );
+    expect(wrapper.get("[data-test='queue-row']").text()).not.toContain("Next up");
+  });
+
   it("exposes advertised queue controls and disables lane changes for running jobs", async () => {
     const wrapper = mount(QueueCard, {
       props: {

--- a/web/src/components/machines/QueueCard.vue
+++ b/web/src/components/machines/QueueCard.vue
@@ -17,7 +17,13 @@ import { modelDisplayNameForId } from "@studio/lib/modelDisplay";
 import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import type { QueuePlan } from "@studio/api/queuePlan";
 import { queuePlanOnlyWork } from "@studio/lib/queuePlanPresentation";
-import { queueWaitLabel, resolveQueueWait } from "@studio/lib/queuePosition";
+import {
+  buildQueueStatusIndex,
+  queueRuntimeLabel,
+  queueStatusFor,
+  queueWaitLabel,
+  resolveQueueWait,
+} from "@studio/lib/queuePosition";
 import { compareNewestQueueEntry } from "@studio/lib/activityOrder";
 
 const props = withDefaults(
@@ -81,6 +87,16 @@ const visibleWorkCount = computed(
   () =>
     props.entries.length + queuePlanOnlyWork(props.plan, entryIds.value).length,
 );
+const queueStatus = computed(() =>
+  buildQueueStatusIndex([
+    {
+      hostId: "host",
+      entries: props.entries,
+      plan: props.plan,
+      paused: props.paused,
+    },
+  ]),
+);
 
 function laneValue(entry: QueueEntry): string {
   const lane = entry.target_gpu ?? null;
@@ -88,13 +104,16 @@ function laneValue(entry: QueueEntry): string {
 }
 
 function entryStateLabel(entry: QueueEntry): string {
+  if (entry.state === "running") {
+    return queueRuntimeLabel(props.plan, entry.id) ?? "Running";
+  }
   return queueWaitLabel(
-    resolveQueueWait({
-      state: entry.state,
-      position: entry.position,
-      blockedReason:
-        props.paused && entry.state === "queued" ? "queue_paused" : null,
-    }),
+    resolveQueueWait(
+      queueStatusFor(queueStatus.value, "host", entry.id) ?? {
+        state: entry.state,
+        position: entry.position,
+      },
+    ),
   );
 }
 

--- a/web/src/lib/durableGenerationPresentation.test.ts
+++ b/web/src/lib/durableGenerationPresentation.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { applyDurablePresentation } from "./durableGenerationPresentation";
+
+function job() {
+  return {
+    state: "running",
+    settledAt: null,
+    cancelling: false,
+    cancelRequested: false,
+    previewUrl: null,
+    holdError: null,
+    holdCode: null,
+    retryable: false,
+    retrying: false,
+    workStarted: true,
+    progress: { stage: "Loading model", queuePosition: null },
+  };
+}
+
+describe("web durable generation presentation", () => {
+  it("keeps the host's running sub-stage across lifecycle reconciliation", () => {
+    const current = job();
+
+    applyDurablePresentation(
+      current as never,
+      { kind: "running", label: "Developing" },
+      1,
+    );
+
+    expect(current.progress.stage).toBe("Loading model");
+  });
+});

--- a/web/src/lib/durableGenerationPresentation.ts
+++ b/web/src/lib/durableGenerationPresentation.ts
@@ -52,7 +52,7 @@ export function applyDurablePresentation(
       return;
     case "running":
       // A retry can move a held child straight to running; the hold is over.
-      job.progress.stage = p.label;
+      if (!job.workStarted || !job.progress.stage) job.progress.stage = p.label;
       job.workStarted = true;
       job.progress.queuePosition = null;
       clearHold(job);


### PR DESCRIPTION
## Summary
- publish throttled preparation progress while model dependencies are verified and warmed
- distinguish queued, preparing, loading, running, and finalizing work across desktop, web, mobile, CLI, TUI, Discord, and MCP surfaces
- preserve secure artifact digest attestation and cover batch-child, restart/recovery, model-loading, and scheduler-owned work semantics

## Root cause
The scheduler held generation work in preparation while computing model equivalence and verifying artifacts, but that state was not published as live queue authority. Clients therefore retained the admission-time `queued` label. After dispatch, server-owned clients also lacked the worker stage needed to distinguish model loading from denoising.

## Validation
- `nix develop -c cargo clippy --workspace --all-targets -- -D warnings`
- `nix develop -c cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4`
- focused Rust scheduler/activity/equivalence regressions
- Studio, web, and desktop frontend suites (isolated environment-sensitive reruns green)
- web and desktop production builds
- `bash scripts/release/check-changelog-fragments.sh 154a8cb79ea9d93d2a7ec6942f3bdd1e18f10fc7 220a19cc814ca4b4af4e6e6962534752c4e0e1b4`
- `nix flake check`

## Review
- plan peer review completed before implementation
- implementation peer review completed after implementation; all P0-P2 findings addressed and final review clean
