### PR TITLE
fix(desktop): optimize library source picker

### DIFF
--- a/changelog.d/desktop-library-picker-performance.md
+++ b/changelog.d/desktop-library-picker-performance.md
@@ -1,0 +1,1 @@
+- **Faster, image-only desktop library picker.** Choosing a source image from a large Library now renders only the visible rows, reuses the Library's persistent prioritized thumbnail cache, and excludes gallery rows whose metadata identifies them as video even when their stored filename looks like an image.

--- a/desktop/docs/feature-parity.md
+++ b/desktop/docs/feature-parity.md
@@ -201,6 +201,8 @@ and clears terminal, error, null-id, removed-host, and unmount state for retry.
 
 ## 4. Gallery / media management
 
+The desktop **Choose from gallery…** square grid follows the Library's performance contract: it virtualizes to visible rows plus overscan, keeps off-screen rows keyboard-reachable, and passes each print's media-version identity and visible/near priority into the shared persistent thumbnail path. Its image-only filter requires the stored filename and gallery metadata to agree on PNG/JPEG, so a mislabelled video cannot be attached to an image input.
+
 - **Browse** (web `LibraryPage.vue` + `gallery/GalleryGrid.vue`, `GET /api/gallery`): returns `GalleryImage[]` = `{filename, metadata (OutputMetadata), timestamp, format, size_bytes, metadata_synthetic, media_version}` — `media_version` is the key every persistent thumbnail cache is keyed on, plus the organization fields below.
 - **Image/thumbnail** URLs: `GET /api/gallery/image/:filename`, `/api/gallery/preview/:filename`, thumbnail endpoint.
 - **Delete**: `DELETE /api/gallery/image/:filename` — always enabled (`capabilities.gallery.can_delete: true`); pair with `MOLD_API_KEY` if exposed. On current servers it moves the print to the host's trash (`<output_dir>/.trash/` + `generations.trashed_at_ms` + tombstone); `?permanent=true` hard-deletes as before.

--- a/desktop/src/components/generate/ImagePickerModal.test.ts
+++ b/desktop/src/components/generate/ImagePickerModal.test.ts
@@ -138,6 +138,134 @@ describe("ImagePickerModal", () => {
     expect(wrapper.emitted("close")).toBeTruthy();
   });
 
+  it("excludes video rows even when their stored filename looks like an image", async () => {
+    const gallery = seedTwoHostGallery();
+    gallery.buckets.local = loadedBucket([
+      img("still.png", 4),
+      { ...img("mislabelled.png", 3), format: "mp4" },
+      {
+        ...img("legacy-video.png", 2),
+        metadata: { ...meta, video_frames: 25 },
+      },
+      {
+        ...img("current-video.png", 1),
+        format: null,
+        metadata: { ...meta, frames: 97 },
+      },
+    ]);
+    gallery.buckets["hal9000-7680"] = loadedBucket([]);
+
+    mount(ImagePickerModal, {
+      props: { open: true, galleryOnly: true },
+      global: { plugins: [pinia] },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const labels = Array.from(
+      document.body.querySelectorAll("[data-test='picker-gallery-item']"),
+    ).map((tile) => tile.getAttribute("aria-label"));
+    expect(labels).toEqual(["still.png"]);
+  });
+
+  it("keeps a 2,000-print library bounded to the visible picker rows", async () => {
+    const gallery = seedTwoHostGallery();
+    gallery.buckets.local = loadedBucket(
+      Array.from({ length: 2_000 }, (_, index) => ({
+        ...img(`print-${index}.png`, 2_000 - index),
+        size_bytes: 100_000 + index,
+      })),
+    );
+    gallery.buckets["hal9000-7680"] = loadedBucket([]);
+
+    const wrapper = mount(ImagePickerModal, {
+      props: { open: true, galleryOnly: true, multiple: true },
+      global: { plugins: [pinia] },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const tiles = document.body.querySelectorAll("[data-test='picker-gallery-item']");
+    expect(tiles.length).toBeGreaterThan(0);
+    expect(tiles.length).toBeLessThanOrEqual(80);
+
+    const media = wrapper.findAllComponents({ name: "AuthedMedia" });
+    expect(media.length).toBe(tiles.length);
+    expect(media.every((component) => component.props("mediaVersion") != null)).toBe(true);
+
+    const firstBeforeScroll = tiles[0]!.getAttribute("aria-label");
+    const scroller = bodyGet<HTMLElement>("[data-test='picker-gallery-scroll']");
+    scroller.element.scrollTop = 10_000;
+    await scroller.trigger("scroll");
+    await nextTick();
+
+    const scrolledTiles = document.body.querySelectorAll("[data-test='picker-gallery-item']");
+    expect(scrolledTiles.length).toBeLessThanOrEqual(80);
+    expect(scrolledTiles[0]!.getAttribute("aria-label")).not.toBe(firstBeforeScroll);
+    await new DOMWrapper(scrolledTiles[0] as HTMLElement).trigger("click");
+    expect(scrolledTiles[0]!.getAttribute("aria-pressed")).toBe("true");
+  });
+
+  it("moves keyboard focus to and selects an item outside the mounted window", async () => {
+    const gallery = seedTwoHostGallery();
+    gallery.buckets.local = loadedBucket(
+      Array.from({ length: 2_000 }, (_, index) => img(`print-${index}.png`, 2_000 - index)),
+    );
+    gallery.buckets["hal9000-7680"] = loadedBucket([]);
+
+    const wrapper = mount(ImagePickerModal, {
+      props: { open: true, galleryOnly: true },
+      global: { plugins: [pinia] },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    await nextTick();
+
+    const first = bodyGet<HTMLButtonElement>("[data-test='picker-gallery-item']");
+    first.element.focus();
+    await first.trigger("keydown", { key: "End" });
+    await nextTick();
+
+    const last = bodyGet<HTMLButtonElement>("[aria-label='print-1999.png']");
+    expect(document.activeElement).toBe(last.element);
+    await last.trigger("keydown", { key: "Enter" });
+    await vi.waitFor(() => expect(wrapper.emitted("pick")).toBeTruthy());
+    const picked = wrapper.emitted("pick")?.[0]?.[0] as Array<{ filename: string }>;
+    expect(picked[0]!.filename).toBe("print-1999.png");
+  });
+
+  it("keeps a shortened gallery visible after the prior list was deeply scrolled", async () => {
+    const gallery = seedTwoHostGallery();
+    gallery.buckets.local = loadedBucket(
+      Array.from({ length: 2_000 }, (_, index) => img(`print-${index}.png`, 2_000 - index)),
+    );
+    gallery.buckets["hal9000-7680"] = loadedBucket([]);
+
+    mount(ImagePickerModal, {
+      props: { open: true, galleryOnly: true },
+      global: { plugins: [pinia] },
+      attachTo: document.body,
+    });
+    await flushPromises();
+    const scroller = bodyGet<HTMLElement>("[data-test='picker-gallery-scroll']");
+    scroller.element.scrollTop = 10_000;
+    await scroller.trigger("scroll");
+    await nextTick();
+
+    gallery.buckets.local!.items = Array.from({ length: 10 }, (_, index) =>
+      img(`short-${index}.png`, 10 - index),
+    );
+    await nextTick();
+
+    const labels = Array.from(
+      document.body.querySelectorAll("[data-test='picker-gallery-item']"),
+    ).map((tile) => tile.getAttribute("aria-label"));
+    expect(labels).toHaveLength(10);
+    expect(labels[0]).toBe("short-0.png");
+  });
+
   it("keeps multi-host gallery picks in the order selected until confirmation", async () => {
     apiFetchTo.mockImplementation(() =>
       Promise.resolve(

--- a/desktop/src/components/generate/ImagePickerModal.vue
+++ b/desktop/src/components/generate/ImagePickerModal.vue
@@ -3,10 +3,12 @@ import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue"
 import AuthedMedia from "../gallery/AuthedMedia.vue";
 import { galleryMediaPath } from "../../lib/gallery/media";
 import { readGalleryMediaBase64 } from "../../lib/gallery/sourceMedia";
-import { fileToBase64, isStillImageFile } from "../../lib/image";
+import { fileToBase64, isStillImageFile, isStillImageGalleryItem } from "../../lib/image";
 import { inTauri, ipc } from "../../lib/ipc";
 import type { PickedImage } from "../../lib/generateForm";
 import { useGalleryStore, type MergedPrint } from "../../stores/gallery";
+import { virtualGridWindow } from "@studio/lib/virtualGrid";
+import type { ThumbnailPriority } from "@studio/lib/thumbnailScheduler";
 
 const props = withDefaults(
   defineProps<{
@@ -37,7 +39,9 @@ const closeBtn = ref<HTMLButtonElement | null>(null);
 const fallbackFileInput = ref<HTMLInputElement | null>(null);
 const selectedGallery = ref<MergedPrint[]>([]);
 const pickingGallery = ref(false);
+const galleryScrollEl = ref<HTMLElement | null>(null);
 let restoreFocusEl: HTMLElement | null = null;
+let galleryResizeObserver: ResizeObserver | null = null;
 
 // The gallery tab is the same unified multi-host view as the Gallery's All
 // section: every connected host's bucket, merged and deduped by the store.
@@ -57,7 +61,7 @@ function loadGallery() {
 // Only PNG/JPEG are valid as source_image / mask / keyframe conditioning;
 // hide video and animated outputs so a pick can't fail at generation time.
 const entries = computed<MergedPrint[]>(() =>
-  gallery.merged.filter((entry) => isStillImageFile(entry.item.filename)),
+  gallery.merged.filter((entry) => isStillImageGalleryItem(entry.item)),
 );
 const loading = computed(() => entries.value.length === 0 && !gallery.loaded);
 /** Bucket fetch failures, shown only when there is nothing to render —
@@ -67,6 +71,199 @@ const galleryError = computed(() =>
 );
 /** Per-tile origin labels only matter with more than one gallery source. */
 const showHostLabels = computed(() => gallery.sources.length > 1);
+
+// The full Library virtualizes its justified rows. This picker uses a simpler
+// square grid, but it must keep the same bounded-DOM contract: mounting every
+// AuthedMedia at once queues every thumbnail, decodes off-screen images, and
+// makes opening/scrolling increasingly expensive as the Library grows.
+const PICKER_GRID_GAP = 8;
+const PICKER_GRID_FALLBACK_WIDTH = 720;
+const PICKER_GRID_FALLBACK_HEIGHT = 600;
+const galleryViewport = ref({
+  width: PICKER_GRID_FALLBACK_WIDTH,
+  height: PICKER_GRID_FALLBACK_HEIGHT,
+  scrollTop: 0,
+});
+const focusedGalleryIndex = ref(0);
+
+function syncGalleryViewport() {
+  const element = galleryScrollEl.value;
+  if (!element) return;
+  galleryViewport.value = {
+    width: element.clientWidth || PICKER_GRID_FALLBACK_WIDTH,
+    height: element.clientHeight || PICKER_GRID_FALLBACK_HEIGHT,
+    scrollTop: element.scrollTop,
+  };
+}
+
+function bindGalleryViewport() {
+  galleryResizeObserver?.disconnect();
+  galleryResizeObserver = null;
+  void nextTick(() => {
+    const element = galleryScrollEl.value;
+    if (!element) return;
+    syncGalleryViewport();
+    if (typeof ResizeObserver !== "undefined") {
+      galleryResizeObserver = new ResizeObserver(syncGalleryViewport);
+      galleryResizeObserver.observe(element);
+    }
+  });
+}
+
+const pickerLayout = computed(() =>
+  virtualGridWindow({
+    itemCount: entries.value.length,
+    containerWidth: galleryViewport.value.width,
+    minimumItemWidth: 120,
+    minimumColumns: 3,
+    maximumColumns: 5,
+    gap: PICKER_GRID_GAP,
+    viewportStart: 0,
+    viewportSize: 0,
+    overscanRows: 0,
+  }),
+);
+const clampedGalleryScrollTop = computed(() =>
+  Math.min(
+    galleryViewport.value.scrollTop,
+    Math.max(0, pickerLayout.value.totalSize - galleryViewport.value.height),
+  ),
+);
+const pickerGrid = computed(() =>
+  virtualGridWindow({
+    itemCount: entries.value.length,
+    containerWidth: galleryViewport.value.width,
+    minimumItemWidth: 120,
+    minimumColumns: 3,
+    maximumColumns: 5,
+    gap: PICKER_GRID_GAP,
+    viewportStart: clampedGalleryScrollTop.value,
+    viewportSize: galleryViewport.value.height,
+    overscanRows: 2,
+  }),
+);
+const pickerVisibleGrid = computed(() =>
+  virtualGridWindow({
+    itemCount: entries.value.length,
+    containerWidth: galleryViewport.value.width,
+    minimumItemWidth: 120,
+    minimumColumns: 3,
+    maximumColumns: 5,
+    gap: PICKER_GRID_GAP,
+    viewportStart: clampedGalleryScrollTop.value,
+    viewportSize: galleryViewport.value.height,
+    overscanRows: 0,
+  }),
+);
+const galleryTabStopIndex = computed(() => {
+  const window = pickerGrid.value;
+  return focusedGalleryIndex.value >= window.startIndex &&
+    focusedGalleryIndex.value < window.endIndex
+    ? focusedGalleryIndex.value
+    : window.startIndex;
+});
+
+interface PickerTile {
+  entry: MergedPrint;
+  index: number;
+  x: number;
+  y: number;
+  priority: ThumbnailPriority;
+  mediaVersion: string;
+}
+
+const visibleEntries = computed<PickerTile[]>(() => {
+  const window = pickerGrid.value;
+  const visible = pickerVisibleGrid.value;
+  return entries.value.slice(window.startIndex, window.endIndex).map((entry, offset) => {
+    const index = window.startIndex + offset;
+    const row = Math.floor(index / window.columns);
+    return {
+      entry,
+      index,
+      x: (index % window.columns) * window.rowStep,
+      y: row * window.rowStep,
+      priority:
+        row >= visible.startRow && row < visible.endRow ? ("visible" as const) : ("near" as const),
+      mediaVersion:
+        entry.item.media_version ?? `${entry.item.timestamp}:${entry.item.size_bytes ?? "unknown"}`,
+    };
+  });
+});
+
+async function focusGalleryIndex(index: number) {
+  if (entries.value.length === 0) return;
+  const target = Math.max(0, Math.min(entries.value.length - 1, index));
+  focusedGalleryIndex.value = target;
+
+  const element = galleryScrollEl.value;
+  if (element) {
+    const layout = pickerLayout.value;
+    const row = Math.floor(target / layout.columns);
+    const top = row * layout.rowStep;
+    const bottom = top + layout.itemSize;
+    const viewportTop = clampedGalleryScrollTop.value;
+    const viewportBottom = viewportTop + galleryViewport.value.height;
+    if (top < viewportTop) element.scrollTop = top;
+    else if (bottom > viewportBottom) {
+      element.scrollTop = Math.max(0, bottom - galleryViewport.value.height);
+    }
+    syncGalleryViewport();
+  }
+
+  await nextTick();
+  document.querySelector<HTMLButtonElement>(`[data-picker-index="${target}"]`)?.focus();
+}
+
+function onGalleryItemKeydown(event: KeyboardEvent, index: number) {
+  if (event.key === "Enter" || event.key === " ") {
+    event.preventDefault();
+    const entry = entries.value[index];
+    if (entry) void pickFromGallery(entry);
+    return;
+  }
+
+  const columns = pickerLayout.value.columns;
+  const pageRows = Math.max(
+    1,
+    Math.floor(galleryViewport.value.height / pickerLayout.value.rowStep),
+  );
+  const moves: Partial<Record<string, number>> = {
+    ArrowLeft: index - 1,
+    ArrowRight: index + 1,
+    ArrowUp: index - columns,
+    ArrowDown: index + columns,
+    PageUp: index - pageRows * columns,
+    PageDown: index + pageRows * columns,
+    Home: 0,
+    End: entries.value.length - 1,
+  };
+  const target = moves[event.key];
+  if (target === undefined) return;
+  event.preventDefault();
+  void focusGalleryIndex(target);
+}
+
+watch(
+  [
+    () => entries.value.length,
+    () => pickerLayout.value.totalSize,
+    () => galleryViewport.value.height,
+  ],
+  () => {
+    focusedGalleryIndex.value = Math.min(
+      focusedGalleryIndex.value,
+      Math.max(0, entries.value.length - 1),
+    );
+    void nextTick(() => {
+      const element = galleryScrollEl.value;
+      if (!element) return;
+      const clamped = clampedGalleryScrollTop.value;
+      if (element.scrollTop !== clamped) element.scrollTop = clamped;
+      if (galleryViewport.value.scrollTop !== clamped) syncGalleryViewport();
+    });
+  },
+);
 
 // Escape must close the dialog wherever focus sits: WKWebView (Tauri on
 // macOS) does not focus clicked buttons, so a keydown handler scoped to the
@@ -81,6 +278,7 @@ onMounted(() => {
 });
 onBeforeUnmount(() => {
   document.removeEventListener("keydown", onDocumentKeydown);
+  galleryResizeObserver?.disconnect();
 });
 watch(
   () => props.open,
@@ -95,6 +293,9 @@ watch(
     }
   },
 );
+watch([() => props.open, tab], ([open, activeTab]) => {
+  if (open && activeTab === "gallery") bindGalleryViewport();
+});
 
 async function ingestFiles(files: File[]) {
   // Same constraint as the gallery tab: the engine only accepts PNG/JPEG for
@@ -279,7 +480,13 @@ async function emitGallerySelection(entries: readonly MergedPrint[]) {
           </p>
         </div>
 
-        <div v-else class="mt-4 flex-1 overflow-y-auto">
+        <div
+          v-else
+          ref="galleryScrollEl"
+          class="mt-4 flex-1 overflow-y-auto"
+          data-test="picker-gallery-scroll"
+          @scroll.passive="syncGalleryViewport"
+        >
           <p v-if="loading" class="text-caption text-ink-3">Loading…</p>
           <p v-else-if="error" class="text-caption text-stop">{{ error }}</p>
           <p
@@ -292,51 +499,71 @@ async function emitGallerySelection(entries: readonly MergedPrint[]) {
           <p v-else-if="entries.length === 0" class="text-caption text-ink-3">
             No prints in the gallery yet.
           </p>
-          <ul v-else class="grid grid-cols-3 gap-2 sm:grid-cols-5">
-            <li v-for="entry in entries" :key="`${entry.sourceKey}:${entry.item.filename}`">
+          <ul
+            v-else
+            class="relative"
+            :style="{ height: `${pickerGrid.totalSize}px` }"
+            data-test="picker-gallery-grid"
+          >
+            <li
+              v-for="tile in visibleEntries"
+              :key="`${tile.entry.sourceKey}:${tile.entry.item.filename}`"
+              class="absolute top-0 left-0"
+              :style="{
+                width: `${pickerGrid.itemSize}px`,
+                height: `${pickerGrid.itemSize}px`,
+                transform: `translate(${tile.x}px, ${tile.y}px)`,
+              }"
+            >
               <button
                 type="button"
                 class="border-edge relative aspect-square w-full overflow-hidden rounded-media border transition hover:brightness-110"
                 :class="
-                  galleryEntrySelected(entry)
+                  galleryEntrySelected(tile.entry)
                     ? 'ring-2 ring-safelight ring-offset-2 ring-offset-bench'
                     : ''
                 "
                 data-test="picker-gallery-item"
-                :aria-label="entry.item.filename"
+                :data-picker-index="tile.index"
+                :aria-label="tile.entry.item.filename"
                 :disabled="pickingGallery"
-                :aria-pressed="multiple ? galleryEntrySelected(entry) : undefined"
-                @click="pickFromGallery(entry)"
+                :tabindex="tile.index === galleryTabStopIndex ? 0 : -1"
+                :aria-pressed="multiple ? galleryEntrySelected(tile.entry) : undefined"
+                @click="pickFromGallery(tile.entry)"
+                @focus="focusedGalleryIndex = tile.index"
+                @keydown="onGalleryItemKeydown($event, tile.index)"
               >
                 <AuthedMedia
                   :path="
                     galleryMediaPath(
-                      entry.item.filename,
-                      gallery.mediaSourceOf(entry.sourceKey),
+                      tile.entry.item.filename,
+                      gallery.mediaSourceOf(tile.entry.sourceKey),
                       true,
                     )
                   "
-                  :target="gallery.targetOf(entry.sourceKey)"
-                  :cache-key="entry.sourceKey"
-                  :alt="entry.item.filename"
+                  :target="gallery.targetOf(tile.entry.sourceKey)"
+                  :cache-key="tile.entry.sourceKey"
+                  :media-version="tile.mediaVersion"
+                  :priority="tile.priority"
+                  :alt="tile.entry.item.filename"
                 />
                 <span
                   v-if="showHostLabels"
                   class="edge-code absolute bottom-1 left-1 rounded-control bg-black/60 px-1 !text-on-media"
                   data-test="picker-item-host"
                 >
-                  {{ entry.hostLabel }}
+                  {{ tile.entry.hostLabel }}
                 </span>
                 <span
-                  v-if="multiple && galleryEntrySelected(entry)"
+                  v-if="multiple && galleryEntrySelected(tile.entry)"
                   class="absolute top-1 right-1 grid h-6 w-6 place-items-center rounded-full bg-safelight text-caption font-bold text-on-accent"
                   aria-hidden="true"
                 >
                   {{
                     selectedGallery.findIndex(
                       (selected) =>
-                        selected.sourceKey === entry.sourceKey &&
-                        selected.item.filename === entry.item.filename,
+                        selected.sourceKey === tile.entry.sourceKey &&
+                        selected.item.filename === tile.entry.item.filename,
                     ) + 1
                   }}
                 </span>

--- a/desktop/src/lib/image.test.ts
+++ b/desktop/src/lib/image.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isStillImageFile } from "./image";
+import { isStillImageFile, isStillImageGalleryItem } from "./image";
 
 describe("isStillImageFile", () => {
   it("accepts PNG and JPEG regardless of case", () => {
@@ -18,5 +18,38 @@ describe("isStillImageFile", () => {
     expect(isStillImageFile("a.mp4.png")).toBe(true);
     expect(isStillImageFile("a.png.mp4")).toBe(false);
     expect(isStillImageFile("  spaced.jpg  ")).toBe(true);
+  });
+});
+
+describe("isStillImageGalleryItem", () => {
+  const metadata = {
+    prompt: "",
+    model: "m",
+    seed: 1,
+    steps: 4,
+    guidance: 3,
+    width: 8,
+    height: 8,
+  };
+
+  it("requires both the filename and metadata to describe a still image", () => {
+    expect(isStillImageGalleryItem({ filename: "still.png", format: "png", metadata })).toBe(true);
+    expect(isStillImageGalleryItem({ filename: "mislabelled.png", format: "mp4", metadata })).toBe(
+      false,
+    );
+    expect(
+      isStillImageGalleryItem({
+        filename: "legacy-video.png",
+        format: null,
+        metadata: { ...metadata, video_frames: 25 },
+      }),
+    ).toBe(false);
+    expect(
+      isStillImageGalleryItem({
+        filename: "current-video.png",
+        format: null,
+        metadata: { ...metadata, frames: 97 },
+      }),
+    ).toBe(false);
   });
 });

--- a/desktop/src/lib/image.ts
+++ b/desktop/src/lib/image.ts
@@ -1,4 +1,5 @@
 import { blobToBase64 } from "@studio/lib/base64";
+import type { GalleryImage } from "./api/types";
 
 export { blobToBase64 };
 
@@ -28,4 +29,19 @@ export function base64ToDataUrl(b64: string, mime = "image/png"): string {
  */
 export function isStillImageFile(filename: string): boolean {
   return /\.(png|jpe?g)$/i.test(filename.trim());
+}
+
+/**
+ * Gallery metadata is an independent authority from the stored filename.
+ * Require both to describe a still image so a legacy/mislabelled video row
+ * cannot enter an image-only source picker merely because its poster or
+ * filename ends in `.png`.
+ */
+export function isStillImageGalleryItem(
+  item: Pick<GalleryImage, "filename" | "format" | "metadata">,
+): boolean {
+  if (!isStillImageFile(item.filename)) return false;
+  const format = item.format?.toLowerCase();
+  if (format && format !== "png" && format !== "jpeg") return false;
+  return !item.metadata.frames && !item.metadata.video_frames;
 }


### PR DESCRIPTION
## Summary

- virtualize the desktop Choose from gallery picker so large libraries mount only visible and overscan rows
- reuse Library thumbnail media-version identity and visible/near scheduling priorities
- keep the virtualized grid keyboard reachable and clamp stale deep-scroll positions when the library shrinks
- reject gallery rows identified as video by format, canonical frames metadata, or legacy video_frames metadata from image-only source inputs

## Verification

- 5,468 desktop tests passed
- desktop production build passed
- frontend architecture check passed
- focused picker/image tests: 25 passed
- Prettier and git diff checks passed
- changelog fragment policy passed
- native macOS UAT: large multi-host gallery opened and scrolled smoothly; Tab + End reached an off-window item and Return attached it
- independent agent peer review approved the final exact diff with no actionable findings