### PR TITLE
fix(ui): keep LTX audio controls visible

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -150,7 +150,9 @@ jobs:
           key: tauri-cli-${{ runner.os }}-${{ runner.arch }}-2.11.4
       - name: Install Tauri CLI
         if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
-        run: cargo install tauri-cli --version 2.11.4 --locked
+        # rust-cache can restore cargo-tauri even when the dedicated binary
+        # cache misses. Keep this fallback idempotent across both cache layers.
+        run: cargo install tauri-cli --version 2.11.4 --locked --force
       - name: Verify Tauri CLI
         run: cargo tauri --version | grep -F '2.11.4'
       - name: Install frontend dependencies

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -149,9 +149,11 @@ pushed screen opened from the header.
   to the selected model's defaults while preserving the prompt, model choice,
   and any prepared batch size; the Advanced sheet keeps its narrower
   advanced-only Reset.
-  For LTX-2 checkpoints, the sheet honors additive `supports_audio` model
-  metadata: video-only community checkpoints disable generated audio with an
-  explanation while source-image video remains available. It also exposes the
+  For LTX-2 checkpoints, the primary Create settings honor additive
+  `supports_audio` model metadata and the resolved recipe: audio-capable host
+  recipes expose generated audio, while video-only checkpoints or hosts that
+  cannot deliver audio keep that control visible but disabled with the exact
+  available explanation. The Advanced sheet also exposes the
   additive `guidance_overrides` contract (STG scale/blocks, CFG rescale,
   modality scale, and skip stride), validates before queueing, counts the group
   in its badge, and keeps empty fields absent so pipeline defaults remain exact.

--- a/changelog.d/mobile-ltx-audio-controls.md
+++ b/changelog.d/mobile-ltx-audio-controls.md
@@ -1,0 +1,1 @@
+- **Keep LTX audio controls visible on mobile.** LTX-2 and LTX-2.5 checkpoints now keep the Generate audio control and advanced video settings visible when checkpoint metadata or the active host recipe reports that audio cannot be delivered; the control is disabled with the available explanation instead of disappearing, while non-configurable audio families remain unchanged.

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -208,6 +208,44 @@ describe("InspectorPanel — layout", () => {
     expect(form.frames).toBe(241);
   });
 
+  it("keeps the audio control visible for a video-only LTX-2.5 checkpoint", () => {
+    const model = noteModel(
+      "ltx-2.5-22b-distilled:q4",
+      "ltx2",
+      { default: 8, min: 8, max: 8, step: 1, mode: "fixed" },
+      { default: 1, min: 1, max: 1, step: 0.1, mode: "fixed" },
+    );
+    model.supports_audio = false;
+    useModelStore().all = [model];
+    const form = formFor("ltx2");
+    form.model = model.name;
+
+    const wrapper = mount(InspectorPanel, { props: { form } });
+
+    expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(true);
+    expect(wrapper.getComponent(SwitchToggle).props("disabled")).toBe(true);
+    expect(wrapper.text()).toContain("Audio assets are not included with this checkpoint");
+  });
+
+  it("keeps LTX-2.5 audio visible when the host recipe cannot deliver it", () => {
+    const model = noteModel(
+      "ltx-2.5-22b-distilled:q4",
+      "ltx2",
+      { default: 8, min: 8, max: 8, step: 1, mode: "fixed" },
+      { default: 1, min: 1, max: 1, step: 0.1, mode: "fixed" },
+    );
+    model.supports_audio = true;
+    useModelStore().all = [model];
+    const form = formFor("ltx2");
+    form.model = model.name;
+
+    const wrapper = mount(InspectorPanel, { props: { form } });
+
+    expect(wrapper.find('[data-test="generate-audio-control"]').exists()).toBe(true);
+    expect(wrapper.getComponent(SwitchToggle).props("disabled")).toBe(true);
+    expect(wrapper.text()).toContain("Generated audio is unavailable for this recipe");
+  });
+
   it("does not expose the audio toggle for an H3 model restored without a family", () => {
     const form = formFor("");
     form.model = "minimax-h3-fl2va:official-bf16";

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -10,7 +10,6 @@ import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import BadgePill from "@ui/components/BadgePill.vue";
 import Icon from "@ui/components/Icon.vue";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
-import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
 import { defaultClipFrames, modelsForOutput, sequenceMotionTailFrames } from "@studio/lib/sequence";
 import { filterRestrictedModels } from "@studio/lib/modelAccess";
 import {
@@ -269,15 +268,27 @@ const advancedCount = computed(() =>
       ) + Number(Boolean(draft.clips.some((clip) => clip.cameraControl)))
     : advancedActiveCount(props.form),
 );
-const showGenerateAudio = computed(() =>
-  isSequence.value
-    ? props.chainLimits?.supports_audio === true
-    : caps.value.supportsAudio && !isMinimaxH3Identity(props.form.family, props.form.model),
-);
+const showGenerateAudio = computed(() => caps.value.offersAudioControl);
 const generateAudio = computed(() =>
   isSequence.value ? draft.enableAudio : props.form.enableAudio,
 );
-const audioOutputSupported = computed(() => selectedModel.value?.supports_audio !== false);
+const audioOutputSupported = computed(() =>
+  isSequence.value
+    ? props.chainLimits?.supports_audio === true
+    : caps.value.supportsAudio && selectedModel.value?.supports_audio !== false,
+);
+const audioOutputUnavailableReason = computed(() => {
+  if (!showGenerateAudio.value || audioOutputSupported.value) return null;
+  if (isSequence.value) {
+    return props.chainLimits?.supports_audio === false
+      ? "Generated audio is unavailable for this sequence on the selected host."
+      : null;
+  }
+  if (selectedModel.value?.supports_audio === false) {
+    return "Audio assets are not included with this checkpoint. Video generation remains available.";
+  }
+  return caps.value.outputDeliveryReason ?? "Generated audio is unavailable for this recipe.";
+});
 function setGenerateAudio(value: boolean) {
   if (isSequence.value) draft.enableAudio = value;
   else props.form.enableAudio = value;
@@ -885,16 +896,13 @@ function resetSettings() {
         <span class="ms-field__label ms-field__label--inline">Generate audio</span>
         <SwitchToggle
           :model-value="generateAudio"
-          :disabled="!isSequence && !audioOutputSupported"
+          :disabled="!audioOutputSupported"
           label="Generate audio"
           @update:model-value="setGenerateAudio"
         />
       </div>
-      <p
-        v-if="showGenerateAudio && !isSequence && !audioOutputSupported"
-        class="ms-field__hint -mt-2"
-      >
-        Audio assets are not included with this checkpoint. Video generation remains available.
+      <p v-if="audioOutputUnavailableReason" class="ms-field__hint -mt-2">
+        {{ audioOutputUnavailableReason }}
       </p>
 
       <!-- Seed -->

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -7674,6 +7674,28 @@ describe("MobileApp create settings reset", () => {
     expect(liveForm.enableAudio).toBe(true);
   });
 
+  it("keeps LTX-2.5 audio visible and disabled for a video-only checkpoint", async () => {
+    const base = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/models") {
+        return Promise.resolve([
+          {
+            ...model,
+            name: "ltx-2.5-22b-distilled:q4",
+            supports_audio: false,
+          },
+        ]);
+      }
+      return base(callTarget, path, init);
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+
+    const control = wrapper.get("[data-test='mobile-generate-audio-control']");
+    expect(control.get("input").attributes()).toHaveProperty("disabled");
+    expect(wrapper.text()).toContain("Audio assets are not included with this checkpoint");
+  });
+
   it("keeps the visible source across an H3 round trip via the shared bridge", async () => {
     wrapper = mountMobileApp();
     await flushPromises();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -1539,6 +1539,16 @@ const caps = computed(() =>
     effectiveGenerationRecipe(selectedGenerationModel.value, form.pipeline),
   ),
 );
+const generatedAudioSupported = computed(
+  () => caps.value.supportsAudio && selectedGenerationModel.value?.supports_audio !== false,
+);
+const generatedAudioUnavailableReason = computed(() => {
+  if (!caps.value.offersAudioControl || generatedAudioSupported.value) return null;
+  if (selectedGenerationModel.value?.supports_audio === false) {
+    return "Audio assets are not included with this checkpoint. Video generation remains available.";
+  }
+  return caps.value.outputDeliveryReason ?? "Generated audio is unavailable for this recipe.";
+});
 /** The model's image-attachment shape — one shared policy (`sourceMediaPlan`).
  * Only `none` hides the primary conditioning editor. */
 const sourcePlan = computed(() => sourceMediaPlan(caps.value));
@@ -11609,7 +11619,7 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
             <MobileBatchControl :form="form" :selected-model="selectedGenerationModel" />
 
             <label
-              v-if="caps.supportsAudio && !isMinimaxH3Identity(form.family, form.model)"
+              v-if="caps.offersAudioControl"
               class="mobile-generate-toggle-row"
               data-test="mobile-generate-audio-control"
             >
@@ -11620,20 +11630,12 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
               <input
                 v-model="form.enableAudio"
                 type="checkbox"
-                :disabled="selectedGenerationModel?.supports_audio === false"
+                :disabled="!generatedAudioSupported"
                 data-test="mobile-enable-audio"
               />
             </label>
-            <p
-              v-if="
-                caps.supportsAudio &&
-                !isMinimaxH3Identity(form.family, form.model) &&
-                selectedGenerationModel?.supports_audio === false
-              "
-              class="mobile-generate-validation"
-            >
-              Audio assets are not included with this checkpoint. Video generation remains
-              available.
+            <p v-if="generatedAudioUnavailableReason" class="mobile-generate-validation">
+              {{ generatedAudioUnavailableReason }}
             </p>
 
             <div class="mobile-advanced-row">

--- a/desktop/src/mobile/MobileSequenceComposer.test.ts
+++ b/desktop/src/mobile/MobileSequenceComposer.test.ts
@@ -494,9 +494,11 @@ describe("MobileSequenceComposer guardrails", () => {
     );
   });
 
-  it("surfaces audio only when the routed checkpoint bundles it", async () => {
+  it("keeps audio visible and explains when the routed checkpoint lacks it", async () => {
     mountComposer();
-    expect(wrapper!.find("[data-test='mobile-sequence-audio']").exists()).toBe(false);
+    const unavailable = wrapper!.get("[data-test='mobile-sequence-audio'] input");
+    expect((unavailable.element as HTMLInputElement).disabled).toBe(true);
+    expect(wrapper!.text()).toContain("Audio assets are not included with this checkpoint");
 
     wrapper!.unmount();
     mountComposer({ chainLimits: { ...limits, supports_audio: true } });

--- a/desktop/src/mobile/MobileSequenceComposer.vue
+++ b/desktop/src/mobile/MobileSequenceComposer.vue
@@ -95,12 +95,15 @@ function submitOrCancel(): void {
 const draft = useSequenceDraftStore();
 const guidanceCaps = computed(() =>
   generationCapabilitiesForFamily(
-    props.form.family,
-    props.form.model,
+    props.selectedModel?.family ?? props.form.family,
+    props.selectedModel?.name ?? props.form.model,
     props.form.pipeline,
     props.selectedModel?.guidance_capabilities,
   ),
 );
+const offersAudioControl = computed(() => guidanceCaps.value.offersAudioControl);
+const audioOutputSupported = computed(() => props.chainLimits?.supports_audio === true);
+const audioOutputUnavailable = computed(() => props.chainLimits?.supports_audio === false);
 
 const motionTail = computed(() => sequenceMotionTailFrames(props.selectedModel));
 const maxStages = computed(() => props.chainLimits?.max_stages ?? 16);
@@ -483,13 +486,20 @@ function removeClip(id: string): void {
     </button>
 
     <label
-      v-if="chainLimits?.supports_audio"
+      v-if="offersAudioControl"
       class="mobile-sequence-check"
       data-test="mobile-sequence-audio"
     >
-      <input v-model="draft.enableAudio" type="checkbox" :disabled="locked" />
+      <input
+        v-model="draft.enableAudio"
+        type="checkbox"
+        :disabled="locked || !audioOutputSupported"
+      />
       Generate audio
     </label>
+    <p v-if="offersAudioControl && audioOutputUnavailable" class="mobile-sequence-error">
+      Audio assets are not included with this checkpoint. Video generation remains available.
+    </p>
 
     <p
       v-if="blockingReason"

--- a/studio/lib/generationCapabilities.test.ts
+++ b/studio/lib/generationCapabilities.test.ts
@@ -65,9 +65,71 @@ describe("baseGenerationCapabilities", () => {
       expect(baseGenerationCapabilities(family)).toMatchObject({
         supportsVideo: true,
         supportsAudio: true,
+        offersAudioControl: true,
       });
       expect(isAdvancedVideoFamily(family)).toBe(true);
     }
+  });
+
+  it("keeps the LTX audio control visible when a checkpoint lacks audio assets", () => {
+    const videoOnlyRecipe = {
+      capabilities: {
+        guidance: { adjustable: false, supports_negative_prompt: false },
+        negative_prompt: { mode: "hidden", required: false },
+        supports_audio: false,
+        source_video: { mode: "adjustable", required: false },
+        mask: { mode: "hidden", required: false },
+        keyframes: { mode: "adjustable", required: false },
+        audio: { mode: "hidden", required: false },
+        lora: { mode: "adjustable", max_count: 4 },
+        controlnet: { mode: "hidden", max_count: 0 },
+        output: {
+          default_format: "mp4",
+          formats: ["mp4"],
+          audio_requires_mp4: false,
+        },
+        wan_recipe: {
+          mode: "hidden",
+          supports_distill_strength: false,
+          supports_first_last_frame: false,
+        },
+        schedulers: [],
+      },
+    } as unknown as GenerationRecipeProfile;
+
+    for (const family of ["ltx2", "ltx-2"]) {
+      expect(
+        baseGenerationCapabilities(
+          family,
+          "ltx-video-only",
+          null,
+          null,
+          null,
+          videoOnlyRecipe,
+        ),
+      ).toMatchObject({
+        supportsAudio: false,
+        offersAudioControl: true,
+      });
+    }
+
+    expect(baseGenerationCapabilities("ltx-video")).toMatchObject({
+      supportsAudio: false,
+      offersAudioControl: false,
+    });
+    expect(baseGenerationCapabilities("wan")).toMatchObject({
+      supportsAudio: false,
+      offersAudioControl: false,
+    });
+    expect(
+      baseGenerationCapabilities(
+        "minimax-h3",
+        "minimax-h3-fl2va:official-bf16",
+      ),
+    ).toMatchObject({
+      supportsAudio: true,
+      offersAudioControl: false,
+    });
   });
 
   it("treats wan as video without audio or a bespoke advanced panel", () => {

--- a/studio/lib/generationCapabilities.ts
+++ b/studio/lib/generationCapabilities.ts
@@ -55,6 +55,11 @@ export interface BaseGenerationCapabilities {
   supportsCfgPlus: boolean;
   supportsVideo: boolean;
   supportsAudio: boolean;
+  /** Whether the family exposes a user-controlled generated-audio switch.
+   * This remains true for a video-only LTX checkpoint so clients can render
+   * the disabled control and explain which checkpoint asset is missing.
+   * H3 always generates audio and therefore has no switch. */
+  offersAudioControl: boolean;
   supportsLora: boolean;
   maxLoraStack: number;
   supportsControlNet: boolean;
@@ -357,6 +362,7 @@ export function baseGenerationCapabilities(
     supportsVideo,
     supportsAudio:
       profileCaps?.supports_audio ?? (h3 || AUDIO_FAMILIES.has(normalized)),
+    offersAudioControl: ADVANCED_VIDEO_FAMILIES.has(normalized),
     supportsLora: profileCaps?.lora
       ? profileControlVisible(profileCaps.lora.mode)
       : !flux2Dev &&

--- a/web/src/components/SequenceComposer.vue
+++ b/web/src/components/SequenceComposer.vue
@@ -94,6 +94,7 @@ const emit = defineEmits<{
   "expand-clip": [clipId: string, prompt: string];
   "import-shared": [shared: Partial<SequenceSharedParams>];
   "play-clip": [clipId: string];
+  "limits-change": [limits: ChainLimits | null];
 }>();
 
 const draft = useSequenceDraftStore();
@@ -147,6 +148,7 @@ let limitsFetch = 0;
 async function loadLimits() {
   const version = ++limitsFetch;
   limitsLoaded.value = false;
+  emit("limits-change", null);
   const next = await fetchChainLimits(
     props.model,
     props.target,
@@ -155,6 +157,7 @@ async function loadLimits() {
   if (version !== limitsFetch) return;
   limits.value = next;
   limitsLoaded.value = true;
+  emit("limits-change", next);
   // A non-AV model must not carry a stale audio request onto the wire.
   if (!limits.value?.supports_audio) draft.enableAudio = false;
   if (!draft.editing && limits.value) {

--- a/web/src/components/create/AdvancedDrawer.test.ts
+++ b/web/src/components/create/AdvancedDrawer.test.ts
@@ -471,6 +471,34 @@ describe("AdvancedDrawer video suite", () => {
     );
   });
 
+  it("keeps the LTX-2 suite visible when the active recipe cannot deliver audio", async () => {
+    const model = {
+      name: "ltx-2.5-22b-distilled:q4",
+      family: "ltx2",
+      downloaded: true,
+      generation_profile: {
+        default_recipe_id: "default",
+        recipes: [
+          {
+            id: "default",
+            request_selector: {},
+            capabilities: { supports_audio: false },
+          },
+        ],
+      },
+    } as ModelInfoExtended;
+    const wrapper = factory(
+      "ltx2",
+      { model: model.name, modelFamily: "ltx2" },
+      { models: [model] },
+    );
+    await wrapper
+      .get("[data-test='section-video'] .ms-acc__head")
+      .trigger("click");
+
+    expect(wrapper.find("[data-test='ltx2-suite']").exists()).toBe(true);
+  });
+
   it("hides the video suite entirely for flux", () => {
     expect(sections("flux").video).toBe(false);
   });

--- a/web/src/components/create/AdvancedDrawer.vue
+++ b/web/src/components/create/AdvancedDrawer.vue
@@ -359,10 +359,13 @@ function addNegative(word: string) {
 }
 
 // LTX-2 / LTX-2.3 own the full advanced video suite (pipeline, conditioning,
-// keyframes, retake, spatial/temporal). `supportsAudio` is true for
-// exactly those families, so it doubles as the suite gate; plain
-// ltx-video keeps just frames/fps/GIF.
-const showLtx2 = computed(() => caps.value.supportsAudio && !h3Family.value);
+// keyframes, retake, spatial/temporal). The family-level control capability
+// remains true for a checkpoint whose audio assets are absent; the resolved
+// recipe may correctly set `supportsAudio` false without hiding this suite.
+// Plain ltx-video keeps just frames/fps/GIF.
+const showLtx2 = computed(
+  () => caps.value.offersAudioControl && !h3Family.value,
+);
 
 // ── Output & seed: exact size follows the active recipe grid ──────────
 /** Advisory beside the exact-size inputs — a size the recipe would refuse

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -22,6 +22,7 @@ import {
 import { __testing__ as routingTesting } from "../../composables/useHostRouting";
 import { CAPABLE_TARGET_ID } from "../../lib/hostRouting";
 import type { GenerateFormState } from "../../types";
+import type { ChainLimits } from "../../api";
 
 const pushMock = vi.hoisted(() => vi.fn());
 vi.mock("vue-router", () => ({
@@ -51,6 +52,21 @@ function factory(overrides: Partial<GenerateFormState> = {}, family = "flux") {
   return mount(ControlsAside, {
     props: { modelValue: baseForm(overrides), family, advCount: 0 },
   });
+}
+
+function chainLimits(supportsAudio: boolean): ChainLimits {
+  return {
+    model: "ltx-2-19b-distilled:fp8",
+    frames_per_clip_cap: 121,
+    frames_per_clip_recommended: 97,
+    max_stages: 16,
+    max_total_frames: 1936,
+    fade_frames_max: 24,
+    transition_modes: ["smooth", "cut", "fade"],
+    quantization_family: "fp8",
+    supports_audio: supportsAudio,
+    supports_sequence: true,
+  };
 }
 
 describe("ControlsAside", () => {
@@ -268,6 +284,56 @@ describe("ControlsAside", () => {
     expect(next.enableAudio).toBe(false);
   });
 
+  it("shows why generated audio is unavailable for a video-only LTX checkpoint", () => {
+    const model = noteModel(
+      "ltx-2.5-22b-distilled:q4",
+      "ltx2",
+      { default: 8, min: 8, max: 8, step: 1, mode: "fixed" },
+      { default: 1, min: 1, max: 1, step: 0.1, mode: "fixed" },
+    );
+    model.supports_audio = false;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ model: model.name, modelFamily: "ltx2" }),
+        family: "ltx2",
+        model,
+      },
+    });
+
+    expect(wrapper.find("[data-test='generate-audio-control']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.getComponent(SwitchToggle).props("disabled")).toBe(true);
+    expect(wrapper.text()).toContain(
+      "Audio assets are not included with this checkpoint",
+    );
+  });
+
+  it("keeps LTX audio visible when the host recipe cannot deliver it", () => {
+    const model = noteModel(
+      "ltx-2.5-22b-distilled:q4",
+      "ltx2",
+      { default: 8, min: 8, max: 8, step: 1, mode: "fixed" },
+      { default: 1, min: 1, max: 1, step: 0.1, mode: "fixed" },
+    );
+    model.supports_audio = true;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ model: model.name, modelFamily: "ltx2" }),
+        family: "ltx2",
+        model,
+      },
+    });
+
+    expect(wrapper.find("[data-test='generate-audio-control']").exists()).toBe(
+      true,
+    );
+    expect(wrapper.getComponent(SwitchToggle).props("disabled")).toBe(true);
+    expect(wrapper.text()).toContain(
+      "Generated audio is unavailable for this recipe",
+    );
+  });
+
   it("keeps sequence generated audio in the primary settings", async () => {
     const draft = useSequenceDraftStore();
     const model = {
@@ -281,10 +347,33 @@ describe("ControlsAside", () => {
         family: "ltx2",
         model,
         output: "sequence",
+        chainLimits: chainLimits(true),
       },
     });
     wrapper.getComponent(SwitchToggle).vm.$emit("update:modelValue", true);
     expect(draft.enableAudio).toBe(true);
+  });
+
+  it("keeps sequence audio disabled when the routed host rejects it", () => {
+    const model = {
+      name: "ltx-2-19b-distilled:fp8",
+      family: "ltx2",
+      supports_audio: true,
+    } as ModelInfoExtended;
+    const wrapper = mount(ControlsAside, {
+      props: {
+        modelValue: baseForm({ model: model.name, modelFamily: "ltx2" }),
+        family: "ltx2",
+        model,
+        output: "sequence",
+        chainLimits: chainLimits(false),
+      },
+    });
+
+    expect(wrapper.getComponent(SwitchToggle).props("disabled")).toBe(true);
+    expect(wrapper.text()).toContain(
+      "Generated audio is unavailable for this sequence on the selected host",
+    );
   });
 
   it("does not expose the audio toggle for an H3 model restored without a family", () => {

--- a/web/src/components/create/ControlsAside.vue
+++ b/web/src/components/create/ControlsAside.vue
@@ -42,7 +42,7 @@ import {
 import HostRoutingPicker from "./HostRoutingPicker.vue";
 import { useHostRouting } from "../../composables/useHostRouting";
 import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
-import { isMinimaxH3Identity } from "@studio/lib/minimaxH3Authoring";
+import type { ChainLimits } from "../../api";
 
 const props = withDefaults(
   defineProps<{
@@ -66,6 +66,8 @@ const props = withDefaults(
     /** Clips currently parked on the composer rail (sequence caption). */
     clipCount?: number;
     routingRequest?: Partial<GenerateRoutingRequest> | null | undefined;
+    /** Authoritative limits from the host selected for this sequence. */
+    chainLimits?: ChainLimits | null;
   }>(),
   {
     advCount: 0,
@@ -100,6 +102,7 @@ const capabilities = computed(() =>
     props.modelValue.pipeline,
     props.model?.guidance_capabilities,
     props.model?.source_image ?? props.modelValue.sourceImageCapability,
+    effectiveGenerationRecipe(props.model, props.modelValue.pipeline),
   ),
 );
 const activeRecipe = computed(() =>
@@ -139,23 +142,32 @@ function setPredictDuration(value: boolean) {
   });
 }
 const draft = useSequenceDraftStore();
-const showGenerateAudio = computed(() =>
-  sequenceMode.value
-    ? props.family === "ltx2" && props.model?.supports_audio !== false
-    : capabilities.value.supportsAudio &&
-      !isMinimaxH3Identity(
-        props.family,
-        props.model?.name ?? props.modelValue.model,
-      ),
-);
+const showGenerateAudio = computed(() => capabilities.value.offersAudioControl);
 const generateAudio = computed(() =>
   sequenceMode.value
     ? draft.enableAudio
     : props.modelValue.enableAudio !== false,
 );
-const audioOutputSupported = computed(
-  () => props.model?.supports_audio !== false,
+const audioOutputSupported = computed(() =>
+  sequenceMode.value
+    ? props.chainLimits?.supports_audio === true
+    : capabilities.value.supportsAudio && props.model?.supports_audio !== false,
 );
+const audioOutputUnavailableReason = computed(() => {
+  if (!showGenerateAudio.value || audioOutputSupported.value) return null;
+  if (sequenceMode.value) {
+    return props.chainLimits?.supports_audio === false
+      ? "Generated audio is unavailable for this sequence on the selected host."
+      : null;
+  }
+  if (props.model?.supports_audio === false) {
+    return "Audio assets are not included with this checkpoint. Video generation remains available.";
+  }
+  return (
+    capabilities.value.outputDeliveryReason ??
+    "Generated audio is unavailable for this recipe."
+  );
+});
 function setGenerateAudio(value: boolean) {
   if (sequenceMode.value) draft.enableAudio = value;
   else patch({ enableAudio: value });
@@ -427,16 +439,15 @@ function lockLastSeed() {
       >
       <SwitchToggle
         :model-value="generateAudio"
-        :disabled="!sequenceMode && !audioOutputSupported"
+        :disabled="!audioOutputSupported"
         label="Generate audio"
         @update:model-value="setGenerateAudio"
       />
       <p
-        v-if="!sequenceMode && !audioOutputSupported"
+        v-if="audioOutputUnavailableReason"
         class="controls__hint controls__hint--full"
       >
-        Audio assets are not included with this checkpoint. Video generation
-        remains available.
+        {{ audioOutputUnavailableReason }}
       </p>
     </div>
 

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -134,6 +134,7 @@ import {
   imageUrl,
   listGallery,
   upscaleStream,
+  type ChainLimits,
   type StreamTarget,
 } from "../api";
 import { apiJsonTo } from "@studio/api/client";
@@ -1924,6 +1925,7 @@ const sharedParams = computed<SequenceSharedParams>(() =>
 const sequenceTarget = computed<StreamTarget | undefined>(
   () => routing.resolve(form.state.value.model || null)?.target,
 );
+const sequenceChainLimits = ref<ChainLimits | null>(null);
 
 // Edit sessions snapshot the shared params at load so shape/detail changes
 // mark every clip as re-rendering in the rail's plan badges.
@@ -5315,6 +5317,7 @@ onBeforeUnmount(() => {
               :last-seed="lastSeedUsed"
               :output="sequenceMode ? 'sequence' : 'single'"
               :clip-count="sequenceMode ? draft.clips.length : 0"
+              :chain-limits="sequenceMode ? sequenceChainLimits : null"
               data-test="phone-sequence-controls"
               @update:output="setOutput"
               @open-advanced="openAdvanced"
@@ -5336,6 +5339,7 @@ onBeforeUnmount(() => {
             :stage-media-by-clip-id="sequenceFilmstripMediaByClipId"
             :playing-clip-id="playingSequenceClipId"
             :submitting="sequenceSubmitInFlight"
+            @limits-change="sequenceChainLimits = $event"
             @submit="onSubmitSequence"
             @cancel="cancelSequenceSubmit"
             @duplicate-as-new="onDuplicateAsNew"
@@ -5525,6 +5529,7 @@ onBeforeUnmount(() => {
                   :last-seed="lastSeedUsed"
                   :output="sequenceMode ? 'sequence' : 'single'"
                   :clip-count="sequenceMode ? draft.clips.length : 0"
+                  :chain-limits="sequenceMode ? sequenceChainLimits : null"
                   @update:output="setOutput"
                   @open-advanced="openAdvanced"
                   @reset-settings="onResetSettings"
@@ -5781,6 +5786,7 @@ onBeforeUnmount(() => {
           :last-seed="lastSeedUsed"
           :output="sequenceMode ? 'sequence' : 'single'"
           :clip-count="sequenceMode ? draft.clips.length : 0"
+          :chain-limits="sequenceMode ? sequenceChainLimits : null"
           @update:output="setOutput"
           @open-advanced="openAdvanced"
           @reset-settings="onResetSettings"


### PR DESCRIPTION
## Summary

- separate family-level LTX audio-control visibility from recipe/checkpoint delivery support
- keep LTX-2/LTX-2.5 audio controls and advanced settings visible, disabling them with an exact explanation when audio is unavailable
- make web sequences honor the selected host's authoritative chain limits across phone and desktop layouts
- preserve legacy LTX Video, Wan, and always-audio MiniMax H3 behavior

## Validation

- `nix develop -c bun run check:frontend` (studio 1,498; web 1,757; desktop 5,467 tests)
- web and desktop production builds
- targeted web audio controls/advanced drawer: 101 tests
- targeted desktop/mobile controls: 430 tests
- Rust downloaded LTX-2.5 split-audio capability test
- `nix develop -c bun run fmt:check`
- `bash scripts/release/check-changelog-fragments.sh <base> HEAD`
- independent sub-agent peer review; P2 host-chain-limits finding fixed and re-review clean

## Browser QA

- verified the mobile app at 390x844 against an isolated local Mold host
- catalog/model surface rendered without console errors; component tests cover the unavailable-audio Create states because the synthetic sidecar was intentionally excluded from the Create picker