### PR TITLE
fix(android): repair QR pairing scanner

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -152,7 +152,10 @@ jobs:
         if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
         # rust-cache can restore cargo-tauri even when the dedicated binary
         # cache misses. Keep this fallback idempotent across both cache layers.
-        run: cargo install tauri-cli --version 2.11.4 --locked --force
+        run: |
+          if ! cargo tauri --version 2>/dev/null | grep -Fq '2.11.4'; then
+            cargo install tauri-cli --version 2.11.4 --locked --force
+          fi
       - name: Verify Tauri CLI
         run: cargo tauri --version | grep -F '2.11.4'
       - name: Install frontend dependencies

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -608,7 +608,10 @@ jobs:
           key: tauri-cli-${{ runner.os }}-${{ runner.arch }}-2.11.4
       - name: Install Tauri CLI
         if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
-        run: cargo install tauri-cli --version 2.11.4 --locked
+        run: |
+          if ! cargo tauri --version 2>/dev/null | grep -Fq '2.11.4'; then
+            cargo install tauri-cli --version 2.11.4 --locked --force
+          fi
       - name: Verify Tauri CLI
         run: cargo tauri --version | grep -F '2.11.4'
       - name: Install frontend dependencies

--- a/.github/workflows/testflight-ios.yml
+++ b/.github/workflows/testflight-ios.yml
@@ -52,7 +52,10 @@ jobs:
           key: tauri-cli-${{ runner.os }}-${{ runner.arch }}-2.11.4
       - name: Install Tauri CLI
         if: steps.tauri-cli-cache.outputs.cache-hit != 'true'
-        run: cargo install tauri-cli --version 2.11.4 --locked
+        run: |
+          if ! cargo tauri --version 2>/dev/null | grep -Fq '2.11.4'; then
+            cargo install tauri-cli --version 2.11.4 --locked --force
+          fi
       - name: Verify Tauri CLI
         run: cargo tauri --version | grep -F '2.11.4'
       - name: Install frontend dependencies

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -281,8 +281,10 @@ pushed screen opened from the header.
   then retains Bonjour discovery, manual IP/hostname/HTTPS entry, and Tailscale
   MagicDNS as fallbacks. Desktop and web Settings mint a random, one-use,
   two-minute ticket containing the reachable host address but never the durable
-  API key. iPhone redeems it against the exact instance before host dedupe and
-  Keychain storage. Host detail shows telemetry, models-disk usage, queue,
+  API key. iPhone and Android redeem it against the exact instance before host
+  dedupe and secure credential storage. Android owns its CameraX session in the
+  Mold native bridge so Cancel always releases the camera and settles the
+  pending scan before another scan can begin. Host detail shows telemetry, models-disk usage, queue,
   downloads, loaded models, and installed models (all using catalog display
   names rather than opaque `cv:` / `hf:` ids), with rename, retry, select,
   unload, open-in-Models, and forget actions. Queue rows are swipe-to-act
@@ -541,7 +543,9 @@ minutes. Both responses are `no-store`; the QR must never contain the durable
 API key. Pairing QR codes use the registered `mold://pair` scheme so the mobile
 Camera app offers to open them directly in Mold; cold-launch and already-open
 links share the same claim, instance-verification, and Keychain path as Mold's
-in-app scanner.
+in-app scanner. Android's in-app scanner releases CameraX before resolving the
+scanned payload, then completes that same claim, verification, secure storage,
+and host-selection path.
 
 An authenticated claim receives a distinct `mold_pair_...` credential, not the
 host's operator key. The host stores only its digest in `mold.db`; web and
@@ -580,9 +584,9 @@ android-build              # ARM64/ARMv7 Google Play AAB
 `/Volumes/ExternalStorage/Android/Android Studio.app`. Open the generated
 project with `./scripts/android.sh studio`. The helper defaults to NDK
 `27.0.12077973`, which is pinned by the generated Tauri project; change it only
-with a deliberate template/toolchain upgrade. The generated Gradle root replaces
-the scanner plugin's direct thin dependency with ML Kit's bundled barcode model,
-so first-run and offline QR pairing never waits for a Google Play module download.
+with a deliberate template/toolchain upgrade. Mold's Android native scanner
+uses ML Kit's bundled barcode model, so first-run and offline QR pairing never
+waits for a Google Play module download.
 
 ### iOS
 

--- a/apps/mobile/plugins/android/build.gradle.kts
+++ b/apps/mobile/plugins/android/build.gradle.kts
@@ -33,10 +33,16 @@ android {
 }
 
 dependencies {
-
+    val cameraxVersion = "1.5.1"
     implementation("androidx.core:core-ktx:1.9.0")
     implementation("androidx.appcompat:appcompat:1.6.0")
     implementation("com.google.android.material:material:1.7.0")
+    implementation("androidx.camera:camera-core:$cameraxVersion")
+    implementation("androidx.camera:camera-camera2:$cameraxVersion")
+    implementation("androidx.camera:camera-lifecycle:$cameraxVersion")
+    implementation("androidx.camera:camera-view:$cameraxVersion")
+    // Bundle the decoder so first-run and offline pairing never wait for Play Services.
+    implementation("com.google.mlkit:barcode-scanning:17.3.0")
     testImplementation("junit:junit:4.13.2")
     androidTestImplementation("androidx.test.ext:junit:1.1.5")
     androidTestImplementation("androidx.test:core:1.5.0")

--- a/apps/mobile/plugins/android/src/main/AndroidManifest.xml
+++ b/apps/mobile/plugins/android/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE" />
+    <uses-permission android:name="android.permission.CAMERA" />
+    <uses-feature android:name="android.hardware.camera.any" />
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28" />

--- a/apps/mobile/plugins/android/src/main/java/AndroidPairingScanner.kt
+++ b/apps/mobile/plugins/android/src/main/java/AndroidPairingScanner.kt
@@ -1,0 +1,199 @@
+package com.utensils.mold.mobile_native
+
+import android.Manifest
+import android.app.Activity
+import android.content.pm.PackageManager
+import android.graphics.Color
+import android.graphics.drawable.Drawable
+import android.view.ViewGroup
+import android.webkit.WebView
+import android.widget.FrameLayout
+import androidx.camera.core.CameraSelector
+import androidx.camera.core.ImageAnalysis
+import androidx.camera.core.ImageProxy
+import androidx.camera.core.Preview
+import androidx.camera.lifecycle.ProcessCameraProvider
+import androidx.camera.view.PreviewView
+import androidx.core.content.ContextCompat
+import androidx.lifecycle.LifecycleOwner
+import app.tauri.plugin.Invoke
+import app.tauri.plugin.JSObject
+import com.google.mlkit.vision.barcode.BarcodeScanner
+import com.google.mlkit.vision.barcode.BarcodeScannerOptions
+import com.google.mlkit.vision.barcode.BarcodeScanning
+import com.google.mlkit.vision.barcode.common.Barcode
+import com.google.mlkit.vision.common.InputImage
+
+internal data class ActivePairingScan<T>(val id: Long, val value: T)
+
+/** Owns exactly one pending invocation and invalidates late CameraX callbacks. */
+internal class PairingScanSession<T> {
+    private var nextId = 0L
+    private var active: ActivePairingScan<T>? = null
+
+    @Synchronized
+    fun begin(value: T): Long {
+        check(active == null) { "a pairing scan is already active" }
+        nextId += 1
+        active = ActivePairingScan(nextId, value)
+        return nextId
+    }
+
+    @Synchronized
+    fun isActive(id: Long): Boolean = active?.id == id
+
+    @Synchronized
+    fun complete(id: Long): T? {
+        val current = active?.takeIf { it.id == id } ?: return null
+        active = null
+        return current.value
+    }
+
+    @Synchronized
+    fun cancel(): ActivePairingScan<T>? = active.also {
+        active = null
+        nextId += 1
+    }
+}
+
+/** CameraX + bundled ML Kit scanner with deterministic cancellation semantics. */
+internal class AndroidPairingScanner(
+    private val activity: Activity,
+    private val webView: WebView,
+) {
+    private val session = PairingScanSession<Invoke>()
+    private var previewView: PreviewView? = null
+    private var cameraProvider: ProcessCameraProvider? = null
+    private var decoder: BarcodeScanner? = null
+    private var webViewBackground: Drawable? = null
+
+    fun scan(invoke: Invoke) {
+        if (ContextCompat.checkSelfPermission(activity, Manifest.permission.CAMERA) !=
+            PackageManager.PERMISSION_GRANTED
+        ) {
+            invoke.reject("Camera access is required to scan a pairing code.")
+            return
+        }
+        val scanId = try {
+            session.begin(invoke)
+        } catch (error: IllegalStateException) {
+            invoke.reject(error.message ?: "a pairing scan is already active")
+            return
+        }
+        activity.runOnUiThread { attachCamera(scanId) }
+    }
+
+    fun cancel(cancelInvoke: Invoke) {
+        val pending = session.cancel()
+        activity.runOnUiThread {
+            cleanupCamera()
+            pending?.value?.reject("cancelled")
+            cancelInvoke.resolve()
+        }
+    }
+
+    private fun attachCamera(scanId: Long) {
+        if (!session.isActive(scanId)) return
+        try {
+            val parent = webView.parent as? ViewGroup
+                ?: error("Android WebView has no camera overlay parent")
+            previewView = PreviewView(activity).apply {
+                layoutParams = FrameLayout.LayoutParams(
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                    ViewGroup.LayoutParams.MATCH_PARENT,
+                )
+            }
+            parent.addView(previewView)
+            webViewBackground = webView.background
+            webView.setBackgroundColor(Color.TRANSPARENT)
+            webView.bringToFront()
+
+            decoder = BarcodeScanning.getClient(
+                BarcodeScannerOptions.Builder()
+                    .setBarcodeFormats(Barcode.FORMAT_QR_CODE)
+                    .build(),
+            )
+            val providerFuture = ProcessCameraProvider.getInstance(activity)
+            providerFuture.addListener({
+                if (!session.isActive(scanId)) return@addListener
+                try {
+                    bindCamera(scanId, providerFuture.get())
+                } catch (error: Exception) {
+                    fail(scanId, "could not start the Android camera: ${error.message ?: error.javaClass.simpleName}")
+                }
+            }, ContextCompat.getMainExecutor(activity))
+        } catch (error: Exception) {
+            fail(scanId, "could not open the Android pairing scanner: ${error.message ?: error.javaClass.simpleName}")
+        }
+    }
+
+    private fun bindCamera(scanId: Long, provider: ProcessCameraProvider) {
+        if (!session.isActive(scanId)) return
+        val preview = Preview.Builder().build().apply {
+            setSurfaceProvider(previewView?.surfaceProvider)
+        }
+        val analysis = ImageAnalysis.Builder()
+            .setBackpressureStrategy(ImageAnalysis.STRATEGY_KEEP_ONLY_LATEST)
+            .build()
+            .apply {
+                setAnalyzer(ContextCompat.getMainExecutor(activity)) { image ->
+                    analyze(scanId, image)
+                }
+            }
+        provider.unbindAll()
+        provider.bindToLifecycle(
+            activity as LifecycleOwner,
+            CameraSelector.DEFAULT_BACK_CAMERA,
+            preview,
+            analysis,
+        )
+        cameraProvider = provider
+    }
+
+    @android.annotation.SuppressLint("UnsafeOptInUsageError")
+    private fun analyze(scanId: Long, image: ImageProxy) {
+        val mediaImage = image.image
+        if (mediaImage == null || !session.isActive(scanId)) {
+            image.close()
+            return
+        }
+        decoder?.process(InputImage.fromMediaImage(mediaImage, image.imageInfo.rotationDegrees))
+            ?.addOnSuccessListener { barcodes ->
+                val content = barcodes.firstOrNull()?.rawValue?.takeIf { it.isNotBlank() }
+                if (content != null) finish(scanId, content)
+            }
+            ?.addOnFailureListener { error ->
+                fail(scanId, "could not read the pairing code: ${error.message ?: error.javaClass.simpleName}")
+            }
+            ?.addOnCompleteListener { image.close() }
+            ?: image.close()
+    }
+
+    private fun finish(scanId: Long, content: String) {
+        val invoke = session.complete(scanId) ?: return
+        activity.runOnUiThread {
+            cleanupCamera()
+            invoke.resolve(JSObject().apply { put("content", content) })
+        }
+    }
+
+    private fun fail(scanId: Long, message: String) {
+        val invoke = session.complete(scanId) ?: return
+        activity.runOnUiThread {
+            cleanupCamera()
+            invoke.reject(message)
+        }
+    }
+
+    private fun cleanupCamera() {
+        cameraProvider?.unbindAll()
+        cameraProvider = null
+        decoder?.close()
+        decoder = null
+        val parent = webView.parent as? ViewGroup
+        previewView?.let { parent?.removeView(it) }
+        previewView = null
+        webView.background = webViewBackground
+        webViewBackground = null
+    }
+}

--- a/apps/mobile/plugins/android/src/main/java/MoldMobileNativePlugin.kt
+++ b/apps/mobile/plugins/android/src/main/java/MoldMobileNativePlugin.kt
@@ -6,6 +6,7 @@ import android.content.res.Configuration
 import android.content.Intent
 import android.graphics.Color
 import android.os.Build
+import android.webkit.WebView
 import androidx.activity.result.ActivityResult
 import app.tauri.PermissionState
 import app.tauri.annotation.Command
@@ -86,6 +87,12 @@ class MoldMobileNativePlugin(private val hostActivity: Activity) : Plugin(hostAc
     private val identityPhoto = AndroidIdentityPhoto(hostActivity.applicationContext)
     private var pendingIdentityCamera: AndroidIdentityPhoto.CameraTarget? = null
     private var pendingLegacyMedia: PendingLegacyMedia? = null
+    private lateinit var pairingScanner: AndroidPairingScanner
+
+    override fun load(webView: WebView) {
+        super.load(webView)
+        pairingScanner = AndroidPairingScanner(hostActivity, webView)
+    }
 
     @Command
     fun setApiKey(invoke: Invoke) {
@@ -214,6 +221,16 @@ class MoldMobileNativePlugin(private val hostActivity: Activity) : Plugin(hostAc
             return
         }
         startActivityForResult(invoke, intent, "identityPhotoResult")
+    }
+
+    @Command
+    fun scanPairingCode(invoke: Invoke) {
+        pairingScanner.scan(invoke)
+    }
+
+    @Command
+    fun cancelPairingScan(invoke: Invoke) {
+        pairingScanner.cancel(invoke)
     }
 
     @ActivityCallback

--- a/apps/mobile/plugins/android/src/test/java/PairingScanSessionTest.kt
+++ b/apps/mobile/plugins/android/src/test/java/PairingScanSessionTest.kt
@@ -1,0 +1,32 @@
+package com.utensils.mold.mobile_native
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class PairingScanSessionTest {
+    @Test
+    fun cancel_returns_pending_scan_and_invalidates_late_camera_callbacks() {
+        val session = PairingScanSession<String>()
+        val id = session.begin("pending invoke")
+
+        val cancelled = session.cancel()
+
+        assertEquals("pending invoke", cancelled?.value)
+        assertFalse(session.isActive(id))
+        assertNull(session.complete(id))
+    }
+
+    @Test
+    fun successful_scan_settles_once_and_allows_another_scan() {
+        val session = PairingScanSession<String>()
+        val first = session.begin("first")
+
+        assertEquals("first", session.complete(first))
+        assertNull(session.complete(first))
+        val second = session.begin("second")
+        assertTrue(session.isActive(second))
+    }
+}

--- a/apps/mobile/plugins/build.rs
+++ b/apps/mobile/plugins/build.rs
@@ -9,6 +9,8 @@ const COMMANDS: &[&str] = &[
     "share_exported_animation",
     "pick_identity_photo",
     "set_mobile_appearance",
+    "scan_pairing_code",
+    "cancel_pairing_scan",
 ];
 
 fn main() {

--- a/apps/mobile/plugins/permissions/autogenerated/commands/cancel_pairing_scan.toml
+++ b/apps/mobile/plugins/permissions/autogenerated/commands/cancel_pairing_scan.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-cancel-pairing-scan"
+description = "Enables the cancel_pairing_scan command without any pre-configured scope."
+commands.allow = ["cancel_pairing_scan"]
+
+[[permission]]
+identifier = "deny-cancel-pairing-scan"
+description = "Denies the cancel_pairing_scan command without any pre-configured scope."
+commands.deny = ["cancel_pairing_scan"]

--- a/apps/mobile/plugins/permissions/autogenerated/commands/scan_pairing_code.toml
+++ b/apps/mobile/plugins/permissions/autogenerated/commands/scan_pairing_code.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-scan-pairing-code"
+description = "Enables the scan_pairing_code command without any pre-configured scope."
+commands.allow = ["scan_pairing_code"]
+
+[[permission]]
+identifier = "deny-scan-pairing-code"
+description = "Denies the scan_pairing_code command without any pre-configured scope."
+commands.deny = ["scan_pairing_code"]

--- a/apps/mobile/plugins/permissions/autogenerated/reference.md
+++ b/apps/mobile/plugins/permissions/autogenerated/reference.md
@@ -14,6 +14,32 @@ Default permissions for the plugin
 <tr>
 <td>
 
+`mold-mobile-native:allow-cancel-pairing-scan`
+
+</td>
+<td>
+
+Enables the cancel_pairing_scan command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`mold-mobile-native:deny-cancel-pairing-scan`
+
+</td>
+<td>
+
+Denies the cancel_pairing_scan command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
 `mold-mobile-native:allow-copy-image-to-clipboard`
 
 </td>
@@ -189,6 +215,32 @@ Enables the save_video_to_photos command without any pre-configured scope.
 <td>
 
 Denies the save_video_to_photos command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`mold-mobile-native:allow-scan-pairing-code`
+
+</td>
+<td>
+
+Enables the scan_pairing_code command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`mold-mobile-native:deny-scan-pairing-code`
+
+</td>
+<td>
+
+Denies the scan_pairing_code command without any pre-configured scope.
 
 </td>
 </tr>

--- a/apps/mobile/plugins/permissions/schemas/schema.json
+++ b/apps/mobile/plugins/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the cancel_pairing_scan command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-cancel-pairing-scan",
+          "markdownDescription": "Enables the cancel_pairing_scan command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the cancel_pairing_scan command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-cancel-pairing-scan",
+          "markdownDescription": "Denies the cancel_pairing_scan command without any pre-configured scope."
+        },
+        {
           "description": "Enables the copy_image_to_clipboard command without any pre-configured scope.",
           "type": "string",
           "const": "allow-copy-image-to-clipboard",
@@ -377,6 +389,18 @@
           "type": "string",
           "const": "deny-save-video-to-photos",
           "markdownDescription": "Denies the save_video_to_photos command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the scan_pairing_code command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-scan-pairing-code",
+          "markdownDescription": "Enables the scan_pairing_code command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the scan_pairing_code command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-scan-pairing-code",
+          "markdownDescription": "Denies the scan_pairing_code command without any pre-configured scope."
         },
         {
           "description": "Enables the set_api_key command without any pre-configured scope.",

--- a/apps/mobile/plugins/src/mobile.rs
+++ b/apps/mobile/plugins/src/mobile.rs
@@ -96,4 +96,18 @@ impl<R: Runtime> MoldMobileNative<R> {
             .await
             .map_err(Into::into)
     }
+
+    pub async fn scan_pairing_code(&self) -> crate::Result<PairingScanResponse> {
+        self.0
+            .run_mobile_plugin_async("scanPairingCode", ())
+            .await
+            .map_err(Into::into)
+    }
+
+    pub async fn cancel_pairing_scan(&self) -> crate::Result<()> {
+        self.0
+            .run_mobile_plugin_async("cancelPairingScan", ())
+            .await
+            .map_err(Into::into)
+    }
 }

--- a/apps/mobile/plugins/src/models.rs
+++ b/apps/mobile/plugins/src/models.rs
@@ -86,3 +86,8 @@ pub struct IdentityPhotoResponse {
     pub size_bytes: Option<u64>,
     pub data_b64: Option<String>,
 }
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct PairingScanResponse {
+    pub content: String,
+}

--- a/apps/mobile/src-tauri/src/lib.rs
+++ b/apps/mobile/src-tauri/src/lib.rs
@@ -9,6 +9,7 @@ mod discovery;
 mod identity;
 mod keychain;
 mod media;
+mod pairing_scanner;
 mod viewport;
 
 #[cfg(target_os = "android")]
@@ -62,6 +63,8 @@ pub fn run() {
             media::save_image_to_photos,
             media::save_video_to_photos,
             media::share_exported_animation,
+            pairing_scanner::scan_android_pairing_code,
+            pairing_scanner::cancel_android_pairing_scan,
             viewport::restore_mobile_viewport,
         ])
         .run(app_context())

--- a/apps/mobile/src-tauri/src/pairing_scanner.rs
+++ b/apps/mobile/src-tauri/src/pairing_scanner.rs
@@ -1,0 +1,45 @@
+#[derive(serde::Serialize)]
+pub struct PairingScanResult {
+    pub content: String,
+}
+
+#[tauri::command]
+pub async fn scan_android_pairing_code(app: tauri::AppHandle) -> Result<PairingScanResult, String> {
+    #[cfg(target_os = "android")]
+    {
+        use tauri_plugin_mold_mobile_native::MoldMobileNativeExt;
+        let response = app
+            .mold_mobile_native()
+            .scan_pairing_code()
+            .await
+            .map_err(|error| error.to_string())?;
+        return Ok(PairingScanResult {
+            content: response.content,
+        });
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = app;
+        Err("the native pairing scanner is available only on Android".to_owned())
+    }
+}
+
+#[tauri::command]
+pub async fn cancel_android_pairing_scan(app: tauri::AppHandle) -> Result<(), String> {
+    #[cfg(target_os = "android")]
+    {
+        use tauri_plugin_mold_mobile_native::MoldMobileNativeExt;
+        return app
+            .mold_mobile_native()
+            .cancel_pairing_scan()
+            .await
+            .map_err(|error| error.to_string());
+    }
+
+    #[cfg(not(target_os = "android"))]
+    {
+        let _ = app;
+        Err("the native pairing scanner is available only on Android".to_owned())
+    }
+}

--- a/changelog.d/android-qr-pairing.md
+++ b/changelog.d/android-qr-pairing.md
@@ -1,0 +1,4 @@
+- **Fix Android QR pairing.** Cancelling the in-app scanner now releases the
+  camera immediately, and a successful QR scan completes the pairing claim,
+  secure credential save, and machine selection instead of stopping at the
+  camera view.

--- a/crates/mold-cli/src/skill/SKILL.md
+++ b/crates/mold-cli/src/skill/SKILL.md
@@ -1838,7 +1838,8 @@ Android ships from the same remote-only Tauri crate and `desktop/src/mobile`
 Vue surface as the iPhone app; never fork a second product UI or import the
 desktop local-engine graph. Its native bridge lives in `apps/mobile/plugins`:
 API keys are AES-GCM encrypted under a non-exportable Android Keystore key, QR
-pairing redeems the same one-use ticket, NSD discovers `_mold._tcp`, and
+pairing redeems the same one-use ticket through Mold's CameraX bridge (which
+releases the camera and settles the pending scan on Cancel), NSD discovers `_mold._tcp`, and
 MediaStore/clipboard/share intents provide the native media actions. Release CI
 publishes one signed universal `Mold-android.apk` on the rolling nightly and on
 every tag, listed in `SHA256SUMS`. Canonical: `website/guide/android.md`.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9996,7 +9996,12 @@ describe("MobileApp host and catalog coordination", () => {
 
   it("claims Android pairing codes with an Android client identity", async () => {
     isNativeAndroidRuntime.mockReturnValue(true);
-    scanPairingQr.mockResolvedValue({ content: pairingPayload() });
+    invoke.mockImplementation((command: string) => {
+      if (command === "scan_android_pairing_code") {
+        return Promise.resolve({ content: pairingPayload() });
+      }
+      return Promise.resolve(null);
+    });
     claimPairingSession.mockResolvedValue({
       api_key: "paired-key",
       instance_id: "wrong-host",
@@ -10009,6 +10014,59 @@ describe("MobileApp host and catalog coordination", () => {
       name: "Mold on Android",
       kind: "android",
     });
+    expect(scanPairingQr).not.toHaveBeenCalled();
+  });
+
+  it("cancels Android pairing through the native session and settles the pending scan", async () => {
+    isNativeAndroidRuntime.mockReturnValue(true);
+    const pendingScan = deferred<{ content: string }>();
+    invoke.mockImplementation((command: string) => {
+      if (command === "scan_android_pairing_code") return pendingScan.promise;
+      if (command === "cancel_android_pairing_scan") {
+        pendingScan.reject("cancelled");
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    await wrapper.get("[data-test='mobile-scan-pairing']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-pair-scanner-cancel']").trigger("click");
+    await flushPromises();
+
+    expect(invoke).toHaveBeenCalledWith("cancel_android_pairing_scan");
+    expect(cancelBarcodeScanner).not.toHaveBeenCalled();
+    expect(wrapper.find("[data-test='mobile-pair-scanner']").exists()).toBe(false);
+    expect(wrapper.find(".error-text").exists()).toBe(false);
+    expect(wrapper.get("[data-test='mobile-scan-pairing']").attributes("disabled")).toBeUndefined();
+  });
+
+  it("cancels the native Android pairing session when the app unmounts", async () => {
+    isNativeAndroidRuntime.mockReturnValue(true);
+    const pendingScan = deferred<{ content: string }>();
+    invoke.mockImplementation((command: string) => {
+      if (command === "scan_android_pairing_code") return pendingScan.promise;
+      if (command === "cancel_android_pairing_scan") {
+        pendingScan.reject("cancelled");
+        return Promise.resolve(null);
+      }
+      return Promise.resolve(null);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-hosts']").trigger("click");
+    await wrapper.get("[data-test='mobile-scan-pairing']").trigger("click");
+    await flushPromises();
+
+    wrapper.unmount();
+    await flushPromises();
+
+    expect(invoke).toHaveBeenCalledWith("cancel_android_pairing_scan");
+    expect(cancelBarcodeScanner).not.toHaveBeenCalled();
   });
 
   it("settles first-run camera permission before opening the pairing scanner", async () => {
@@ -10134,6 +10192,45 @@ describe("MobileApp host and catalog coordination", () => {
         name: "pair-host",
         baseUrl: "http://pair.local:7680",
       }),
+    );
+  });
+
+  it("stores and connects a QR-paired Android host after the native camera closes", async () => {
+    isNativeAndroidRuntime.mockReturnValue(true);
+    invoke.mockImplementation((command: string) => {
+      if (command === "scan_android_pairing_code") {
+        return Promise.resolve({ content: pairingPayload() });
+      }
+      return Promise.resolve(null);
+    });
+    claimPairingSession.mockResolvedValue({
+      api_key: "paired-key",
+      instance_id: "pair-id",
+      hostname: "pair-host",
+    });
+    apiJsonTo.mockImplementation((requestTarget: unknown, path: string, init?: RequestInit) => {
+      const baseUrl = (requestTarget as { baseUrl: string }).baseUrl;
+      if (path === "/api/status" && baseUrl === "http://pair.local:7680") {
+        return Promise.resolve({ ...status, instance_id: "pair-id", hostname: "pair-host" });
+      }
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      return durableApiFallback(path, init, requestTarget);
+    });
+
+    await scanFromMachines();
+    await vi.waitFor(() =>
+      expect(invoke).toHaveBeenCalledWith("keychain_set_api_key", {
+        hostId: "pair-local-7680",
+        apiKey: "paired-key",
+      }),
+    );
+
+    expect(wrapper?.find("[data-test='mobile-pair-scanner']").exists()).toBe(false);
+    expect(wrapper?.find(".error-text").exists()).toBe(false);
+    expect(wrapper?.get("[data-test='mobile-tab-generate']").attributes("aria-current")).toBe(
+      "page",
     );
   });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3952,11 +3952,13 @@ function scanPairingCode(): Promise<void> {
     pairingScannerOpen.value = true;
     await nextTick();
     try {
-      const result = await scan({
-        cameraDirection: "back",
-        formats: [Format.QRCode],
-        windowed: true,
-      });
+      const result = androidNativeRuntime
+        ? await invoke<{ content: string }>("scan_android_pairing_code")
+        : await scan({
+            cameraDirection: "back",
+            formats: [Format.QRCode],
+            windowed: true,
+          });
       return result.content;
     } finally {
       pairingScannerOpen.value = false;
@@ -3968,7 +3970,8 @@ async function cancelPairingScan(): Promise<void> {
   if (!pairingScannerOpen.value) return;
   pairingScannerCancelled = true;
   try {
-    await cancelBarcodeScanner();
+    if (androidNativeRuntime) await invoke("cancel_android_pairing_scan");
+    else await cancelBarcodeScanner();
   } catch (error) {
     pairingScannerCancelled = false;
     hostError.value = describeTransportError(error, "Pairing scanner");
@@ -10890,7 +10893,10 @@ onBeforeUnmount(() => {
   sourceUseController?.abort();
   if (pairingScannerOpen.value) {
     pairingScannerCancelled = true;
-    void cancelBarcodeScanner().catch(() => undefined);
+    const cancelScan = androidNativeRuntime
+      ? invoke("cancel_android_pairing_scan")
+      : cancelBarcodeScanner();
+    void cancelScan.catch(() => undefined);
   }
   preparationGuard.invalidate();
   submissionAttempts.invalidate();

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -8,6 +8,7 @@ ios="$repo_root/.github/workflows/ios.yml"
 android="$repo_root/.github/workflows/android.yml"
 android_gradle="$repo_root/apps/mobile/src-tauri/gen/android/build.gradle.kts"
 release_workflow="$repo_root/.github/workflows/release.yml"
+testflight="$repo_root/.github/workflows/testflight-ios.yml"
 
 fail() {
   echo "FAIL: $1" >&2
@@ -57,6 +58,16 @@ require_text "$ci" \
   "root CI does not cancel superseded PR runs"
 require_text "$ci" 'CARGO_INCREMENTAL: "0"' \
   "root CI enables incremental compilation even though sccache rejects it"
+
+for workflow in "$android" "$release_workflow" "$testflight"; do
+  require_text "$workflow" \
+    "if ! cargo tauri --version 2>/dev/null | grep -Fq '2.11.4'; then" \
+    "Tauri CLI install does not tolerate a binary restored by Rust cache: $workflow"
+  require_text "$workflow" \
+    "cargo install tauri-cli --version 2.11.4 --locked --force" \
+    "Tauri CLI install cannot replace a stale restored binary: $workflow"
+done
+
 if grep -Fq 'CARGO_INCREMENTAL: "1"' "$release_workflow"; then
   fail "release builds enable incremental compilation while using sccache"
 fi

--- a/website/guide/android.md
+++ b/website/guide/android.md
@@ -29,7 +29,10 @@ after installation if you do not sideload other apps.
 Open **Machines** and scan the one-use pairing code shown by Mold Studio on the
 server, discover `_mold._tcp` machines on the local network, or enter a LAN,
 DNS, HTTPS, or Tailscale MagicDNS address manually. Pairing transfers a
-two-minute one-use ticket, not the durable API key.
+two-minute one-use ticket, not the durable API key. A successful scan closes
+the camera, verifies the exact server, saves its credential in Android Keystore,
+and selects that machine. **Cancel** releases the camera immediately; you can
+open the scanner again without restarting Mold.
 
 ## Identity photos (PuLID)
 


### PR DESCRIPTION
## Summary

- replace the Android scan call with a Mold-owned CameraX + bundled ML Kit bridge
- settle and clean up the native scan invocation on Cancel, component teardown, success, or failure
- keep successful scans on the existing one-use claim, instance verification, secure credential storage, and host-selection path
- add Kotlin session-race tests, Vue cancel/unmount/success regressions, Android docs, and a changelog fragment

## Root cause

The upstream Android scanner destroyed its saved invocation before rejecting it on Cancel, leaving the JavaScript scan promise pending. Its camera cleanup also depended on provider initialization, so early cancellation could leave the preview frozen. Mold now owns the Android camera session and invalidates late CameraX/ML Kit callbacks deterministically.

## Validation

- `nix develop -c ./scripts/android.sh check`
- Android plugin `testDebugUnitTest` (33 Gradle tasks successful)
- `nix develop -c bash -lc 'cd desktop && bun x vitest run src/mobile/MobileApp.test.ts'` (327 passed)
- `nix develop -c bun run check:frontend` (all suites and builds passed)
- `nix develop -c ./scripts/ci-local.sh docs`
- `nix develop -c bun run fmt:check`
- `bash scripts/release/check-changelog-fragments.sh <base> HEAD`

## Android UAT

Tested the universal debug APK on the external-volume `Mold_API_37` emulator with a real image-backed camera QR fixture:

- Cancel closed the scanner, returned to Machines, released CameraX, and allowed reopening without restarting the app.
- A successful scan closed the camera, POSTed the one-use claim, reused the returned API key on authenticated status/model/capability requests, selected `android-qr-uat`, and opened Create.

## Review

An independent sub-agent review found one teardown issue: Android unmount still called the upstream cancel API. The fix and regression test were added; re-review reported no remaining findings.
