### PR TITLE
fix(mobile): keep generation lifecycle status visible

### DIFF
--- a/changelog.d/mobile-generation-lifecycle-parity.md
+++ b/changelog.d/mobile-generation-lifecycle-parity.md
@@ -1,0 +1,1 @@
+- **Mobile generation status.** Keeps Create queue status aligned with Machines lifecycle feedback and prevents long preparation details from clipping on phone layouts.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -2248,6 +2248,114 @@ describe("MobileApp generation queue", () => {
     expect(wrapper.text()).toContain("Queued");
   });
 
+  it("uses the Machines lifecycle authority for a locally submitted print", async () => {
+    let activityItems: Array<Record<string, unknown>> = [];
+    apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/status") return Promise.resolve(status);
+      if (path === "/api/models") return Promise.resolve([model]);
+      if (path === "/api/gallery") return Promise.resolve([print]);
+      if (path === "/api/capabilities") {
+        return Promise.resolve({ events: { available: true }, ...durableQueueCapabilities });
+      }
+      if (path === "/api/activity") {
+        return Promise.resolve({
+          instance_id: "studio-id",
+          observed_at_unix_ms: Date.now(),
+          items: activityItems,
+        });
+      }
+      if (path === "/api/queue") {
+        return Promise.resolve({
+          entries: [
+            {
+              id: "lifecycle-job",
+              model: model.name,
+              state: "queued",
+              started_at_unix_ms: 1,
+              position: 0,
+            },
+          ],
+          plan: null,
+        });
+      }
+      if (path === "/api/generation-batches" && init?.method === "POST") {
+        const clientBatchId = JSON.parse(String(init.body)).client_batch_id as string;
+        return Promise.resolve({
+          id: "lifecycle-batch",
+          client_batch_id: clientBatchId,
+          instance_id: "studio-id",
+          durable: true,
+          children: [
+            {
+              index: 1,
+              job_id: "lifecycle-job",
+              state: "queued",
+              created_at_ms: 10,
+              updated_at_ms: 11,
+            },
+          ],
+        });
+      }
+      return durableApiFallback(path, init, callTarget);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await submitPrompt("show the real lifecycle");
+    window.dispatchEvent(new Event("pageshow"));
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-generation-status']").text()).toBe("NEXT UP");
+
+    activityItems = [
+      {
+        id: "lifecycle-job",
+        kind: "generation",
+        phase: "preparing",
+        model: model.name,
+        created_at_unix_ms: 10,
+        updated_at_unix_ms: 12,
+        preparation_progress: {
+          component: "Opening MiniMax H3 checkpoints",
+          bytes_done: 0,
+          bytes_total: 0,
+        },
+        can_cancel: true,
+      },
+    ];
+    window.dispatchEvent(new Event("pageshow"));
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-generation-status']").text()).toBe(
+      "PREPARING · OPENING MINIMAX H3 CHECKPOINTS",
+    );
+    expect(wrapper.get(".mobile-generation-job").classes()).toContain(
+      "mobile-generation-job--detailed-status",
+    );
+
+    activityItems = [
+      {
+        id: "lifecycle-job",
+        kind: "generation",
+        phase: "running",
+        model: model.name,
+        stage: "Encoding video",
+        created_at_unix_ms: 10,
+        updated_at_unix_ms: 12,
+        can_cancel: true,
+      },
+    ];
+    window.dispatchEvent(new Event("pageshow"));
+    await flushPromises();
+
+    expect(wrapper.get("[data-test='mobile-generation-status']").text()).toBe("ENCODING VIDEO");
+    expect(wrapper.get(".mobile-generation-job").classes()).not.toContain(
+      "mobile-generation-job--detailed-status",
+    );
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toBe("Encoding video");
+    expect(wrapper.get("[data-test='mobile-queue-count']").text()).toBe("1 active");
+  });
+
   it("confirms and tracks the exact model download when a pinned v2 host is missing it", async () => {
     let installed = false;
     apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -159,6 +159,7 @@ import {
   resolveQueueWait,
 } from "@studio/lib/queuePosition";
 import {
+  activeWorkPhaseLabel,
   mergeFleetActivity,
   listActiveWork,
   reconcileActivityHost,
@@ -546,6 +547,8 @@ type ActivityRow =
       queueState: string | null;
       blockedReason: string | null;
       preparation: Extract<ActivityJobVM, { kind: "print" }>["preparation"];
+      /** Matching fresh `/api/activity` lifecycle, when the host has one. */
+      live: FleetActiveWork | null;
       sequence: null;
     }
   | { key: string; print: null; sequence: Extract<ActivityJobVM, { kind: "sequence" }> };
@@ -2383,9 +2386,36 @@ const queueStatusIndex = computed(() =>
     })),
   ),
 );
+const liveGenerationActivityIndex = computed(() => {
+  const index = new Map<string, FleetActiveWork>();
+  for (const row of mergeFleetActivity(Object.values(liveActivityHosts.value))) {
+    if (row.kind === "generation" && !row.stale) index.set(row.key, row);
+  }
+  return index;
+});
+
+function liveGenerationActivityFor(job: Job): FleetActiveWork | null {
+  const hostId = job.hostId ?? selectedHostId.value;
+  return job.id
+    ? (liveGenerationActivityIndex.value.get(`${hostId}:generation:${job.id}`) ?? null)
+    : null;
+}
+
+function mobilePrintPhase(job: Job, live: FleetActiveWork | null): PrintActivityVM["phase"] {
+  if (live) {
+    if (live.phase === "paused") return "paused";
+    if (live.phase === "queued" || live.phase === "preparing" || live.phase === "held") {
+      return "queued";
+    }
+    return "running";
+  }
+  return job.status === "queued" ? "queued" : "running";
+}
+
 const printActivity = computed<ActivityJobVM[]>(() => {
   const ordered = queuedJobs.value;
   return ordered.map((job) => {
+    const live = liveGenerationActivityFor(job);
     const vm: PrintActivityVM = {
       kind: "print" as const,
       key: `print:${job.clientId}`,
@@ -2393,7 +2423,7 @@ const printActivity = computed<ActivityJobVM[]>(() => {
       hostLabel: job.hostLabel ?? "",
       model: job.model,
       prompt: job.prompt,
-      phase: job.status === "queued" ? ("queued" as const) : ("running" as const),
+      phase: mobilePrintPhase(job, live),
       progress: null,
       chain: null,
       actions: ["cancel" as const],
@@ -2434,6 +2464,7 @@ const activityRows = computed<ActivityRow[]>(() =>
             queueState: vm.queueState ?? null,
             blockedReason: vm.blockedReason ?? null,
             preparation: vm.preparation ?? null,
+            live: liveGenerationActivityFor(print),
           },
         ]
       : [];
@@ -2447,7 +2478,9 @@ function activityRowHostId(row: ActivityRow): string {
 }
 
 function activityRowIsQueued(row: ActivityRow): boolean {
-  return row.print ? row.print.status === "queued" : row.sequence?.state === "queued";
+  return row.print
+    ? mobilePrintPhase(row.print, row.live) === "queued"
+    : row.sequence?.state === "queued";
 }
 
 function canPauseActivityRow(row: ActivityRow): boolean {
@@ -2564,6 +2597,9 @@ function fleetQueueResumeNeeded(row: FleetActiveWork): boolean {
  */
 function activityRowStatus(row: ActivityRow): string {
   if (!row.print) return "";
+  if (row.live && row.live.phase !== "queued" && row.live.phase !== "paused") {
+    return activeWorkPhaseLabel(row.live).toLocaleUpperCase();
+  }
   if (row.print.status !== "queued") return jobStatusCode(row.print);
   if (durableHold(row.print)) return "HELD";
   if (activityRowQueuePaused(row)) return "QUEUE PAUSED";
@@ -2575,6 +2611,10 @@ function activityRowStatus(row: ActivityRow): string {
       preparation: row.preparation,
     }),
   );
+}
+
+function activityRowHasDetailedStatus(row: ActivityRow): boolean {
+  return row.print !== null && activityRowStatus(row).length > 18;
 }
 const sharedMobileActivity = computed(() => {
   const local = new Set(
@@ -2914,13 +2954,17 @@ async function openMobileLiveWork(row: FleetActiveWork): Promise<void> {
 const runningRowCount = computed(
   () =>
     activityRows.value.filter((row) =>
-      row.print ? row.print.status !== "queued" : row.sequence.state === "running",
+      row.print
+        ? mobilePrintPhase(row.print, row.live) === "running"
+        : row.sequence.state === "running",
     ).length,
 );
 const waitingRowCount = computed(
   () =>
     activityRows.value.filter((row) =>
-      row.print ? row.print.status === "queued" : row.sequence.state === "queued",
+      row.print
+        ? mobilePrintPhase(row.print, row.live) !== "running"
+        : row.sequence.state === "queued",
     ).length,
 );
 const activityCounts = computed(() => ({
@@ -3109,6 +3153,10 @@ const generationStatus = computed(() => {
   }
   const active = activeGeneration.value;
   if (!active) return progress.value;
+  const live = liveGenerationActivityFor(active);
+  if (live && live.phase !== "queued" && live.phase !== "paused") {
+    return activeWorkPhaseLabel(live);
+  }
   switch (active.status) {
     case "queued": {
       if (active.stage) return active.stage;
@@ -11861,6 +11909,11 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
                   >
                     <div
                       class="mobile-generation-job"
+                      :class="{
+                        'mobile-generation-job--detailed-status': activityRowHasDetailedStatus(
+                          entry.local,
+                        ),
+                      }"
                       role="button"
                       tabindex="0"
                       @click="

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -2548,7 +2548,10 @@ button:disabled {
 
 .mobile-generation-job {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
+  flex: 1;
+  width: 100%;
+  min-width: 0;
+  grid-template-columns: minmax(0, 1fr) minmax(72px, 42%);
   align-items: center;
   gap: 12px;
   min-height: 72px;
@@ -2557,6 +2560,12 @@ button:disabled {
 
 .mobile-generation-job + .mobile-generation-job {
   border-top: 1px solid var(--edge);
+}
+
+.mobile-generation-job--detailed-status {
+  grid-template-columns: minmax(0, 1fr);
+  align-items: start;
+  gap: 7px;
 }
 
 .mobile-generation-job-copy {
@@ -2588,12 +2597,27 @@ button:disabled {
 
 .mobile-generation-job-action {
   display: grid;
+  min-width: 0;
   justify-items: end;
 }
 
 .mobile-generation-job-action > span {
+  max-width: 100%;
   margin-top: 0;
   color: var(--halide);
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+  text-align: right;
+  text-overflow: clip;
+  white-space: normal;
+}
+
+.mobile-generation-job--detailed-status .mobile-generation-job-action {
+  justify-items: start;
+}
+
+.mobile-generation-job--detailed-status .mobile-generation-job-action > span {
+  text-align: left;
 }
 
 .mobile-generation-cancel {

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -9,6 +9,8 @@ const pullComponent = readFileSync("src/mobile/MobileExpansionPullStatus.vue", "
 const composerComponent = readFileSync("src/mobile/MobileSequenceComposer.vue", "utf8");
 const sharedParamsComponent = readFileSync("src/mobile/MobileSharedParams.vue", "utf8");
 const seamPillComponent = readFileSync("../ui/components/SeamPill.vue", "utf8");
+const liveActivityComponent = readFileSync("../ui/components/LiveActivityList.vue", "utf8");
+const swipeActionRowComponent = readFileSync("../studio/components/SwipeActionRow.vue", "utf8");
 
 describe("mobile theme bootstrap", () => {
   it("paints fresh installs as Safelight Dark before Vue mounts", () => {
@@ -149,6 +151,33 @@ describe("mobile scrolling", () => {
     const wideDetail = css.match(/@media \(min-width: 900px\) \{([\s\S]*?)\n\}/);
     expect(wideDetail?.[1]).toMatch(
       /\.mobile-catalog-detail-scroll\s*\{[\s\S]*minmax\(320px,[\s\S]*minmax\(420px,/,
+    );
+  });
+});
+
+describe("mobile generation status containment", () => {
+  it("bounds local queue rows and wraps detailed backend status", () => {
+    const row = css.match(/\.mobile-generation-job\s*\{([^}]*)\}/s);
+    const detailed = css.match(/\.mobile-generation-job--detailed-status\s*\{([^}]*)\}/s);
+
+    expect(row?.[1]).toMatch(/width:\s*100%\s*;/);
+    expect(row?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(row?.[1]).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)/);
+    expect(detailed?.[1]).toMatch(/grid-template-columns:\s*minmax\(0,\s*1fr\)\s*;/);
+    expect(css).toMatch(
+      /\.mobile-generation-job-action\s*>\s*span\s*\{[^}]*max-width:\s*100%\s*;[^}]*overflow-wrap:\s*anywhere\s*;[^}]*white-space:\s*normal\s*;/s,
+    );
+  });
+
+  it("bounds shared and swipeable activity surfaces before truncating detail", () => {
+    expect(liveActivityComponent).toMatch(
+      /\.live-activity-surface\s*\{[^}]*width:\s*100%\s*;[^}]*min-width:\s*0\s*;[^}]*box-sizing:\s*border-box\s*;/s,
+    );
+    expect(liveActivityComponent).toMatch(
+      /\.live-activity-copy\s+span\s*\{[^}]*overflow:\s*hidden\s*;[^}]*text-overflow:\s*ellipsis\s*;[^}]*white-space:\s*nowrap\s*;/s,
+    );
+    expect(swipeActionRowComponent).toMatch(
+      /\.swipe-row__surface\s*\{[^}]*width:\s*100%\s*;[^}]*min-width:\s*0\s*;[^}]*box-sizing:\s*border-box\s*;/s,
     );
   });
 });

--- a/studio/api/activity.test.ts
+++ b/studio/api/activity.test.ts
@@ -1,9 +1,44 @@
 import { describe, expect, it } from "vitest";
 import {
+  activeWorkPhaseLabel,
   mergeFleetActivity,
   parseActiveWorkSnapshot,
   reconcileActivityHost,
 } from "./activity";
+
+describe("activeWorkPhaseLabel", () => {
+  it("prefers the backend stage over a generic running phase", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "job-1",
+        kind: "generation",
+        phase: "running",
+        stage: "Encoding video",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        can_cancel: true,
+      }),
+    ).toBe("Encoding video");
+  });
+
+  it("names the component while preparation is still active", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "job-1",
+        kind: "generation",
+        phase: "preparing",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        preparation_progress: {
+          component: "Opening MiniMax H3 checkpoints",
+          bytes_done: 0,
+          bytes_total: 0,
+        },
+        can_cancel: true,
+      }),
+    ).toBe("Preparing · Opening MiniMax H3 checkpoints");
+  });
+});
 
 const route = {
   hostId: "host-a",

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -21,6 +21,19 @@ export interface ActiveWorkItem {
   can_cancel: boolean;
 }
 
+/**
+ * Human-readable lifecycle detail from the host's active-work authority.
+ * Keep this shared so a job cannot say "Encoding" under Machines while the
+ * same snapshot is reduced to a generic phase on Create.
+ */
+export function activeWorkPhaseLabel(row: ActiveWorkItem): string {
+  if (row.phase === "preparing" && row.preparation_progress?.component) {
+    return `Preparing · ${row.preparation_progress.component}`;
+  }
+  if (row.stage?.trim()) return row.stage.trim();
+  return row.phase.replaceAll("_", " ");
+}
+
 export interface ActiveWorkSnapshot {
   instance_id: string;
   observed_at_unix_ms: number;

--- a/studio/components/SwipeActionRow.vue
+++ b/studio/components/SwipeActionRow.vue
@@ -209,6 +209,9 @@ defineExpose({ close });
 .swipe-row__surface {
   position: relative;
   display: flex;
+  width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   align-items: center;
   gap: 8px;
   background: var(--bench, var(--bath));

--- a/ui/components/LiveActivityList.test.ts
+++ b/ui/components/LiveActivityList.test.ts
@@ -62,4 +62,29 @@ describe("LiveActivityList swipe actions", () => {
     expect(vertical.defaultPrevented).toBe(false);
     expect(item.classes()).not.toContain("live-activity-row--actions-open");
   });
+
+  it("contains a long preparation status inside the available phone row", () => {
+    const wrapper = mount(LiveActivityList, {
+      props: {
+        rows: [
+          {
+            ...row,
+            phase: "preparing",
+            preparation_progress: {
+              component: "Opening MiniMax H3 checkpoints",
+              bytes_done: 0,
+              bytes_total: 0,
+            },
+          },
+        ],
+      },
+    });
+    const detail = wrapper.get(".live-activity-copy > span");
+    expect(detail.text()).toContain(
+      "Preparing · Opening MiniMax H3 checkpoints",
+    );
+    expect(wrapper.get(".live-activity-surface").classes()).toContain(
+      "live-activity-surface",
+    );
+  });
 });

--- a/ui/components/LiveActivityList.vue
+++ b/ui/components/LiveActivityList.vue
@@ -1,6 +1,9 @@
 <script setup lang="ts">
 import { ref } from "vue";
-import type { FleetActiveWork } from "@studio/api/activity";
+import {
+  activeWorkPhaseLabel,
+  type FleetActiveWork,
+} from "@studio/api/activity";
 import { resolveSwipeAxis, type SwipePhase } from "@studio/lib/swipeAction";
 
 const props = withDefaults(
@@ -94,14 +97,6 @@ function progress(row: FleetActiveWork): number | null {
     Math.min(100, Math.round((row.current / row.total) * 100)),
   );
 }
-
-function phase(row: FleetActiveWork): string {
-  if (row.phase === "preparing" && row.preparation_progress?.component) {
-    return `Preparing · ${row.preparation_progress.component}`;
-  }
-  if (row.stage) return row.stage;
-  return row.phase.replaceAll("_", " ");
-}
 </script>
 
 <template>
@@ -146,7 +141,7 @@ function phase(row: FleetActiveWork): string {
         <span class="live-activity-copy">
           <strong>{{ title(row) }}</strong>
           <span>
-            {{ row.hostLabel }} · {{ phase(row) }}
+            {{ row.hostLabel }} · {{ activeWorkPhaseLabel(row) }}
             <template v-if="progress(row) !== null">
               · {{ progress(row) }}%</template
             >
@@ -189,6 +184,8 @@ function phase(row: FleetActiveWork): string {
   z-index: 1;
   display: flex;
   width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   align-items: center;
   text-align: left;
   gap: 9px;
@@ -248,6 +245,7 @@ function phase(row: FleetActiveWork): string {
 }
 .live-activity-copy {
   display: grid;
+  flex: 1;
   min-width: 0;
   gap: 2px;
 }
@@ -259,9 +257,12 @@ function phase(row: FleetActiveWork): string {
   white-space: nowrap;
 }
 .live-activity-copy span {
+  overflow: hidden;
   color: var(--ink-3);
   font-size: 11px;
+  text-overflow: ellipsis;
   text-transform: capitalize;
+  white-space: nowrap;
 }
 .live-activity-list--compact .live-activity-surface {
   min-height: 38px;


### PR DESCRIPTION
## Summary

- use `/api/activity` as the authoritative lifecycle overlay for locally submitted mobile jobs so Create matches Machines during preparation, encoding, and other backend stages
- contain and wrap long local queue statuses on phone layouts while keeping shared/recovered activity rows bounded
- add lifecycle, component, and CSS-contract regression coverage plus a user-facing changelog fragment

## Verification

- `nix develop -c bun run --cwd desktop test --run src/mobile/mobile.css.test.ts src/mobile/MobileApp.test.ts ../studio/api/activity.test.ts ../ui/components/LiveActivityList.test.ts` — 394 passed
- `nix develop -c bun run --cwd desktop fmt:check`
- `nix develop -c bun run --cwd desktop build:mobile`
- `bash scripts/release/check-changelog-fragments.sh <base> <head>`
- iPhone-sized rendered UAT at 390×844: full `PREPARING · OPENING MINIMAX H3 CHECKPOINTS` visible, no horizontal overflow (`scrollWidth = 390`), swipe actions open/close correctly, clean console
- repo-supported iPhone Simulator build/install/launch on iPhone 16 Pro (iOS 18.6) passed

## Review

Independent sub-agent peer review completed. Its CSS-contract coverage finding was addressed; final re-review found no remaining P0–P3 issues.

## Physical-device note

A paired iPhone 13 Pro build was attempted, but this Mac has no configured Apple developer account/development certificate for team `28X9H69QGE`. Simulator and browser UAT completed successfully.
