### PR TITLE
fix(mobile): share queue progress cards

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -287,8 +287,11 @@ pushed screen opened from the header.
   pending scan before another scan can begin. Host detail shows telemetry, models-disk usage, queue,
   downloads, loaded models, and installed models (all using catalog display
   names rather than opaque `cv:` / `hf:` ids), with rename, retry, select,
-  unload, open-in-Models, and forget actions. Queue rows are swipe-to-act
-  (`studio/components/SwipeActionRow.vue`, gesture math in
+  unload, open-in-Models, and forget actions. Queue rows render through the
+  same `MobileGenerationQueueCard` used by Create, so
+  prompt/model/host hierarchy, long-stage wrapping, and live `current/total`
+  progress stay visually and semantically identical on both tabs. They are
+  swipe-to-act (`studio/components/SwipeActionRow.vue`, gesture math in
   `studio/lib/swipeAction.ts`): a right-to-left swipe reveals a 44pt tray, and
   from that revealed tray a tap or a second full swipe past 60% of the row
   commits **Cancel**, which reaches queued rows always and running singletons

--- a/changelog.d/mobile-shared-queue-progress.md
+++ b/changelog.d/mobile-shared-queue-progress.md
@@ -1,0 +1,1 @@
+- **Consistent mobile generation progress.** Create now keeps each running job's live step count visible, and Create and Machines share the same clean queue-card presentation.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -2340,6 +2340,8 @@ describe("MobileApp generation queue", () => {
         phase: "running",
         model: model.name,
         stage: "Encoding video",
+        current: 15,
+        total: 20,
         created_at_unix_ms: 10,
         updated_at_unix_ms: 12,
         can_cancel: true,
@@ -2348,11 +2350,15 @@ describe("MobileApp generation queue", () => {
     window.dispatchEvent(new Event("pageshow"));
     await flushPromises();
 
-    expect(wrapper.get("[data-test='mobile-generation-status']").text()).toBe("ENCODING VIDEO");
-    expect(wrapper.get(".mobile-generation-job").classes()).not.toContain(
+    expect(wrapper.get("[data-test='mobile-generation-status']").text()).toBe(
+      "ENCODING VIDEO · 15/20",
+    );
+    expect(wrapper.get(".mobile-generation-job").classes()).toContain(
       "mobile-generation-job--detailed-status",
     );
-    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toBe("Encoding video");
+    expect(wrapper.get("[data-test='mobile-generation-summary']").text()).toBe(
+      "Encoding video · 15/20",
+    );
     expect(wrapper.get("[data-test='mobile-queue-count']").text()).toBe("1 active");
   });
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -19,6 +19,7 @@ import {
 } from "@tauri-apps/plugin-barcode-scanner";
 import { getCurrent, onOpenUrl } from "@tauri-apps/plugin-deep-link";
 import EstimateBadge from "../components/generate/EstimateBadge.vue";
+import MobileGenerationQueueCard from "./MobileGenerationQueueCard.vue";
 import { ApiError, apiFetchTo, apiJsonTo, type ApiTarget } from "../lib/api/client";
 import { describeTransportError } from "../lib/api/errors";
 import { expandPrompt } from "../lib/api/expand";
@@ -2613,9 +2614,6 @@ function activityRowStatus(row: ActivityRow): string {
   );
 }
 
-function activityRowHasDetailedStatus(row: ActivityRow): boolean {
-  return row.print !== null && activityRowStatus(row).length > 18;
-}
 const sharedMobileActivity = computed(() => {
   const local = new Set(
     allGenerationJobs.value.flatMap((job) =>
@@ -11907,96 +11905,65 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
                     :data-test="entry.local.print ? 'mobile-generation-job' : 'mobile-sequence-job'"
                     @act="onMobileQueueRowAction(entry.local, $event)"
                   >
+                    <MobileGenerationQueueCard
+                      v-if="entry.local.print"
+                      :title="entry.local.print.prompt"
+                      :subtitle="`${modelLabel(entry.local.print.model)} · ${entry.local.print.hostLabel}`"
+                      :status="activityRowStatus(entry.local)"
+                      :detail="durableHold(entry.local.print)?.error ?? null"
+                      :cancelling="entry.local.print.cancelling === true"
+                      :aria-label="entry.local.print.prompt"
+                      @activate="selectMobilePrint(entry.local.print)"
+                    />
                     <div
+                      v-if="entry.local.sequence"
                       class="mobile-generation-job"
-                      :class="{
-                        'mobile-generation-job--detailed-status': activityRowHasDetailedStatus(
-                          entry.local,
-                        ),
-                      }"
                       role="button"
                       tabindex="0"
-                      @click="
-                        entry.local.print
-                          ? selectMobilePrint(entry.local.print)
-                          : selectCurrentMobileSequence()
-                      "
-                      @keydown.enter.prevent="
-                        entry.local.print
-                          ? selectMobilePrint(entry.local.print)
-                          : selectCurrentMobileSequence()
-                      "
+                      @click="selectCurrentMobileSequence()"
+                      @keydown.enter.prevent="selectCurrentMobileSequence()"
                     >
-                      <template v-if="entry.local.print">
-                        <div class="mobile-generation-job-copy">
-                          <p>{{ entry.local.print.prompt }}</p>
-                          <span>
-                            {{ modelLabel(entry.local.print.model) }} ·
-                            {{ entry.local.print.hostLabel }}
+                      <div class="mobile-generation-job-copy">
+                        <p>
+                          {{ modelLabel(entry.local.sequence.model) || "Sequence" }} ·
+                          {{ entry.local.sequence.stageCount }} clips
+                        </p>
+                        <span>
+                          {{ entry.local.sequence.phase ?? entry.local.sequence.state }} · clip
+                          {{
+                            Math.min(
+                              entry.local.sequence.currentStage + 1,
+                              entry.local.sequence.stageCount,
+                            )
+                          }}/{{ entry.local.sequence.stageCount }}
+                          <template v-if="sequenceRowProgress !== null">
+                            · {{ sequenceRowProgress }}%
+                          </template>
+                        </span>
+                        <button
+                          v-if="entry.local.sequence.error"
+                          type="button"
+                          class="mobile-sequence-row-error"
+                          :class="{
+                            'mobile-sequence-row-error--expanded': expandedQueueFailures.has(
+                              entry.local.key,
+                            ),
+                          }"
+                          data-test="mobile-sequence-error-disclosure"
+                          :aria-expanded="expandedQueueFailures.has(entry.local.key)"
+                          @click.stop="toggleQueueFailure(entry.local.key)"
+                        >
+                          <span>{{ entry.local.sequence.error }}</span>
+                          <span aria-hidden="true">
+                            {{ expandedQueueFailures.has(entry.local.key) ? "Less" : "Details" }}
                           </span>
-                          <p
-                            v-if="durableHold(entry.local.print)?.error"
-                            class="mobile-generation-held-error"
-                            data-test="mobile-generation-held-error"
-                          >
-                            {{ durableHold(entry.local.print)?.error }}
-                          </p>
-                        </div>
-                        <div class="mobile-generation-job-action">
-                          <span data-test="mobile-generation-status">{{
-                            activityRowStatus(entry.local)
-                          }}</span>
-                          <span
-                            v-if="entry.local.print.cancelling"
-                            data-test="mobile-generation-cancelling"
-                          >
-                            Cancelling…
-                          </span>
-                        </div>
-                      </template>
-                      <template v-else-if="entry.local.sequence">
-                        <div class="mobile-generation-job-copy">
-                          <p>
-                            {{ modelLabel(entry.local.sequence.model) || "Sequence" }} ·
-                            {{ entry.local.sequence.stageCount }} clips
-                          </p>
-                          <span>
-                            {{ entry.local.sequence.phase ?? entry.local.sequence.state }} · clip
-                            {{
-                              Math.min(
-                                entry.local.sequence.currentStage + 1,
-                                entry.local.sequence.stageCount,
-                              )
-                            }}/{{ entry.local.sequence.stageCount }}
-                            <template v-if="sequenceRowProgress !== null">
-                              · {{ sequenceRowProgress }}%
-                            </template>
-                          </span>
-                          <button
-                            v-if="entry.local.sequence.error"
-                            type="button"
-                            class="mobile-sequence-row-error"
-                            :class="{
-                              'mobile-sequence-row-error--expanded': expandedQueueFailures.has(
-                                entry.local.key,
-                              ),
-                            }"
-                            data-test="mobile-sequence-error-disclosure"
-                            :aria-expanded="expandedQueueFailures.has(entry.local.key)"
-                            @click.stop="toggleQueueFailure(entry.local.key)"
-                          >
-                            <span>{{ entry.local.sequence.error }}</span>
-                            <span aria-hidden="true">
-                              {{ expandedQueueFailures.has(entry.local.key) ? "Less" : "Details" }}
-                            </span>
-                          </button>
-                        </div>
-                        <div class="mobile-generation-job-action">
-                          <span data-test="mobile-sequence-status">
-                            {{ entry.local.sequence.hostLabel }}
-                          </span>
-                        </div>
-                      </template>
+                        </button>
+                      </div>
+                      <div class="mobile-generation-job-action">
+                        <span data-test="mobile-sequence-status">
+                          {{ entry.local.sequence.hostLabel }}
+                        </span>
+                      </div>
                     </div>
                   </SwipeActionRow>
                 </div>

--- a/desktop/src/mobile/MobileGenerationQueueCard.test.ts
+++ b/desktop/src/mobile/MobileGenerationQueueCard.test.ts
@@ -1,0 +1,21 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+import MobileGenerationQueueCard from "./MobileGenerationQueueCard.vue";
+
+describe("MobileGenerationQueueCard", () => {
+  it("activates with Enter and Space", async () => {
+    const view = mount(MobileGenerationQueueCard, {
+      props: {
+        title: "Recovered print",
+        subtitle: "MiniMax H3 FL2VA · plato",
+        status: "STREAMING MINIMAX H3 TRANSFORMER BLOCKS · 17/20",
+      },
+    });
+    const card = view.get("[data-test='mobile-generation-queue-card']");
+
+    await card.trigger("keydown", { key: "Enter" });
+    await card.trigger("keydown", { key: " " });
+
+    expect(view.emitted("activate")).toHaveLength(2);
+  });
+});

--- a/desktop/src/mobile/MobileGenerationQueueCard.vue
+++ b/desktop/src/mobile/MobileGenerationQueueCard.vue
@@ -1,0 +1,54 @@
+<script setup lang="ts">
+import { computed } from "vue";
+
+const props = withDefaults(
+  defineProps<{
+    title: string;
+    subtitle: string;
+    status: string;
+    detail?: string | null;
+    cancelling?: boolean;
+    ariaLabel?: string;
+  }>(),
+  {
+    detail: null,
+    cancelling: false,
+  },
+);
+
+const emit = defineEmits<{
+  activate: [];
+}>();
+
+const detailedStatus = computed(() => props.status.length > 18);
+</script>
+
+<template>
+  <div
+    class="mobile-generation-job"
+    :class="{ 'mobile-generation-job--detailed-status': detailedStatus }"
+    role="button"
+    tabindex="0"
+    :aria-label="ariaLabel"
+    data-test="mobile-generation-queue-card"
+    @click="emit('activate')"
+    @keydown.enter.prevent="emit('activate')"
+    @keydown.space.prevent="emit('activate')"
+  >
+    <div class="mobile-generation-job-copy">
+      <p>{{ title }}</p>
+      <span>{{ subtitle }}</span>
+      <p
+        v-if="detail"
+        class="mobile-generation-held-error"
+        data-test="mobile-generation-held-error"
+      >
+        {{ detail }}
+      </p>
+    </div>
+    <div class="mobile-generation-job-action">
+      <span data-test="mobile-generation-status">{{ status }}</span>
+      <span v-if="cancelling" data-test="mobile-generation-cancelling"> Cancelling… </span>
+    </div>
+  </div>
+</template>

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -323,6 +323,8 @@ describe("MobileHostDetail remote host data", () => {
                 activity_phase: "active",
                 runtime_phase: "loading",
                 runtime_stage: "Loading Flux.2 transformer",
+                runtime_current: 17,
+                runtime_total: 20,
               },
             ],
           },
@@ -333,7 +335,7 @@ describe("MobileHostDetail remote host data", () => {
 
     const view = await mountDetail();
     const row = view.get("[data-test='host-detail-queue-row-job-queued']");
-    expect(row.text()).toContain("LOADING FLUX.2 TRANSFORMER");
+    expect(row.text()).toContain("LOADING FLUX.2 TRANSFORMER · 17/20");
     expect(row.text()).not.toContain("NEXT UP");
   });
 
@@ -528,8 +530,8 @@ describe("MobileHostDetail remote host data", () => {
 
     const queueRows = view.get("[data-test='host-detail-queue']").findAll("li");
     expect(queueRows).toHaveLength(2);
-    expect(queueRows[0]!.text()).toContain("z-image:q8QUEUED #2");
-    expect(queueRows[1]!.text()).toContain("flux-dev:q8RUNNING · GPU 0");
+    expect(queueRows[0]!.text()).toContain("z-image:q8StudioQUEUED #2");
+    expect(queueRows[1]!.text()).toContain("flux-dev:q8StudioRUNNING · GPU 0");
 
     const modelRows = view.get("[data-test='host-detail-models']").findAll("li");
     expect(modelRows).toHaveLength(2);
@@ -642,7 +644,9 @@ describe("MobileHostDetail remote host data", () => {
   it("renders the machine queue newest-first", async () => {
     const view = await mountDetail();
     expect(
-      view.findAll("[data-test^='host-detail-queue-row-']").map((row) => row.find("strong").text()),
+      view
+        .findAll("[data-test^='host-detail-queue-row-']")
+        .map((row) => row.get(".mobile-generation-job-copy p").text()),
     ).toEqual(["z-image:q8", "flux-dev:q8"]);
   });
 

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -17,6 +17,7 @@ import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import QueueEntryDetail from "@studio/components/QueueEntryDetail.vue";
 import SwipeActionRow from "@studio/components/SwipeActionRow.vue";
 import MobileLibrarySheet from "./MobileLibrarySheet.vue";
+import MobileGenerationQueueCard from "./MobileGenerationQueueCard.vue";
 import { queueEntryDetailModel, type QueueDetailMetadata } from "@studio/lib/queueEntryDetail";
 import type { SwipeRowAction } from "@studio/lib/swipeAction";
 import MinimaxH3InventoryPanel from "@studio/components/MinimaxH3InventoryPanel.vue";
@@ -1306,16 +1307,19 @@ onBeforeUnmount(() => {
               :data-test="`host-detail-queue-row-${entry.id}`"
               @act="onQueueRowAction(entry, $event)"
             >
-              <button
-                type="button"
-                class="mobile-queue-open"
-                :data-test="`host-detail-queue-open-${entry.id}`"
+              <MobileGenerationQueueCard
+                :title="entry.metadata?.prompt?.trim() || modelLabel(entry.model)"
+                :subtitle="
+                  entry.metadata?.prompt?.trim()
+                    ? `${modelLabel(entry.model)} · ${host.name}`
+                    : host.name
+                "
+                :status="queueRowBusy(entry) ? 'WORKING…' : queueCode(entry)"
+                :detail="entry.state === 'held' ? entry.error || entry.held_reason || null : null"
                 :aria-label="`Job details for ${modelLabel(entry.model)}`"
-                @click="inspectedQueueId = entry.id"
-              >
-                <strong>{{ modelLabel(entry.model) }}</strong>
-                <span>{{ queueRowBusy(entry) ? "WORKING…" : queueCode(entry) }}</span>
-              </button>
+                :data-test="`host-detail-queue-open-${entry.id}`"
+                @activate="inspectedQueueId = entry.id"
+              />
             </SwipeActionRow>
           </li>
         </ul>

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -4541,6 +4541,10 @@ button:disabled {
   border-top: 1px solid var(--edge);
 }
 
+.mobile-data-list li.mobile-queue-item {
+  padding: 0;
+}
+
 .mobile-data-list li > div {
   min-width: 0;
   flex: 1;

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -4,6 +4,8 @@ import { describe, expect, it } from "vitest";
 const css = readFileSync("src/mobile/mobile.css", "utf8");
 const mobileHtml = readFileSync("index.mobile.html", "utf8");
 const mobileAppComponent = readFileSync("src/mobile/MobileApp.vue", "utf8");
+const mobileHostDetailComponent = readFileSync("src/mobile/MobileHostDetail.vue", "utf8");
+const mobileGenerationQueueCard = readFileSync("src/mobile/MobileGenerationQueueCard.vue", "utf8");
 const preparedComponent = readFileSync("src/mobile/MobilePreparedExpansionBatch.vue", "utf8");
 const pullComponent = readFileSync("src/mobile/MobileExpansionPullStatus.vue", "utf8");
 const composerComponent = readFileSync("src/mobile/MobileSequenceComposer.vue", "utf8");
@@ -156,6 +158,12 @@ describe("mobile scrolling", () => {
 });
 
 describe("mobile generation status containment", () => {
+  it("renders Create and Machines queue jobs through one shared card", () => {
+    expect(mobileAppComponent).toContain("<MobileGenerationQueueCard");
+    expect(mobileHostDetailComponent).toContain("<MobileGenerationQueueCard");
+    expect(mobileGenerationQueueCard).toContain('data-test="mobile-generation-status"');
+  });
+
   it("bounds local queue rows and wraps detailed backend status", () => {
     const row = css.match(/\.mobile-generation-job\s*\{([^}]*)\}/s);
     const detailed = css.match(/\.mobile-generation-job--detailed-status\s*\{([^}]*)\}/s);

--- a/studio/api/activity.test.ts
+++ b/studio/api/activity.test.ts
@@ -21,6 +21,23 @@ describe("activeWorkPhaseLabel", () => {
     ).toBe("Encoding video");
   });
 
+  it("keeps the host's current and total progress in the shared activity label", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "generation-1",
+        kind: "generation",
+        phase: "running",
+        model: "minimax-h3-fl2va:comfy-pruned-int8",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        current: 17,
+        total: 20,
+        stage: "Streaming MiniMax H3 transformer blocks",
+        can_cancel: true,
+      }),
+    ).toBe("Streaming MiniMax H3 transformer blocks · 17/20");
+  });
+
   it("names the component while preparation is still active", () => {
     expect(
       activeWorkPhaseLabel({

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -30,8 +30,11 @@ export function activeWorkPhaseLabel(row: ActiveWorkItem): string {
   if (row.phase === "preparing" && row.preparation_progress?.component) {
     return `Preparing · ${row.preparation_progress.component}`;
   }
-  if (row.stage?.trim()) return row.stage.trim();
-  return row.phase.replaceAll("_", " ");
+  const stage = row.stage?.trim() || row.phase.replaceAll("_", " ");
+  if (row.current != null && row.total != null && row.total > 0) {
+    return `${stage} · ${row.current}/${row.total}`;
+  }
+  return stage;
 }
 
 export interface ActiveWorkSnapshot {


### PR DESCRIPTION
## Summary

- keep live `current/total` generation progress visible on Create
- render Create and Machines queue jobs through one shared mobile card
- preserve the cleaner prompt/model/host hierarchy and wrap detailed runtime stages

## Validation

- `nix develop -c bun run test:studio` — 1,505 passed
- full desktop Vitest suite — 5,495 passed
- focused post-review mobile tests — 434 passed
- `nix develop -c bun run check:architecture`
- `nix develop -c bun run build:mobile`
- `nix develop -c bun run fmt:check`
- changelog fragment policy check

## UAT

- verified at 390×844 that Create reports live `15/20` progress
- verified Machines uses the same generation card and wraps the detailed runtime stage without clipping
- opened the Machines job detail sheet and verified `Step 15 of 20`, prompt, dimensions, steps, guidance, and GPU lane

## Peer review

Independent agent review completed. Its Space-key accessibility and Machines `17/20` regression-test findings were addressed before push.
