### PR TITLE
fix(queue): settle stalled model switches

### DIFF
--- a/changelog.d/queue-warm-wait-settlement.md
+++ b/changelog.d/queue-warm-wait-settlement.md
@@ -1,0 +1,5 @@
+- **Queued generations keep moving after a model switch.** Bounded warm-model
+  waits now expire correctly instead of restarting forever, private H3 renders
+  settle their durable queue rows through the same dispatch boundary as every
+  other model, and queue estimates use plain language across web, desktop, and
+  mobile.

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -3246,6 +3246,14 @@ fn run_claimed_h3_generation(
         }
     };
 
+    // The private H3 route bypasses `process_job_with_sink`, but durable
+    // dispatch accounting is a generation-owner invariant rather than an
+    // engine implementation detail. Claim at the same allocation boundary as
+    // every other model so completion can settle the exact running row.
+    let Some(job) = claim_generation_dispatch(job) else {
+        return false;
+    };
+
     #[cfg(any(feature = "h3", feature = "h3-private-uat"))]
     let _private_load_lock = match worker.model_load_lock.lock() {
         Ok(lock) => lock,
@@ -3879,33 +3887,10 @@ fn process_job_with_sink(
         return false;
     }
 
-    // Charge the attempt here, on the owner thread, immediately before the
-    // model load — the phase that can take the process down with it. Charging
-    // at replay instead would delete a job that merely waited behind a long
-    // render through a few deploys, having never touched a GPU.
-    if let Some(ticket) = job.journal.as_ref() {
-        match ticket.claim_dispatch() {
-            crate::queue_journal::DispatchClaim::Exhausted { attempts, cap } => {
-                durable_generation_settlement::refuse_exhausted_dispatch_blocking(
-                    job,
-                    &model_name,
-                    attempts,
-                    cap,
-                );
-                return false;
-            }
-            crate::queue_journal::DispatchClaim::Fenced => {
-                durable_generation_settlement::refuse_fenced_dispatch(job, &job_id);
-                return false;
-            }
-            crate::queue_journal::DispatchClaim::Cancelled => {
-                finish_generation_cancelled(job, true);
-                return false;
-            }
-            crate::queue_journal::DispatchClaim::Granted
-            | crate::queue_journal::DispatchClaim::Untracked => {}
-        }
-    }
+    let Some(claimed_job) = claim_generation_dispatch(job) else {
+        return false;
+    };
+    job = claimed_job;
 
     // Every job gets a token, so a shutdown aborts it at the next inference
     // checkpoint instead of holding the deploy open. Registered through a
@@ -4707,6 +4692,39 @@ fn process_job_with_sink(
             );
             false
         }
+    }
+}
+
+/// Charge a durable generation attempt on its GPU owner immediately before
+/// model-specific allocation begins. Keeping this outside either engine route
+/// prevents a private model adapter from executing a queue row that completion
+/// can never settle.
+fn claim_generation_dispatch(job: GpuJob) -> Option<GpuJob> {
+    let Some(ticket) = job.journal.as_ref() else {
+        return Some(job);
+    };
+    let model_name = job.model.clone();
+    let job_id = job.id.clone();
+    match ticket.claim_dispatch() {
+        crate::queue_journal::DispatchClaim::Exhausted { attempts, cap } => {
+            durable_generation_settlement::refuse_exhausted_dispatch_blocking(
+                job,
+                &model_name,
+                attempts,
+                cap,
+            );
+            None
+        }
+        crate::queue_journal::DispatchClaim::Fenced => {
+            durable_generation_settlement::refuse_fenced_dispatch(job, &job_id);
+            None
+        }
+        crate::queue_journal::DispatchClaim::Cancelled => {
+            finish_generation_cancelled(job, true);
+            None
+        }
+        crate::queue_journal::DispatchClaim::Granted
+        | crate::queue_journal::DispatchClaim::Untracked => Some(job),
     }
 }
 
@@ -6959,6 +6977,32 @@ mod tests {
             claimed_h3_job_fixture(id).await;
         let output = tempfile::tempdir().unwrap();
         job.output_dir = Some(output.path().to_path_buf());
+        let durable_db = Arc::new(Some(mold_db::MetadataDb::open_in_memory().unwrap()));
+        let journal = Arc::new(crate::queue_journal::QueueJournal::new(
+            durable_db.clone(),
+            Some(output.path()),
+            "test-instance",
+        ));
+        // `record_for_test` intentionally refuses raw private-H3 admissions:
+        // production seals their durable media first. The ticket state
+        // machine itself is model-neutral, so mint a media-free row and attach
+        // its real ticket to the private owner route under test.
+        let mut durable_request = job.request.clone();
+        durable_request.model = "flux-dev:q4".to_string();
+        job.journal = Some(
+            journal
+                .record_for_test(crate::queue_journal::JournalAdmission {
+                    id,
+                    request: &durable_request,
+                    output_dir: Some(output.path()),
+                    target_gpu: None,
+                    target_device_id: None,
+                    completion_payload: SseCompletionPayload::Full,
+                    batch_child: false,
+                })
+                .expect("fake H3 generation is durably queued"),
+        );
+        job.metadata_db = durable_db;
         let (runs, drops) = install_fake_h3_attempt(&mut job, FakeH3Outcome::Success);
         let worker = single_worker_pool_with_parked("cache-sentinel", Duration::ZERO);
         let scheduler = fake_scheduler_v2(FakeSchedulerV2Mode::Live);
@@ -6975,6 +7019,10 @@ mod tests {
         assert_eq!(runs.load(Ordering::SeqCst), 1);
         assert_eq!(drops.load(Ordering::SeqCst), 1);
         assert_eq!(settlements.load(Ordering::SeqCst), 1);
+        assert!(
+            journal.list_all().is_empty(),
+            "the private H3 owner must claim and settle its durable queue row"
+        );
         assert_eq!(queue.pending(), 1);
         assert!(registry.snapshot().entries.is_empty());
         assert_eq!(result.response.gpu, Some(0));
@@ -11470,6 +11518,39 @@ mod tests {
         let event_json = serde_json::to_string(&event).unwrap();
         assert!(!event_json.contains("runtime-secret"));
         assert!(!event_json.contains("source.mp4"));
+    }
+
+    #[test]
+    fn generic_generation_owner_charges_the_shared_durable_dispatch_boundary() {
+        let tmp = tempfile::tempdir().unwrap();
+        let db = Arc::new(Some(mold_db::MetadataDb::open_in_memory().unwrap()));
+        let journal = Arc::new(crate::queue_journal::QueueJournal::new(
+            db.clone(),
+            Some(tmp.path()),
+            "test-instance",
+        ));
+        let mut job = fake_upscale_job(Config::default(), "unused");
+        job.id = "generic-owner-route".to_string();
+        job.model = "flux-dev:q4".to_string();
+        job.journal = Some(
+            journal
+                .record_for_test(crate::queue_journal::JournalAdmission {
+                    id: &job.id,
+                    request: &job.request,
+                    output_dir: Some(tmp.path()),
+                    target_gpu: None,
+                    target_device_id: None,
+                    completion_payload: SseCompletionPayload::Full,
+                    batch_child: false,
+                })
+                .expect("test generation is durable"),
+        );
+
+        let claimed = claim_generation_dispatch(job).expect("generic owner receives its claim");
+        let row = journal.list_all().into_iter().next().unwrap();
+        assert_eq!(row.state, mold_db::generation_queue::QueueRowState::Running);
+        assert_eq!(row.dispatch_attempts, 1);
+        assert_eq!(claimed.model, "flux-dev:q4");
     }
 
     /// A replayed job has no client, so the gallery file IS the delivery.

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -1869,6 +1869,22 @@ impl Coordinator {
         self.clear_dispatch_retry();
     }
 
+    fn remember_warm_waits_and_is_held(&mut self, plan: &Plan) -> bool {
+        for wait in &plan.warm_waits {
+            if let Some(pending) = self.pending.get_mut(wait.work_id.as_str()) {
+                pending
+                    .warm_wait_started_ms
+                    .get_or_insert(wait.started_at_ms);
+            }
+            if let Some(pending) = self.pending_owner_work.get_mut(wait.work_id.as_str()) {
+                pending
+                    .warm_wait_started_ms
+                    .get_or_insert(wait.started_at_ms);
+            }
+        }
+        plan.immediate_leases.is_empty()
+    }
+
     fn enqueue(&mut self, mut job: GenerationJob, immediate: &mut bool) {
         if job.id.is_empty() {
             job.id = format!("runtime-generation-{}", self.synthetic_id);
@@ -5764,7 +5780,11 @@ impl Coordinator {
                 return None;
             }
             self.plan_version = plan.plan_version;
-            if plan.immediate_leases.is_empty() {
+            // A warm wait commonly produces no immediate lease. Persist its
+            // original start before that early return; otherwise each replan
+            // starts a fresh bounded wait and an idle cold device can be held
+            // forever. This is shared scheduler state for every model family.
+            if self.remember_warm_waits_and_is_held(&plan) {
                 self.clear_dispatch_retry();
                 log_typed_blocks(&plan);
                 return Some(plan.state_version);
@@ -6429,14 +6449,6 @@ impl Coordinator {
                     self.pending_owner_work.get_mut(update.work_id.as_str())
                 {
                     pending.bypass_count = update.new_count;
-                }
-            }
-            for wait in &plan.warm_waits {
-                if let Some(pending) = self.pending.get_mut(wait.work_id.as_str()) {
-                    pending.warm_wait_started_ms = Some(wait.started_at_ms);
-                }
-                if let Some(pending) = self.pending_owner_work.get_mut(wait.work_id.as_str()) {
-                    pending.warm_wait_started_ms = Some(wait.started_at_ms);
                 }
             }
             self.state_version = self.state_version.saturating_add(1);
@@ -9471,6 +9483,79 @@ mod tests {
         assert!(
             coordinator.dirty.deadline().is_none(),
             "an empty queue must not retry the elapsed debounce on every tick"
+        );
+    }
+
+    #[test]
+    fn the_no_lease_branch_keeps_a_generation_warm_waits_original_start() {
+        let (worker, _worker_rx) = test_worker(0);
+        let pool = Arc::new(GpuPool {
+            workers: vec![worker].into(),
+        });
+        let (ingress_tx, _ingress_rx) = tokio::sync::mpsc::channel(1);
+        let state = AppState::empty(
+            mold_core::Config::default(),
+            QueueHandle::new(ingress_tx),
+            pool,
+            1,
+        );
+        let (generation, _result) = fake_generation("generation-wait");
+        let mut coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+        coordinator.pending.insert(
+            "generation-wait".to_string(),
+            PendingGeneration {
+                job: generation,
+                ready_at_ms: 0,
+                queue_rank: 0,
+                bypass_count: 0,
+                warm_wait_started_ms: None,
+                preparation: PreparationState::Ready,
+                prepared_inputs: None,
+                retry_not_before_ms: None,
+                preparation_retry_attempts: 0,
+                preparation_refresh_observation: None,
+                unschedulable_since_ms: None,
+                unschedulable_reason: None,
+                announced_position: None,
+                capacity_park: None,
+                memory_block: None,
+                preparation_started_ms: None,
+                preparation_progress: Default::default(),
+            },
+        );
+        let mut plan = coordinator
+            .planner
+            .plan(&PlannerSnapshot::new(1, 1, 1_000, 8 << 30, vec![], vec![]))
+            .unwrap();
+        plan.warm_waits.push(mold_scheduler::WarmWait {
+            work_id: WorkId::new("generation-wait"),
+            warm_device_id: DeviceId::new("warm-device"),
+            started_at_ms: 1_000,
+            deadline_ms: 3_000,
+            predicted_warm_finish_ms: 2_000,
+            best_cold_finish_ms: 2_500,
+            declined_device_ids: vec![],
+        });
+
+        assert!(
+            coordinator.remember_warm_waits_and_is_held(&plan),
+            "the exact no-lease branch must persist the wait before returning"
+        );
+        assert_eq!(
+            coordinator.pending["generation-wait"].warm_wait_started_ms,
+            Some(1_000)
+        );
+
+        plan.warm_waits[0].started_at_ms = 2_000;
+        assert!(coordinator.remember_warm_waits_and_is_held(&plan));
+        assert_eq!(
+            coordinator.pending["generation-wait"].warm_wait_started_ms,
+            Some(1_000),
+            "a later no-lease replan must not restart the bounded wait"
         );
     }
 

--- a/desktop/src/components/settings/AdvancedSection.test.ts
+++ b/desktop/src/components/settings/AdvancedSection.test.ts
@@ -113,7 +113,7 @@ describe("AdvancedSection device snapshots", () => {
         },
       },
     });
-    await vi.waitFor(() => expect(wrapper.text()).toContain("desktop-cpu-work"));
+    await vi.waitFor(() => expect(wrapper.text()).toContain("Prompt expansion"));
 
     expect(wrapper.get('[data-test="cpu-utility-lane"]').text()).toContain("Host utility");
     expect(wrapper.findAll('[data-test="device-card"]')).toHaveLength(0);
@@ -209,17 +209,10 @@ describe("AdvancedSection device snapshots", () => {
         },
       },
     });
-    await vi.waitFor(() => expect(wrapper.text()).toContain("desktop-future-collision"));
+    await vi.waitFor(() => expect(wrapper.text()).toContain("Future utility"));
 
-    expect(wrapper.get('[data-test="other-compute-lane"]').text()).toContain(
-      "desktop-future-collision",
-    );
-    expect(wrapper.get('[data-test="device-lane"]').text()).toContain("desktop-typed-device");
-    expect(wrapper.get('[data-test="device-lane"]').text()).not.toContain(
-      "desktop-future-collision",
-    );
-    expect(wrapper.text().match(/desktop-future-collision/g)).toHaveLength(1);
-    expect(wrapper.text().match(/desktop-typed-device/g)).toHaveLength(1);
+    expect(wrapper.get('[data-test="other-compute-lane"]').text()).toContain("Future utility");
+    expect(wrapper.get('[data-test="device-lane"]').text()).toContain("Generation");
   });
 
   it("subscribes to the exact authenticated target and refetches on invalidation", async () => {

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -400,9 +400,7 @@ describe("MobileHostDetail remote host data", () => {
     const view = await mountDetail();
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("1 total");
-    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "All 1 job loaded",
-    );
+    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe("All 1 job loaded");
     expect(view.get("[data-test='host-detail-planned-work']").text()).toContain(
       "activeChain stage · stage 1sequence-1GPU 2",
     );
@@ -1626,9 +1624,7 @@ describe("MobileHostDetail remote host data", () => {
     const view = await mountDetail();
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
-    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "Showing 1 of 7 jobs",
-    );
+    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe("Showing 1 of 7 jobs");
   });
 
   it("does not infer total backlog from an older host's loaded page or runtime window", async () => {
@@ -1677,9 +1673,7 @@ describe("MobileHostDetail remote host data", () => {
 
     const view = await mountDetail();
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("3 total");
-    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "Showing 2 of 3 jobs",
-    );
+    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe("Showing 2 of 3 jobs");
     expect(view.get("[data-test='host-detail-queue']").findAll("li")).toHaveLength(2);
 
     await view.get("[data-test='host-detail-queue-load-more']").trigger("click");

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -400,6 +400,9 @@ describe("MobileHostDetail remote host data", () => {
     const view = await mountDetail();
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("1 total");
+    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
+      "All 1 job loaded",
+    );
     expect(view.get("[data-test='host-detail-planned-work']").text()).toContain(
       "activeChain stage · stage 1sequence-1GPU 2",
     );
@@ -495,13 +498,8 @@ describe("MobileHostDetail remote host data", () => {
 
     const view = await mountDetail();
 
-    expect(view.get('[data-test="other-compute-lane"]').text()).toContain(
-      "mobile-future-collision",
-    );
-    expect(view.get('[data-test="device-lane"]').text()).toContain("mobile-typed-device");
-    expect(view.get('[data-test="device-lane"]').text()).not.toContain("mobile-future-collision");
-    expect(view.text().match(/mobile-future-collision/g)).toHaveLength(1);
-    expect(view.text().match(/mobile-typed-device/g)).toHaveLength(1);
+    expect(view.get('[data-test="other-compute-lane"]').text()).toContain("Future utility");
+    expect(view.get('[data-test="device-lane"]').text()).toContain("Generation");
   });
 
   it("targets the exact remote and renders telemetry, queue, downloads, and installed models", async () => {
@@ -1629,7 +1627,7 @@ describe("MobileHostDetail remote host data", () => {
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
     expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "1 loaded · Runtime window 8",
+      "Showing 1 of 7 jobs",
     );
   });
 
@@ -1646,9 +1644,7 @@ describe("MobileHostDetail remote host data", () => {
     const view = await mountDetail();
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("1 loaded");
-    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "1 loaded · Runtime window 2",
-    );
+    expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe("1 job loaded");
   });
 
   it("pages by host capacity and loads the durable queue tail on demand", async () => {
@@ -1682,7 +1678,7 @@ describe("MobileHostDetail remote host data", () => {
     const view = await mountDetail();
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("3 total");
     expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "2 loaded · Runtime window 2",
+      "Showing 2 of 3 jobs",
     );
     expect(view.get("[data-test='host-detail-queue']").findAll("li")).toHaveLength(2);
 
@@ -1710,7 +1706,7 @@ describe("MobileHostDetail remote host data", () => {
 
     expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
     expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-      "Queue page unavailable · Runtime window 8",
+      "Queue details unavailable",
     );
   });
 
@@ -1789,30 +1785,30 @@ describe("MobileHostDetail remote host data", () => {
         });
 
         const view = await mountDetail();
-        expect(view.text()).toContain("stale-cpu-work");
+        expect(view.text()).toContain("Post upscale");
         expect(view.find("[data-test='host-detail-queue']").exists()).toBe(true);
         expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
         expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-          "1 loaded · Runtime window 8",
+          "Showing 2 of 7 jobs",
         );
 
         await vi.advanceTimersByTimeAsync(5_000);
         await flushPromises();
 
-        expect(view.text()).not.toContain("stale-cpu-work");
+        expect(view.text()).not.toContain("Post upscale");
         expect(view.find("[data-test='host-detail-queue']").exists()).toBe(false);
         expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
         expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-          "Queue page unavailable · Runtime window 8",
+          "Queue details unavailable",
         );
 
         await vi.advanceTimersByTimeAsync(5_000);
         await flushPromises();
 
-        expect(view.text()).toContain("restored-cpu-work");
+        expect(view.text()).toContain("Post upscale");
         expect(view.get("[data-test='host-detail-queue-total']").text()).toBe("7 total");
         expect(view.get("[data-test='host-detail-queue-scope']").text()).toBe(
-          "1 loaded · Runtime window 8",
+          "Showing 2 of 7 jobs",
         );
       } finally {
         vi.useRealTimers();

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -14,6 +14,7 @@ import {
 } from "@studio/api/queuePlan";
 import { watchSelectedQueuePreview, type QueueJobProgress } from "@studio/api/generationSelection";
 import DevicePanel from "@studio/components/DevicePanel.vue";
+import { queueScopeLabel } from "@studio/lib/queuePlanPresentation";
 import QueuePlanWorkList from "@studio/components/QueuePlanWorkList.vue";
 import QueueEntryDetail from "@studio/components/QueueEntryDetail.vue";
 import SwipeActionRow from "@studio/components/SwipeActionRow.vue";
@@ -149,12 +150,6 @@ const durableBacklog = computed(() => {
   const depth = status.value?.queue_depth;
   return typeof depth === "number" && Number.isSafeInteger(depth) && depth >= 0 ? depth : null;
 });
-const runtimeWindow = computed(() => {
-  const capacity = status.value?.queue_capacity;
-  return typeof capacity === "number" && Number.isSafeInteger(capacity) && capacity > 0
-    ? capacity
-    : null;
-});
 const queueEntryIds = computed(() => queue.value.map((entry) => entry.id));
 const queueStatus = computed(() =>
   buildQueueStatusIndex([
@@ -168,10 +163,11 @@ const queueStatus = computed(() =>
 );
 const displayQueue = computed(() => [...queue.value].sort(compareNewestQueueEntry));
 const planOnlyWork = computed(() => queuePlanOnlyWork(queuePlan.value, queueEntryIds.value));
+const visibleQueueWork = computed(() => queue.value.length + planOnlyWork.value.length);
 const queueSummary = computed(() => {
-  const visibleWork = queue.value.length + planOnlyWork.value.length;
-  if (durableBacklog.value !== null) return `${Math.max(durableBacklog.value, visibleWork)} total`;
-  return `${visibleWork} loaded`;
+  if (durableBacklog.value !== null)
+    return `${Math.max(durableBacklog.value, visibleQueueWork.value)} total`;
+  return `${visibleQueueWork.value} loaded`;
 });
 const modelLabel = (name: string) => modelDisplayNameForId(name, installed.value);
 
@@ -1283,9 +1279,7 @@ onBeforeUnmount(() => {
           </div>
         </div>
         <p class="mobile-empty-note" data-test="host-detail-queue-scope">
-          <template v-if="queueApiAvailable">{{ queue.length }} loaded</template>
-          <template v-else>Queue page unavailable</template>
-          <template v-if="runtimeWindow"> · Runtime window {{ runtimeWindow }}</template>
+          {{ queueScopeLabel(visibleQueueWork, durableBacklog, queueApiAvailable) }}
         </p>
         <div
           v-if="devices !== null || queuePlan !== null || deviceError"

--- a/desktop/src/mobile/MobileSettingsView.test.ts
+++ b/desktop/src/mobile/MobileSettingsView.test.ts
@@ -234,7 +234,7 @@ describe("MobileSettingsView", () => {
 
     expect(wrapper.text()).toContain("Compute devices");
     expect(wrapper.text()).toContain("Host utility");
-    expect(wrapper.text()).toContain("mobile-cpu-work");
+    expect(wrapper.text()).toContain("Post upscale");
   });
 
   it("keeps a queue-plan compute lane visible when device inventory is unavailable", async () => {
@@ -294,7 +294,7 @@ describe("MobileSettingsView", () => {
       expect(wrapper.find("[data-test='mobile-settings-devices']").exists()).toBe(true),
     );
 
-    expect(wrapper.get("[data-test='other-compute-lane']").text()).toContain("future-mobile-lane");
+    expect(wrapper.get("[data-test='other-compute-lane']").text()).toContain("Future utility");
   });
 
   it("opens the public privacy policy from About", async () => {

--- a/studio/components/DevicePanel.test.ts
+++ b/studio/components/DevicePanel.test.ts
@@ -132,11 +132,18 @@ describe("DevicePanel", () => {
     });
 
     expect(wrapper.get(".device-card__line-label").text()).toBe("Running now");
-    expect(wrapper.get(".device-card__line-value").text()).toBe("Video generation");
+    expect(wrapper.get(".device-card__line-value").text()).toBe(
+      "Video generation",
+    );
     expect(
-      wrapper.get('[data-test="device-lane"]').findAll("li").map((row) => row.text()),
+      wrapper
+        .get('[data-test="device-lane"]')
+        .findAll("li")
+        .map((row) => row.text()),
     ).toHaveLength(1);
-    expect(wrapper.get('[data-test="device-lane"]').text()).toContain("Next · Generation");
+    expect(wrapper.get('[data-test="device-lane"]').text()).toContain(
+      "Next · Generation",
+    );
     expect(wrapper.text()).not.toContain("active-internal-id");
     expect(wrapper.text()).not.toContain("queued-internal-id");
     expect(wrapper.find('[title="active-internal-id"]').exists()).toBe(false);

--- a/studio/components/DevicePanel.test.ts
+++ b/studio/components/DevicePanel.test.ts
@@ -90,6 +90,59 @@ describe("DevicePanel", () => {
     expect(wrapper.emitted("toggle")?.[0]).toEqual([device(0).id, false]);
   });
 
+  it("separates running work from the queued lane without exposing internal ids", () => {
+    const gpu = device(0, { active_work_id: "active-internal-id" });
+    const wrapper = mount(DevicePanel, {
+      props: {
+        devices: [gpu],
+        plan: {
+          plan_version: 1,
+          state_version: 1,
+          optimizer_state: "optimized",
+          dirty_since_unix_ms: null,
+          next_replan_at_unix_ms: null,
+          work_items: [
+            {
+              work_id: "active-internal-id",
+              parent_id: "active-parent",
+              work_kind: "video_generation",
+              priority_class: "user",
+              queue_rank: 0,
+              bypass_count: 0,
+              planned_device_id: gpu.id,
+              planned_lane_kind: "device",
+              lane_order: 0,
+              estimate_confidence: "high",
+            },
+            {
+              work_id: "queued-internal-id",
+              parent_id: "queued-parent",
+              work_kind: "generation",
+              priority_class: "user",
+              queue_rank: 1,
+              bypass_count: 0,
+              planned_device_id: gpu.id,
+              planned_lane_kind: "device",
+              lane_order: 1,
+              estimate_confidence: "low",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(wrapper.get(".device-card__line-label").text()).toBe("Running now");
+    expect(wrapper.get(".device-card__line-value").text()).toBe("Video generation");
+    expect(
+      wrapper.get('[data-test="device-lane"]').findAll("li").map((row) => row.text()),
+    ).toHaveLength(1);
+    expect(wrapper.get('[data-test="device-lane"]').text()).toContain("Next · Generation");
+    expect(wrapper.text()).not.toContain("active-internal-id");
+    expect(wrapper.text()).not.toContain("queued-internal-id");
+    expect(wrapper.find('[title="active-internal-id"]').exists()).toBe(false);
+    expect(wrapper.find('[title="queued-internal-id"]').exists()).toBe(false);
+  });
+
   it("disables every device with an in-flight mutation", () => {
     const wrapper = mount(DevicePanel, {
       props: {
@@ -257,10 +310,7 @@ describe("DevicePanel", () => {
       }
       expect(
         utility.findAll(".device-card__work").map((row) => row.text()),
-      ).toEqual([
-        "expand-parent-1 · Prompt expansion",
-        "future-parent-2 · Future utility",
-      ]);
+      ).toEqual(["Next · Prompt expansion", "After that · Future utility"]);
       wrapper.unmount();
     }
   });
@@ -295,7 +345,7 @@ describe("DevicePanel", () => {
     });
 
     expect(wrapper.get('[data-test="other-compute-lane"]').text()).toContain(
-      "future-lane-work",
+      "Next · Future utility",
     );
   });
 
@@ -343,16 +393,11 @@ describe("DevicePanel", () => {
     });
 
     expect(wrapper.get('[data-test="other-compute-lane"]').text()).toContain(
-      "future-collision",
+      "Future utility",
     );
     expect(wrapper.get('[data-test="device-lane"]').text()).toContain(
-      "typed-device-work",
+      "Generation",
     );
-    expect(wrapper.get('[data-test="device-lane"]').text()).not.toContain(
-      "future-collision",
-    );
-    expect(wrapper.text().match(/future-collision/g)).toHaveLength(1);
-    expect(wrapper.text().match(/typed-device-work/g)).toHaveLength(1);
     expect(
       wrapper.get('[data-test="other-compute-lane"]').text(),
     ).not.toContain("HOST");
@@ -454,23 +499,23 @@ describe("DevicePanel", () => {
     const utility = wrapper.get('[data-test="cpu-utility-lane"]');
     const blocked = wrapper.get('[data-test="blocked-work"]');
 
-    expect(known.text()).toContain("known-device-work");
+    expect(known.text()).toContain("Next · Generation");
     expect(unknown.text()).toContain("Unassigned / unknown device");
-    expect(unknown.text()).toContain("missing-device-work");
-    expect(unknown.text()).toContain("future-lane-missing-device");
+    expect(unknown.text()).toContain("Generation");
+    expect(unknown.text()).toContain("Future utility");
     // Not yet placed on any lane (no lane kind, no device) while it waits on
     // a dependency: ordinary queued work, never an "unknown device" row.
     expect(wrapper.text()).not.toContain("unplaced-waiting-work");
-    expect(utility.text()).toContain("host-utility-work");
-    expect(blocked.text()).toContain("blocked-unassigned-work");
+    expect(utility.text()).toContain("Prompt expansion");
+    expect(blocked.text()).toContain("Generation · no capacity");
+    expect(blocked.text()).not.toContain("blocked-unassigned-work");
     for (const workId of [
       "known-device-work",
       "missing-device-work",
       "future-lane-missing-device",
       "host-utility-work",
-      "blocked-unassigned-work",
     ]) {
-      expect(wrapper.text().match(new RegExp(workId, "g"))).toHaveLength(1);
+      expect(wrapper.text()).not.toContain(workId);
     }
   });
 
@@ -513,7 +558,7 @@ describe("DevicePanel", () => {
 
     expect(wrapper.find('[data-test="cpu-utility-lane"]').exists()).toBe(false);
     expect(wrapper.get('[data-test="blocked-work"]').text()).toContain(
-      "blocked-cpu-work",
+      "Prompt expansion · host ram",
     );
   });
 
@@ -549,16 +594,20 @@ describe("DevicePanel", () => {
         },
       });
       expect(wrapper.get('[data-test="replan-countdown"]').text()).toContain(
-        "optimizing in 4s",
+        "Updating order in 4s",
       );
-      expect(wrapper.get('[data-test="device-lane"]').text()).toContain("~5s");
+      expect(wrapper.get('[data-test="device-lane"]').text()).toContain(
+        "under a minute",
+      );
 
       await vi.advanceTimersByTimeAsync(1_100);
 
       expect(wrapper.get('[data-test="replan-countdown"]').text()).toContain(
-        "optimizing in 3s",
+        "Updating order in 3s",
       );
-      expect(wrapper.get('[data-test="device-lane"]').text()).toContain("~4s");
+      expect(wrapper.get('[data-test="device-lane"]').text()).toContain(
+        "under a minute",
+      );
       wrapper.unmount();
     } finally {
       vi.useRealTimers();

--- a/studio/components/DevicePanel.vue
+++ b/studio/components/DevicePanel.vue
@@ -3,6 +3,11 @@ import { computed, onBeforeUnmount, onMounted, ref } from "vue";
 import type { DeviceInfo } from "../api/devices";
 import type { QueuePlan, QueueWorkItem } from "../api/queuePlan";
 import { normalizeBlockedReason } from "../lib/queuePosition";
+import {
+  queueCompletionLabel,
+  queueLanePositionLabel,
+  queuePlanUpdateLabel,
+} from "../lib/queuePlanPresentation";
 
 const props = withDefaults(
   defineProps<{
@@ -95,16 +100,12 @@ const lifecycleNote = computed(() => {
   return "Live GPU controls are unavailable on this server.";
 });
 
-function shortId(id: string): string {
-  return id.length > 14 ? `…${id.slice(-12)}` : id;
-}
-
 function gib(bytes: number | null): string {
   return bytes === null ? "—" : `${(bytes / 1024 ** 3).toFixed(1)} GB`;
 }
 
 function memoryLabel(device: DeviceInfo): string {
-  return `${gib(device.memory.used_bytes)} / ${gib(device.memory.total_bytes)}`;
+  return `${gib(device.memory.used_bytes)} of ${gib(device.memory.total_bytes)}`;
 }
 
 function stateLabel(device: DeviceInfo): string {
@@ -122,10 +123,18 @@ function planned(device: DeviceInfo): QueueWorkItem[] {
         (work) =>
           work.planned_lane_kind === "device" &&
           work.planned_device_id === device.id &&
+          work.work_id !== device.active_work_id &&
           !blockedReason(work),
       )
       .sort((a, b) => (a.lane_order ?? 0) - (b.lane_order ?? 0)) ?? []
   );
+}
+
+function activeWorkLabel(device: DeviceInfo): string {
+  const work = props.plan?.work_items.find(
+    (candidate) => candidate.work_id === device.active_work_id,
+  );
+  return work ? workLabel(work) : "Generation in progress";
 }
 
 /**
@@ -150,11 +159,16 @@ function pinnedDevice(work: QueueWorkItem): DeviceInfo | null {
   );
 }
 
+function pinnedDeviceLabel(work: QueueWorkItem): string {
+  return pinnedDevice(work)?.name ?? "an unavailable machine";
+}
+
 function eta(work: QueueWorkItem): string {
-  const finish = work.estimated_finish_unix_ms;
-  if (finish == null) return "ETA pending";
-  const seconds = Math.max(0, Math.ceil((finish - nowUnixMs.value) / 1000));
-  return `~${seconds}s · ${work.estimate_confidence} confidence`;
+  return queueCompletionLabel(
+    work.estimated_finish_unix_ms,
+    work.estimate_confidence,
+    nowUnixMs.value,
+  );
 }
 
 function workKindLabel(kind: unknown): string {
@@ -170,12 +184,10 @@ function workLabel(work: QueueWorkItem): string {
 }
 
 function replanLabel(): string | null {
-  const deadline = props.plan?.next_replan_at_unix_ms;
-  if (deadline == null) return null;
-  return `Tentative plan · optimizing in ${Math.max(
-    0,
-    Math.ceil((deadline - nowUnixMs.value) / 1000),
-  )}s`;
+  return queuePlanUpdateLabel(
+    props.plan?.next_replan_at_unix_ms,
+    nowUnixMs.value,
+  );
 }
 
 function canToggle(): boolean {
@@ -217,7 +229,7 @@ onBeforeUnmount(() => {
     data-test="device-panel"
   >
     <header class="device-panel__head">
-      <span>Compute</span>
+      <span>Compute plan</span>
       <span
         v-if="replanLabel()"
         class="device-panel__tentative"
@@ -257,15 +269,14 @@ onBeforeUnmount(() => {
           </span>
         </div>
         <div class="device-card__meta">
-          <code :title="device.id">{{ shortId(device.id) }}</code>
           <span v-if="device.ordinal !== null">GPU {{ device.ordinal }}</span>
           <span>{{ stateLabel(device) }}</span>
         </div>
 
         <div class="device-card__metrics">
-          <span>VRAM {{ memoryLabel(device) }}</span>
+          <span>GPU memory {{ memoryLabel(device) }}</span>
           <span>
-            Utilization
+            GPU use
             {{
               device.telemetry.utilization_percent === null
                 ? "—"
@@ -283,21 +294,19 @@ onBeforeUnmount(() => {
           </span>
         </div>
         <div v-if="device.active_work_id" class="device-card__line">
-          <span class="device-card__line-label">Active</span>
-          <code class="device-card__line-value" :title="device.active_work_id">
-            {{ shortId(device.active_work_id) }}
-          </code>
+          <span class="device-card__line-label">Running now</span>
+          <span class="device-card__line-value">{{ activeWorkLabel(device) }}</span>
         </div>
         <ol
           v-if="planned(device).length"
           class="device-card__lane"
           data-test="device-lane"
         >
-          <li v-for="work in planned(device)" :key="work.work_id">
-            <span class="device-card__work" :title="work.work_id">
-              {{ work.work_id }} · {{ workLabel(work) }}
+          <li v-for="(work, index) in planned(device)" :key="work.work_id">
+            <span class="device-card__work">
+              {{ queueLanePositionLabel(index) }} · {{ workLabel(work) }}
             </span>
-            <span class="device-card__eta">· {{ eta(work) }}</span>
+            <span class="device-card__eta">{{ eta(work) }}</span>
           </li>
         </ol>
         <button
@@ -325,11 +334,11 @@ onBeforeUnmount(() => {
           <span>No matching compute device in this snapshot</span>
         </div>
         <ol class="device-card__lane">
-          <li v-for="work in unassignedDeviceWork" :key="work.work_id">
-            <span class="device-card__work" :title="work.work_id">
-              {{ work.work_id }} · {{ workLabel(work) }}
+          <li v-for="(work, index) in unassignedDeviceWork" :key="work.work_id">
+            <span class="device-card__work">
+              {{ queueLanePositionLabel(index) }} · {{ workLabel(work) }}
             </span>
-            <span class="device-card__eta">· {{ eta(work) }}</span>
+            <span class="device-card__eta">{{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -346,11 +355,11 @@ onBeforeUnmount(() => {
           <span>One task at a time</span>
         </div>
         <ol class="device-card__lane" data-test="cpu-utility-lane-list">
-          <li v-for="work in cpuUtilityWork" :key="work.work_id">
-            <span class="device-card__work" :title="work.work_id">
-              {{ work.work_id }} · {{ workLabel(work) }}
+          <li v-for="(work, index) in cpuUtilityWork" :key="work.work_id">
+            <span class="device-card__work">
+              {{ queueLanePositionLabel(index) }} · {{ workLabel(work) }}
             </span>
-            <span class="device-card__eta">· {{ eta(work) }}</span>
+            <span class="device-card__eta">{{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -364,11 +373,11 @@ onBeforeUnmount(() => {
           <span class="device-card__badge">OTHER</span>
         </div>
         <ol class="device-card__lane">
-          <li v-for="work in otherComputeWork" :key="work.work_id">
-            <span class="device-card__work" :title="work.work_id">
-              {{ work.work_id }} · {{ workLabel(work) }}
+          <li v-for="(work, index) in otherComputeWork" :key="work.work_id">
+            <span class="device-card__work">
+              {{ queueLanePositionLabel(index) }} · {{ workLabel(work) }}
             </span>
-            <span class="device-card__eta">· {{ eta(work) }}</span>
+            <span class="device-card__eta">{{ eta(work) }}</span>
           </li>
         </ol>
       </article>
@@ -381,9 +390,9 @@ onBeforeUnmount(() => {
     >
       <strong>Blocked</strong>
       <div v-for="work in blocked" :key="work.work_id">
-        {{ work.work_id }} · {{ blockedReason(work) }}
+        {{ workLabel(work) }} · {{ blockedReason(work) }}
         <template v-if="work.hard_pinned_device_id">
-          · pinned to {{ shortId(work.hard_pinned_device_id) }}
+          · pinned to {{ pinnedDeviceLabel(work) }}
           <button
             v-if="mutable"
             type="button"

--- a/studio/components/DevicePanel.vue
+++ b/studio/components/DevicePanel.vue
@@ -295,7 +295,9 @@ onBeforeUnmount(() => {
         </div>
         <div v-if="device.active_work_id" class="device-card__line">
           <span class="device-card__line-label">Running now</span>
-          <span class="device-card__line-value">{{ activeWorkLabel(device) }}</span>
+          <span class="device-card__line-value">{{
+            activeWorkLabel(device)
+          }}</span>
         </div>
         <ol
           v-if="planned(device).length"

--- a/studio/lib/queuePlanPresentation.test.ts
+++ b/studio/lib/queuePlanPresentation.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from "vitest";
+import {
+  queueCompletionLabel,
+  queueLanePositionLabel,
+  queuePlanUpdateLabel,
+  queueScopeLabel,
+} from "./queuePlanPresentation";
+
+describe("human queue-plan presentation", () => {
+  it("keeps loaded rows distinct from the durable queue total", () => {
+    expect(queueScopeLabel(1, 7)).toBe("Showing 1 of 7 jobs");
+    expect(queueScopeLabel(7, 7)).toBe("All 7 jobs loaded");
+    expect(queueScopeLabel(1, null)).toBe("1 job loaded");
+    expect(queueScopeLabel(0, 200, false)).toBe("Queue details unavailable");
+  });
+
+  it("never leaves an expired optimization countdown at zero seconds", () => {
+    expect(queuePlanUpdateLabel(14_000, 10_000)).toBe("Updating order in 4s");
+    expect(queuePlanUpdateLabel(10_000, 10_000)).toBe("Updating order…");
+  });
+
+  it("translates raw seconds and confidence into an understandable completion estimate", () => {
+    expect(queueCompletionLabel(285_000, "low", 10_000)).toBe(
+      "Done in about 5 minutes · estimate may change",
+    );
+    expect(queueCompletionLabel(70_000, "high", 10_000)).toBe(
+      "Done in about 1 minute",
+    );
+    expect(queueCompletionLabel(null, "low", 10_000)).toBe(
+      "Completion time is still being estimated",
+    );
+  });
+
+  it("uses lane order instead of exposing internal work ids", () => {
+    expect([0, 1, 2, 3, 10].map(queueLanePositionLabel)).toEqual([
+      "Next",
+      "After that",
+      "3rd in this lane",
+      "4th in this lane",
+      "11th in this lane",
+    ]);
+  });
+});

--- a/studio/lib/queuePlanPresentation.ts
+++ b/studio/lib/queuePlanPresentation.ts
@@ -26,3 +26,65 @@ export function queuePlanOnlyWork(
           (b.lane_order ?? Number.MAX_SAFE_INTEGER),
     );
 }
+
+export function queueScopeLabel(
+  loadedCount: number,
+  totalCount: number | null | undefined,
+  available = true,
+): string {
+  if (!available) return "Queue details unavailable";
+  const loaded = `${loadedCount} ${loadedCount === 1 ? "job" : "jobs"}`;
+  if (totalCount == null) return `${loaded} loaded`;
+  const total = Math.max(loadedCount, totalCount);
+  return loadedCount < total
+    ? `Showing ${loadedCount} of ${total} jobs`
+    : `All ${loaded} loaded`;
+}
+
+export function queuePlanUpdateLabel(
+  deadlineUnixMs: number | null | undefined,
+  nowUnixMs: number,
+): string | null {
+  if (deadlineUnixMs == null) return null;
+  const seconds = Math.ceil((deadlineUnixMs - nowUnixMs) / 1_000);
+  return seconds > 1 ? `Updating order in ${seconds}s` : "Updating order…";
+}
+
+function approximateDuration(milliseconds: number): string {
+  const seconds = Math.max(0, Math.ceil(milliseconds / 1_000));
+  if (seconds < 45) return "under a minute";
+  const minutes = Math.max(1, Math.round(seconds / 60));
+  if (minutes < 60)
+    return `about ${minutes} ${minutes === 1 ? "minute" : "minutes"}`;
+  const hours = Math.round((minutes / 60) * 2) / 2;
+  return `about ${hours} ${hours === 1 ? "hour" : "hours"}`;
+}
+
+export function queueCompletionLabel(
+  finishUnixMs: number | null | undefined,
+  confidence: string | null | undefined,
+  nowUnixMs: number,
+): string {
+  if (finishUnixMs == null) return "Completion time is still being estimated";
+  if (finishUnixMs <= nowUnixMs) return "Finishing now";
+  const base = `Done in ${approximateDuration(finishUnixMs - nowUnixMs)}`;
+  return confidence === "high" ? base : `${base} · estimate may change`;
+}
+
+export function queueLanePositionLabel(index: number): string {
+  if (index === 0) return "Next";
+  if (index === 1) return "After that";
+  const position = index + 1;
+  const remainder100 = position % 100;
+  const suffix =
+    remainder100 >= 11 && remainder100 <= 13
+      ? "th"
+      : position % 10 === 1
+        ? "st"
+        : position % 10 === 2
+          ? "nd"
+          : position % 10 === 3
+            ? "rd"
+            : "th";
+  return `${position}${suffix} in this lane`;
+}

--- a/web/src/pages/SettingsPage.test.ts
+++ b/web/src/pages/SettingsPage.test.ts
@@ -520,7 +520,7 @@ describe("SettingsPage", () => {
 
     expect(wrapper.findAll('[data-test="device-card"]')).toHaveLength(0);
     expect(wrapper.get('[data-test="cpu-utility-lane"]').text()).toContain(
-      "cpu-expand",
+      "Next · Prompt expansion",
     );
   });
 
@@ -587,21 +587,14 @@ describe("SettingsPage", () => {
     }) as typeof fetch;
 
     const wrapper = mount(SettingsPage);
-    await vi.waitFor(() =>
-      expect(wrapper.text()).toContain("web-future-collision"),
-    );
+    await vi.waitFor(() => expect(wrapper.text()).toContain("Future utility"));
 
     expect(wrapper.get('[data-test="other-compute-lane"]').text()).toContain(
-      "web-future-collision",
+      "Future utility",
     );
     expect(wrapper.get('[data-test="device-lane"]').text()).toContain(
-      "web-typed-device",
+      "Generation",
     );
-    expect(wrapper.get('[data-test="device-lane"]').text()).not.toContain(
-      "web-future-collision",
-    );
-    expect(wrapper.text().match(/web-future-collision/g)).toHaveLength(1);
-    expect(wrapper.text().match(/web-typed-device/g)).toHaveLength(1);
   });
 
   it("clears a stale queue plan when a device-panel refresh fails", async () => {
@@ -661,11 +654,13 @@ describe("SettingsPage", () => {
     }) as typeof fetch;
 
     const wrapper = mount(SettingsPage);
-    await vi.waitFor(() => expect(wrapper.text()).toContain("stale-work"));
+    await vi.waitFor(() => expect(wrapper.text()).toContain("Host utility"));
     failPanel = true;
     const refresh = subscribeToDeviceSnapshots.mock.calls[0]?.[2] as () => void;
     refresh();
-    await vi.waitFor(() => expect(wrapper.text()).not.toContain("stale-work"));
+    await vi.waitFor(() =>
+      expect(wrapper.text()).not.toContain("Host utility"),
+    );
   });
 
   it("keeps concurrent device mutations busy through out-of-order completion", async () => {


### PR DESCRIPTION
## Summary

- preserve the first bounded warm-model wait before the coordinator's no-lease return, so a cold idle GPU is released after the deadline instead of waiting forever
- route private H3 generations through the same durable dispatch claim and terminal settlement boundary as every other model family
- replace raw queue IDs, seconds, confidence, and ambiguous loaded/runtime counts with shared plain-language labels across web, desktop, and mobile
- distinguish running work from the next queued item and keep durable rows, plan-only work, and total backlog numerically consistent

## Root cause

HAL 9000 had two independent queue defects. Completed private H3 jobs had never transitioned their durable rows to Running because that owner path bypassed the shared dispatch claim. Separately, the scheduler persisted warm-wait state only after granting a lease, but a beneficial warm wait intentionally grants no immediate lease. Every replan therefore restarted the bounded wait and could leave any model family parked forever on an idle cold GPU.

## Regression guards

- the real fake claimed-H3 success route now owns a durable ticket and proves exact terminal row settlement
- the no-lease branch predicate itself persists the original warm-wait start and proves a later replan cannot slide it
- shared presentation tests cover durable pagination, plan-only sequence work, active-versus-next lanes, relative estimates, and absence of internal IDs

## Validation

- `cargo test -p mold-ai-server scheduler::tests:: --lib` (140 passed)
- targeted private-H3 durable settlement test
- `cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `bun run check:frontend` (1,521 studio, 1,762 web, and 5,526 desktop tests; web and desktop production builds)
- `bun run build:mobile`
- `cargo fmt --all -- --check`
- live HAL queue inspection plus rendered desktop and 390x844 mobile QA
- release changelog fragment contract against the exact PR head

## Peer review

Three independent read-only reviews covered scheduler/concurrency, durable H3/model isolation, and cross-surface UI semantics. Their initial regression and presentation findings were addressed, all three re-reviewed the final diff, and all three gave clean approval before this PR was opened.
