### PR TITLE
fix(mobile): keep job details within viewport

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -316,7 +316,9 @@ pushed screen opened from the header.
   `QueueEntryDetail` in a bottom
   sheet with the prompt, setting groups, queue facts, the running preview, any
   hold reason in full with Copy, and its own inline two-step cancel; failures
-  stay in a persistent inline line, never a toast. Android renders the same
+  stay in a persistent inline line, never a toast. Compact details and actions
+  remain bounded to the phone viewport, and a downward swipe from the top of
+  the sheet dismisses it. Android renders the same
   component — nothing in the gesture is iOS-only.
   When a host advertises `capabilities.gallery.trash`, host detail adds a
   **Library** card: a **Trash retention** select reading and writing that

--- a/changelog.d/mobile-job-detail-sheet.md
+++ b/changelog.d/mobile-job-detail-sheet.md
@@ -1,0 +1,1 @@
+- **Keep mobile job details on screen.** Keep Machine job details and actions inside the mobile viewport and allow dismissing the sheet with a downward swipe.

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -1027,6 +1027,32 @@ describe("MobileHostDetail remote host data", () => {
     );
   });
 
+  it("dismisses queue details with a natural downward swipe", async () => {
+    const view = await mountDetail();
+    await view.get("[data-test='host-detail-queue-open-job-queued']").trigger("click");
+    await flushPromises();
+
+    const panel = view.get(".mobile-library-sheet-panel").element;
+    const touch = (type: string, y: number, ended = false) => {
+      const event = new Event(type, { bubbles: true, cancelable: true });
+      const point = { identifier: 9, clientX: 120, clientY: y };
+      Object.defineProperty(event, "touches", { value: ended ? [] : [point] });
+      Object.defineProperty(event, "changedTouches", { value: [point] });
+      return event;
+    };
+
+    panel.dispatchEvent(touch("touchstart", 100));
+    const move = touch("touchmove", 240);
+    panel.dispatchEvent(move);
+    expect(move.defaultPrevented).toBe(true);
+    await flushPromises();
+    expect(view.get(".mobile-library-sheet-panel").attributes("style")).toContain("translateY");
+
+    panel.dispatchEvent(touch("touchend", 240, true));
+    await flushPromises();
+    expect(view.get("[data-test='host-detail-queue-sheet']").classes()).not.toContain("is-open");
+  });
+
   it("arms the sheet's cancel before it touches the host", async () => {
     const fetchMock = vi.fn(async () => new Response(null, { status: 204 }));
     vi.stubGlobal("fetch", fetchMock);

--- a/desktop/src/mobile/MobileHostDetail.vue
+++ b/desktop/src/mobile/MobileHostDetail.vue
@@ -1532,6 +1532,7 @@ onBeforeUnmount(() => {
       :open="inspectedQueueModel !== null"
       title="Job details"
       :focus-first-control="false"
+      swipe-to-dismiss
       test-id="host-detail-queue-sheet"
       @close="inspectedQueueId = null"
     >

--- a/studio/components/QueueEntryDetail.test.ts
+++ b/studio/components/QueueEntryDetail.test.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { resolve } from "node:path";
 import { mount } from "@vue/test-utils";
 import { describe, expect, it } from "vitest";
 import QueueEntryDetail from "./QueueEntryDetail.vue";
@@ -6,6 +8,20 @@ import {
   type QueueDetailMetadata,
 } from "../lib/queueEntryDetail";
 import type { QueueEntry } from "../api/queuePlan";
+
+const componentPath = [
+  "components/QueueEntryDetail.vue",
+  "studio/components/QueueEntryDetail.vue",
+  "../studio/components/QueueEntryDetail.vue",
+]
+  .map((candidate) => resolve(process.cwd(), candidate))
+  .find((candidate) => existsSync(candidate));
+
+if (!componentPath) {
+  throw new Error("Could not locate QueueEntryDetail.vue from the test root");
+}
+
+const componentSource = readFileSync(componentPath, "utf8");
 
 const metadata: QueueDetailMetadata = {
   prompt: "a cat on a porch",
@@ -36,6 +52,25 @@ function model(entry: Partial<QueueEntry> = {}, extra = {}) {
 }
 
 describe("QueueEntryDetail", () => {
+  it("bounds compact details and actions to viewport-safe columns", () => {
+    const root = componentSource.match(/\.qed\s*\{([^}]*)\}/s);
+    const compactActions = componentSource.match(
+      /\.qed--compact \.qed__actions\s*\{([^}]*)\}/s,
+    );
+    const compactButton = componentSource.match(
+      /\.qed--compact \.qed__actions button\s*\{([^}]*)\}/s,
+    );
+
+    expect(root?.[1]).toMatch(/width:\s*100%\s*;/);
+    expect(root?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(root?.[1]).toMatch(/max-width:\s*100%\s*;/);
+    expect(root?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+    expect(compactActions?.[1]).toMatch(
+      /grid-template-columns:\s*repeat\(2,\s*minmax\(0,\s*1fr\)\)\s*;/,
+    );
+    expect(compactButton?.[1]).toMatch(/min-width:\s*0\s*;/);
+  });
+
   it("renders the prompt, the settings groups, and the queue facts", () => {
     const wrapper = mount(QueueEntryDetail, { props: { model: model() } });
 

--- a/studio/components/QueueEntryDetail.vue
+++ b/studio/components/QueueEntryDetail.vue
@@ -236,7 +236,11 @@ async function copyDetail(): Promise<void> {
 <style scoped>
 .qed {
   display: flex;
+  width: 100%;
+  min-width: 0;
+  max-width: 100%;
   min-height: 0;
+  box-sizing: border-box;
   flex-direction: column;
   color: var(--ink-2, currentColor);
   font-size: 12px;
@@ -246,6 +250,7 @@ async function copyDetail(): Promise<void> {
 }
 .qed__head {
   display: flex;
+  min-width: 0;
   align-items: center;
   gap: 8px;
   padding: 12px 16px;
@@ -295,11 +300,13 @@ async function copyDetail(): Promise<void> {
 }
 .qed__body {
   display: flex;
+  min-width: 0;
   min-height: 0;
   flex: 1;
   flex-direction: column;
   gap: 12px;
   padding: 14px 16px;
+  overflow-x: hidden;
   overflow-y: auto;
 }
 .qed__preview {
@@ -377,6 +384,7 @@ async function copyDetail(): Promise<void> {
 }
 .qed__foot {
   display: flex;
+  min-width: 0;
   flex-direction: column;
   gap: 8px;
   padding: 12px 16px;
@@ -394,6 +402,7 @@ async function copyDetail(): Promise<void> {
 }
 .qed__actions {
   display: flex;
+  min-width: 0;
   flex-wrap: wrap;
   gap: 8px;
 }
@@ -408,8 +417,13 @@ async function copyDetail(): Promise<void> {
   cursor: pointer;
 }
 .qed--compact .qed__actions button {
+  min-width: 0;
   min-height: 44px;
   font-size: 16px;
+}
+.qed--compact .qed__actions {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
 }
 .qed__actions button:disabled {
   cursor: default;


### PR DESCRIPTION
## Summary

- constrain compact mobile job details and action controls to the available viewport
- lay compact actions out in two bounded columns
- enable the existing natural swipe-down dismissal gesture on the Machine job-details sheet
- add regression coverage and mobile maintainer documentation

## Validation

- `nix develop -c bun run test:studio -- studio/components/QueueEntryDetail.test.ts` (10 passed)
- `cd desktop && nix develop -c bunx vitest run src/mobile/MobileHostDetail.test.ts` (53 passed)
- `nix develop -c bun run test:desktop` (5,554 passed)
- `nix develop -c bash scripts/ios.sh simulator`
- `bash scripts/release/check-changelog-fragments.sh "$(git merge-base origin/main HEAD)" HEAD`
- `git diff --check origin/main...HEAD`

## Native UAT

Passed on an iPhone 17 simulator at 368×800 using a live queued/running job on the UAT CUDA machine. The title and all actions stayed within the viewport, and a downward sheet gesture dismissed Job details back to the Machine view.

## Peer review

Independent agent review approved with no remaining actionable findings.