### PR TITLE
fix(queue): prevent H3 grant livelock

### DIFF
--- a/changelog.d/h3-queue-grant-livelock.md
+++ b/changelog.d/h3-queue-grant-livelock.md
@@ -1,0 +1,5 @@
+- **Keep queued generations moving through harmless GPU telemetry changes.**
+  Multiple prepared MiniMax H3 jobs no longer leave an idle GPU stuck in a
+  high-CPU planning loop when CUDA context memory changes between planning and
+  dispatch; genuinely insufficient VRAM and changed execution plans still stop
+  the grant.

--- a/crates/mold-scheduler/src/types.rs
+++ b/crates/mold-scheduler/src/types.rs
@@ -861,16 +861,12 @@ impl Plan {
                 available_bytes: current.available_vram_bytes,
             });
         }
-        if !lease.placement.frozen_device_capacity
-            && lease.placement.device_available_vram_bytes != u64::MAX
-            && current.available_vram_bytes != lease.placement.device_available_vram_bytes
-        {
-            return Err(PlanValidationError::DeviceVramSampleChanged {
-                device_id: lease.device_id.clone(),
-                planned_bytes: lease.placement.device_available_vram_bytes,
-                current_bytes: current.available_vram_bytes,
-            });
-        }
+        // Free-VRAM telemetry is an observation, not execution identity. A
+        // harmless allocator/context delta may change it between planning and
+        // this fence even though the freshly resolved fingerprint is identical.
+        // Requiring byte equality turns that ordinary drift into an endless
+        // plan/replan loop. The immutable fingerprint above protects the chosen
+        // placement and load strategy; the lower-bound check protects capacity.
         if !self.immediate_leases.contains(lease) {
             return Err(PlanValidationError::LeaseNotProposed {
                 work_id: lease.work_id.clone(),
@@ -971,6 +967,9 @@ pub enum PlanValidationError {
         planned_bytes: u64,
         available_bytes: u64,
     },
+    /// Retained for downstream source compatibility. Grant validation no
+    /// longer emits this error because a changed sample is safe when the
+    /// execution fingerprint is unchanged and the predicted peak still fits.
     DeviceVramSampleChanged {
         device_id: DeviceId,
         planned_bytes: u64,

--- a/crates/mold-scheduler/tests/planner_contract.rs
+++ b/crates/mold-scheduler/tests/planner_contract.rs
@@ -1205,26 +1205,6 @@ fn runtime_grant_fences_are_typed_and_include_worker_readiness() {
         plan.validate_lease_for_grant(
             lease,
             &GrantValidationSnapshot {
-                available_vram_bytes: lease
-                    .placement
-                    .device_available_vram_bytes
-                    .saturating_sub(1),
-                ..current.clone()
-            }
-        ),
-        Err(PlanValidationError::DeviceVramSampleChanged {
-            device_id: "gpu-0".into(),
-            planned_bytes: lease.placement.device_available_vram_bytes,
-            current_bytes: lease
-                .placement
-                .device_available_vram_bytes
-                .saturating_sub(1),
-        })
-    );
-    assert_eq!(
-        plan.validate_lease_for_grant(
-            lease,
-            &GrantValidationSnapshot {
                 available_vram_bytes: lease.placement.predicted_vram_bytes.saturating_sub(1),
                 ..current.clone()
             }
@@ -1353,6 +1333,61 @@ fn runtime_grant_fences_are_typed_and_include_worker_readiness() {
             work_id: "other-job".into(),
             device_id: "gpu-0".into(),
         })
+    );
+}
+
+#[test]
+fn prepared_h3_capacity_drift_grants_the_first_of_three_jobs_when_the_peak_still_fits() {
+    // Private H3 preparation freezes the admission observation into every
+    // candidate. The generic scheduler sees only that 24 GiB value, the
+    // immutable execution fingerprint, and the predicted 8 GiB peak.
+    let jobs = (0..3)
+        .map(|index| work(&format!("h3-{index}"), index, vec![candidate("gpu-0", 1)]))
+        .collect();
+    let plan = Planner::default()
+        .plan(&snapshot(vec![device("gpu-0")], jobs, 128))
+        .expect("three prepared H3 candidates produce a valid queue plan");
+    let lease = plan
+        .immediate_leases
+        .first()
+        .expect("the oldest prepared H3 job owns the idle device");
+    assert_eq!(lease.work_id.as_str(), "h3-0");
+
+    let current = GrantValidationSnapshot {
+        work_id: lease.work_id.clone(),
+        device_id: lease.device_id.clone(),
+        state_version: plan.state_version,
+        plan_version: plan.plan_version,
+        sample_generation: plan.reservation.sample_generation,
+        ledger_sequence: plan.reservation.ledger_sequence,
+        work_ready: true,
+        work_cancelled: false,
+        worker_generation: lease.worker_generation,
+        worker_ready: true,
+        device_admin_state: DeviceAdminState::Enabled,
+        device_health: DeviceHealth::Healthy,
+        execution_fingerprint: lease.placement.execution_fingerprint.clone(),
+        available_vram_bytes: 23 * GIB,
+    };
+    assert_eq!(
+        plan.validate_lease_for_grant(lease, &current),
+        Ok(()),
+        "a harmless CUDA context delta must not livelock the prepared H3 queue"
+    );
+    assert_eq!(
+        plan.validate_lease_for_grant(
+            lease,
+            &GrantValidationSnapshot {
+                available_vram_bytes: lease.placement.predicted_vram_bytes.saturating_sub(1),
+                ..current
+            }
+        ),
+        Err(PlanValidationError::InsufficientCurrentVram {
+            device_id: "gpu-0".into(),
+            planned_bytes: lease.placement.predicted_vram_bytes,
+            available_bytes: lease.placement.predicted_vram_bytes.saturating_sub(1),
+        }),
+        "the same H3 grant must still fail closed on a real shortfall"
     );
 }
 

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -5870,15 +5870,15 @@ impl Coordinator {
                     let current_execution = current_generation_plans
                         .get(&work_id)
                         .and_then(|plans| exact_leased_execution_plan(plans, lease));
-                    if planned_execution.is_none() || planned_execution != current_execution {
+                    let (Some(planned_execution), Some(current_execution)) =
+                        (planned_execution, current_execution)
+                    else {
+                        return false;
+                    };
+                    if !same_execution_contract(&planned_execution, &current_execution) {
                         return false;
                     }
-                    ExecutionFingerprint::new(
-                        current_execution
-                            .expect("checked equal concrete execution plans")
-                            .execution_fingerprint
-                            .clone(),
-                    )
+                    ExecutionFingerprint::new(current_execution.execution_fingerprint.clone())
                 } else {
                     let Some(utility) = utility else {
                         return false;
@@ -7105,6 +7105,25 @@ fn exact_leased_execution_plan(
                 && plan.execution_fingerprint == lease.placement.execution_fingerprint.as_str()
         })
         .cloned()
+}
+
+/// Compare the immutable worker contract without treating the sampled free
+/// VRAM that admitted it as part of that identity.
+///
+/// The selected plan still has to resolve again with the same fingerprint and
+/// every artifact/placement/load field. The grant fence separately proves the
+/// fresh device still covers the predicted peak. Keeping the observation in a
+/// full derived equality made small CUDA context deltas invalidate every H3
+/// lease while several prepared rows kept the coordinator busy replanning.
+fn same_execution_contract(
+    planned: &crate::execution_plan::ResolvedExecutionPlan,
+    current: &crate::execution_plan::ResolvedExecutionPlan,
+) -> bool {
+    let mut planned = planned.clone();
+    let mut current = current.clone();
+    planned.admitted_available_vram_bytes = 0;
+    current.admitted_available_vram_bytes = 0;
+    planned == current
 }
 
 /// Deterministic planning and validation refusals remain visible but cannot
@@ -13031,6 +13050,22 @@ mod tests {
         .unwrap()
         .remove(0);
         wanted.execution_fingerprint = "wanted".into();
+        let mut capacity_drift = wanted.clone();
+        capacity_drift.admitted_available_vram_bytes = capacity_drift
+            .admitted_available_vram_bytes
+            .saturating_sub(1 << 20);
+        assert!(
+            same_execution_contract(&wanted, &capacity_drift),
+            "sampled free VRAM is not part of the immutable execution contract"
+        );
+        let mut changed_demand = wanted.clone();
+        changed_demand.predicted_vram_peak_bytes = changed_demand
+            .predicted_vram_peak_bytes
+            .saturating_add(1 << 20);
+        assert!(
+            !same_execution_contract(&wanted, &changed_demand),
+            "a changed execution demand must still invalidate the grant"
+        );
         let mut stale = wanted.clone();
         stale.execution_fingerprint = "stale".into();
         let lease = mold_scheduler::ImmediateLease {


### PR DESCRIPTION
## Summary

- stop treating byte-for-byte free-VRAM telemetry as execution identity at the grant fence
- preserve immutable execution-plan, fingerprint, and predicted-peak validation
- cover three queued prepared H3 jobs with frozen admission evidence and a lower live CUDA sample

## Root cause

On hal9000, three prepared MiniMax H3 jobs remained queued while the RTX 4090 was idle. CUDA context/allocator memory changed the observed free-VRAM value between planning and dispatch. The grant path required exact equality with the earlier admission sample, rejected the otherwise unchanged plan, and repeatedly replanned without transporting work.

## Safety

The grant still fails closed when current free VRAM is below the conservative predicted/learned peak. Fresh execution fingerprints and all artifact, placement, load-strategy, and demand fields must still match. The legacy public validation error variant remains available for source compatibility but is no longer emitted.

## Validation

- `nix develop -c cargo test -p mold-ai-scheduler --test planner_contract` (58 passed, 2 ignored)
- `nix develop -c cargo test -p mold-ai-server scheduler::tests:: --lib` (140 passed)
- `nix develop -c cargo clippy -p mold-ai-server -p mold-ai-scheduler --all-targets -- -D warnings`
- `nix develop -c cargo fmt --all -- --check`
- independent agent peer review; two findings addressed, clean re-review
