### PR TITLE
fix(ci): restore main and Windows nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -622,6 +622,34 @@ jobs:
       - name: Record protected gate success
         run: echo "Required Rust and release routes completed successfully."
 
+  # The shipping Windows CLI compiles mold-server routes that Unix cfgs can
+  # accidentally hide from every Linux PR gate. Keep this as a typecheck: the
+  # signed installer remains main-only in windows-nightly.yml.
+  windows-rust:
+    timeout-minutes: 45
+    needs: changes
+    if: >-
+      always() && !cancelled() &&
+      (needs.changes.result != 'success' ||
+       ((needs.changes.outputs.rust == 'true' ||
+         needs.changes.outputs.workflow == 'true') &&
+        needs.changes.outputs.trusted_release_pr != 'true'))
+    runs-on: windows-latest
+    steps:
+      - name: Require successful change classification
+        if: needs.changes.result != 'success'
+        run: |
+          Write-Error 'The required path classifier did not complete successfully.'
+          exit 1
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: windows-server-typecheck
+          save-if: ${{ github.ref == 'refs/heads/main' }}
+      - name: Typecheck Windows server routes
+        run: cargo check --locked -p mold-ai-server
+
   # The `flash-attn` feature was decorative for months (issue #598) precisely
   # because nothing ever compiled it: the cfg-stripped fallback in
   # `attention.rs` rotted into dead code that only a `--features flash-attn`

--- a/changelog.d/windows-nightly-gallery-source-media.md
+++ b/changelog.d/windows-nightly-gallery-source-media.md
@@ -1,0 +1,1 @@
+- Fixed Windows nightly builds after durable gallery source-media retention and made the restart GPU-renumbering CI regression deterministic.

--- a/crates/mold-server/src/queue_media.rs
+++ b/crates/mold-server/src/queue_media.rs
@@ -1046,6 +1046,8 @@ pub fn into_seal_media(
         .zip(&mut serialized_json)
         .zip(opened_paths)
     {
+        #[cfg(not(unix))]
+        let _ = &opened_path;
         let role = record.role.wire_label();
         let position = record.position.wire_label();
         let item = match record.payload {

--- a/crates/mold-server/src/queue_media_lifecycle.rs
+++ b/crates/mold-server/src/queue_media_lifecycle.rs
@@ -336,7 +336,6 @@ impl QueueMediaLifecycle {
             .load_from_gallery_pin(&GalleryMediaPinRef::new(media_set, pin_id)?)
     }
 
-    #[cfg(unix)]
     pub(crate) fn gallery_member_bytes(
         &self,
         media_set: MediaSetRef,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -9666,19 +9666,14 @@ mod tests {
                     "clip_l": { "kind": "cpu" }
                 }
             });
-            let task = tokio::spawn(async move {
-                app.oneshot(json_request("POST", "/api/generate", body))
-                    .await
-            });
-            tokio::time::timeout(Duration::from_secs(5), async {
-                while journal.list_all().is_empty() {
-                    tokio::task::yield_now().await;
-                }
-            })
+            let response = tokio::time::timeout(
+                Duration::from_secs(5),
+                app.oneshot(json_request("POST", "/api/generate/stream", body)),
+            )
             .await
-            .expect("direct admission");
-            task.abort();
-            let _ = task.await;
+            .expect("direct admission")
+            .expect("direct route response");
+            assert_eq!(response.status(), StatusCode::OK);
             let row = journal
                 .list_all()
                 .into_iter()

--- a/scripts/tests/ci-routing-contract.sh
+++ b/scripts/tests/ci-routing-contract.sh
@@ -43,6 +43,7 @@ extract_filter() {
 }
 
 rust_job=$(extract_job "$ci" rust)
+windows_rust_job=$(extract_job "$ci" windows-rust)
 cuda_job=$(extract_job "$ci" cuda-check)
 producer_command='cargo clippy -p mold-ai-inference --features dev-bins,h3-cuda --bin h3_runtime_qualification_record -- -D warnings'
 if grep -Fq -- "$producer_command" <<< "$rust_job"; then
@@ -50,6 +51,10 @@ if grep -Fq -- "$producer_command" <<< "$rust_job"; then
 fi
 [[ -z "$cuda_job" ]] \
   || fail "routine CI still contains the redundant 40-minute CUDA forced-local job"
+[[ -n "$windows_rust_job" ]] \
+  || fail "PR-visible Windows Rust typecheck is missing"
+grep -Fq 'cargo check --locked -p mold-ai-server' <<< "$windows_rust_job" \
+  || fail "Windows Rust gate does not compile the server routes used by the nightly CLI"
 grep -Fq 'cargo build --release -p mold-ai --features cuda' "$release_workflow" \
   || fail "release CI no longer compiles the shipped CUDA artifacts"
 


### PR DESCRIPTION
## Summary

- compile gallery source-media reads on Windows while preserving secure unavailable behavior
- make the restart GPU-renumbering regression wait for committed direct admission instead of racing journal persistence
- add a PR-visible Windows server typecheck so nightly-only cfg regressions are caught before merge

## Validation

- affected restart regression: 5 consecutive exact passes
- `cargo clippy -p mold-ai-server --all-targets -- -D warnings`
- `cargo check --locked -p mold-ai-server`
- `cargo fmt --all -- --check`
- `scripts/tests/ci-routing-contract.sh`
- actionlint on `.github/workflows/ci.yml`
- `git diff --check`

Fixes the failures from main CI run 33470730270 and Windows Nightly run 33470730222.
