### PR TITLE
fix(mobile): contain upscale dialog on narrow screens

### DIFF
--- a/changelog.d/mobile-upscale-sheet-containment.md
+++ b/changelog.d/mobile-upscale-sheet-containment.md
@@ -1,0 +1,1 @@
+- **Mobile upscale sheet containment.** Keeps image and Framewise video upscale controls inside narrow phone screens and shows submission failures directly in the open dialog instead of appearing unresponsive.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -9205,6 +9205,41 @@ describe("MobileApp gallery", () => {
     );
   });
 
+  it("shows a failed mobile Framewise submission inside the open upscale sheet", async () => {
+    const upscaler: ModelEntry = {
+      ...model,
+      name: "real-esrgan-x4plus:fp16",
+      family: "upscaler",
+      description: "4x video upscaler",
+      downloaded: false,
+    };
+    const base = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
+      if (path === "/api/models") return Promise.resolve([model, upscaler]);
+      if (path === "/api/video-upscale-jobs" && init?.method === "POST") {
+        return Promise.reject(new Error("Framewise upscale is unavailable on this machine"));
+      }
+      if (path === "/api/video-upscale-jobs") return Promise.resolve([]);
+      return base(callTarget, path, init);
+    });
+
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-tab-gallery']").trigger("click");
+    await vi.waitFor(() => expect(wrapper?.find("[data-test='gallery-item']").exists()).toBe(true));
+    await wrapper.get("[data-test='gallery-item']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-viewer-upscale']").trigger("click");
+    await flushPromises();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='upscale-dialog']")).not.toBeNull();
+    expect(document.querySelector("[data-test='upscale-error']")?.textContent).toContain(
+      "Framewise upscale is unavailable on this machine",
+    );
+  });
+
   it("uses the selected Library image as the older-host upscale fallback source", async () => {
     serveStillModel();
     const imagePrint: GalleryImage = {

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -10126,6 +10126,7 @@ const viewerUpscaleItem = ref<GalleryPrint | null>(null);
 const viewerUpscaleModel = ref("");
 const viewerUpscaleBusy = ref(false);
 const viewerUpscaleJob = ref<VideoUpscaleJob | null>(null);
+const viewerUpscaleError = ref("");
 let viewerUpscalePoll: ReturnType<typeof setTimeout> | null = null;
 let viewerUpscaleEpoch = 0;
 const viewerUpscaleKind = computed(() =>
@@ -10141,6 +10142,7 @@ function closeViewerUpscale(): void {
   stopViewerUpscalePoll();
   viewerUpscaleItem.value = null;
   viewerUpscaleJob.value = null;
+  viewerUpscaleError.value = "";
 }
 async function openUpscaleForPrint(print: GalleryPrint | null): Promise<void> {
   if (!print || isAudioItem(print) || isMeshItem(print)) return;
@@ -10148,6 +10150,7 @@ async function openUpscaleForPrint(print: GalleryPrint | null): Promise<void> {
   const epoch = ++viewerUpscaleEpoch;
   viewerUpscaleItem.value = print;
   viewerUpscaleJob.value = null;
+  viewerUpscaleError.value = "";
   viewerUpscaleModel.value = defaultUpscaler(upscalers.value);
   if (isVideoItem(print)) {
     try {
@@ -10192,7 +10195,7 @@ async function pollViewerUpscale(): Promise<void> {
     }
   } catch (error) {
     if (epoch !== viewerUpscaleEpoch || viewerUpscaleItem.value !== print) return;
-    generationAnnouncement.value = describeTransportError(error, print.hostName);
+    viewerUpscaleError.value = describeTransportError(error, print.hostName);
     return;
   }
   if (shouldPollFramewiseJob(viewerUpscaleJob.value))
@@ -10203,6 +10206,7 @@ async function startViewerUpscale(): Promise<void> {
   if (!print || viewerUpscaleBusy.value) return;
   const epoch = ++viewerUpscaleEpoch;
   stopViewerUpscalePoll();
+  viewerUpscaleError.value = "";
   viewerUpscaleBusy.value = true;
   try {
     if (isVideoItem(print)) {
@@ -10236,7 +10240,7 @@ async function startViewerUpscale(): Promise<void> {
     }
   } catch (error) {
     if (epoch !== viewerUpscaleEpoch || viewerUpscaleItem.value !== print) return;
-    generationAnnouncement.value = describeTransportError(error, print.hostName);
+    viewerUpscaleError.value = describeTransportError(error, print.hostName);
   } finally {
     viewerUpscaleBusy.value = false;
   }
@@ -10247,6 +10251,7 @@ async function transitionViewerUpscale(action: "pause" | "resume" | "cancel"): P
   if (!print || !job) return;
   stopViewerUpscalePoll();
   const epoch = ++viewerUpscaleEpoch;
+  viewerUpscaleError.value = "";
   try {
     const transitioned = await transitionFramewiseUpscale(print.target, job.id, action);
     if (epoch !== viewerUpscaleEpoch || viewerUpscaleItem.value !== print) return;
@@ -10254,7 +10259,7 @@ async function transitionViewerUpscale(action: "pause" | "resume" | "cancel"): P
     if (action === "resume") void pollViewerUpscale();
   } catch (error) {
     if (epoch !== viewerUpscaleEpoch || viewerUpscaleItem.value !== print) return;
-    generationAnnouncement.value = describeTransportError(error, print.hostName);
+    viewerUpscaleError.value = describeTransportError(error, print.hostName);
   }
 }
 
@@ -13484,6 +13489,7 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       :job-state="viewerUpscaleJob?.state ?? null"
       :status="viewerUpscaleJob ? framewiseStatus(viewerUpscaleJob) : null"
       :progress="viewerUpscaleJob ? framewiseProgress(viewerUpscaleJob) : null"
+      :error="viewerUpscaleError || null"
       @confirm="startViewerUpscale"
       @close="closeViewerUpscale"
       @pause="transitionViewerUpscale('pause')"

--- a/desktop/src/mobile/UpscaleDialog.layout.test.ts
+++ b/desktop/src/mobile/UpscaleDialog.layout.test.ts
@@ -1,0 +1,25 @@
+import { readFileSync } from "node:fs";
+import { describe, expect, it } from "vitest";
+
+const component = readFileSync("../ui/components/UpscaleDialog.vue", "utf8");
+
+describe("UpscaleDialog responsive containment", () => {
+  it("includes padding inside the sheet width on narrow viewports", () => {
+    const dialog = component.match(/\.upscale-dialog\s*\{([^}]*)\}/s);
+
+    expect(dialog?.[1]).toMatch(/width:\s*min\(460px,\s*100%\)\s*;/);
+    expect(dialog?.[1]).toMatch(/max-width:\s*100%\s*;/);
+    expect(dialog?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(dialog?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+  });
+
+  it("lets long model names shrink within the sheet", () => {
+    const field = component.match(/\.upscale-dialog__field\s*\{([^}]*)\}/s);
+    const select = component.match(/select\s*\{([^}]*)\}/s);
+
+    expect(field?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(select?.[1]).toMatch(/min-width:\s*0\s*;/);
+    expect(select?.[1]).toMatch(/max-width:\s*100%\s*;/);
+    expect(select?.[1]).toMatch(/box-sizing:\s*border-box\s*;/);
+  });
+});

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -601,6 +601,40 @@ describe("LibraryView source reuse", () => {
     );
     wrapper.unmount();
   });
+
+  it("keeps a failed desktop Framewise submission visible in the dialog", async () => {
+    createFramewiseUpscaleMock.mockRejectedValueOnce(
+      new Error("Framewise upscale is unavailable on this machine"),
+    );
+    const video = {
+      ...prints[0]!,
+      filename: "unsupported-clip.mp4",
+      format: "mp4",
+    } as GalleryImage;
+    const { wrapper } = await mountView(
+      undefined,
+      (gallery) => {
+        gallery.buckets.local!.items = [video];
+      },
+      "/library",
+      true,
+    );
+
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
+    );
+    useContextMenuStore().activate(upscale!);
+    await flushPromises();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='upscale-dialog']")).not.toBeNull();
+    expect(document.querySelector("[data-test='upscale-error']")?.textContent).toContain(
+      "Framewise upscale is unavailable on this machine",
+    );
+    wrapper.unmount();
+  });
 });
 
 describe("LibraryView header + NEW badges", () => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -339,6 +339,7 @@ const upscalingFilename = ref<string | null>(null);
 const upscaleEntry = ref<MergedPrint | null>(null);
 const upscaleModel = ref(defaultUpscaler(models.upscalers));
 const upscaleJob = ref<VideoUpscaleJob | null>(null);
+const upscaleError = ref("");
 let upscalePoll: ReturnType<typeof setTimeout> | null = null;
 let upscaleEpoch = 0;
 const upscaleKind = computed(() =>
@@ -355,6 +356,7 @@ function closeUpscaleDialog() {
   stopUpscalePoll();
   upscaleEntry.value = null;
   upscaleJob.value = null;
+  upscaleError.value = "";
 }
 
 async function openUpscaleDialog(entry: MergedPrint) {
@@ -363,6 +365,7 @@ async function openUpscaleDialog(entry: MergedPrint) {
   const epoch = ++upscaleEpoch;
   upscaleEntry.value = entry;
   upscaleJob.value = null;
+  upscaleError.value = "";
   upscaleModel.value = defaultUpscaler(models.upscalers);
   if (isVideo(entry.item)) {
     try {
@@ -399,7 +402,8 @@ async function pollUpscaleJob() {
     }
   } catch (error) {
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
-    toasts.push(error instanceof Error ? error.message : String(error), "error");
+    upscaleError.value = error instanceof Error ? error.message : String(error);
+    toasts.push(upscaleError.value, "error");
     return;
   }
   if (shouldPollFramewiseJob(upscaleJob.value))
@@ -452,6 +456,7 @@ async function startUpscale() {
   if (!entry || !target || upscalingFilename.value) return;
   const epoch = ++upscaleEpoch;
   stopUpscalePoll();
+  upscaleError.value = "";
   upscalingFilename.value = entry.item.filename;
   try {
     if (isVideo(entry.item)) {
@@ -476,7 +481,8 @@ async function startUpscale() {
     }
   } catch (error) {
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
-    toasts.push(error instanceof Error ? error.message : String(error), "error");
+    upscaleError.value = error instanceof Error ? error.message : String(error);
+    toasts.push(upscaleError.value, "error");
   } finally {
     upscalingFilename.value = null;
   }
@@ -489,6 +495,7 @@ async function transitionUpscale(action: "pause" | "resume" | "cancel") {
   if (!entry || !target || !job) return;
   stopUpscalePoll();
   const epoch = ++upscaleEpoch;
+  upscaleError.value = "";
   try {
     const transitioned = await transitionFramewiseUpscale(target, job.id, action);
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
@@ -496,7 +503,8 @@ async function transitionUpscale(action: "pause" | "resume" | "cancel") {
     if (action === "resume") void pollUpscaleJob();
   } catch (error) {
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
-    toasts.push(error instanceof Error ? error.message : String(error), "error");
+    upscaleError.value = error instanceof Error ? error.message : String(error);
+    toasts.push(upscaleError.value, "error");
   }
 }
 
@@ -2809,6 +2817,7 @@ onUnmounted(() => {
       :job-state="upscaleJob?.state ?? null"
       :status="upscaleJob ? framewiseStatus(upscaleJob) : null"
       :progress="upscaleJob ? framewiseProgress(upscaleJob) : null"
+      :error="upscaleError || null"
       @confirm="startUpscale"
       @close="closeUpscaleDialog"
       @pause="transitionUpscale('pause')"

--- a/ui/components/UpscaleDialog.vue
+++ b/ui/components/UpscaleDialog.vue
@@ -12,6 +12,7 @@ const props = withDefaults(
     jobState?: string | null;
     status?: string | null;
     progress?: number | null;
+    error?: string | null;
   }>(),
   {
     models: () => [],
@@ -19,6 +20,7 @@ const props = withDefaults(
     jobState: null,
     status: null,
     progress: null,
+    error: null,
   },
 );
 
@@ -126,6 +128,15 @@ const emit = defineEmits<{
           ></progress>
         </div>
 
+        <p
+          v-if="error"
+          class="upscale-dialog__error"
+          role="alert"
+          data-test="upscale-error"
+        >
+          {{ error }}
+        </p>
+
         <footer>
           <button class="upscale-dialog__secondary" @click="emit('close')">
             {{ jobState ? "Close" : "Cancel" }}
@@ -187,6 +198,9 @@ const emit = defineEmits<{
 }
 .upscale-dialog {
   width: min(460px, 100%);
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.14));
   border-radius: 18px;
   padding: 22px;
@@ -231,6 +245,13 @@ h2 {
   text-overflow: ellipsis;
   white-space: nowrap;
 }
+.upscale-dialog__error {
+  max-width: 100%;
+  margin: 14px 0 0;
+  overflow-wrap: anywhere;
+  color: var(--danger, #ff7f72);
+  font-size: 13px;
+}
 .upscale-dialog__copy {
   margin: 0 0 18px;
   color: var(--text-secondary, #c7cbbf);
@@ -238,12 +259,17 @@ h2 {
 }
 .upscale-dialog__field {
   display: grid;
+  min-width: 0;
+  box-sizing: border-box;
   gap: 7px;
   font-size: 13px;
   font-weight: 650;
 }
 select {
   width: 100%;
+  max-width: 100%;
+  min-width: 0;
+  box-sizing: border-box;
   min-height: 42px;
   border: 1px solid var(--border-subtle, rgba(255, 255, 255, 0.14));
   border-radius: 10px;


### PR DESCRIPTION
## Summary
- contain the shared image/video upscale dialog and long model names on narrow mobile screens
- surface start, polling, and lifecycle failures inline across mobile and desktop Library dialogs
- add regression coverage and a user-facing changelog fragment

## Validation
- 407 targeted frontend tests passed
- mobile production build passed
- native iPhone 17 simulator UAT passed
- two real Framewise jobs completed from `/Volumes/ExternalStorage/mold/uat-mobile-upscale`
- verified 320x180 -> 1280x720, 12/12 frames, 12 FPS, 1.000 s duration, AAC 48 kHz audio, and Gallery publication
- independent Claude Sonnet peer review completed; no actionable findings remain