### PR TITLE
fix(video): ship reliable Framewise codec runtime

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -174,6 +174,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # because the builder stage has the dev package installed.
 # libcuda.so.1 (the NVIDIA driver) is injected at runtime by the NVIDIA
 # Container Toolkit on GPU hosts like RunPod — it is never in the image.
+# Container builds intentionally resolve ffmpeg/ffprobe from this fixed runtime
+# PATH. Nix builds instead embed exact store paths at compile time.
 # Same apt retry wrapper as the builder stage — the tini fetch in particular
 # has timed out on GHA before.
 RUN set -eux; \

--- a/Dockerfile
+++ b/Dockerfile
@@ -180,6 +180,7 @@ RUN set -eux; \
     for attempt in 1 2 3 4 5; do \
         apt-get update && apt-get install -y --no-install-recommends \
             ca-certificates \
+            ffmpeg \
             libcudnn9-cuda-12 \
             libwebp7 \
             tini \

--- a/README.md
+++ b/README.md
@@ -66,6 +66,9 @@ mold serve
 
 Models download automatically on first use. Generated media is saved locally
 with prompt, model, seed, and generation metadata.
+Framewise video upscale also needs the host codec bridge: Nix packages and
+CUDA containers include it, while raw binary installs must provide `ffmpeg`
+and `ffprobe` on `PATH` before the server advertises that feature.
 
 ## What it supports
 

--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -233,6 +233,10 @@ pushed screen opened from the header.
   offers **Upscale…** for images and **Framewise upscale…** for videos through
   the shared model/progress dialog, including first-use model download and
   pause/resume/cancel for durable video jobs.
+  Video processing runs on the selected Mold host. Official Nix and CUDA
+  container hosts include the required FFmpeg codec bridge; other server
+  installations advertise Framewise upscale only when both `ffmpeg` and
+  `ffprobe` are available.
   Library organization (V3) rides each host's advertised
   `capabilities.gallery`: when a connected host advertises `organize` or
   `trash`, a 44pt **Prints | Collections | Trash** scope row (with counts)

--- a/changelog.d/framewise-ffmpeg-runtime.md
+++ b/changelog.d/framewise-ffmpeg-runtime.md
@@ -1,0 +1,3 @@
+- **Ship the Framewise codec runtime.** Nix and CUDA-container hosts now provide
+  `ffmpeg` and `ffprobe` for video upscaling, while other hosts stop advertising
+  Framewise upscale when those required tools are unavailable.

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1149,16 +1149,45 @@ pub(crate) async fn require_server_generation_request_activation(
         // by Library. Refuse before generation starts if the host cannot
         // assemble the result, rather than rendering an expensive source clip
         // that can only fail during settlement.
-        if request.frames.unwrap_or(1) > 1 {
+        if generation_request_produces_video(request, family) {
             let codec_available = tokio::task::spawn_blocking(
                 crate::video_upscale::framewise_codec_runtime_available,
             )
             .await
             .unwrap_or(false);
-            crate::video_upscale::require_framewise_codec_runtime_with(codec_available)?;
+            require_generation_framewise_runtime(request, family, codec_available)?;
         }
     }
     Ok(())
+}
+
+fn require_generation_framewise_runtime(
+    request: &mold_core::GenerateRequest,
+    family: Option<&str>,
+    codec_available: bool,
+) -> Result<(), ApiError> {
+    if request.upscale_model.is_some() && generation_request_produces_video(request, family) {
+        crate::video_upscale::require_framewise_codec_runtime_with(codec_available)?;
+    }
+    Ok(())
+}
+
+fn generation_request_produces_video(
+    request: &mold_core::GenerateRequest,
+    family: Option<&str>,
+) -> bool {
+    family.is_some_and(|family| {
+        matches!(
+            mold_core::ExpandTask::for_generation(family, request),
+            mold_core::ExpandTask::TextToVideo
+                | mold_core::ExpandTask::ImageToVideo
+                | mold_core::ExpandTask::VideoToVideo
+                | mold_core::ExpandTask::Retake
+                | mold_core::ExpandTask::KeyframeInterpolation
+                | mold_core::ExpandTask::AudioDrivenVideo
+                | mold_core::ExpandTask::ReferenceToAudioVideo
+        )
+    })
 }
 
 pub(crate) struct PreparedGenerationRoute {
@@ -10648,6 +10677,32 @@ mod tests {
         let ready = video_upscale_capabilities(true, true);
         assert!(ready.available);
         assert!(ready.gallery_image);
+    }
+
+    #[test]
+    fn generation_framewise_gate_uses_video_family_defaults_not_explicit_frames() {
+        let request = |model: &str| {
+            serde_json::from_value::<mold_core::GenerateRequest>(serde_json::json!({
+                "prompt": "a ship",
+                "model": model,
+                "width": 512,
+                "height": 512,
+                "steps": 4,
+                "guidance": 1.0,
+                "batch_size": 1,
+                "upscale_model": "real-esrgan-x4plus:fp16"
+            }))
+            .unwrap()
+        };
+
+        let video = request("wan2.2-t2v:a14b");
+        assert!(video.frames.is_none());
+        let error = require_generation_framewise_runtime(&video, Some("wan"), false).unwrap_err();
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.code, "VIDEO_UPSCALE_CODEC_RUNTIME_UNAVAILABLE");
+
+        let image = request("flux-schnell:q8");
+        require_generation_framewise_runtime(&image, Some("flux"), false).unwrap();
     }
 
     #[test]

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -1145,6 +1145,18 @@ pub(crate) async fn require_server_generation_request_activation(
     }
     if let Some(upscale_model) = request.upscale_model.as_deref() {
         require_server_model_activation(state, upscale_model).await?;
+        // Video post-processing is the same durable Framewise pipeline exposed
+        // by Library. Refuse before generation starts if the host cannot
+        // assemble the result, rather than rendering an expensive source clip
+        // that can only fail during settlement.
+        if request.frames.unwrap_or(1) > 1 {
+            let codec_available = tokio::task::spawn_blocking(
+                crate::video_upscale::framewise_codec_runtime_available,
+            )
+            .await
+            .unwrap_or(false);
+            crate::video_upscale::require_framewise_codec_runtime_with(codec_available)?;
+        }
     }
     Ok(())
 }
@@ -7348,6 +7360,12 @@ async fn server_capabilities(
     State(state): State<AppState>,
     auth_state: Option<Extension<crate::auth::AuthState>>,
 ) -> Json<mold_core::ServerCapabilities> {
+    // Executable startup can briefly block. Keep the first probe off the
+    // async worker; subsequent calls read the cached result.
+    let framewise_codec_available =
+        tokio::task::spawn_blocking(crate::video_upscale::framewise_codec_runtime_available)
+            .await
+            .unwrap_or(false);
     let catalog_available = std::env::var("MOLD_CATALOG_DISABLE")
         .map(|v| v != "1" && !v.eq_ignore_ascii_case("true"))
         .unwrap_or(true);
@@ -7391,10 +7409,8 @@ async fn server_capabilities(
             .read()
             .unwrap_or_else(|poisoned| poisoned.into_inner())
             .is_none();
-    let framewise_capabilities = video_upscale_capabilities(
-        framewise_base_available,
-        crate::video_upscale::framewise_codec_runtime_available(),
-    );
+    let framewise_capabilities =
+        video_upscale_capabilities(framewise_base_available, framewise_codec_available);
     let gallery = mold_core::GalleryCapabilities {
         can_delete: true,
         trash: Some(mold_core::GalleryTrashCapabilities {

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -7384,6 +7384,17 @@ async fn server_capabilities(
     // needs somewhere to move bytes to. With the DB disabled, DELETE stays a
     // hard delete and the organization routes answer 501.
     let db_available = state.metadata_db.is_some();
+    let framewise_base_available = db_available
+        && !state.is_output_disabled(&config)
+        && state
+            .generation_unavailable_reason
+            .read()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .is_none();
+    let framewise_capabilities = video_upscale_capabilities(
+        framewise_base_available,
+        crate::video_upscale::framewise_codec_runtime_available(),
+    );
     let gallery = mold_core::GalleryCapabilities {
         can_delete: true,
         trash: Some(mold_core::GalleryTrashCapabilities {
@@ -7428,34 +7439,7 @@ async fn server_capabilities(
                 .generation_admitted()
                 .then_some(MAX_HETEROGENEOUS_BATCH_OUTPUTS as u32),
         },
-        video_upscale: mold_core::VideoUpscaleCapabilities {
-            available: db_available
-                && !state.is_output_disabled(&config)
-                && state
-                    .generation_unavailable_reason
-                    .read()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .is_none(),
-            gallery_image: db_available
-                && !state.is_output_disabled(&config)
-                && state
-                    .generation_unavailable_reason
-                    .read()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner())
-                    .is_none(),
-            contract_version: mold_core::VIDEO_UPSCALE_CONTRACT_VERSION,
-            source_library: true,
-            source_upload: false,
-            input_containers: ["mp4", "mov", "webm"]
-                .into_iter()
-                .map(str::to_string)
-                .collect(),
-            output_container: "mp4".into(),
-            preserves_primary_audio_when_compatible: true,
-            supports_vfr: false,
-            supports_hdr: false,
-            disclosure: mold_core::VIDEO_UPSCALE_DISCLOSURE.into(),
-        },
+        video_upscale: framewise_capabilities,
         durable_media: readiness.advertised_media(),
         reference_uploads: mold_core::ReferenceUploadCapabilities {
             // The request-bound upload protocol derives its authority from an
@@ -7491,6 +7475,28 @@ async fn server_capabilities(
         },
         mesh: Some(mesh_capabilities()),
     })
+}
+
+fn video_upscale_capabilities(
+    base_available: bool,
+    codec_runtime_available: bool,
+) -> mold_core::VideoUpscaleCapabilities {
+    mold_core::VideoUpscaleCapabilities {
+        available: base_available && codec_runtime_available,
+        gallery_image: base_available,
+        contract_version: mold_core::VIDEO_UPSCALE_CONTRACT_VERSION,
+        source_library: true,
+        source_upload: false,
+        input_containers: ["mp4", "mov", "webm"]
+            .into_iter()
+            .map(str::to_string)
+            .collect(),
+        output_container: "mp4".into(),
+        preserves_primary_audio_when_compatible: true,
+        supports_vfr: false,
+        supports_hdr: false,
+        disclosure: mold_core::VIDEO_UPSCALE_DISCLOSURE.into(),
+    }
 }
 
 /// What this build can do with 3-D artifacts.
@@ -10616,6 +10622,17 @@ mod tests {
     use crate::test_support::env_lock;
     use std::sync::atomic::Ordering;
     use std::sync::Arc;
+
+    #[test]
+    fn framewise_capability_requires_codec_runtime_without_disabling_image_upscale() {
+        let missing_codec = video_upscale_capabilities(true, false);
+        assert!(!missing_codec.available);
+        assert!(missing_codec.gallery_image);
+
+        let ready = video_upscale_capabilities(true, true);
+        assert!(ready.available);
+        assert!(ready.gallery_image);
+    }
 
     #[test]
     fn event_stream_gap_has_explicit_resync_wire_contract() {

--- a/crates/mold-server/src/video_upscale.rs
+++ b/crates/mold-server/src/video_upscale.rs
@@ -426,7 +426,25 @@ pub(crate) fn enqueue_gallery_video_job(
     model: String,
     tile_size: Option<u32>,
 ) -> Result<VideoUpscaleJob, ApiError> {
-    require_framewise_codec_runtime()?;
+    enqueue_gallery_video_job_with_codec_runtime(
+        output_dir,
+        database,
+        filename,
+        model,
+        tile_size,
+        framewise_codec_runtime_available(),
+    )
+}
+
+fn enqueue_gallery_video_job_with_codec_runtime(
+    output_dir: &FsPath,
+    database: &mold_db::MetadataDb,
+    filename: &str,
+    model: String,
+    tile_size: Option<u32>,
+    codec_runtime_available: bool,
+) -> Result<VideoUpscaleJob, ApiError> {
+    require_framewise_codec_runtime_with(codec_runtime_available)?;
     let source_metadata = database
         .get(output_dir, filename)
         .map_err(|e| ApiError::internal(e.to_string()))?
@@ -1533,12 +1551,13 @@ mod tests {
             shutdown: lifecycle_shutdown,
             handle,
         };
-        let job = enqueue_gallery_video_job(
+        let job = enqueue_gallery_video_job_with_codec_runtime(
             temp.path(),
             state.metadata_db.as_ref().as_ref().unwrap(),
             "source.mp4",
             "real-esrgan-x4plus:fp16".into(),
             None,
+            true,
         )
         .unwrap();
 
@@ -1645,12 +1664,13 @@ mod tests {
             shutdown: lifecycle_shutdown,
             handle,
         };
-        let job = enqueue_gallery_video_job(
+        let job = enqueue_gallery_video_job_with_codec_runtime(
             temp.path(),
             state.metadata_db.as_ref().as_ref().unwrap(),
             "source.mp4",
             "real-esrgan-x4plus:fp16".into(),
             None,
+            true,
         )
         .unwrap();
 
@@ -1746,12 +1766,13 @@ mod tests {
         );
         db.upsert(&record).unwrap();
 
-        let job = enqueue_gallery_video_job(
+        let job = enqueue_gallery_video_job_with_codec_runtime(
             gallery,
             &db,
             "source.mp4",
             "real-esrgan-x4plus:fp16".into(),
             None,
+            true,
         )
         .unwrap();
         let stored = jobs::get(&db, &job.id).unwrap().unwrap();

--- a/crates/mold-server/src/video_upscale.rs
+++ b/crates/mold-server/src/video_upscale.rs
@@ -82,8 +82,10 @@ pub(crate) fn require_framewise_codec_runtime_with(available: bool) -> Result<()
     }
 }
 
-fn require_framewise_codec_runtime() -> Result<(), ApiError> {
-    require_framewise_codec_runtime_with(framewise_codec_runtime_available())
+async fn framewise_codec_runtime_available_async() -> bool {
+    tokio::task::spawn_blocking(framewise_codec_runtime_available)
+        .await
+        .unwrap_or(false)
 }
 
 fn now_ms() -> i64 {
@@ -406,13 +408,17 @@ async fn create_library_job(
         .map_err(ApiError::model_activation)?;
     let output_dir = state.config.read().await.effective_output_dir();
     match &request.source {
-        VideoUpscaleSource::Library { filename } => enqueue_gallery_video_job(
-            &output_dir,
-            db(state)?,
-            filename,
-            model,
-            request.tile_size,
-        ),
+        VideoUpscaleSource::Library { filename } => {
+            let codec_runtime_available = framewise_codec_runtime_available_async().await;
+            enqueue_gallery_video_job_with_codec_runtime(
+                &output_dir,
+                db(state)?,
+                filename,
+                model,
+                request.tile_size,
+                codec_runtime_available,
+            )
+        }
         VideoUpscaleSource::Upload { .. } => Err(ApiError::structured(
             "Video upload handles are not advertised by this first capability; import the video into Library first",
             "VIDEO_UPSCALE_UPLOAD_UNAVAILABLE", StatusCode::NOT_IMPLEMENTED, None, None)),
@@ -753,7 +759,7 @@ pub async fn resume_job(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<VideoUpscaleJob>, ApiError> {
-    require_framewise_codec_runtime()?;
+    require_framewise_codec_runtime_with(framewise_codec_runtime_available_async().await)?;
     let job = transition_job(
         &state,
         &id,
@@ -1469,6 +1475,27 @@ mod tests {
         let error = require_framewise_codec_runtime_with(false).unwrap_err();
         assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
         assert_eq!(error.code, "VIDEO_UPSCALE_CODEC_RUNTIME_UNAVAILABLE");
+    }
+
+    #[test]
+    fn enqueue_refuses_unavailable_codec_runtime_before_persisting() {
+        let temp = tempfile::tempdir().unwrap();
+        let db = mold_db::MetadataDb::open_in_memory().unwrap();
+
+        let error = enqueue_gallery_video_job_with_codec_runtime(
+            temp.path(),
+            &db,
+            "source.mp4",
+            "real-esrgan-x4plus:fp16".into(),
+            None,
+            false,
+        )
+        .unwrap_err();
+
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.code, "VIDEO_UPSCALE_CODEC_RUNTIME_UNAVAILABLE");
+        assert!(jobs::list(&db).unwrap().is_empty());
+        assert!(!temp.path().join(".mold-video-upscale-jobs").exists());
     }
 
     fn ffmpeg_fixture_tools_available() -> bool {

--- a/crates/mold-server/src/video_upscale.rs
+++ b/crates/mold-server/src/video_upscale.rs
@@ -70,8 +70,8 @@ pub(crate) fn framewise_codec_runtime_available() -> bool {
     })
 }
 
-fn require_framewise_codec_runtime() -> Result<(), ApiError> {
-    if framewise_codec_runtime_available() {
+pub(crate) fn require_framewise_codec_runtime_with(available: bool) -> Result<(), ApiError> {
+    if available {
         Ok(())
     } else {
         Err(ApiError::with_code(
@@ -80,6 +80,10 @@ fn require_framewise_codec_runtime() -> Result<(), ApiError> {
             StatusCode::SERVICE_UNAVAILABLE,
         ))
     }
+}
+
+fn require_framewise_codec_runtime() -> Result<(), ApiError> {
+    require_framewise_codec_runtime_with(framewise_codec_runtime_available())
 }
 
 fn now_ms() -> i64 {
@@ -731,6 +735,7 @@ pub async fn resume_job(
     State(state): State<AppState>,
     Path(id): Path<String>,
 ) -> Result<Json<VideoUpscaleJob>, ApiError> {
+    require_framewise_codec_runtime()?;
     let job = transition_job(
         &state,
         &id,
@@ -1439,6 +1444,13 @@ mod tests {
         assert!(!available);
         assert_eq!(checked, ["ffmpeg", "ffprobe"]);
         assert!(detect_framewise_codec_runtime(|_| true));
+    }
+
+    #[test]
+    fn unavailable_codec_runtime_returns_typed_service_unavailable() {
+        let error = require_framewise_codec_runtime_with(false).unwrap_err();
+        assert_eq!(error.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(error.code, "VIDEO_UPSCALE_CODEC_RUNTIME_UNAVAILABLE");
     }
 
     fn ffmpeg_fixture_tools_available() -> bool {

--- a/crates/mold-server/src/video_upscale.rs
+++ b/crates/mold-server/src/video_upscale.rs
@@ -25,6 +25,7 @@ use std::{
     io::{BufRead, Read, Write},
     path::{Path as FsPath, PathBuf},
     process::{Command, Stdio},
+    sync::OnceLock,
 };
 
 use crate::{routes::ApiError, state::AppState};
@@ -36,6 +37,50 @@ const MAX_FRAME_BYTES: u64 = 128 * 1024 * 1024;
 const DISK_SAFETY_BYTES: u64 = 1024 * 1024 * 1024;
 const SOURCE_DIGEST_FILE: &str = "source.sha256";
 const SOURCE_METADATA_FILE: &str = "source-metadata.json";
+const FRAMEWISE_CODEC_UNAVAILABLE: &str =
+    "Framewise upscale is unavailable because this Mold host does not provide ffmpeg and ffprobe";
+
+fn codec_command(tool: &str) -> Command {
+    let bundled = match tool {
+        "ffmpeg" => option_env!("MOLD_BUNDLED_FFMPEG"),
+        "ffprobe" => option_env!("MOLD_BUNDLED_FFPROBE"),
+        _ => None,
+    };
+    Command::new(bundled.unwrap_or(tool))
+}
+
+fn detect_framewise_codec_runtime(mut available: impl FnMut(&str) -> bool) -> bool {
+    let ffmpeg = available("ffmpeg");
+    let ffprobe = available("ffprobe");
+    ffmpeg && ffprobe
+}
+
+pub(crate) fn framewise_codec_runtime_available() -> bool {
+    static AVAILABLE: OnceLock<bool> = OnceLock::new();
+    *AVAILABLE.get_or_init(|| {
+        detect_framewise_codec_runtime(|tool| {
+            codec_command(tool)
+                .arg("-version")
+                .stdin(Stdio::null())
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .status()
+                .is_ok_and(|status| status.success())
+        })
+    })
+}
+
+fn require_framewise_codec_runtime() -> Result<(), ApiError> {
+    if framewise_codec_runtime_available() {
+        Ok(())
+    } else {
+        Err(ApiError::with_code(
+            FRAMEWISE_CODEC_UNAVAILABLE,
+            "VIDEO_UPSCALE_CODEC_RUNTIME_UNAVAILABLE",
+            StatusCode::SERVICE_UNAVAILABLE,
+        ))
+    }
+}
 
 fn now_ms() -> i64 {
     mold_core::time::now_epoch_ms_u64() as i64
@@ -377,6 +422,7 @@ pub(crate) fn enqueue_gallery_video_job(
     model: String,
     tile_size: Option<u32>,
 ) -> Result<VideoUpscaleJob, ApiError> {
+    require_framewise_codec_runtime()?;
     let source_metadata = database
         .get(output_dir, filename)
         .map_err(|e| ApiError::internal(e.to_string()))?
@@ -786,7 +832,7 @@ fn rational(value: &str) -> anyhow::Result<(u64, u64)> {
 }
 
 fn probe(path: &FsPath) -> anyhow::Result<VideoUpscaleMediaFacts> {
-    let output = Command::new("ffprobe")
+    let output = codec_command("ffprobe")
         .args([
             "-v",
             "error",
@@ -902,7 +948,7 @@ fn validate_constant_frame_timestamps(
     let (numerator, denominator) = rational(fps)?;
     let expected_delta = denominator as f64 / numerator as f64;
     let tolerance = (expected_delta * 0.001).max(0.000_002);
-    let mut child = Command::new("ffprobe")
+    let mut child = codec_command("ffprobe")
         .args([
             "-v",
             "error",
@@ -1000,7 +1046,7 @@ fn spawn_decoder(source: &FsPath, start: u64, count: u64) -> anyhow::Result<std:
         "trim=start_frame={start}:end_frame={},setpts=PTS-STARTPTS",
         start + count
     );
-    Ok(Command::new("ffmpeg")
+    Ok(codec_command("ffmpeg")
         .args(["-v", "error", "-i"])
         .arg(source)
         .args([
@@ -1018,7 +1064,7 @@ fn spawn_encoder(
     height: u32,
     fps: &str,
 ) -> anyhow::Result<std::process::Child> {
-    Ok(Command::new("ffmpeg")
+    Ok(codec_command("ffmpeg")
         .args([
             "-v",
             "error",
@@ -1265,7 +1311,7 @@ async fn run_job(state: AppState, id: &str) -> anyhow::Result<()> {
     }
     list.sync_all()?;
     let video_only = stored.work_dir.join("video-only.mp4");
-    let concat = Command::new("ffmpeg")
+    let concat = codec_command("ffmpeg")
         .current_dir(&stored.work_dir)
         .args([
             "-v",
@@ -1291,7 +1337,7 @@ async fn run_job(state: AppState, id: &str) -> anyhow::Result<()> {
         return Ok(());
     }
     let final_path = stored.work_dir.join("final.mp4");
-    let mut mux = Command::new("ffmpeg");
+    let mut mux = codec_command("ffmpeg");
     mux.args(["-v", "error", "-y", "-i"]).arg(&video_only);
     if facts.primary_audio_codec.is_some() {
         mux.args(["-i"]).arg(&stored.source_path).args([
@@ -1381,6 +1427,19 @@ mod tests {
     use std::sync::Mutex;
 
     static FFMPEG_FIXTURE_LOCK: Mutex<()> = Mutex::new(());
+
+    #[test]
+    fn framewise_codec_runtime_requires_ffmpeg_and_ffprobe() {
+        let mut checked = Vec::new();
+        let available = detect_framewise_codec_runtime(|tool| {
+            checked.push(tool.to_string());
+            tool == "ffmpeg"
+        });
+
+        assert!(!available);
+        assert_eq!(checked, ["ffmpeg", "ffprobe"]);
+        assert!(detect_framewise_codec_runtime(|_| true));
+    }
 
     fn ffmpeg_fixture_tools_available() -> bool {
         ["ffmpeg", "ffprobe"].into_iter().all(|tool| {

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -5142,6 +5142,16 @@ impl App {
                     && !self.upscale_in_progress
                     && self.gallery.entries.get(self.gallery.selected).is_some() =>
             {
+                let can_upscale = self
+                    .gallery
+                    .entries
+                    .get(self.gallery.selected)
+                    .is_some_and(|entry| self.can_upscale_entry(entry));
+                if !can_upscale {
+                    self.generate.error_message =
+                        Some("Framewise video upscale is unavailable on this Mold host".into());
+                    return;
+                }
                 let models = self.available_upscaler_models();
                 self.popup = Some(Popup::UpscaleModelSelector {
                     filter: String::new(),
@@ -6061,6 +6071,20 @@ impl App {
             return self.machines.capabilities.get(crate::hosts::LOCAL_HOST_ID);
         }
         None
+    }
+
+    /// Whether Library may offer its immediate upscale action for `entry`.
+    /// Images retain the local/legacy fallback. Videos require the durable
+    /// server pipeline and its explicit codec-backed capability.
+    pub(crate) fn can_upscale_entry(&self, entry: &GalleryEntry) -> bool {
+        if !crate::gallery_scan::is_video_filename(&entry.filename()) {
+            return true;
+        }
+        let origin = entry.primary_origin();
+        (origin.url.is_some() || self.server_url.is_some())
+            && self
+                .capabilities_for_origin(&origin)
+                .is_some_and(|caps| caps.video_upscale.available)
     }
 
     /// Whether a print held by `origin` is moved to a trash (recoverable)
@@ -17022,6 +17046,29 @@ mod tests {
         app.machines
             .apply_capabilities(crate::hosts::LOCAL_HOST_ID.into(), Some(caps));
         assert_eq!(app.removal_kind_for(&entry), RemovalKind::Trash);
+    }
+
+    #[test]
+    fn framewise_library_action_requires_the_selected_hosts_capability() {
+        let runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .unwrap();
+        let _guard = runtime.enter();
+        let mut app = make_settings_test_app();
+        app.server_url = Some("http://bender:7680".into());
+        let mut video = make_test_entry_with_name("clip.mp4");
+        video.origins = vec![GalleryOrigin::remote_from_url("http://bender:7680")];
+
+        assert!(!app.can_upscale_entry(&video));
+        let mut caps = mold_core::ServerCapabilities::default();
+        caps.video_upscale.available = true;
+        app.machines
+            .apply_capabilities(crate::hosts::LOCAL_HOST_ID.into(), Some(caps));
+        assert!(app.can_upscale_entry(&video));
+
+        let image = make_test_entry_with_name("still.png");
+        assert!(app.can_upscale_entry(&image));
     }
 
     #[tokio::test]

--- a/crates/mold-tui/src/ui/library_details.rs
+++ b/crates/mold-tui/src/ui/library_details.rs
@@ -61,6 +61,7 @@ pub(crate) fn render(frame: &mut Frame, app: &mut App, area: Rect) {
     let pipeline = entry.metadata.pipeline.map(|pipeline| pipeline.to_string());
     let identity = crate::identity::metadata_summary(&entry.metadata);
     let machine = entry.machine_label();
+    let can_upscale = app.can_upscale_entry(entry);
 
     // ── Thumbnail (fixed protocol, one-slot cache) ──────────────
     let mut y = inner.y;
@@ -154,7 +155,11 @@ pub(crate) fn render(frame: &mut Frame, app: &mut App, area: Rect) {
         crate::ui::widgets::kv_row_line(theme, "Machine", &machine, 8, false),
         Line::from(""),
     ]);
-    for (key, label) in [("[r]", "Recall prompt"), ("[u]", "Upscale")] {
+    let mut actions = vec![("[r]", "Recall prompt")];
+    if can_upscale {
+        actions.push(("[u]", "Upscale"));
+    }
+    for (key, label) in actions {
         lines.push(Line::from(vec![
             Span::styled(key, theme.status_key()),
             Span::raw(" "),

--- a/desktop/docs/feature-parity.md
+++ b/desktop/docs/feature-parity.md
@@ -92,6 +92,12 @@ Desktop parity: `edit_images` is surfaced by `SourceImageWell.vue`'s qwen-edit b
 
 The earlier image-only upscale description is superseded by cross-media parity: `upscale_model` appears for still and video generation on web, desktop, mobile, and TUI. Stills upscale inline; videos publish the original and then queue a durable Framewise job. Library context menus and full-media/info viewers offer **Upscale…** for images and **Framewise upscale…** for videos through a shared model/progress dialog. First use downloads the selected model on the owning host; durable video work supports pause, resume, cancel, and restart recovery. `POST /api/gallery/upscale` publishes image results and `/api/video-upscale-jobs` owns video processing.
 
+Frame decoding, constant-FPS validation, H.264 encoding, and compatible audio
+muxing use a process-isolated FFmpeg bridge on the owning host. Nix packages
+bind exact `ffmpeg` and `ffprobe` store paths and the CUDA container installs
+them; raw binary hosts advertise video upscale as unavailable when either tool
+is absent while preserving server-side image upscale capability.
+
 Post-generation image upscale persists distinct `-original` and `-upscaled` entries on the serving host. Remote-output auto-save mirrors both to This Mac, and gallery reuse restores the pre-upscale generation dimensions rather than the upscaled raster size. If upscaling fails after generation, the job completes with the original image as a single artifact.
 
 `GenerateResponse`: `images[]` (`{data,width,height,index}`), optional `video` (`{data,format,width,height,frames,fps,thumbnail,gif_preview}`), `generation_time_ms`, `model`, `seed_used`, `gpu` (ordinal, multi-GPU).

--- a/desktop/src/components/gallery/Lightbox.test.ts
+++ b/desktop/src/components/gallery/Lightbox.test.ts
@@ -73,6 +73,14 @@ function mountLightbox(
   });
 }
 
+describe("upscale capability", () => {
+  it("hides Framewise upscale when the video host cannot execute it", () => {
+    const video = { ...item, filename: "clip.mp4", format: "mp4" } as GalleryImage;
+    const wrapper = mountLightbox(video, true, { upscaleEnabled: false });
+    expect(wrapper.find("[data-test='lightbox-upscale']").exists()).toBe(false);
+  });
+});
+
 describe("Lightbox reuse", () => {
   it("hands the composer the full metadata so nothing is dropped", async () => {
     const metadata = {

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -64,6 +64,8 @@ const props = withDefaults(
     mesh?: boolean;
     /** Audio-only print: no raster to show, a transport instead. */
     audio?: boolean;
+    /** The origin host can actually execute this media's upscale workflow. */
+    upscaleEnabled?: boolean;
     source?: GallerySource;
     /** Origin host to fetch media from; null = the primary connection. */
     target?: ApiTarget | null;
@@ -98,6 +100,7 @@ const props = withDefaults(
   {
     mesh: false,
     audio: false,
+    upscaleEnabled: true,
     source: "host",
     target: null,
     cacheKey: null,
@@ -836,7 +839,7 @@ async function performVideoExport(options: VideoExportOptions) {
           </button>
         </div>
         <button
-          v-if="!audio && !trashed"
+          v-if="upscaleEnabled && !audio && !trashed"
           type="button"
           data-test="lightbox-upscale"
           class="border-ce mt-2.5 h-10 w-full rounded-control border text-body font-semibold text-ink-2 transition-colors duration-100 hover:text-ink"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -465,6 +465,7 @@ function serveStillModel(): void {
 }
 
 const durableQueueCapabilities = {
+  video_upscale: { available: true },
   queue: { heterogeneous_batch_max_outputs: 64 },
   durable_media: {
     protocol_version: 2,

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3135,11 +3135,15 @@ const generatedPreviewTarget = computed<ApiTarget>(() => {
   const host = generatedPreviewHost.value;
   return host ? mobileHostTarget(host) : { baseUrl: "", apiKey: null };
 });
+function canUpscalePrint(print: GalleryPrint | null): boolean {
+  if (!print || isAudioItem(print) || isMeshItem(print)) return false;
+  return !isVideoItem(print) || serverCapabilities[print.hostId]?.video_upscale?.available === true;
+}
 const generatedUpscalePrint = computed<GalleryPrint | null>(() => {
   const item = generatedPreviewItem.value;
   const host = generatedPreviewHost.value;
   if (!item || !host || isAudioItem(item) || isMeshItem(item)) return null;
-  return {
+  const print: GalleryPrint = {
     ...item,
     hostId: host.id,
     cacheKey: host.id,
@@ -3148,6 +3152,7 @@ const generatedUpscalePrint = computed<GalleryPrint | null>(() => {
     thumbnailUrl: resultUrl.value,
     thumbnailPending: false,
   };
+  return canUpscalePrint(print) ? print : null;
 });
 const resultPreviewError = computed(() => {
   const job = latestResultJob.value;
@@ -10145,7 +10150,7 @@ function closeViewerUpscale(): void {
   viewerUpscaleError.value = "";
 }
 async function openUpscaleForPrint(print: GalleryPrint | null): Promise<void> {
-  if (!print || isAudioItem(print) || isMeshItem(print)) return;
+  if (!print || !canUpscalePrint(print)) return;
   stopViewerUpscalePoll();
   const epoch = ++viewerUpscaleEpoch;
   viewerUpscaleItem.value = print;
@@ -10352,7 +10357,7 @@ const singleSelectedUpscalePrint = computed<GalleryPrint | null>(() => {
   const selected = selectedRepresentatives();
   if (selected.length !== 1) return null;
   const print = selected[0];
-  return print && !isAudioItem(print) && !isMeshItem(print) ? (print as GalleryPrint) : null;
+  return canUpscalePrint(print as GalleryPrint) ? (print as GalleryPrint) : null;
 });
 
 function openSelectedGalleryUpscale(): void {
@@ -10374,10 +10379,10 @@ function toggleGallerySelection(print: GalleryPrint): void {
 function rememberNativeGalleryContext(print: GalleryPrint): void {
   nativeGalleryContextKey = galleryPrintKey(print);
   if (isNativeIOSRuntime()) {
-    const upscaleLabel = isVideoItem(print)
-      ? "Framewise upscale…"
-      : isAudioItem(print) || isMeshItem(print)
-        ? null
+    const upscaleLabel = !canUpscalePrint(print)
+      ? null
+      : isVideoItem(print)
+        ? "Framewise upscale…"
         : "Upscale…";
     void invoke("extend_gallery_context_menu", { upscaleLabel }).catch(() => undefined);
   }
@@ -13460,6 +13465,7 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
       :has-next="selectedPrintIndex >= 0 && selectedPrintIndex < gallery.length - 1"
       :organization="selectedPrintOrganization ?? null"
       :organize-enabled="libraryOrganizeEnabled"
+      :upscale-enabled="canUpscalePrint(selectedPrint)"
       :trashed="selectedPrintTrashed"
       :organizing="organizationBusy"
       :organization-error="organizationError"

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -602,6 +602,30 @@ describe("LibraryView source reuse", () => {
     wrapper.unmount();
   });
 
+  it("disables Framewise upscale when the local host reports it unavailable", async () => {
+    const video = {
+      ...prints[0]!,
+      filename: "unavailable-clip.mp4",
+      format: "mp4",
+    } as GalleryImage;
+    const { wrapper } = await mountView(
+      undefined,
+      (gallery) => {
+        gallery.buckets.local!.items = [video];
+      },
+      "/library",
+      true,
+    );
+    useHostsStore().capabilities.local = {
+      video_upscale: { available: false },
+    } as never;
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
+    );
+    expect(upscale).toMatchObject({ disabled: true });
+  });
+
   it("keeps a failed desktop Framewise submission visible in the dialog", async () => {
     createFramewiseUpscaleMock.mockRejectedValueOnce(
       new Error("Framewise upscale is unavailable on this machine"),

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -360,7 +360,7 @@ function closeUpscaleDialog() {
 }
 
 async function openUpscaleDialog(entry: MergedPrint) {
-  if (isAudio(entry.item) || !targetFor(entry)) return;
+  if (!canUpscaleEntry(entry) || !targetFor(entry)) return;
   stopUpscalePoll();
   const epoch = ++upscaleEpoch;
   upscaleEntry.value = entry;
@@ -381,6 +381,13 @@ async function openUpscaleDialog(entry: MergedPrint) {
       // Old hosts do not expose durable video-upscale history.
     }
   }
+}
+
+function canUpscaleEntry(entry: MergedPrint | null): boolean {
+  if (!entry || isAudio(entry.item) || isMesh(entry.item)) return false;
+  return (
+    !isVideo(entry.item) || hosts.capabilities[entry.sourceKey]?.video_upscale?.available === true
+  );
 }
 
 async function pollUpscaleJob() {
@@ -1203,7 +1210,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
         upscalingFilename.value === item.filename
           ? "Upscaling…"
           : libraryUpscaleLabel(isVideo(item) ? "video" : "image").replace("…", ""),
-      disabled: !targetFor(entry) || upscalingFilename.value !== null || isAudio(item),
+      disabled: !targetFor(entry) || upscalingFilename.value !== null || !canUpscaleEntry(entry),
       action: () => openUpscaleDialog(entry),
     },
     {
@@ -2788,6 +2795,7 @@ onUnmounted(() => {
       :can-organize="organizeAvailable && canOrganizeEntry(selectedEntry)"
       :can-trash="entryTrashCapable(selectedEntry)"
       :trashed="inTrash"
+      :upscale-enabled="canUpscaleEntry(selectedEntry)"
       :collections="gallery.mergedCollections"
       :collection-counts="gallery.collectionCounts"
       :tag-suggestions="gallery.mergedTags"

--- a/flake.nix
+++ b/flake.nix
@@ -579,6 +579,8 @@
               MOLD_BUILD_DATE = gitDate;
               # The embedded engine serves the regular web SPA to browsers.
               MOLD_WEB_DIST = "${mold-web}";
+              MOLD_BUNDLED_FFMPEG = "${pkgs.ffmpeg}/bin/ffmpeg";
+              MOLD_BUNDLED_FFPROBE = "${pkgs.ffmpeg}/bin/ffprobe";
               CUDA_PATH = lib.optionalString isLinux "${cudaToolkit}";
               CUDA_COMPUTE_CAP = lib.optionalString isLinux computeCap;
               NIX_LDFLAGS = lib.optionalString isLinux "-L${pkgs.cudaPackages.cuda_cudart}/lib/stubs";
@@ -708,6 +710,10 @@
               // {
                 inherit cargoArtifacts meta;
                 MOLD_WEB_DIST = "${mold-web}";
+                # The codec bridge stays process-isolated, but the packaged
+                # server does not depend on the caller's PATH.
+                MOLD_BUNDLED_FFMPEG = "${pkgs.ffmpeg}/bin/ffmpeg";
+                MOLD_BUNDLED_FFPROBE = "${pkgs.ffmpeg}/bin/ffprobe";
                 cargoExtraArgs = "-p mold-ai --features ${releaseFeaturesFor computeCap}";
                 postInstall =
                   if isLinux then

--- a/scripts/tests/cuda-distribution-contract.sh
+++ b/scripts/tests/cuda-distribution-contract.sh
@@ -310,6 +310,11 @@ docker_runtime_copy_line="$(
 )"
 [[ "$docker_seal_line" -lt "$docker_runtime_copy_line" ]] \
   || fail "Docker PTX sealing must precede runtime image publication"
+docker_runtime_packages="$(sed -n '/# Same apt retry wrapper as the builder stage/,/rm -rf \/var\/lib\/apt\/lists/p' "$repo_root/Dockerfile")"
+grep -Eq '^[[:space:]]+ffmpeg[[:space:]]*\\$' <<< "$docker_runtime_packages" \
+  || fail "Docker runtime omits ffmpeg/ffprobe required by Framewise upscale"
+require_text "flake.nix" 'MOLD_BUNDLED_FFMPEG = "${pkgs.ffmpeg}/bin/ffmpeg";'
+require_text "flake.nix" 'MOLD_BUNDLED_FFPROBE = "${pkgs.ffmpeg}/bin/ffprobe";'
 require_release_job_text "docker" \
   'Create once and verify immutable stable tag'
 require_release_job_text "docker" \

--- a/web/src/components/gallery/Lightbox.test.ts
+++ b/web/src/components/gallery/Lightbox.test.ts
@@ -220,6 +220,15 @@ describe("Lightbox (desktop two-pane)", () => {
     expect(wrapper.emitted("upscale")?.[0]?.[0]).toEqual(video);
   });
 
+  it("hides video upscale when the origin host cannot execute it", async () => {
+    const video = { ...item, filename: "clip.mp4", format: "mp4" };
+    const wrapper = mountWide({ item: video, upscaleEnabled: false });
+    await wrapper.find(".lb__morebtn").trigger("click");
+    expect(
+      wrapper.findAll(".lb__menu button").map((button) => button.text()),
+    ).not.toContain("Framewise upscale…");
+  });
+
   it("disables navigation at the ends", () => {
     const wrapper = mountWide({ hasPrev: false, hasNext: false });
     expect(

--- a/web/src/components/gallery/Lightbox.vue
+++ b/web/src/components/gallery/Lightbox.vue
@@ -46,32 +46,39 @@ import {
   type VideoExportOptions,
 } from "@studio/lib/videoExport";
 
-const props = defineProps<{
-  item: GalleryImage | null;
-  // Position in the filtered list — surfaced as "n / N".
-  index: number;
-  total: number;
-  hasPrev: boolean;
-  hasNext: boolean;
-  // Global audio preference; native controls still let the user override.
-  muted: boolean;
-  models?: ModelInfoExtended[] | undefined;
-  /** Stitched from a sequence (`metadata.chain`): reuse loads a clip rail. */
-  isSequence?: boolean;
-  /** Its producing job is (without probing) still on its origin host. */
-  canEditSequence?: boolean;
-  /** Some copy of this print lives on a host with `gallery.organize`:
-   * title / favorite / tags / collections are editable. */
-  canOrganize?: boolean;
-  /** Some copy lives on a host with `gallery.trash`: Delete reads Trash. */
-  canTrash?: boolean;
-  /** Viewing the Trash scope: Restore / Delete forever replace Delete. */
-  inTrash?: boolean;
-  /** Merged collections with this print's membership state. */
-  collections?: CollectionPickerRow[];
-  /** Merged cross-host tag vocabulary for autocomplete. */
-  tagSuggestions?: TagCount[];
-}>();
+const props = withDefaults(
+  defineProps<{
+    item: GalleryImage | null;
+    // Position in the filtered list — surfaced as "n / N".
+    index: number;
+    total: number;
+    hasPrev: boolean;
+    hasNext: boolean;
+    // Global audio preference; native controls still let the user override.
+    muted: boolean;
+    /** The origin host can actually execute this media's upscale workflow. */
+    upscaleEnabled?: boolean;
+    models?: ModelInfoExtended[] | undefined;
+    /** Stitched from a sequence (`metadata.chain`): reuse loads a clip rail. */
+    isSequence?: boolean;
+    /** Its producing job is (without probing) still on its origin host. */
+    canEditSequence?: boolean;
+    /** Some copy of this print lives on a host with `gallery.organize`:
+     * title / favorite / tags / collections are editable. */
+    canOrganize?: boolean;
+    /** Some copy lives on a host with `gallery.trash`: Delete reads Trash. */
+    canTrash?: boolean;
+    /** Viewing the Trash scope: Restore / Delete forever replace Delete. */
+    inTrash?: boolean;
+    /** Merged collections with this print's membership state. */
+    collections?: CollectionPickerRow[];
+    /** Merged cross-host tag vocabulary for autocomplete. */
+    tagSuggestions?: TagCount[];
+  }>(),
+  {
+    upscaleEnabled: true,
+  },
+);
 
 const emit = defineEmits<{
   (e: "close"): void;
@@ -377,7 +384,7 @@ function onMediaContextMenu(event: MouseEvent) {
 }
 function onUpscale() {
   menuOpen.value = false;
-  if (props.item) emit("upscale", props.item);
+  if (props.item && props.upscaleEnabled !== false) emit("upscale", props.item);
 }
 function onDelete() {
   menuOpen.value = false;
@@ -583,7 +590,11 @@ async function performVideoExport(options: VideoExportOptions) {
                     </button>
                   </template>
                   <template v-else>
-                    <button role="menuitem" @click="onUpscale">
+                    <button
+                      v-if="upscaleEnabled !== false"
+                      role="menuitem"
+                      @click="onUpscale"
+                    >
                       {{
                         mediaKind(item.format, item.filename) === "video"
                           ? "Framewise upscale…"
@@ -869,7 +880,11 @@ async function performVideoExport(options: VideoExportOptions) {
                   </button>
                 </template>
                 <template v-else>
-                  <button role="menuitem" @click="onUpscale">
+                  <button
+                    v-if="upscaleEnabled !== false"
+                    role="menuitem"
+                    @click="onUpscale"
+                  >
                     {{ isVideoFile ? "Framewise upscale…" : "Upscale…" }}
                   </button>
                   <button

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -197,6 +197,7 @@ const rawEntries = ref<HostGalleryImage[]>([]);
 /** Per-host organization: capabilities, collections, tags, trash listing. */
 const snapshots = ref<HostOrganizationSnapshot[]>([]);
 const galleryImageUpscaleByHost = ref<Record<string, boolean>>({});
+const framewiseVideoUpscaleByHost = ref<Record<string, boolean>>({});
 /** Copies moved to the trash locally (undo window elapsed) until a
  * SUCCESSFUL server listing confirms them (or they age out). */
 const pendingTrashed = ref<HostGalleryImage[]>([]);
@@ -460,6 +461,14 @@ function hostForEntry(entry: GalleryImage) {
   const id = (entry as { hostId?: string }).hostId ?? ORIGIN_HOST_ID;
   if (id === ORIGIN_HOST_ID) return originHost();
   return getHost(id);
+}
+function canUpscaleItem(entry: GalleryImage | null): boolean {
+  if (!entry) return false;
+  const kind = mediaKind(entry.format, entry.filename);
+  if (kind === "audio") return false;
+  if (kind !== "video") return true;
+  const host = hostForEntry(entry);
+  return !!host && framewiseVideoUpscaleByHost.value[host.id] === true;
 }
 const hostById = (id: string) =>
   id === ORIGIN_HOST_ID ? originHost() : getHost(id);
@@ -1506,17 +1515,22 @@ async function performRefresh() {
       fetchMergedGallery(hosts),
       fetchOrganization(hosts).catch(() => null),
       Promise.all(
-        hosts.map(
-          async (host) =>
-            [
-              host.id,
-              (await hostCapabilities(host)).video_upscale?.gallery_image ===
-                true,
-            ] as const,
-        ),
+        hosts.map(async (host) => {
+          const capability = (await hostCapabilities(host)).video_upscale;
+          return [
+            host.id,
+            capability?.gallery_image === true,
+            capability?.available === true,
+          ] as const;
+        }),
       ),
     ]);
-    galleryImageUpscaleByHost.value = Object.fromEntries(upscaleCapabilities);
+    galleryImageUpscaleByHost.value = Object.fromEntries(
+      upscaleCapabilities.map(([hostId, image]) => [hostId, image]),
+    );
+    framewiseVideoUpscaleByHost.value = Object.fromEntries(
+      upscaleCapabilities.map(([hostId, , video]) => [hostId, video]),
+    );
     if (organization) {
       snapshots.value = organization;
       // Drop a shadow copy only once its host's trash listing SUCCEEDED and
@@ -1988,7 +2002,7 @@ function closeUpscaleDialog() {
   upscaleJob.value = null;
 }
 async function onUpscale(item: GalleryImage) {
-  if (mediaKind(item.format, item.filename) === "audio") return;
+  if (!canUpscaleItem(item)) return;
   stopUpscalePoll();
   const epoch = ++upscaleEpoch;
   upscaleItem.value = item;
@@ -2227,7 +2241,7 @@ async function contextSource() {
 function contextUpscale() {
   const item = contextMenu.value?.item;
   closeContextMenu();
-  if (item) onUpscale(item);
+  if (canUpscaleItem(item ?? null)) onUpscale(item!);
 }
 async function contextDelete() {
   const item = contextMenu.value?.item;
@@ -2985,10 +2999,7 @@ onBeforeUnmount(() => {
           Use as source
         </button>
         <button
-          v-if="
-            mediaKind(contextMenu.item.format, contextMenu.item.filename) !==
-            'audio'
-          "
+          v-if="canUpscaleItem(contextMenu.item)"
           type="button"
           role="menuitem"
           data-test="context-upscale"
@@ -3223,6 +3234,7 @@ onBeforeUnmount(() => {
       :has-prev="selectedIndex > 0"
       :has-next="selectedIndex >= 0 && selectedIndex < filtered.length - 1"
       :muted="muted"
+      :upscale-enabled="canUpscaleItem(selected)"
       :is-sequence="isSequencePrint(selected)"
       :can-edit-sequence="canEditSequence(selected)"
       :can-organize="canOrganizeEntry(selected)"


### PR DESCRIPTION
## Summary

- ship FFmpeg/ffprobe in Docker and embed exact Nix store paths for CLI, desktop, and mobile-served hosts
- advertise Framewise video upscale only when the codec runtime is executable while leaving image upscale available
- gate create, resume, and video-generation post-upscale admission before expensive rendering
- hide unavailable video actions consistently in web, desktop, native mobile, and TUI Library surfaces

## Validation

- `cargo test -p mold-ai-server video_upscale::tests`
- server default-frame admission regression test
- TUI capability and details-hint regression tests
- `cargo clippy -p mold-ai-server -p mold-ai-tui --all-targets -- -D warnings`
- affected web tests: 60 passed
- affected desktop/mobile tests: 430 passed
- web and desktop production builds
- external-volume UAT with `PATH=/usr/bin:/bin`: 320x180 H.264/AAC source -> neural 1280x720 H.264, 12/12 frames, exact 12 fps, 1.000 s, AAC 48 kHz mono preserved
- independent Claude peer review: no actionable findings after fixes

## Notes

The full frontend run has one unrelated existing HostDetailView inventory test that depends on ambient local network state; all tests changed or affected by this PR pass. The repository knowledge-graph baseline is stale enough that its deterministic hook requests a future `/understand --full` rebuild; no generated graph artifacts are included.