### PR TITLE
fix(wan): refuse to auto-chain a text-to-video checkpoint

### DIFF
--- a/changelog.d/wan-t2v-autochain-restart.md
+++ b/changelog.d/wan-t2v-autochain-restart.md
@@ -1,0 +1,9 @@
+- **A long text-to-video Wan render is refused instead of repeating itself.**
+  `mold run wan22-t2v-a14b --frames 201` chained into three stages and handed
+  back roughly the same four-second clip three times, because a text-to-video
+  checkpoint has no image conditioning to carry motion across a clip boundary —
+  every stage re-derived the scene from the same prompt and seed. It now
+  refuses up front and names both ways forward: a single continuous clip within the
+  model's own budget, or an image-to-video tier, whose continuations are seeded
+  with the previous clip's final frame. Image-conditioned and unclassified
+  checkpoints chain exactly as before.

--- a/crates/mold-cli/src/commands/chain.rs
+++ b/crates/mold-cli/src/commands/chain.rs
@@ -182,6 +182,40 @@ pub fn decide_chain_routing(
     // continuation with the previous clip's final frame, so exactly one frame
     // is duplicated; a text-to-video checkpoint carries nothing and trims
     // nothing.
+    //
+    // "Carries nothing" is the whole problem, so it is a refusal rather than a
+    // zero. Stitching stages that cannot hand off does not make a longer video:
+    // with no image conditioning, every stage re-derives the scene from the
+    // same prompt and seed, so the render repeats. Measured on
+    // `wan22-t2v-a14b:q8` at 219 frames / 3 stages, frames a whole stage apart
+    // scored 38.1-44.2 dB PSNR against each other while frames ten apart INSIDE
+    // a stage scored 26.0 dB — a stage boundary moved the picture less than ten
+    // frames of ordinary motion did. Three renders, one clip's worth of video.
+    //
+    // Only the `--frames` auto-chain reaches here. An authored `--script`
+    // sequence builds its own `ChainRequest` and is untouched: there, repeated
+    // stages are what the author asked for.
+    // Scoped to a checkpoint that DECLARES it carries nothing. An
+    // unclassified model (an opaque `cv:`/`hf:` catalog id, `None` here) may
+    // well be image-conditioned, and #783 added wan auto-chaining precisely so
+    // those route; refusing them on a guess would undo that.
+    if is_wan
+        && matches!(
+            source_image,
+            Some(mold_core::SourceImageCapability::Unsupported)
+        )
+    {
+        return ChainRoutingDecision::Rejected {
+            reason: format!(
+                "'{model}' is text-to-video and cannot continue motion across a clip \
+                 boundary, so rendering {total_frames} frames would repeat the same \
+                 ~{effective_clip_frames}-frame clip rather than extend it. Use \
+                 --frames {effective_clip_frames} or fewer for one continuous clip, \
+                 or an image-to-video tier (wan22-i2v-a14b, wan22-ti2v-5b), which \
+                 seeds each continuation with the previous clip's final frame."
+            ),
+        };
+    }
     let motion_tail = if is_wan {
         if wan_carries_context(source_image) {
             WAN_HANDOFF_DUPLICATED_FRAMES
@@ -1890,7 +1924,12 @@ mod tests {
         );
 
         // A text-to-video checkpoint has no conditioning channel at all, so
-        // the seam carries nothing however large a tail was requested.
+        // the seam carries nothing however large a tail was requested — and
+        // that is now a refusal rather than a zero-length seam. Chaining it
+        // did not produce a longer video: with nothing handed across, every
+        // stage re-derived the scene from the same prompt and seed, so the
+        // render repeated (measured 38.1-44.2 dB PSNR between stage starts
+        // against 26.0 dB between frames ten apart inside one stage).
         let t2v = decide_chain_routing(
             Some(300),
             Some("wan"),
@@ -1901,12 +1940,9 @@ mod tests {
             None,
             Some(Unsupported),
         );
-        assert_eq!(
-            t2v,
-            ChainRoutingDecision::Chain {
-                clip_frames: 81,
-                motion_tail: 0,
-            },
+        assert!(
+            matches!(t2v, ChainRoutingDecision::Rejected { .. }),
+            "a declared t2v checkpoint must refuse rather than repeat: {t2v:?}"
         );
         // An unclassified checkpoint is "unknown", not an assumed handoff.
         assert_eq!(
@@ -2192,6 +2228,90 @@ mod tests {
                 motion_tail: 4,
             },
         );
+    }
+
+    /// A wan text-to-video checkpoint cannot carry motion across a stage
+    /// boundary, so auto-chaining one does not produce a longer video — it
+    /// produces the same clip again.
+    ///
+    /// Measured on `wan22-t2v-a14b:q8` at 219 frames / 3 stages: frames a whole
+    /// stage apart (73) scored 38.1-44.2 dB PSNR against each other, while
+    /// frames 10 apart INSIDE a stage scored 26.0 dB. A stage boundary moved the
+    /// picture less than ten frames of ordinary motion did, because with no
+    /// image conditioning each stage re-derives the scene from the same prompt
+    /// and seed. Refuse it the way a non-chainable family is refused, rather
+    /// than spending three renders to hand back one clip repeated.
+    #[test]
+    fn a_text_to_video_wan_checkpoint_refuses_to_auto_chain() {
+        let d = decide_chain_routing(
+            Some(201),
+            Some("wan"),
+            "wan22-t2v-a14b:q8",
+            None,
+            0,
+            16,
+            None,
+            Some(mold_core::SourceImageCapability::Unsupported),
+        );
+        match d {
+            ChainRoutingDecision::Rejected { reason } => {
+                assert!(
+                    reason.contains("--frames"),
+                    "the refusal must name the flag to change: {reason}"
+                );
+                assert!(
+                    reason.contains("continue") || reason.contains("continuous"),
+                    "the refusal must say WHY, not just that it declined: {reason}"
+                );
+                assert!(
+                    reason.contains("i2v") || reason.contains("ti2v"),
+                    "the refusal must name a tier that CAN do it: {reason}"
+                );
+            }
+            other => panic!("a declared t2v checkpoint must not auto-chain, got {other:?}"),
+        }
+
+        // An unclassified checkpoint is not refused on a guess: it may be
+        // image-conditioned, and #783 added wan auto-chaining so opaque
+        // catalog ids route rather than being rejected.
+        assert!(
+            matches!(
+                decide_chain_routing(Some(201), Some("wan"), "cv:12345", None, 0, 16, None, None),
+                ChainRoutingDecision::Chain { .. }
+            ),
+            "an unknown checkpoint must still chain"
+        );
+    }
+
+    /// The refusal must be scoped to checkpoints that genuinely cannot hand
+    /// off. TI2V/I2V carry the previous clip's final frame, so they still chain.
+    #[test]
+    fn an_image_conditioned_wan_checkpoint_still_auto_chains() {
+        for capability in [
+            mold_core::SourceImageCapability::Optional,
+            mold_core::SourceImageCapability::Required,
+        ] {
+            let d = decide_chain_routing(
+                Some(241),
+                Some("wan"),
+                "wan22-ti2v-5b:q8",
+                None,
+                0,
+                24,
+                None,
+                Some(capability),
+            );
+            assert!(
+                matches!(
+                    d,
+                    ChainRoutingDecision::Chain {
+                        motion_tail: WAN_HANDOFF_DUPLICATED_FRAMES,
+                        ..
+                    }
+                ),
+                "{capability:?} carries context and must still chain, got {d:?}"
+            );
+        }
     }
 
     #[test]

--- a/website/models/wan.md
+++ b/website/models/wan.md
@@ -641,6 +641,17 @@ than a silent no-op) on the 4-step Lightning distill tiers and on schedules
 under 12 steps — neither has redundant steps to skip. `off` (the default) is
 bit-identical to the uncached engine.
 
+### Long clips and `--frames`
+
+`--frames` past a tier's single-pass budget auto-chains into stages. That only
+produces a longer _video_ on a checkpoint that can hand motion to the next
+stage: an I2V or TI2V tier seeds each continuation with the previous clip's
+final frame. A **text-to-video** checkpoint has no image conditioning at all, so
+it carries nothing across the boundary and every stage re-derives the scene from
+the same prompt and seed — the result is the same clip repeated, not a longer
+one. `mold run` refuses that up front rather than spending the renders; ask for
+`--frames` within the tier's budget, or use `wan22-i2v-a14b` / `wan22-ti2v-5b`.
+
 ## Quantized checkpoints and adapters
 
 A14B ships as GGUF. Quantized weights stay quantized in memory and dequantize


### PR DESCRIPTION
`mold run wan22-t2v-a14b --frames 201` chained into three stages and handed back roughly the same four-second clip three times. Reported as "videos resetting around 10 seconds".

## Cause

A chain only makes a longer video if the checkpoint can hand motion to the next stage. I2V/TI2V seed each continuation with the previous clip's final frame. A **text-to-video** checkpoint has no image conditioning at all, so it carries nothing across the boundary and every stage re-derives the scene from the same prompt and seed.

`decide_chain_routing` already knew — its own comment reads *"a text-to-video checkpoint carries nothing and trims nothing"* — and chained anyway, producing a zero-length seam. `wan22-t2v-a14b` declares this explicitly (`manifest.rs`: `A14bTask::T2v => SourceImageCapability::Unsupported`).

## Evidence

`wan22-t2v-a14b:q8`, 219 frames across 3 stages of 73. PSNR between frames, higher = more identical:

| Pair | PSNR |
| --- | --- |
| f0 vs f73 (stage 1 vs 2 start) | 38.1 dB |
| f0 vs f146 (stage 1 vs 3 start) | 38.1 dB |
| f73 vs f146 (stage 2 vs 3 start) | **44.2 dB** |
| f0 vs f10 (same stage, 10 frames) | 26.0 dB |

**Frames a whole stage apart are more similar than frames ten apart inside a stage** — a stage boundary moved the picture less than ten frames of ordinary motion did. Reproduced with `MOLD_WAN_STEP_CACHE` both on and off, and absent from a single-pass render, so it is the chain, not the step cache.

## The change

`decide_chain_routing` refuses, in the same style this file already uses for a non-chainable family:

```
error: 'wan22-t2v-a14b:q8' is text-to-video and cannot continue motion across a
clip boundary, so rendering 201 frames would repeat the same ~73-frame clip
rather than extend it. Use --frames 73 or fewer for one continuous clip, or an
image-to-video tier (wan22-i2v-a14b, wan22-ti2v-5b), which seeds each
continuation with the previous clip's final frame.
```

## This narrows #783 — please weigh it

#783 added wan auto-chaining *including* t2v, with a test asserting a `tail 0` chain. That assertion is now a refusal. It is a capability removal, justified by the measurement above: three renders producing one clip repeated is not what `--frames 201` promises. If you would rather keep rendering behind a loud warning, that is a one-line change.

Scope is deliberately narrow — only checkpoints that **declare** `SourceImageCapability::Unsupported`. An unclassified `cv:`/`hf:` catalog id may well be image-conditioned, and refusing it on a guess would undo what #783 set out to do. Authored `--script` chains are untouched: there, repeated stages are what the author asked for.

## Verification (plato, 4x L40S, renders retained in the library)

| Check | Result |
| --- | --- |
| The failing command | refuses in **0.13 s** (was ~80 min for an unusable clip) |
| Authored `--script` on the same t2v model | still works — `OK — 2 stages, 146 frames estimated` |
| `ti2v-5b:q8 --frames 241` | still chains — `Chain mode: 241 frames across 2 stages (tail 1)` |

Post-fix renders, same PSNR method:

- **t2v 73f single pass** — 24.2 dB (10 apart) -> 20.7 (36) -> 18.9 (72). Monotonic: motion accumulates continuously.
- **ti2v 241f chained** — stage starts f0 vs f121 = **11.6 dB**, the *most different* pair measured (broken case: 38-44 dB). Boundary f120 vs f121 = 18.4 dB, more similar than frames ten apart, as consecutive frames in a continuous shot should be. Visually the train advances along the track across the seam.

Two new tests: the refusal must name the flag, the reason, and a tier that can do it; an unclassified checkpoint must still chain.

729 CLI tests passing, clippy `-D warnings` clean, fmt clean. Rebased on `origin/main` @ 7ac82b76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G43E8ijWrep1A4UxyiKU3c