### PR TITLE
fix(desktop): prevent confirm labels clipping

### DIFF
--- a/changelog.d/desktop-confirm-dialog-labels.md
+++ b/changelog.d/desktop-confirm-dialog-labels.md
@@ -1,0 +1,1 @@
+- Fixed long desktop confirmation labels clipping inside their action buttons.

--- a/desktop/src/components/shell/ConfirmDialog.test.ts
+++ b/desktop/src/components/shell/ConfirmDialog.test.ts
@@ -37,14 +37,19 @@ describe("ConfirmDialog", () => {
         open: true,
         title: "Launch GPU instance?",
         confirmLabel: "Launch — billing begins immediately",
+        cancelLabel: "Keep choosing instance settings",
       },
       attachTo: document.body,
     });
 
     const accept = document.querySelector("[data-test='confirm-accept']") as HTMLButtonElement;
+    const cancel = document.querySelector("[data-test='confirm-cancel']") as HTMLButtonElement;
     expect(accept.classList).toContain("min-h-8");
     expect(accept.classList).toContain("py-1.5");
     expect(accept.classList).not.toContain("h-8");
+    expect(cancel.classList).toContain("min-h-8");
+    expect(cancel.classList).toContain("py-1.5");
+    expect(cancel.classList).not.toContain("h-8");
   });
 
   it("emits confirm / cancel", async () => {

--- a/desktop/src/components/shell/ConfirmDialog.test.ts
+++ b/desktop/src/components/shell/ConfirmDialog.test.ts
@@ -31,6 +31,22 @@ describe("ConfirmDialog", () => {
     );
   });
 
+  it("lets a long confirmation label grow vertically instead of clipping", () => {
+    mount(ConfirmDialog, {
+      props: {
+        open: true,
+        title: "Launch GPU instance?",
+        confirmLabel: "Launch — billing begins immediately",
+      },
+      attachTo: document.body,
+    });
+
+    const accept = document.querySelector("[data-test='confirm-accept']") as HTMLButtonElement;
+    expect(accept.classList).toContain("min-h-8");
+    expect(accept.classList).toContain("py-1.5");
+    expect(accept.classList).not.toContain("h-8");
+  });
+
   it("emits confirm / cancel", async () => {
     const wrapper = mount(ConfirmDialog, {
       props: { open: true, title: "Delete?" },

--- a/desktop/src/components/shell/ConfirmDialog.vue
+++ b/desktop/src/components/shell/ConfirmDialog.vue
@@ -72,7 +72,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           <button
             type="button"
             data-test="confirm-cancel"
-            class="h-8 rounded-control px-3 text-body text-ink-2 hover:text-ink disabled:opacity-50"
+            class="min-h-8 rounded-control px-3 py-1.5 text-center text-body leading-tight text-ink-2 hover:text-ink disabled:opacity-50"
             :disabled="busy"
             @click="cancel"
           >

--- a/desktop/src/components/shell/ConfirmDialog.vue
+++ b/desktop/src/components/shell/ConfirmDialog.vue
@@ -81,7 +81,7 @@ onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
           <button
             type="button"
             data-test="confirm-accept"
-            class="h-8 rounded-control px-3.5 text-body font-semibold text-on-accent hover:brightness-105 active:translate-y-px disabled:opacity-50"
+            class="min-h-8 rounded-control px-3.5 py-1.5 text-center text-body leading-tight font-semibold text-on-accent hover:brightness-105 active:translate-y-px disabled:opacity-50"
             :class="danger ? 'bg-stop' : 'bg-safelight'"
             :disabled="busy"
             @click="emit('confirm')"


### PR DESCRIPTION
## Summary
- let long confirmation labels grow vertically instead of clipping
- add regression coverage for the RunPod billing confirmation label
- document the user-visible desktop fix

## Testing
- `nix develop -c bun run test:desktop` (431 files, 5,574 tests)
- `nix develop -c bun run build:desktop`
- rendered UAT at 1440x900: Launch GPU instance opens a fully contained 44.5px-high action; Cancel closes the dialog
- `git diff --check origin/main...HEAD`