### PR TITLE
fix(expand): retry an ambiguous overshoot instead of failing the batch

### DIFF
--- a/changelog.d/expand-ambiguous-overshoot-retry.md
+++ b/changelog.d/expand-ambiguous-overshoot-retry.md
@@ -1,0 +1,20 @@
+- **One rambling completion no longer kills a whole expansion batch.** When an
+  expansion backend answered a chunk with more prompts than were requested —
+  the shape a small local model reliably produces when a batch template asks it
+  for exactly one variation — the request failed outright with
+  `expansion backend returned 3 prompts when exactly 1 were requested`, even
+  though the chunk had two unused retries left. That response now spends one
+  attempt and asks again, and the failure after a chunk's whole budget says how
+  many prompts it did assemble.
+- **Expansion chunks are evened out instead of filled greedily.** A batch of
+  five was asked for four prompts and then a lone one, which handed a batch
+  instruction — "generate 1 distinct prompts, output as a JSON array of 1
+  strings" — to the model; it is now asked for three and then two, at no extra
+  cost in model calls.
+- **A short run of one-prompt JSON arrays is no longer glued into one prompt.**
+  A backend that emits `["a"]` per line and came up short had its lines joined
+  into a single literal `["a"] ["b"]` prompt; those lines are now kept as the
+  prompts they are and the remainder is retried.
+- **The host records why an expansion failed.** A failed expansion left only a
+  bare `500` in the server journal, so the reason existed nowhere but in the
+  client's error toast. Backend URL credentials are redacted from that entry.

--- a/crates/mold-core/src/expand.rs
+++ b/crates/mold-core/src/expand.rs
@@ -201,6 +201,26 @@ pub fn validate_expansion_variation_count(variations: usize) -> Result<()> {
     Ok(())
 }
 
+/// Split `remaining` prompts into the fewest chunks of at most
+/// `EXPANSION_CHUNK_SIZE`, then even those chunks out.
+///
+/// Taking `EXPANSION_CHUNK_SIZE` greedily leaves every batch of `4k + 1` ending
+/// on a chunk of exactly one, which is rendered through the BATCH template —
+/// "Generate 1 distinct prompts ... Output as a JSON array of 1 strings". A
+/// small local model answers that degenerate instruction with prose often
+/// enough to matter, and prose is what `parse_variations` must refuse to
+/// truncate. Evening the chunks costs no extra completions (the chunk count is
+/// unchanged) and no chunk is ever asked for one prompt unless the whole batch
+/// is one, where the single-prompt template is used instead.
+///
+/// A retry can still ask for one — a chunk of three that collected two needs
+/// one more — so this narrows the trigger rather than removing it. The attempt
+/// budget covers the rest.
+fn balanced_chunk_target(remaining: usize) -> usize {
+    let chunks = remaining.div_ceil(EXPANSION_CHUNK_SIZE).max(1);
+    remaining.div_ceil(chunks)
+}
+
 /// Generate an exact logical expansion from bounded backend completions.
 ///
 /// `generate` receives a cloned config whose `variations` and `max_tokens` are
@@ -217,8 +237,13 @@ where
     let mut expanded = Vec::new();
     let mut normalized = HashSet::new();
     while expanded.len() < config.variations {
-        let chunk_target = (config.variations - expanded.len()).min(EXPANSION_CHUNK_SIZE);
+        let chunk_target = balanced_chunk_target(config.variations - expanded.len());
         let mut chunk = Vec::with_capacity(chunk_target);
+
+        // Records the last attempt that over-delivered, so an exhausted budget
+        // can name that cause instead of the generic shortfall. Cleared by any
+        // later attempt, which is what actually ended the chunk.
+        let mut overshoot: Option<(usize, usize)> = None;
 
         for _ in 0..EXPANSION_CHUNK_ATTEMPTS {
             let missing = chunk_target - chunk.len();
@@ -236,11 +261,16 @@ where
             };
             let attempt = generate(&attempt_config, attempt_context)?;
             if attempt.len() > missing {
-                anyhow::bail!(
-                    "expansion backend returned {} prompts when exactly {missing} were requested",
-                    attempt.len()
-                );
+                // An over-delivering completion is ambiguous: `parse_variations`
+                // deliberately refuses to truncate a response it cannot prove is
+                // all prompts, so the extras may be reasoning rather than
+                // variations and none of them may be kept. Spend one of this
+                // chunk's attempts and ask again — a single ambiguous completion
+                // must never fail a whole batch.
+                overshoot = Some((attempt.len(), missing));
+                continue;
             }
+            overshoot = None;
             for prompt in attempt {
                 let key = normalize_expanded_prompt(&prompt);
                 if !key.is_empty() && normalized.insert(key) {
@@ -250,6 +280,13 @@ where
         }
 
         if chunk.len() != chunk_target {
+            if let Some((returned, requested)) = overshoot {
+                anyhow::bail!(
+                    "expansion backend returned {returned} prompts when exactly {requested} were requested, and did not return a usable count in {EXPANSION_CHUNK_ATTEMPTS} attempts; assembled {} of {} prompts",
+                    expanded.len() + chunk.len(),
+                    config.variations
+                );
+            }
             anyhow::bail!(
                 "expected exactly {} distinct non-empty prompts, but the expansion backend returned {}",
                 config.variations,
@@ -530,6 +567,30 @@ fn parse_variations(text: &str, expected: usize) -> Vec<String> {
         }
     }
 
+    // A response whose every line is a singleton JSON array is the one-array-per
+    // -variation shape some local backends emit. Unquoted prose cannot parse as
+    // JSON, so the structure is as good a delimiter as a consecutive numbered
+    // list and an overshoot may be capped the same way. It is not proof that
+    // every line is a PROMPT — a model that wrapped its own preamble in the
+    // requested syntax would pass — which is the same bounded trade the
+    // numbered-list cap already makes. A short response is retained for the
+    // exact-count retry rather than left to the paragraph fallback, which would
+    // otherwise join these lines into one literal `["a"] ["b"]` prompt.
+    let singleton_arrays = raw_lines
+        .iter()
+        .map(|line| singleton_json_array_item(line))
+        .collect::<Option<Vec<_>>>();
+    if let Some(items) = singleton_arrays {
+        let items = items
+            .iter()
+            .map(|item| clean_expanded_prompt(item))
+            .filter(|item| !item.is_empty())
+            .collect::<Vec<_>>();
+        if !items.is_empty() {
+            return items.into_iter().take(expected).collect();
+        }
+    }
+
     let lines = raw_lines
         .iter()
         .map(|line| clean_expanded_prompt(line))
@@ -579,15 +640,20 @@ fn parse_numbered_variation(line: &str) -> Option<(usize, String)> {
     (!prompt.is_empty()).then_some((number, prompt))
 }
 
+/// Unwrap a lone `["prompt"]` array. Some OpenAI-compatible and local backends
+/// emit one JSON array per requested variation (`["prompt"]\n["prompt"]`)
+/// instead of one shared array. Never flattens a real multi-item array.
+fn singleton_json_array_item(text: &str) -> Option<String> {
+    serde_json::from_str::<Vec<String>>(text.trim())
+        .ok()
+        .and_then(|items| (items.len() == 1).then(|| items.into_iter().next().unwrap()))
+}
+
 /// Clean up an expanded prompt: trim whitespace, remove quotes, collapse whitespace.
 fn clean_expanded_prompt(text: &str) -> String {
-    // Some OpenAI-compatible/local backends emit one JSON array per requested
-    // variation (`["prompt"]\n["prompt"]`) instead of one shared array. The
-    // line fallback feeds each singleton here, so unwrap it before ordinary
-    // quote/whitespace cleanup. Never flatten a real multi-item array.
-    let singleton = serde_json::from_str::<Vec<String>>(text.trim())
-        .ok()
-        .and_then(|items| (items.len() == 1).then(|| items.into_iter().next().unwrap()));
+    // The line fallback feeds each singleton array here, so unwrap it before
+    // ordinary quote/whitespace cleanup.
+    let singleton = singleton_json_array_item(text);
     let trimmed = singleton
         .as_deref()
         .unwrap_or(text)
@@ -1013,6 +1079,46 @@ I need four alternatives [composition, camera, lighting, setting].
         assert_eq!(result, vec!["a cat", "a dog", "a bird"]);
     }
 
+    #[test]
+    fn parse_variations_caps_repeated_singleton_json_arrays() {
+        // Every line is a singleton array, so no line can be prose. That is as
+        // structurally unambiguous as a consecutive numbered list, and an
+        // overshoot may be capped rather than forced through a retry.
+        let input = "[\"a cat\"]\n[\"a dog\"]\n[\"a bird\"]";
+        assert_eq!(parse_variations(input, 1), vec!["a cat"]);
+        assert_eq!(parse_variations(input, 2), vec!["a cat", "a dog"]);
+    }
+
+    #[test]
+    fn parse_variations_keeps_a_short_singleton_array_run_for_the_retry() {
+        // Never let the paragraph fallback join these into one literal
+        // `["a cat"] ["a dog"]` prompt. Two real prompts reach the exact-count
+        // guard, which asks for the third.
+        let input = "[\"a cat\"]\n[\"a dog\"]";
+        assert_eq!(parse_variations(input, 3), vec!["a cat", "a dog"]);
+    }
+
+    #[test]
+    fn parse_variations_caps_a_singleton_run_it_cannot_prove_is_all_prompts() {
+        // Documented trade, not an accident: a model that wrapped its preamble
+        // in the requested syntax passes the structural test. This is the same
+        // exposure the consecutive-numbered-list cap already accepts, and it is
+        // pinned so a future change to that trade is deliberate.
+        let input = "[\"Here are the prompts\"]\n[\"a cat\"]\n[\"a dog\"]";
+        assert_eq!(
+            parse_variations(input, 2),
+            vec!["Here are the prompts", "a cat"]
+        );
+    }
+
+    #[test]
+    fn parse_variations_keeps_mixed_prose_and_singleton_arrays_ambiguous() {
+        // One prose line among the arrays means the structure no longer proves
+        // which lines are prompts, so the exact-count guard must still see it.
+        let input = "Here are the prompts:\n[\"a cat\"]\n[\"a dog\"]";
+        assert_eq!(parse_variations(input, 2).len(), 3);
+    }
+
     // ── bounded exact expansion ─────────────────────────────────────────
 
     #[test]
@@ -1040,8 +1146,32 @@ I need four alternatives [composition, camera, lighting, setting].
         assert_eq!(expanded.len(), 10);
         assert_eq!(
             attempts,
-            vec![(4, 1200, 1, 10), (4, 1200, 5, 10), (2, 600, 9, 10)]
+            vec![(4, 1200, 1, 10), (3, 900, 5, 10), (3, 900, 8, 10)]
         );
+    }
+
+    #[test]
+    fn no_chunk_is_ever_asked_for_a_lone_prompt_inside_a_larger_batch() {
+        // The degenerate `4k + 1` tail is what routed a one-prompt ask through
+        // the batch template. Sweep every reachable batch size rather than
+        // pinning the one that was reported.
+        for variations in 2..=256usize {
+            let mut remaining = variations;
+            let mut chunks = Vec::new();
+            while remaining > 0 {
+                let target = balanced_chunk_target(remaining);
+                assert!(
+                    (2..=EXPANSION_CHUNK_SIZE).contains(&target),
+                    "variations {variations} produced a chunk of {target}"
+                );
+                chunks.push(target);
+                remaining -= target;
+            }
+            assert_eq!(chunks.iter().sum::<usize>(), variations);
+            assert_eq!(chunks.len(), variations.div_ceil(EXPANSION_CHUNK_SIZE));
+        }
+        // A one-print request stays one chunk, which takes the single template.
+        assert_eq!(balanced_chunk_target(1), 1);
     }
 
     #[test]
@@ -1130,11 +1260,224 @@ I need four alternatives [composition, camera, lighting, setting].
             variations: 2,
             ..Default::default()
         };
+        let mut attempts = 0;
         let error = expand_exact_with(&config, |_, _| {
+            attempts += 1;
             Ok(vec!["one".into(), "two".into(), "three".into()])
         })
         .unwrap_err();
+        assert_eq!(attempts, EXPANSION_CHUNK_ATTEMPTS);
         assert!(error.to_string().contains("exactly 2 were requested"));
+    }
+
+    #[test]
+    fn an_ambiguous_overshoot_spends_an_attempt_instead_of_failing_the_batch() {
+        let config = ExpandConfig {
+            variations: 2,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let expanded = expand_exact_with(&config, |_, _| {
+            attempts += 1;
+            if attempts == 1 {
+                // One ambiguous completion: reasoning plus the requested pair.
+                Ok(vec![
+                    "first I will vary the camera".into(),
+                    "one".into(),
+                    "two".into(),
+                ])
+            } else {
+                Ok(vec!["one".into(), "two".into()])
+            }
+        })
+        .unwrap();
+
+        assert_eq!(expanded, vec!["one".to_string(), "two".to_string()]);
+        assert_eq!(attempts, 2);
+    }
+
+    #[test]
+    fn a_tail_chunk_overshoot_recovers_the_whole_logical_batch() {
+        // The reported failure shape, reachable now only through a partial
+        // fill: a five-print batch chunks into 3 + 2, chunk two answers with
+        // one prompt, and the retry that asks for the single missing one draws
+        // a three-line completion from the local model. That last ambiguous
+        // completion must not kill a batch with four prompts already in hand.
+        let config = ExpandConfig {
+            variations: 5,
+            ..Default::default()
+        };
+        let mut asks = Vec::new();
+
+        let expanded = expand_exact_with(&config, |attempt, context| {
+            asks.push(attempt.variations);
+            match asks.as_slice() {
+                [3] => Ok(vec![
+                    "prompt 1".into(),
+                    "prompt 2".into(),
+                    "prompt 3".into(),
+                ]),
+                [3, 2] => Ok(vec!["prompt 4".into()]),
+                [3, 2, 1] => {
+                    assert_eq!(context.start, 5);
+                    Ok(vec![
+                        "here is the final direction".into(),
+                        "prompt 5".into(),
+                        "and that keeps the subject".into(),
+                    ])
+                }
+                _ => Ok(vec!["prompt 5".into()]),
+            }
+        })
+        .unwrap();
+
+        assert_eq!(expanded.len(), 5);
+        assert_eq!(expanded[4], "prompt 5");
+        assert_eq!(asks, vec![3, 2, 1, 1]);
+    }
+
+    #[test]
+    fn an_overshooting_attempt_contributes_none_of_its_prompts() {
+        let config = ExpandConfig {
+            variations: 1,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let expanded = expand_exact_with(&config, |_, _| {
+            attempts += 1;
+            if attempts == 1 {
+                Ok(vec!["reasoning line".into(), "trailing note".into()])
+            } else {
+                Ok(vec!["the real prompt".into()])
+            }
+        })
+        .unwrap();
+
+        assert_eq!(expanded, vec!["the real prompt".to_string()]);
+    }
+
+    #[test]
+    fn a_persistent_overshoot_reports_both_counts_after_the_attempt_budget() {
+        let config = ExpandConfig {
+            variations: 1,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let error = expand_exact_with(&config, |_, _| {
+            attempts += 1;
+            Ok(vec!["one".into(), "two".into(), "three".into()])
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts, EXPANSION_CHUNK_ATTEMPTS);
+        let message = error.to_string();
+        assert!(
+            message.contains("returned 3 prompts when exactly 1 were requested"),
+            "{message}"
+        );
+        assert!(
+            message.contains(&format!("in {EXPANSION_CHUNK_ATTEMPTS} attempts")),
+            "{message}"
+        );
+        assert!(message.contains("assembled 0 of 1 prompts"), "{message}");
+    }
+
+    #[test]
+    fn an_overshoot_in_an_early_chunk_does_not_diagnose_a_later_one() {
+        // `overshoot` state is per chunk. If a refactor ever hoists it out of
+        // the loop, chunk two's shortfall would be reported as chunk one's
+        // overshoot.
+        let config = ExpandConfig {
+            variations: 8,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let error = expand_exact_with(&config, |attempt, context| {
+            attempts += 1;
+            if context.start <= 4 {
+                if attempts == 1 {
+                    // Chunk one over-delivers once, then answers cleanly.
+                    return Ok(vec![
+                        "a".into(),
+                        "b".into(),
+                        "c".into(),
+                        "d".into(),
+                        "e".into(),
+                    ]);
+                }
+                return Ok((0..attempt.variations)
+                    .map(|index| format!("prompt {}", context.start + index))
+                    .collect());
+            }
+            // Chunk two simply under-delivers, forever.
+            Ok(Vec::new())
+        })
+        .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("expected exactly 8 distinct non-empty prompts"),
+            "{error}"
+        );
+    }
+
+    #[test]
+    fn an_overshoot_then_a_partial_fill_still_completes_the_chunk() {
+        let config = ExpandConfig {
+            variations: 4,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let expanded = expand_exact_with(&config, |attempt, _| {
+            attempts += 1;
+            match attempts {
+                1 => Ok(vec!["x".into(); 5]),
+                2 => Ok(vec!["one".into(), "two".into()]),
+                _ => {
+                    assert_eq!(attempt.variations, 2);
+                    Ok(vec!["three".into(), "four".into()])
+                }
+            }
+        })
+        .unwrap();
+
+        assert_eq!(expanded, vec!["one", "two", "three", "four"]);
+        assert_eq!(attempts, 3);
+    }
+
+    #[test]
+    fn an_overshoot_does_not_mask_a_later_shortfall() {
+        // The final diagnosis must describe the attempt state that actually
+        // ended the chunk, not an earlier one that a retry moved past.
+        let config = ExpandConfig {
+            variations: 2,
+            ..Default::default()
+        };
+        let mut attempts = 0;
+
+        let error = expand_exact_with(&config, |_, _| {
+            attempts += 1;
+            if attempts == 1 {
+                Ok(vec!["one".into(), "two".into(), "three".into()])
+            } else {
+                Ok(Vec::new())
+            }
+        })
+        .unwrap_err();
+
+        assert_eq!(attempts, EXPANSION_CHUNK_ATTEMPTS);
+        assert!(
+            error
+                .to_string()
+                .contains("expected exactly 2 distinct non-empty prompts"),
+            "{error}"
+        );
     }
 
     #[test]
@@ -1147,8 +1490,13 @@ I need four alternatives [composition, camera, lighting, setting].
 
         let expanded = expand_exact_with(&config, |attempt, context| {
             attempts += 1;
-            if context.start == 5 && attempts == 2 {
-                Ok(vec!["prompt 1".into(), "prompt 5".into()])
+            if context.start == 4 && attempts == 2 {
+                // One of the three repeats a prompt chunk one already used.
+                Ok(vec![
+                    "prompt 1".into(),
+                    "prompt 4".into(),
+                    "prompt 5".into(),
+                ])
             } else {
                 Ok((0..attempt.variations)
                     .map(|index| format!("prompt {}", context.start + index))

--- a/crates/mold-inference/src/expand.rs
+++ b/crates/mold-inference/src/expand.rs
@@ -748,7 +748,12 @@ impl PromptExpander for LocalExpander {
 }
 
 fn local_expand_error_with_recovery(error: anyhow::Error) -> anyhow::Error {
-    if error.to_string().contains("expected exactly") {
+    // Both exact-count outcomes are a response-shape problem, not a missing
+    // model: the backend under-delivered, or it over-delivered an ambiguous
+    // completion for every attempt in the chunk's budget. Neither is recovered
+    // by pulling weights, so say what actually helps.
+    let message = error.to_string();
+    if message.contains("expected exactly") || message.contains("expansion backend returned") {
         anyhow::anyhow!("{error}. Retry expansion or reduce the batch size.")
     } else {
         error
@@ -1162,6 +1167,20 @@ mod exact_plan_tests {
         .to_string();
 
         assert!(message.contains("Retry expansion or reduce the batch size"));
+        assert!(!message.contains("mold pull"), "{message}");
+    }
+
+    #[test]
+    fn an_exhausted_overshoot_budget_also_carries_the_recovery_hint() {
+        let message = local_expand_error_with_recovery(anyhow::anyhow!(
+            "expansion backend returned 3 prompts when exactly 1 were requested, and did not return a usable count in 3 attempts"
+        ))
+        .to_string();
+
+        assert!(
+            message.contains("Retry expansion or reduce the batch size"),
+            "{message}"
+        );
         assert!(!message.contains("mold pull"), "{message}");
     }
 }

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -2309,7 +2309,59 @@ async fn schedule_local_expansion(
     result_rx
         .await
         .map_err(|_| ApiError::internal("prompt expansion owner worker dropped its result"))?
-        .map_err(|error| ApiError::internal(format!("prompt expansion failed: {error}")))
+        .map_err(expansion_failed)
+}
+
+/// Build the client-facing expansion failure and record it in the host journal.
+///
+/// The response body is the only place an expansion failure was ever described:
+/// the access log records a bare 500, so a batch that died on a bad completion
+/// left nothing on the host to diagnose it with.
+///
+/// The client keeps the message verbatim; the journal entry is redacted,
+/// because an API-backend transport error embeds the configured
+/// `expand.backend` URL and that URL may carry credentials in its userinfo.
+/// The response already went to an authenticated caller — the log is a new sink.
+pub(crate) fn expansion_failed(error: impl std::fmt::Display) -> ApiError {
+    let error = error.to_string();
+    tracing::warn!("prompt expansion failed: {}", redact_url_userinfo(&error));
+    ApiError::internal(format!("prompt expansion failed: {error}"))
+}
+
+/// Replace the `user:password@` userinfo of every URL in `text` with `***@`.
+///
+/// Deliberately conservative: the userinfo ends at the first `@` before the
+/// authority's terminator, so a bare `https://host/a@b` is left alone.
+pub(crate) fn redact_url_userinfo(text: &str) -> std::borrow::Cow<'_, str> {
+    if !text.contains("://") {
+        return std::borrow::Cow::Borrowed(text);
+    }
+    let mut out = String::with_capacity(text.len());
+    let mut rest = text;
+    let mut redacted = false;
+    while let Some(scheme_end) = rest.find("://") {
+        let authority_start = scheme_end + "://".len();
+        out.push_str(&rest[..authority_start]);
+        rest = &rest[authority_start..];
+        let authority_end = rest
+            .find(['/', '?', '#', ' ', '"', '\''])
+            .unwrap_or(rest.len());
+        match rest[..authority_end].rfind('@') {
+            Some(at) => {
+                out.push_str("***");
+                out.push_str(&rest[at..authority_end]);
+                redacted = true;
+            }
+            None => out.push_str(&rest[..authority_end]),
+        }
+        rest = &rest[authority_end..];
+    }
+    out.push_str(rest);
+    if redacted {
+        std::borrow::Cow::Owned(out)
+    } else {
+        std::borrow::Cow::Borrowed(text)
+    }
 }
 
 fn require_expand_model_activation(settings: &mold_core::ExpandSettings) -> Result<(), ApiError> {
@@ -3553,7 +3605,7 @@ async fn maybe_expand_prompt(
         tokio::task::spawn_blocking(move || expander.expand(&original_prompt, &expand_config))
             .await
             .map_err(|e| ApiError::internal(format!("expand task failed: {e}")))?
-            .map_err(|e| ApiError::internal(format!("prompt expansion failed: {e}")))?;
+            .map_err(expansion_failed)?;
 
     if let Some(expanded) = result.expanded.first() {
         req.original_prompt = Some(req.prompt.clone());
@@ -3668,7 +3720,7 @@ async fn expand_prompt(
     let result = tokio::task::spawn_blocking(move || expander.expand(&prompt, &expand_config))
         .await
         .map_err(|e| ApiError::internal(format!("expand task failed: {e}")))?
-        .map_err(|e| ApiError::internal(format!("prompt expansion failed: {e}")))?;
+        .map_err(expansion_failed)?;
 
     Ok(Json(mold_core::ExpandResponse {
         original: req.prompt,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -21129,4 +21129,32 @@ mod tests {
             .expect("sweep runs");
         assert_eq!(result, mold_core::HeldSweepResult::default());
     }
+
+    #[test]
+    fn an_expansion_failure_never_journals_a_backend_url_credential() {
+        use crate::routes::redact_url_userinfo;
+
+        assert_eq!(
+            redact_url_userinfo(
+                "expand API request failed: https://svc:s3cret@llm.example.com/v1/chat/completions timed out"
+            ),
+            "expand API request failed: https://***@llm.example.com/v1/chat/completions timed out"
+        );
+        // A credential-free URL is returned untouched, path `@` included.
+        for untouched in [
+            "expand API request failed: http://127.0.0.1:7791/v1/chat/completions refused",
+            "expansion backend returned 3 prompts when exactly 1 were requested",
+            "expand API request failed: https://llm.example.com/v1/a@b failed",
+        ] {
+            assert_eq!(redact_url_userinfo(untouched), untouched);
+        }
+        // The client-facing message is deliberately NOT redacted.
+        let api_error = crate::routes::expansion_failed(
+            "expand API request failed: https://svc:s3cret@llm.example.com/v1 timed out",
+        );
+        assert!(
+            format!("{api_error:?}").contains("s3cret"),
+            "the authenticated caller keeps the verbatim reason"
+        );
+    }
 }

--- a/website/guide/expansion.md
+++ b/website/guide/expansion.md
@@ -79,9 +79,16 @@ on the same model. When no eligible machine has the model, Create offers to
 pull it and names the machine (the one expansion would have used) instead of
 failing. iPhone pins one machine, so expansion always runs there.
 Large expansions are assembled from bounded
-four-prompt model calls with position-aware instructions and per-chunk token
-budgets. Missing or duplicate positions are retried, and Mold rejects any
-result that is not exactly N distinct, non-empty prompts. Changing the source
+model calls of at most four prompts, with position-aware instructions and
+per-chunk token budgets. The chunks are evened out rather than filled greedily,
+so a batch of five is asked for three prompts and then two — never four and then
+a lone one, which asks a batch instruction for a single variation and is the
+shape a small local model answers with prose. Missing, duplicate, and
+over-delivered positions are each retried within the chunk's attempt budget: a
+response carrying more prompts than were asked for may be reasoning rather than
+variations, so none of it is kept and the chunk simply asks again. Mold still
+rejects any final result that is not exactly N distinct, non-empty prompts, and
+a chunk that exhausts its attempts says which of the two shapes it kept seeing. Changing the source
 prompt, model, host, conditioning task, or Batch count keeps
 the reviewed prompts visible but blocks generation until you refresh or discard
 them. A missing expansion model is pulled on the named host without falling


### PR DESCRIPTION
## The report

A batch of LTX generations with expansion enabled failed on plato:

> Expansion failed on plato: prompt expansion failed: expansion backend returned 3 prompts when exactly 1 were requested

## Root cause

`expand_exact_with` (`crates/mold-core/src/expand.rs`) splits a logical batch into chunks of `EXPANSION_CHUNK_SIZE = 4` and gives each chunk `EXPANSION_CHUNK_ATTEMPTS = 3` attempts, so a flaky completion can be discarded and re-requested. Every failure mode routed into that budget **except one**: an attempt returning more prompts than were requested `bail!`ed out of the whole expansion on its first occurrence.

That is the one failure mode a small local model produces reliably. #1362 deliberately made ambiguous prose parse *fail-closed* — `parse_variations` returns every candidate line rather than truncating reasoning into prompts — so an ambiguous completion lands on precisely the guard with no retry.

And the ask that produces it was manufactured by our own chunking. Taking `EXPANSION_CHUNK_SIZE` greedily leaves every batch of `4k + 1` ending on a chunk of exactly one, rendered through the **batch** template as *"Generate 1 distinct prompts … Output as a JSON array of 1 strings"*. Qwen3-1.7B answers that degenerate instruction with a preamble plus a line often enough to kill a five-print batch.

Host evidence: `expand.backend = local`, `qwen3-expand:q8` (Qwen3-1.7B-Q8_0), and two bare `500`s in the journal at 07:17:23 and 07:20:38 (11.4 s / 37.2 s) beside the LTX chain — with no message, which is why the reason existed only in the client.

## What changed

- **An over-delivering attempt spends one of the chunk's attempts and asks again.** None of its prompts are kept, so nothing is truncated and #1362's fail-closed parse is preserved. Exhausting the budget reports the overshoot counts and how many prompts were assembled, instead of the generic shortfall.
- **Chunks are evened out** (`balanced_chunk_target`): five is asked for 3 + 2, not 4 + 1. Same number of model calls; no chunk is asked for a lone prompt unless the whole batch is one, where the single-prompt template is used. A *retry* can still ask for one — that is what the attempt budget covers.
- **Two parser fixes in the same fallback.** A response whose every line is a singleton JSON array is delimited as well as a numbered list, so an overshoot is capped rather than retried — with the same bounded trade the numbered-list cap already makes, now stated and pinned by a test. A *short* run of those lines is retained for the retry instead of falling into the paragraph fallback, which joined them into one literal `["a cat"] ["a dog"]` prompt.
- **Host-side WARN on expansion failure**, with URL userinfo redacted: an API-backend transport error embeds the configured `expand.backend`, and the log is a new sink for a credential the response already carried.

## Verification

Deterministic A/B on plato with a stub OpenAI-compatible backend that reproduces the shape:

| Binary | Result |
| --- | --- |
| pre-fix | `error: expansion backend returned 3 prompts when exactly 1 were requested` |
| post-fix | all 5 prompts; the tail recovered on the retry |

A persistently over-delivering backend still fails, but only after the whole budget: `…returned 3 prompts when exactly 1 were requested, and did not return a usable count in 3 attempts; assembled 4 of 5 prompts`.

Real Qwen3-1.7B, five-variation batches, `MOLD_HOME=/storage/mold`: 5/5 prompts on every run (11 runs across two builds).

Gates:
- `cargo fmt --all -- --check`
- `cargo clippy -p mold-ai-core -p mold-ai-server -p mold-ai-inference --all-targets --features mold-ai-inference/expand -- -D warnings`
- `cargo test -p mold-ai-core --lib` (1615), `-p mold-ai-inference --lib --features expand expand` (27), `-p mold-ai-server --lib` (2054)

## Regression guards

Twelve new tests. Every new `expand_exact_with` test fails against pre-fix code. Coverage: overshoot then recovery; overshoot in a non-final chunk not diagnosing a later one (guards the per-chunk `let`); overshoot → partial fill → fill; persistent overshoot reporting both counts and the assembled total; an overshoot never masking a later shortfall; an overshooting attempt contributing none of its prompts; a sweep over batch sizes 2..=256 asserting no chunk is ever asked for a lone prompt; the singleton-array cap, its short-run retention, and the bounded trade it makes; mixed prose staying ambiguous; the recovery hint on the new message; and the log redaction, including that the client's message is *not* redacted.

Peer-reviewed by an independent agent: no blocking findings. Its should-fix items — the greedy chunking, the short singleton-array fail-open, the overstated comment, the thin diagnosis, a vacuous assertion, the credential sink, and the stale `website/guide/expansion.md` paragraph — are all applied here.

Docs: `website/guide/expansion.md` updated; changelog fragment added.