### PR TITLE
fix(desktop): open RunPod machine details

### DIFF
--- a/changelog.d/runpod-machine-details.md
+++ b/changelog.d/runpod-machine-details.md
@@ -1,0 +1,1 @@
+- **Open RunPod machines from Machines.** Running pod rows now open their Mold machine details and expose the relevant machine and RunPod actions from the right-click menu.

--- a/desktop/src/components/machines/PodCostMeter.vue
+++ b/desktop/src/components/machines/PodCostMeter.vue
@@ -61,7 +61,7 @@ onBeforeUnmount(() => {
       data-test="pod-cost-stop"
       class="border-edge h-7 shrink-0 rounded-control border px-2.5 text-body text-ink-2 hover:text-ink disabled:opacity-50"
       :disabled="busy"
-      @click="emit('stop')"
+      @click.stop="emit('stop')"
     >
       Stop pod
     </button>

--- a/desktop/src/views/MachinesView.test.ts
+++ b/desktop/src/views/MachinesView.test.ts
@@ -5,6 +5,8 @@ import { createMemoryHistory, createRouter, type Router } from "vue-router";
 
 const appSettingsGet = vi.fn();
 const discoverServers = vi.fn();
+const runpodOverview = vi.fn();
+const runpodStop = vi.fn().mockResolvedValue(undefined);
 const secretGet = vi.fn().mockResolvedValue(null);
 const testRemoteHost = vi.fn().mockResolvedValue({
   ok: true,
@@ -21,6 +23,8 @@ vi.mock("../lib/ipc", () => ({
     secretGet: (...a: unknown[]) => secretGet(...a),
     secretSet: vi.fn().mockResolvedValue(undefined),
     discoverServers: (...a: unknown[]) => discoverServers(...(a as [])),
+    runpodOverview: (...a: unknown[]) => runpodOverview(...(a as [])),
+    runpodStop: (...a: unknown[]) => runpodStop(...a),
     testRemoteHost: (...a: unknown[]) => testRemoteHost(...a),
     forgetRemoteHost: vi.fn().mockResolvedValue([]),
   },
@@ -41,6 +45,18 @@ import { useContextMenuStore } from "../stores/contextMenu";
 
 const stub = { template: "<div />" };
 let router: Router;
+
+function addRunPodHost(hosts: ReturnType<typeof useHostsStore>) {
+  hosts.extras.push({
+    id: "pod-123-7680-proxy-runpod-net",
+    label: "mold-runpod",
+    url: "https://pod-123-7680.proxy.runpod.net",
+    apiKey: null,
+    status: "ready",
+    error: null,
+    instanceId: "uuid-runpod",
+  });
+}
 
 async function mountView(setup?: (hosts: ReturnType<typeof useHostsStore>) => void) {
   router = createRouter({
@@ -134,6 +150,37 @@ beforeEach(() => {
       isThisMachine: false,
     },
   ]);
+  runpodOverview.mockResolvedValue({
+    configured: true,
+    credentialSource: "app",
+    account: null,
+    pods: [
+      {
+        id: "pod-123",
+        name: "mold-runpod",
+        desiredStatus: "RUNNING",
+        imageName: "mold:latest",
+        gpuCount: 1,
+        costPerHr: 0.74,
+        uptimeSeconds: 120,
+        memoryInGb: 26,
+        vcpuCount: 8,
+        volumeInGb: 40,
+        machine: {
+          gpuDisplayName: "NVIDIA GeForce RTX 4090",
+          gpuTypeId: "NVIDIA GeForce RTX 4090",
+          dataCenterId: "US-TX-3",
+          location: "Texas",
+        },
+        gpu: null,
+        networkVolumeId: null,
+        networkVolume: null,
+      },
+    ],
+    gpus: [],
+    datacenters: [],
+    networkVolumes: [],
+  });
 });
 
 describe("MachinesView overview", () => {
@@ -220,6 +267,75 @@ describe("MachinesView overview", () => {
     await wrapper.get("[data-test='host-card']").trigger("click");
     await flushPromises();
     expect(router.currentRoute.value.path).toBe("/machines/hal9000-7680");
+  });
+
+  it("opens the connected machine detail when its RunPod row is clicked", async () => {
+    const wrapper = await mountView(addRunPodHost);
+
+    const pod = wrapper.get("[data-test='runpod-running']");
+    const open = pod.get("[data-test='runpod-open']");
+    expect(open.attributes("aria-label")).toBe("Open mold-runpod machine details");
+    expect(pod.text()).toContain("mold-runpod");
+    expect(pod.find("[data-test='machine-chevron']").exists()).toBe(true);
+
+    await open.trigger("click");
+    await flushPromises();
+    expect(router.currentRoute.value.path).toBe("/machines/pod-123-7680-proxy-runpod-net");
+  });
+
+  it("connects to an unconnected RunPod before opening its machine detail", async () => {
+    const wrapper = await mountView();
+
+    await wrapper.get("[data-test='runpod-open']").trigger("click");
+    await flushPromises();
+
+    expect(testRemoteHost).toHaveBeenCalledWith("https://pod-123-7680.proxy.runpod.net", null);
+    expect(router.currentRoute.value.path).toBe("/machines/pod-123-7680-proxy-runpod-net");
+  });
+
+  it("offers machine and RunPod context actions on a running pod", async () => {
+    const wrapper = await mountView(addRunPodHost);
+
+    await wrapper.get("[data-test='runpod-running']").trigger("contextmenu");
+    expect(
+      useContextMenuStore().entries.flatMap((entry) => ("separator" in entry ? [] : [entry.label])),
+    ).toEqual([
+      "Open details",
+      "Set as generation target",
+      "Copy address",
+      "Open web UI",
+      "Disconnect",
+      "Forget…",
+      "Manage RunPod",
+      "Stop pod",
+    ]);
+  });
+
+  it("does not offer Stop for a pod backed by a network volume", async () => {
+    const overview = await runpodOverview();
+    overview.pods[0].networkVolumeId = "network-volume-1";
+    overview.pods[0].networkVolume = {
+      id: "network-volume-1",
+      name: "models",
+      dataCenterId: "US-TX-3",
+      size: 100,
+    };
+    runpodOverview.mockResolvedValue(overview);
+    const wrapper = await mountView(addRunPodHost);
+
+    await wrapper.get("[data-test='runpod-running']").trigger("contextmenu");
+    expect(
+      useContextMenuStore().entries.flatMap((entry) => ("separator" in entry ? [] : [entry.label])),
+    ).not.toContain("Stop pod");
+  });
+
+  it("stops a pod without also opening its machine detail", async () => {
+    const wrapper = await mountView(addRunPodHost);
+
+    await wrapper.get("[data-test='pod-cost-stop']").trigger("click");
+    await flushPromises();
+    expect(runpodStop).toHaveBeenCalledWith("pod-123");
+    expect(router.currentRoute.value.path).toBe("/machines");
   });
 
   it("lists remembered (offline) hosts with a Connect action", async () => {

--- a/desktop/src/views/MachinesView.vue
+++ b/desktop/src/views/MachinesView.vue
@@ -22,7 +22,7 @@ import { gpuFleetLabel, gpuSnapshotsFromWorkers } from "../lib/api/gpuStatus";
 import { addressLabel, prepareHosts, versionLabel } from "../lib/discovery";
 import { formatGB } from "../lib/format";
 import { hostIdFromUrl, inferBackendFromGpuName } from "../lib/hosts";
-import { podGpuName, type RunPodPod } from "../lib/runpod";
+import { podGpuName, podProxyUrl, runPodForHostUrl, type RunPodPod } from "../lib/runpod";
 import { useHostsStore, type HostView } from "../stores/hosts";
 import { useAppPrefsStore } from "../stores/appPrefs";
 import { useContextMenuStore, type MenuEntry } from "../stores/contextMenu";
@@ -54,6 +54,29 @@ async function stopPod(pod: RunPodPod) {
     toasts.push(`Stopped ${pod.name ?? pod.id}`);
   } catch (err) {
     toasts.push(String(err), "error");
+  }
+}
+
+function hostForPod(pod: RunPodPod): HostView | null {
+  return hosts.all.find((host) => runPodForHostUrl([pod], host.baseUrl) !== null) ?? null;
+}
+
+async function openPodDetail(pod: RunPodPod) {
+  try {
+    const host = hostForPod(pod) ?? (await hosts.connect(podProxyUrl(pod.id), null, pod.name));
+    openDetail(host);
+  } catch (err) {
+    toasts.push(`The instance is still starting: ${String(err)}`, "error");
+  }
+}
+
+async function targetPod(pod: RunPodPod) {
+  try {
+    const host = hostForPod(pod) ?? (await hosts.connect(podProxyUrl(pod.id), null, pod.name));
+    await appPrefs.update({ generateTargetHost: host.id });
+    toasts.push(`${host.label} is the generation target`);
+  } catch (err) {
+    toasts.push(`The instance is still starting: ${String(err)}`, "error");
   }
 }
 
@@ -150,6 +173,35 @@ function connectedHostMenu(host: HostView): MenuEntry[] {
         ]
       : []),
   ];
+}
+
+function podMenu(pod: RunPodPod): MenuEntry[] {
+  const host = hostForPod(pod);
+  const proxyUrl = podProxyUrl(pod.id);
+  const entries: MenuEntry[] = host
+    ? connectedHostMenu(host)
+    : [
+        { label: "Open details", action: () => void openPodDetail(pod) },
+        {
+          label: "Set as generation target",
+          action: () => void targetPod(pod),
+        },
+        { label: "Copy address", action: () => void copyAddress(proxyUrl) },
+        { label: "Open web UI", action: () => void openHostUrl(proxyUrl) },
+      ];
+  entries.push(
+    { separator: true },
+    { label: "Manage RunPod", action: () => void router.push("/machines/runpod") },
+  );
+  if (!pod.networkVolume) {
+    entries.push({
+      label: "Stop pod",
+      danger: true,
+      disabled: runpod.mutating === `stop:${pod.id}`,
+      action: () => void stopPod(pod),
+    });
+  }
+  return entries;
 }
 
 function rememberedHostMenu(host: SavedHost): MenuEntry[] {
@@ -439,10 +491,21 @@ async function onConnected() {
             v-for="pod in runpod.runningPods"
             :key="pod.id"
             data-test="runpod-running"
-            class="border-edge flex items-center gap-3 rounded-chrome border bg-bench px-4 py-3"
+            class="border-edge relative flex cursor-pointer items-center gap-3 rounded-chrome border bg-bench px-4 py-3 text-left transition-colors hover:border-ink-3"
+            @click="openPodDetail(pod)"
+            @contextmenu="contextMenu.open($event, podMenu(pod))"
           >
-            <span class="h-2 w-2 shrink-0 rounded-full bg-halide" />
-            <div class="min-w-0 flex-1">
+            <button
+              type="button"
+              data-test="runpod-open"
+              :aria-label="`Open ${pod.name ?? pod.id} machine details`"
+              class="absolute inset-0 rounded-chrome focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-halide"
+              @click.stop="openPodDetail(pod)"
+            />
+            <span
+              class="pointer-events-none relative z-10 h-2 w-2 shrink-0 rounded-full bg-halide"
+            />
+            <div class="pointer-events-none relative z-10 min-w-0 flex-1">
               <div class="truncate text-body font-semibold text-ink">{{ pod.name ?? pod.id }}</div>
               <div class="data-mono truncate text-caption text-ink-3">
                 {{ podGpuName(pod) }} · RunPod
@@ -453,7 +516,15 @@ async function onConnected() {
               :uptime-seconds="pod.uptimeSeconds"
               :stoppable="!pod.networkVolume"
               :busy="runpod.mutating === `stop:${pod.id}`"
+              class="relative z-10"
               @stop="stopPod(pod)"
+            />
+            <Icon
+              name="chevron-right"
+              data-test="machine-chevron"
+              :size="16"
+              :stroke-width="2"
+              class="pointer-events-none relative z-10 shrink-0 text-ink-3"
             />
           </div>
 


### PR DESCRIPTION
## Summary
- make running RunPod rows open the same machine-detail view as connected hosts, connecting on demand when needed
- add the relevant machine and RunPod actions to each pod context menu
- keep Stop pod independent from row navigation and omit it for network-volume pods

## Validation
- desktop test suite: 431 files, 5,576 tests passed
- focused machine tests: 22 tests passed
- desktop production frontend build passed
- formatting, changelog policy, and `git diff --check` passed
- native UAT in the locally built `Mold - dev` app verified the live RunPod row, full context menu, and machine-detail navigation
- independent agent peer review completed with no actionable findings