### PR TITLE
fix(ui): humanize download progress

### DIFF
--- a/changelog.d/human-readable-download-progress.md
+++ b/changelog.d/human-readable-download-progress.md
@@ -1,0 +1,3 @@
+- **Readable download progress.** Show model-download and weight-loading byte
+  counters in compact KB, MB, GB, or TB units across web, desktop, and mobile
+  activity views instead of long raw byte values.

--- a/desktop/src/mobile/MobileHostDetail.test.ts
+++ b/desktop/src/mobile/MobileHostDetail.test.ts
@@ -323,8 +323,8 @@ describe("MobileHostDetail remote host data", () => {
                 activity_phase: "active",
                 runtime_phase: "loading",
                 runtime_stage: "Loading Flux.2 transformer",
-                runtime_current: 17,
-                runtime_total: 20,
+                runtime_current: 2_539_086_011,
+                runtime_total: 12_923_897_280,
               },
             ],
           },
@@ -335,7 +335,7 @@ describe("MobileHostDetail remote host data", () => {
 
     const view = await mountDetail();
     const row = view.get("[data-test='host-detail-queue-row-job-queued']");
-    expect(row.text()).toContain("LOADING FLUX.2 TRANSFORMER · 17/20");
+    expect(row.text()).toContain("LOADING FLUX.2 TRANSFORMER · 2.5 GB / 12.9 GB");
     expect(row.text()).not.toContain("NEXT UP");
   });
 

--- a/studio/api/activity.test.ts
+++ b/studio/api/activity.test.ts
@@ -38,6 +38,71 @@ describe("activeWorkPhaseLabel", () => {
     ).toBe("Streaming MiniMax H3 transformer blocks · 17/20");
   });
 
+  it("formats download byte progress for every shared activity surface", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "download-1",
+        kind: "download",
+        phase: "downloading",
+        model: "ltx-2.5-22b-distilled:q3",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        current: 3_627_980_783,
+        total: 31_375_569_558,
+        can_cancel: true,
+      }),
+    ).toBe("downloading · 3.6 GB / 31.4 GB");
+  });
+
+  it("formats weight-loading byte progress without changing step counts", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "generation-1",
+        kind: "generation",
+        phase: "loading",
+        stage: "Loading transformer",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        current: 2_539_086_011,
+        total: 12_923_897_280,
+        can_cancel: true,
+      }),
+    ).toBe("Loading transformer · 2.5 GB / 12.9 GB");
+  });
+
+  it("keeps sequence stage counts discrete while a stage is loading", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "sequence-1",
+        kind: "sequence",
+        phase: "loading",
+        stage: "Loading clip 2",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        current: 1,
+        total: 4,
+        can_cancel: true,
+      }),
+    ).toBe("Loading clip 2 · 1/4");
+  });
+
+  it("keeps ephemeral chain stage counts discrete while a stage is loading", () => {
+    expect(
+      activeWorkPhaseLabel({
+        id: "generation-1",
+        kind: "generation",
+        execution: "chain",
+        phase: "loading",
+        stage: "Loading clip 2",
+        created_at_unix_ms: 1,
+        updated_at_unix_ms: 2,
+        current: 1,
+        total: 4,
+        can_cancel: true,
+      }),
+    ).toBe("Loading clip 2 · 1/4");
+  });
+
   it("names the component while preparation is still active", () => {
     expect(
       activeWorkPhaseLabel({

--- a/studio/api/activity.ts
+++ b/studio/api/activity.ts
@@ -1,5 +1,6 @@
 import { apiJsonTo, type ApiTarget } from "./client";
 import { compareNewestSubmitted } from "../lib/activityOrder";
+import { formatByteProgress } from "../lib/formatBytes";
 
 export interface ActiveWorkItem {
   id: string;
@@ -33,7 +34,14 @@ export function activeWorkPhaseLabel(row: ActiveWorkItem): string {
   }
   const stage = row.stage?.trim() || row.phase.replaceAll("_", " ");
   if (row.current != null && row.total != null && row.total > 0) {
-    return `${stage} · ${row.current}/${row.total}`;
+    const progress =
+      row.kind === "download" ||
+      (row.kind === "generation" &&
+        row.execution !== "chain" &&
+        row.phase === "loading")
+        ? formatByteProgress(row.current, row.total)
+        : `${row.current}/${row.total}`;
+    return `${stage} · ${progress}`;
   }
   return stage;
 }

--- a/studio/lib/formatBytes.test.ts
+++ b/studio/lib/formatBytes.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "vitest";
+import { formatByteProgress, formatBytes } from "./formatBytes";
+
+describe("formatBytes", () => {
+  it("uses compact decimal units from bytes through terabytes", () => {
+    expect(formatBytes(0)).toBe("0 B");
+    expect(formatBytes(999)).toBe("999 B");
+    expect(formatBytes(1_250)).toBe("1.3 KB");
+    expect(formatBytes(1_250_000)).toBe("1.3 MB");
+    expect(formatBytes(31_375_569_558)).toBe("31.4 GB");
+    expect(formatBytes(2_400_000_000_000)).toBe("2.4 TB");
+  });
+
+  it("formats readable progress and rejects invalid counters", () => {
+    expect(formatByteProgress(2_539_086_011, 31_375_569_558)).toBe(
+      "2.5 GB / 31.4 GB",
+    );
+    expect(formatBytes(Number.NaN)).toBe("—");
+    expect(formatBytes(-1)).toBe("—");
+  });
+});

--- a/studio/lib/formatBytes.ts
+++ b/studio/lib/formatBytes.ts
@@ -1,0 +1,21 @@
+const BYTE_UNITS = ["B", "KB", "MB", "GB", "TB", "PB"] as const;
+
+/**
+ * Compact decimal byte count shared by web, desktop, and mobile surfaces.
+ * Decimal units match Mold's download and disk-size presentation.
+ */
+export function formatBytes(bytes: number): string {
+  if (!Number.isFinite(bytes) || bytes < 0) return "—";
+  if (bytes < 1_000) return `${Math.round(bytes)} B`;
+
+  const exponent = Math.min(
+    Math.floor(Math.log(bytes) / Math.log(1_000)),
+    BYTE_UNITS.length - 1,
+  );
+  return `${(bytes / 1_000 ** exponent).toFixed(1)} ${BYTE_UNITS[exponent]}`;
+}
+
+/** Human-readable completed/total bytes for live progress rows. */
+export function formatByteProgress(completed: number, total: number): string {
+  return `${formatBytes(completed)} / ${formatBytes(total)}`;
+}

--- a/studio/lib/queuePosition.test.ts
+++ b/studio/lib/queuePosition.test.ts
@@ -6,6 +6,7 @@ import {
   buildQueueStatusIndex,
   normalizeBlockedReason,
   queuePositionLabel,
+  queueRuntimeLabel,
   queueStatusFor,
   queueWaitCode,
   queueWaitLabel,
@@ -43,6 +44,36 @@ function plan(blocked: Record<string, string>): QueuePlan {
 }
 
 describe("buildQueueStatusIndex", () => {
+  it("formats byte totals while a queued job is loading model weights", () => {
+    const loadingPlan: QueuePlan = {
+      plan_version: 1,
+      state_version: 1,
+      optimizer_state: "settled",
+      dirty_since_unix_ms: null,
+      next_replan_at_unix_ms: null,
+      work_items: [
+        {
+          work_id: "job-1",
+          parent_id: "job-1",
+          work_kind: "generation",
+          priority_class: "normal",
+          queue_rank: 0,
+          bypass_count: 0,
+          estimate_confidence: "medium",
+          blocked_reason: "running",
+          runtime_phase: "loading",
+          runtime_stage: "Loading model",
+          runtime_current: 2_539_086_011,
+          runtime_total: 12_923_897_280,
+        },
+      ],
+    };
+
+    expect(queueRuntimeLabel(loadingPlan, "job-1")).toBe(
+      "Loading model · 2.5 GB / 12.9 GB",
+    );
+  });
+
   it("prefers an exact batch child over an earlier parent aggregate", () => {
     const exactPlan: QueuePlan = {
       plan_version: 1,

--- a/studio/lib/queuePosition.ts
+++ b/studio/lib/queuePosition.ts
@@ -10,6 +10,7 @@
  */
 
 import type { QueueEntry, QueuePlan, QueueWorkItem } from "../api/queuePlan";
+import { formatByteProgress } from "./formatBytes";
 
 export interface QueueStatus {
   /** The row's lifecycle as the host listed it (`queued`, `running`, `held`), or null. */
@@ -80,7 +81,11 @@ export function queueRuntimeLabel(
     item.runtime_total != null &&
     item.runtime_total > 0
   ) {
-    return `${stage} · ${item.runtime_current}/${item.runtime_total}`;
+    const progress =
+      item.runtime_phase === "loading"
+        ? formatByteProgress(item.runtime_current, item.runtime_total)
+        : `${item.runtime_current}/${item.runtime_total}`;
+    return `${stage} · ${progress}`;
   }
   return stage;
 }

--- a/ui/components/LiveActivityList.test.ts
+++ b/ui/components/LiveActivityList.test.ts
@@ -36,6 +36,30 @@ function mountList() {
 }
 
 describe("LiveActivityList swipe actions", () => {
+  it("renders remote download progress without raw byte counters", () => {
+    const wrapper = mount(LiveActivityList, {
+      props: {
+        rows: [
+          {
+            ...row,
+            key: "host-1:download:download-1",
+            id: "download-1",
+            kind: "download",
+            phase: "downloading",
+            model: "ltx-2.5-22b-distilled:q3",
+            current: 3_627_980_783,
+            total: 31_375_569_558,
+          },
+        ],
+      },
+    });
+
+    expect(wrapper.text()).toMatch(
+      /hal9000 · downloading · 3\.6 GB \/ 31\.4 GB\s+· 12%/,
+    );
+    expect(wrapper.text()).not.toContain("3627980783/31375569558");
+  });
+
   it("opens actions for a clearly horizontal swipe", async () => {
     const wrapper = mountList();
     const item = wrapper.get(".live-activity-row");


### PR DESCRIPTION
## Summary

- format model download and weight-loading byte counters with compact decimal units
- apply the shared formatter to activity and queue-runtime rows used by web, desktop, and mobile
- preserve ordinary generation steps and chain stage counts as discrete counters
- add cross-surface regression coverage and a changelog fragment

## Testing

- `bun run test:studio` (133 files, 1,560 tests)
- `bun run test:web` (110 files, 1,765 tests)
- `bun run test:desktop` (432 files, 5,580 tests)
- focused shared/desktop regression suite (5 files, 106 tests)
- frontend architecture check
- web production build
- desktop production build
- mobile production build
- Prettier and `git diff --check`
- changelog fragment policy check
- rendered QA at 1440x900 and 390x844

## Review

Independent sub-agent review found and prompted a fix for chain-backed loading stage counts; the corrected diff was re-reviewed with no remaining actionable findings.
