### PR TITLE
fix(desktop): clear downloads after RunPod deletion

### DIFF
--- a/changelog.d/runpod-delete-download-queue.md
+++ b/changelog.d/runpod-delete-download-queue.md
@@ -1,0 +1,1 @@
+- **Clean up deleted RunPod activity.** Deleting a RunPod instance now disconnects its Mold host so stale model-download rows and routing state disappear from Studio.

--- a/desktop/src/lib/runpod.test.ts
+++ b/desktop/src/lib/runpod.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "vitest";
 import {
   friendlyRunPodError,
   isNetworkVolumeDatacenter,
+  isRunPodHostUrl,
   podGpuName,
   podProxyUrl,
   rankRunPodGpus,
@@ -59,6 +60,11 @@ describe("RunPod presentation helpers", () => {
       running,
     );
     expect(runPodForHostUrl([stopped], "https://stopped-7680.proxy.runpod.net")).toBeNull();
+  });
+
+  it("recognizes a pod proxy even after that pod is stopped", () => {
+    expect(isRunPodHostUrl("abc123", "http://abc123-7680.proxy.runpod.net:80/api")).toBe(true);
+    expect(isRunPodHostUrl("abc123", "https://another-7680.proxy.runpod.net")).toBe(false);
   });
 
   it("uses the top-level REST GPU when machine metadata omits it", () => {

--- a/desktop/src/lib/runpod.ts
+++ b/desktop/src/lib/runpod.ts
@@ -190,19 +190,21 @@ function endpointHostname(value: string): string | null {
   }
 }
 
+/** Whether a Mold endpoint is the canonical proxy owned by one RunPod pod. */
+export function isRunPodHostUrl(podId: string, hostUrl: string | null | undefined): boolean {
+  if (!hostUrl) return false;
+  return endpointHostname(hostUrl) === endpointHostname(podProxyUrl(podId));
+}
+
 /** Match a routed Mold host to the running RunPod proxy that owns it. */
 export function runPodForHostUrl(
   pods: readonly RunPodPod[],
   hostUrl: string | null | undefined,
 ): RunPodPod | null {
   if (!hostUrl) return null;
-  const hostname = endpointHostname(hostUrl);
-  if (!hostname) return null;
   return (
     pods.find(
-      (pod) =>
-        pod.desiredStatus.toUpperCase() === "RUNNING" &&
-        endpointHostname(podProxyUrl(pod.id)) === hostname,
+      (pod) => pod.desiredStatus.toUpperCase() === "RUNNING" && isRunPodHostUrl(pod.id, hostUrl),
     ) ?? null
   );
 }

--- a/desktop/src/stores/runpod.test.ts
+++ b/desktop/src/stores/runpod.test.ts
@@ -1,25 +1,46 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { createPinia, setActivePinia } from "pinia";
 
+const runpodOverview = vi.fn().mockResolvedValue({
+  configured: true,
+  credentialSource: "app",
+  account: null,
+  pods: [],
+  gpus: [],
+  datacenters: [],
+  networkVolumes: [],
+});
+const runpodDelete = vi.fn();
+const disconnectHost = vi.fn();
+const extraHosts = [
+  {
+    id: "pod-123-7680-proxy-runpod-net",
+    url: "https://pod-123-7680.proxy.runpod.net",
+  },
+  { id: "hal9000-7680", url: "http://hal9000:7680" },
+];
+
 vi.mock("../lib/ipc", () => ({
   ipc: {
-    runpodOverview: vi.fn().mockResolvedValue({
-      configured: true,
-      credentialSource: "app",
-      account: null,
-      pods: [],
-      gpus: [],
-      datacenters: [],
-      networkVolumes: [],
-    }),
+    runpodOverview: (...args: unknown[]) => runpodOverview(...args),
     runpodCreate: vi.fn().mockRejectedValue(new Error("GPU is unavailable for Pod creation")),
+    runpodDelete: (...args: unknown[]) => runpodDelete(...args),
   },
+}));
+
+vi.mock("./hosts", () => ({
+  useHostsStore: () => ({ extras: extraHosts, disconnect: disconnectHost }),
 }));
 
 import { useRunPodStore } from "./runpod";
 
 describe("RunPod operation errors", () => {
-  beforeEach(() => setActivePinia(createPinia()));
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    runpodOverview.mockClear();
+    runpodDelete.mockReset().mockResolvedValue(undefined);
+    disconnectHost.mockReset().mockResolvedValue(undefined);
+  });
 
   it("keeps launch errors available across background refreshes until dismissed", async () => {
     const store = useRunPodStore();
@@ -31,5 +52,35 @@ describe("RunPod operation errors", () => {
 
     store.clearOperationError();
     expect(store.operationError).toBeNull();
+  });
+
+  it("disconnects the deleted pod's Mold host so its download queue is retired", async () => {
+    const store = useRunPodStore();
+
+    await store.act("delete", "pod-123");
+
+    expect(runpodDelete).toHaveBeenCalledWith("pod-123");
+    expect(disconnectHost).toHaveBeenCalledOnce();
+    expect(disconnectHost).toHaveBeenCalledWith("pod-123-7680-proxy-runpod-net");
+  });
+
+  it("keeps the host connected when RunPod deletion fails", async () => {
+    runpodDelete.mockRejectedValueOnce(new Error("RunPod deletion failed"));
+    const store = useRunPodStore();
+
+    await expect(store.act("delete", "pod-123")).rejects.toThrow("RunPod deletion failed");
+
+    expect(disconnectHost).not.toHaveBeenCalled();
+  });
+
+  it("refreshes after deletion and warns when disconnect persistence fails", async () => {
+    disconnectHost.mockRejectedValueOnce(new Error("settings unavailable"));
+    const store = useRunPodStore();
+
+    await expect(store.act("delete", "pod-123")).resolves.toBeUndefined();
+
+    expect(runpodOverview).toHaveBeenCalledOnce();
+    expect(store.operationError).toContain("was deleted");
+    expect(store.operationError).toContain("may reappear after restart");
   });
 });

--- a/desktop/src/stores/runpod.ts
+++ b/desktop/src/stores/runpod.ts
@@ -3,12 +3,14 @@ import { ipc } from "../lib/ipc";
 import {
   emptyRunPodOverview,
   friendlyRunPodError,
+  isRunPodHostUrl,
   rankRunPodGpus,
   type RunPodCreateInput,
   type RunPodNetworkVolumeCreateInput,
   type RunPodNetworkVolumeUpdateInput,
   type RunPodOverview,
 } from "../lib/runpod";
+import { useHostsStore } from "./hosts";
 
 export const useRunPodStore = defineStore("runpod", {
   state: () => ({
@@ -123,7 +125,20 @@ export const useRunPodStore = defineStore("runpod", {
       try {
         if (action === "start") await ipc.runpodStart(id);
         else if (action === "stop") await ipc.runpodStop(id);
-        else await ipc.runpodDelete(id);
+        else {
+          const hosts = useHostsStore();
+          const connectedHostIds = hosts.extras
+            .filter((host) => isRunPodHostUrl(id, host.url))
+            .map((host) => host.id);
+          await ipc.runpodDelete(id);
+          const cleanup = await Promise.allSettled(
+            connectedHostIds.map((hostId) => hosts.disconnect(hostId)),
+          );
+          if (cleanup.some((result) => result.status === "rejected")) {
+            this.operationError =
+              "The RunPod instance was deleted and its activity was cleared, but Studio couldn't save the disconnected host. It may reappear after restart; disconnect it again if it does.";
+          }
+        }
         await this.load();
       } catch (error) {
         this.operationError = friendlyRunPodError(


### PR DESCRIPTION
## Summary
- disconnect the Mold host after its RunPod instance is deleted
- clear that host's stale model-download activity and routing state without touching other machines
- preserve successful deletion if host-settings persistence fails, while refreshing RunPod state and showing an actionable warning

## Testing
- `nix develop -c bun run check:frontend`
- focused RunPod and host lifecycle tests (117 passing)
- independent agent peer review: approved after addressing cleanup-failure semantics