### PR TITLE
fix(desktop): forget deleted RunPod hosts

### DIFF
--- a/changelog.d/runpod-delete-download-queue.md
+++ b/changelog.d/runpod-delete-download-queue.md
@@ -1,1 +1,1 @@
-- **Clean up deleted RunPod activity.** Deleting a RunPod instance now disconnects its Mold host so stale model-download rows and routing state disappear from Studio.
+- **Clean up deleted RunPod activity.** Deleting a RunPod instance now forgets its Mold host so stale model-download rows, reconnect entries, credentials, and routing state disappear from Studio.

--- a/changelog.d/runpod-delete-download-queue.md
+++ b/changelog.d/runpod-delete-download-queue.md
@@ -1,1 +1,1 @@
-- **Clean up deleted RunPod activity.** Deleting a RunPod instance now forgets its Mold host so stale model-download rows, reconnect entries, credentials, and routing state disappear from Studio.
+- **Clean up deleted RunPod activity.** Deleting a RunPod instance now disconnects its Mold host so stale model-download rows and routing state disappear from Studio.

--- a/changelog.d/runpod-forget-deleted-host.md
+++ b/changelog.d/runpod-forget-deleted-host.md
@@ -1,0 +1,1 @@
+- **Forget deleted RunPod hosts.** Deleting a RunPod instance now removes its saved reconnect entry and credentials, including aliases that are already disconnected.

--- a/desktop/src/stores/runpod.test.ts
+++ b/desktop/src/stores/runpod.test.ts
@@ -12,19 +12,24 @@ const runpodOverview = vi.fn().mockResolvedValue({
 });
 const runpodDelete = vi.fn();
 const disconnectHost = vi.fn();
-const extraHosts = [
+const forgetRemoteHost = vi.fn();
+const appSettingsGet = vi.fn();
+const defaultExtraHosts = [
   {
     id: "pod-123-7680-proxy-runpod-net",
     url: "https://pod-123-7680.proxy.runpod.net",
   },
   { id: "hal9000-7680", url: "http://hal9000:7680" },
 ];
+const extraHosts = [...defaultExtraHosts];
 
 vi.mock("../lib/ipc", () => ({
   ipc: {
     runpodOverview: (...args: unknown[]) => runpodOverview(...args),
     runpodCreate: vi.fn().mockRejectedValue(new Error("GPU is unavailable for Pod creation")),
     runpodDelete: (...args: unknown[]) => runpodDelete(...args),
+    forgetRemoteHost: (...args: unknown[]) => forgetRemoteHost(...args),
+    appSettingsGet: (...args: unknown[]) => appSettingsGet(...args),
   },
 }));
 
@@ -40,6 +45,9 @@ describe("RunPod operation errors", () => {
     runpodOverview.mockClear();
     runpodDelete.mockReset().mockResolvedValue(undefined);
     disconnectHost.mockReset().mockResolvedValue(undefined);
+    forgetRemoteHost.mockReset().mockResolvedValue([]);
+    appSettingsGet.mockReset().mockResolvedValue({ savedHosts: [] });
+    extraHosts.splice(0, extraHosts.length, ...defaultExtraHosts);
   });
 
   it("keeps launch errors available across background refreshes until dismissed", async () => {
@@ -62,6 +70,8 @@ describe("RunPod operation errors", () => {
     expect(runpodDelete).toHaveBeenCalledWith("pod-123");
     expect(disconnectHost).toHaveBeenCalledOnce();
     expect(disconnectHost).toHaveBeenCalledWith("pod-123-7680-proxy-runpod-net");
+    expect(forgetRemoteHost).toHaveBeenCalledOnce();
+    expect(forgetRemoteHost).toHaveBeenCalledWith("pod-123-7680-proxy-runpod-net");
   });
 
   it("keeps the host connected when RunPod deletion fails", async () => {
@@ -71,10 +81,22 @@ describe("RunPod operation errors", () => {
     await expect(store.act("delete", "pod-123")).rejects.toThrow("RunPod deletion failed");
 
     expect(disconnectHost).not.toHaveBeenCalled();
+    expect(forgetRemoteHost).not.toHaveBeenCalled();
   });
 
-  it("refreshes after deletion and warns when disconnect persistence fails", async () => {
+  it("still forgets the host when ordinary disconnect persistence fails", async () => {
     disconnectHost.mockRejectedValueOnce(new Error("settings unavailable"));
+    const store = useRunPodStore();
+
+    await expect(store.act("delete", "pod-123")).resolves.toBeUndefined();
+
+    expect(runpodOverview).toHaveBeenCalledOnce();
+    expect(forgetRemoteHost).toHaveBeenCalledWith("pod-123-7680-proxy-runpod-net");
+    expect(store.operationError).toBeNull();
+  });
+
+  it("refreshes after deletion and warns when the host cannot be fully forgotten", async () => {
+    forgetRemoteHost.mockRejectedValueOnce(new Error("settings unavailable"));
     const store = useRunPodStore();
 
     await expect(store.act("delete", "pod-123")).resolves.toBeUndefined();
@@ -82,5 +104,50 @@ describe("RunPod operation errors", () => {
     expect(runpodOverview).toHaveBeenCalledOnce();
     expect(store.operationError).toContain("was deleted");
     expect(store.operationError).toContain("may reappear after restart");
+  });
+
+  it("forgets a matching saved RunPod host even when it is already disconnected", async () => {
+    extraHosts.splice(0);
+    appSettingsGet.mockResolvedValueOnce({
+      savedHosts: [
+        {
+          id: "saved-pod-alias",
+          url: "http://pod-123-7680.proxy.runpod.net:80/api",
+        },
+        { id: "hal9000-7680", url: "http://hal9000:7680" },
+      ],
+    });
+    const store = useRunPodStore();
+
+    await store.act("delete", "pod-123");
+
+    expect(disconnectHost).not.toHaveBeenCalled();
+    expect(forgetRemoteHost).toHaveBeenCalledOnce();
+    expect(forgetRemoteHost).toHaveBeenCalledWith("saved-pod-alias");
+  });
+
+  it("forgets multiple matching aliases sequentially", async () => {
+    extraHosts.splice(0);
+    appSettingsGet.mockResolvedValueOnce({
+      savedHosts: [
+        { id: "pod-alias-a", url: "https://pod-123-7680.proxy.runpod.net" },
+        { id: "pod-alias-b", url: "http://pod-123-7680.proxy.runpod.net:80/api" },
+      ],
+    });
+    let active = 0;
+    let maxActive = 0;
+    forgetRemoteHost.mockImplementation(async () => {
+      active += 1;
+      maxActive = Math.max(maxActive, active);
+      await Promise.resolve();
+      active -= 1;
+      return [];
+    });
+    const store = useRunPodStore();
+
+    await store.act("delete", "pod-123");
+
+    expect(forgetRemoteHost.mock.calls.map(([id]) => id)).toEqual(["pod-alias-a", "pod-alias-b"]);
+    expect(maxActive).toBe(1);
   });
 });

--- a/desktop/src/stores/runpod.ts
+++ b/desktop/src/stores/runpod.ts
@@ -130,13 +130,42 @@ export const useRunPodStore = defineStore("runpod", {
           const connectedHostIds = hosts.extras
             .filter((host) => isRunPodHostUrl(id, host.url))
             .map((host) => host.id);
+          let savedHostIds: string[] = [];
+          let cleanupFailed = false;
+          try {
+            savedHostIds = (await ipc.appSettingsGet()).savedHosts
+              .filter((host) => isRunPodHostUrl(id, host.url))
+              .map((host) => host.id);
+          } catch {
+            // The pod deletion may still proceed, but without the saved-host
+            // inventory Studio cannot prove every alias was forgotten.
+            cleanupFailed = true;
+          }
+          const connected = new Set(connectedHostIds);
+          const hostIds = [...new Set([...connectedHostIds, ...savedHostIds])];
           await ipc.runpodDelete(id);
-          const cleanup = await Promise.allSettled(
-            connectedHostIds.map((hostId) => hosts.disconnect(hostId)),
-          );
-          if (cleanup.some((result) => result.status === "rejected")) {
+          // Serialize the settings writes: forget_remote_host mutates its
+          // in-memory store under a lock, then saves after releasing the lock.
+          // Concurrent aliases could otherwise persist out of order.
+          for (const hostId of hostIds) {
+            if (connected.has(hostId)) {
+              try {
+                await hosts.disconnect(hostId);
+              } catch {
+                // disconnect() retires the live host and its activity before
+                // persisting. The stronger forget command below independently
+                // removes saved/reconnect state, so it can recover that write.
+              }
+            }
+            try {
+              await ipc.forgetRemoteHost(hostId);
+            } catch {
+              cleanupFailed = true;
+            }
+          }
+          if (cleanupFailed) {
             this.operationError =
-              "The RunPod instance was deleted and its activity was cleared, but Studio couldn't save the disconnected host. It may reappear after restart; disconnect it again if it does.";
+              "The RunPod instance was deleted and its activity was cleared, but Studio couldn't fully forget its Mold host. It may reappear after restart; forget it from Machines if it does.";
           }
         }
         await this.load();


### PR DESCRIPTION
## Summary
- forget the deleted RunPod host from both live and saved host state
- remove stale download activity, reconnect entries, credentials, and routing state
- discover disconnected saved-only aliases and clean multiple aliases sequentially to avoid settings-write races
- keep RunPod deletion successful if host cleanup fails, while surfacing an actionable warning

## Testing
- `nix develop -c bun run check:frontend` (133 Studio files / 1561 tests; 110 web files / 1765 tests; 432 desktop files / 5594 tests)
- focused RunPod and host lifecycle tests (120 passing)
- independent agent peer review: approved with no remaining actionable findings