### PR TITLE
fix(library): preserve upscale across saved copies

### DIFF
--- a/changelog.d/library-upscale-dismiss-local.md
+++ b/changelog.d/library-upscale-dismiss-local.md
@@ -1,0 +1,1 @@
+- **Keep Library upscale actions available after saving locally.** Escape now dismisses the shared upscale dialog, a locally saved video can use another capable copy's Mold host for Framewise upscale, and multi-host prints offer a host selector when more than one copy can run it.

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -588,6 +588,7 @@ describe("LibraryView source reuse", () => {
     expect(upscale).toMatchObject({ disabled: false });
     useContextMenuStore().activate(upscale!);
     await flushPromises();
+    expect(document.querySelector("[data-test='upscale-host']")).toBeNull();
     (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
     await flushPromises();
 
@@ -598,6 +599,56 @@ describe("LibraryView source reuse", () => {
     );
     expect(useToastStore().items.at(-1)?.message).toContain(
       "Framewise upscale queued (vup-desktop-1)",
+    );
+    wrapper.unmount();
+  });
+
+  it("lets the user choose between capable hosts for a multi-host image", async () => {
+    upscaleLibraryImageMock.mockResolvedValueOnce({
+      filename: "origin-still-upscaled.png",
+      model: "real-esrgan-x4plus:fp16",
+      scale_factor: 4,
+    });
+    const remoteImage = {
+      ...prints[0]!,
+      filename: "origin-still.png",
+      size_bytes: 4096,
+    } as GalleryImage;
+    const localImage = {
+      ...remoteImage,
+      filename: "origin-still~made-local.png",
+    } as GalleryImage;
+    const { wrapper } = await mountView(
+      remoteImage,
+      (gallery) => {
+        gallery.buckets.local!.items = [localImage];
+        useHostsStore().capabilities["plato-7680"] = {
+          video_upscale: { gallery_image: true },
+        } as never;
+      },
+      "/library",
+      true,
+    );
+
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Upscale",
+    );
+    useContextMenuStore().activate(upscale!);
+    await flushPromises();
+
+    const host = document.querySelector("[data-test='upscale-host']") as HTMLSelectElement;
+    expect([...host.options].map((option) => option.text)).toEqual(["This device", "plato"]);
+    host.value = "plato-7680";
+    host.dispatchEvent(new Event("change"));
+    await flushPromises();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(upscaleLibraryImageMock).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "origin-still.png",
+      "real-esrgan-x4plus:fp16",
     );
     wrapper.unmount();
   });
@@ -624,6 +675,132 @@ describe("LibraryView source reuse", () => {
       (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
     );
     expect(upscale).toMatchObject({ disabled: true });
+  });
+
+  it("routes a saved-local video through its capable remote copy", async () => {
+    const remoteVideo = {
+      ...prints[0]!,
+      filename: "origin-clip.mp4",
+      format: "mp4",
+      size_bytes: 4096,
+    } as GalleryImage;
+    const localVideo = {
+      ...remoteVideo,
+      filename: "origin-clip~made-local.mp4",
+    } as GalleryImage;
+    const { wrapper } = await mountView(remoteVideo, (gallery) => {
+      gallery.buckets.local!.items = [localVideo];
+      useHostsStore().capabilities.local = {
+        video_upscale: { available: false },
+      } as never;
+      useHostsStore().capabilities["plato-7680"] = {
+        video_upscale: { available: true },
+      } as never;
+    });
+
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
+    );
+    expect(upscale).toMatchObject({ disabled: false });
+    useContextMenuStore().activate(upscale!);
+    await flushPromises();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscaleMock).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "origin-clip.mp4",
+      "real-esrgan-x4plus:fp16",
+    );
+    wrapper.unmount();
+  });
+
+  it("retains remote upscale authority under the local host filter", async () => {
+    const remoteVideo = {
+      ...prints[0]!,
+      filename: "filtered-origin.mp4",
+      format: "mp4",
+      size_bytes: 4096,
+    } as GalleryImage;
+    const localVideo = {
+      ...remoteVideo,
+      filename: "filtered-origin~made-local.mp4",
+    } as GalleryImage;
+    const { wrapper } = await mountView(remoteVideo, (gallery) => {
+      gallery.buckets.local!.items = [localVideo];
+      gallery.filter = "local";
+      useHostsStore().capabilities.local = {
+        video_upscale: { available: false },
+      } as never;
+      useHostsStore().capabilities["plato-7680"] = {
+        video_upscale: { available: true },
+      } as never;
+    });
+
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
+    );
+    expect(upscale).toMatchObject({ disabled: false });
+    useContextMenuStore().activate(upscale!);
+    await flushPromises();
+    expect(document.querySelector("[data-test='upscale-host']")).toBeNull();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscaleMock).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "filtered-origin.mp4",
+      "real-esrgan-x4plus:fp16",
+    );
+    wrapper.unmount();
+  });
+
+  it("lets the user choose between capable hosts for a multi-host video", async () => {
+    const remoteVideo = {
+      ...prints[0]!,
+      filename: "origin-clip.mp4",
+      format: "mp4",
+      size_bytes: 4096,
+    } as GalleryImage;
+    const localVideo = {
+      ...remoteVideo,
+      filename: "origin-clip~made-local.mp4",
+    } as GalleryImage;
+    const { wrapper } = await mountView(
+      remoteVideo,
+      (gallery) => {
+        gallery.buckets.local!.items = [localVideo];
+        useHostsStore().capabilities["plato-7680"] = {
+          video_upscale: { available: true },
+        } as never;
+      },
+      "/library",
+      true,
+    );
+
+    await wrapper.get(".ms-lib-tile").trigger("contextmenu");
+    const upscale = useContextMenuStore().entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Framewise upscale",
+    );
+    useContextMenuStore().activate(upscale!);
+    await flushPromises();
+
+    const host = document.querySelector("[data-test='upscale-host']") as HTMLSelectElement;
+    expect([...host.options].map((option) => option.text)).toEqual(["This device", "plato"]);
+    host.value = "plato-7680";
+    host.dispatchEvent(new Event("change"));
+    await flushPromises();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscaleMock).toHaveBeenCalledWith(
+      { baseUrl: "http://plato:7680", apiKey: "secret" },
+      "origin-clip.mp4",
+      "real-esrgan-x4plus:fp16",
+    );
+    wrapper.unmount();
   });
 
   it("keeps a failed desktop Framewise submission visible in the dialog", async () => {

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -345,6 +345,67 @@ let upscaleEpoch = 0;
 const upscaleKind = computed(() =>
   upscaleEntry.value && isVideo(upscaleEntry.value.item) ? "video" : "image",
 );
+type UpscaleAuthority = {
+  sourceKey: string;
+  label: string;
+  filename: string;
+  target: ApiTarget;
+};
+const upscaleAuthority = ref<UpscaleAuthority | null>(null);
+
+/**
+ * A saved-local print is represented by the local row, but its merged print
+ * still carries the original host copy. Prefer the displayed copy when it can
+ * run the operation; otherwise fall back to a capable copy of the same print.
+ */
+function upscaleAuthoritiesFor(entry: MergedPrint | null): UpscaleAuthority[] {
+  if (!entry || isAudio(entry.item) || isMesh(entry.item)) return [];
+  // Host-chip projections intentionally carry only their displayed bucket.
+  // Recover the logical print here so upscale can still see alternate copies
+  // without widening delete/organize actions on the host-filtered tile.
+  const logical = entry.copies?.length
+    ? entry
+    : (gallery.mergedIndex.get(entry.item.filename) ?? entry);
+  const copies = logical.copies?.length
+    ? [...logical.copies]
+    : [{ sourceKey: entry.sourceKey, item: entry.item }];
+  copies.sort((left, right) => {
+    const leftPreferred = left.sourceKey === entry.sourceKey ? 0 : 1;
+    const rightPreferred = right.sourceKey === entry.sourceKey ? 0 : 1;
+    return leftPreferred - rightPreferred;
+  });
+  const authorities: UpscaleAuthority[] = [];
+  const seen = new Set<string>();
+  for (const copy of copies) {
+    if (seen.has(copy.sourceKey)) continue;
+    seen.add(copy.sourceKey);
+    const target = gallery.targetOf(copy.sourceKey);
+    if (!target) continue;
+    if (
+      isVideo(copy.item) &&
+      hosts.capabilities[copy.sourceKey]?.video_upscale?.available !== true
+    ) {
+      continue;
+    }
+    authorities.push({
+      sourceKey: copy.sourceKey,
+      label:
+        logical.availableOn.find((source) => source.key === copy.sourceKey)?.label ??
+        copy.sourceKey,
+      filename: copy.item.filename,
+      target,
+    });
+  }
+  return authorities;
+}
+
+const upscaleAuthorityFor = (entry: MergedPrint | null) => upscaleAuthoritiesFor(entry)[0] ?? null;
+const upscaleHostChoices = computed(() =>
+  upscaleAuthoritiesFor(upscaleEntry.value).map(({ sourceKey, label }) => ({
+    key: sourceKey,
+    label,
+  })),
+);
 
 function stopUpscalePoll() {
   if (upscalePoll) clearTimeout(upscalePoll);
@@ -355,24 +416,24 @@ function closeUpscaleDialog() {
   upscaleEpoch += 1;
   stopUpscalePoll();
   upscaleEntry.value = null;
+  upscaleAuthority.value = null;
   upscaleJob.value = null;
   upscaleError.value = "";
 }
 
 async function openUpscaleDialog(entry: MergedPrint) {
-  if (!canUpscaleEntry(entry) || !targetFor(entry)) return;
+  const authority = upscaleAuthorityFor(entry);
+  if (!authority) return;
   stopUpscalePoll();
   const epoch = ++upscaleEpoch;
   upscaleEntry.value = entry;
+  upscaleAuthority.value = authority;
   upscaleJob.value = null;
   upscaleError.value = "";
   upscaleModel.value = defaultUpscaler(models.upscalers);
   if (isVideo(entry.item)) {
     try {
-      const recovered = await findRecoverableFramewiseUpscale(
-        targetFor(entry)!,
-        entry.item.filename,
-      );
+      const recovered = await findRecoverableFramewiseUpscale(authority.target, authority.filename);
       if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
       upscaleJob.value = recovered;
       if (recovered) upscaleModel.value = recovered.model;
@@ -383,29 +444,53 @@ async function openUpscaleDialog(entry: MergedPrint) {
   }
 }
 
+async function selectUpscaleAuthority(sourceKey: string) {
+  const entry = upscaleEntry.value;
+  const authority = upscaleAuthoritiesFor(entry).find((choice) => choice.sourceKey === sourceKey);
+  if (!entry || !authority || authority.sourceKey === upscaleAuthority.value?.sourceKey) return;
+  stopUpscalePoll();
+  const epoch = ++upscaleEpoch;
+  upscaleAuthority.value = authority;
+  upscaleJob.value = null;
+  upscaleError.value = "";
+  if (!isVideo(entry.item)) return;
+  try {
+    const recovered = await findRecoverableFramewiseUpscale(authority.target, authority.filename);
+    if (
+      epoch !== upscaleEpoch ||
+      upscaleEntry.value !== entry ||
+      upscaleAuthority.value !== authority
+    ) {
+      return;
+    }
+    upscaleJob.value = recovered;
+    if (recovered) upscaleModel.value = recovered.model;
+    if (shouldPollFramewiseJob(recovered)) void pollUpscaleJob();
+  } catch {
+    // Old hosts do not expose durable video-upscale history.
+  }
+}
+
 function canUpscaleEntry(entry: MergedPrint | null): boolean {
-  if (!entry || isAudio(entry.item) || isMesh(entry.item)) return false;
-  return (
-    !isVideo(entry.item) || hosts.capabilities[entry.sourceKey]?.video_upscale?.available === true
-  );
+  return upscaleAuthorityFor(entry) !== null;
 }
 
 async function pollUpscaleJob() {
   const entry = upscaleEntry.value;
+  const authority = upscaleAuthority.value;
   const job = upscaleJob.value;
-  const target = entry && targetFor(entry);
-  if (!entry || !job || !target || !shouldPollFramewiseJob(job)) {
+  if (!entry || !authority || !job || !shouldPollFramewiseJob(job)) {
     return;
   }
   const epoch = upscaleEpoch;
   try {
-    const next = await getFramewiseUpscale(target, job.id);
+    const next = await getFramewiseUpscale(authority.target, job.id);
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry || upscaleJob.value?.id !== job.id)
       return;
     upscaleJob.value = next;
     if (next.state === "completed") {
       toasts.push(`Framewise upscale complete — ${next.output_filename}`);
-      void gallery.refreshHost(entry.sourceKey);
+      void gallery.refreshHost(authority.sourceKey);
     }
   } catch (error) {
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
@@ -419,15 +504,15 @@ async function pollUpscaleJob() {
 
 async function legacyStreamUpscale(entry: MergedPrint): Promise<string> {
   const { sseStream } = await import("../lib/api/sse");
-  const target = targetFor(entry);
-  if (!target) throw new Error("The print's source host is unavailable.");
+  const authority = upscaleAuthority.value;
+  if (!authority) throw new Error("The print's source host is unavailable.");
   const image = await fetchItemBase64(entry);
   return new Promise<string>((resolve, reject) => {
     const abort = new AbortController();
     let settled = false;
     void sseStream("/api/upscale/stream", {
       method: "POST",
-      target,
+      target: authority.target,
       body: {
         model: upscaleModel.value,
         image,
@@ -459,24 +544,32 @@ async function legacyStreamUpscale(entry: MergedPrint): Promise<string> {
 
 async function startUpscale() {
   const entry = upscaleEntry.value;
-  const target = entry && targetFor(entry);
-  if (!entry || !target || upscalingFilename.value) return;
+  const authority = upscaleAuthority.value;
+  if (!entry || !authority || upscalingFilename.value) return;
   const epoch = ++upscaleEpoch;
   stopUpscalePoll();
   upscaleError.value = "";
   upscalingFilename.value = entry.item.filename;
   try {
     if (isVideo(entry.item)) {
-      const created = await createFramewiseUpscale(target, entry.item.filename, upscaleModel.value);
+      const created = await createFramewiseUpscale(
+        authority.target,
+        authority.filename,
+        upscaleModel.value,
+      );
       if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
       upscaleJob.value = created;
       toasts.push(`Framewise upscale queued (${created.id}).`);
       void pollUpscaleJob();
     } else {
-      if (hosts.capabilities[entry.sourceKey]?.video_upscale?.gallery_image === true) {
-        const result = await upscaleLibraryImage(target, entry.item.filename, upscaleModel.value);
+      if (hosts.capabilities[authority.sourceKey]?.video_upscale?.gallery_image === true) {
+        const result = await upscaleLibraryImage(
+          authority.target,
+          authority.filename,
+          upscaleModel.value,
+        );
         toasts.push(`Upscaled — ${result.filename}`);
-        void gallery.refreshHost(entry.sourceKey);
+        void gallery.refreshHost(authority.sourceKey);
       } else {
         const upscaled = await legacyStreamUpscale(entry);
         const stem = entry.item.filename.replace(/\.[^.]+$/, "");
@@ -497,14 +590,14 @@ async function startUpscale() {
 
 async function transitionUpscale(action: "pause" | "resume" | "cancel") {
   const entry = upscaleEntry.value;
-  const target = entry && targetFor(entry);
+  const authority = upscaleAuthority.value;
   const job = upscaleJob.value;
-  if (!entry || !target || !job) return;
+  if (!entry || !authority || !job) return;
   stopUpscalePoll();
   const epoch = ++upscaleEpoch;
   upscaleError.value = "";
   try {
-    const transitioned = await transitionFramewiseUpscale(target, job.id, action);
+    const transitioned = await transitionFramewiseUpscale(authority.target, job.id, action);
     if (epoch !== upscaleEpoch || upscaleEntry.value !== entry) return;
     upscaleJob.value = transitioned;
     if (action === "resume") void pollUpscaleJob();
@@ -1210,7 +1303,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
         upscalingFilename.value === item.filename
           ? "Upscaling…"
           : libraryUpscaleLabel(isVideo(item) ? "video" : "image").replace("…", ""),
-      disabled: !targetFor(entry) || upscalingFilename.value !== null || !canUpscaleEntry(entry),
+      disabled: upscalingFilename.value !== null || !canUpscaleEntry(entry),
       action: () => openUpscaleDialog(entry),
     },
     {
@@ -2818,14 +2911,17 @@ onUnmounted(() => {
     <UpscaleDialog
       :open="!!upscaleEntry"
       :kind="upscaleKind"
-      :source-name="upscaleEntry?.item.filename ?? ''"
+      :source-name="upscaleAuthority?.filename ?? upscaleEntry?.item.filename ?? ''"
       :models="models.upscalers"
       v-model="upscaleModel"
+      :execution-hosts="upscaleHostChoices"
+      :execution-host-value="upscaleAuthority?.sourceKey ?? ''"
       :busy="upscalingFilename !== null"
       :job-state="upscaleJob?.state ?? null"
       :status="upscaleJob ? framewiseStatus(upscaleJob) : null"
       :progress="upscaleJob ? framewiseProgress(upscaleJob) : null"
       :error="upscaleError || null"
+      @update:execution-host-value="selectUpscaleAuthority"
       @confirm="startUpscale"
       @close="closeUpscaleDialog"
       @pause="transitionUpscale('pause')"

--- a/ui/components/UpscaleDialog.test.ts
+++ b/ui/components/UpscaleDialog.test.ts
@@ -1,0 +1,85 @@
+import { mount } from "@vue/test-utils";
+import { describe, expect, it } from "vitest";
+
+import UpscaleDialog from "./UpscaleDialog.vue";
+
+describe("UpscaleDialog", () => {
+  it("dismisses an open dialog when Escape is pressed", async () => {
+    const wrapper = mount(UpscaleDialog, {
+      attachTo: document.body,
+      props: {
+        open: true,
+        kind: "video",
+        sourceName: "wide.mp4",
+        modelValue: "real-esrgan-x4plus:fp16",
+      },
+    });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toHaveLength(1);
+    wrapper.unmount();
+  });
+
+  it("ignores Escape while the dialog is closed", async () => {
+    const wrapper = mount(UpscaleDialog, {
+      attachTo: document.body,
+      props: {
+        open: false,
+        kind: "image",
+        sourceName: "still.png",
+        modelValue: "real-esrgan-x4plus:fp16",
+      },
+    });
+
+    window.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape" }));
+    await wrapper.vm.$nextTick();
+
+    expect(wrapper.emitted("close")).toBeUndefined();
+    wrapper.unmount();
+  });
+
+  it("offers host selection only when multiple capable copies are available", async () => {
+    const wrapper = mount(UpscaleDialog, {
+      props: {
+        open: true,
+        kind: "video",
+        sourceName: "clip.mp4",
+        modelValue: "real-esrgan-x4plus:fp16",
+        executionHosts: [
+          { key: "local", label: "This Mac" },
+          { key: "plato", label: "plato" },
+        ],
+        executionHostValue: "local",
+      },
+    });
+
+    const host = document.querySelector(
+      "[data-test='upscale-host']",
+    ) as HTMLSelectElement;
+    expect([...host.options].map((option) => option.text)).toEqual([
+      "This Mac",
+      "plato",
+    ]);
+    host.value = "plato";
+    host.dispatchEvent(new Event("change"));
+    await wrapper.vm.$nextTick();
+    expect(wrapper.emitted("update:executionHostValue")).toEqual([["plato"]]);
+    wrapper.unmount();
+
+    const oneHost = mount(UpscaleDialog, {
+      attachTo: document.body,
+      props: {
+        open: true,
+        kind: "image",
+        sourceName: "still.png",
+        modelValue: "real-esrgan-x4plus:fp16",
+        executionHosts: [{ key: "local", label: "This Mac" }],
+        executionHostValue: "local",
+      },
+    });
+    expect(document.querySelector("[data-test='upscale-host']")).toBeNull();
+    oneHost.unmount();
+  });
+});

--- a/ui/components/UpscaleDialog.vue
+++ b/ui/components/UpscaleDialog.vue
@@ -1,5 +1,8 @@
 <script setup lang="ts">
+import { onBeforeUnmount, onMounted } from "vue";
+
 type Choice = { name: string; downloaded?: boolean };
+type ExecutionHost = { key: string; label: string };
 
 const props = withDefaults(
   defineProps<{
@@ -8,6 +11,8 @@ const props = withDefaults(
     sourceName: string;
     models?: Choice[];
     modelValue: string;
+    executionHosts?: ExecutionHost[];
+    executionHostValue?: string;
     busy?: boolean;
     jobState?: string | null;
     status?: string | null;
@@ -16,6 +21,8 @@ const props = withDefaults(
   }>(),
   {
     models: () => [],
+    executionHosts: () => [],
+    executionHostValue: "",
     busy: false,
     jobState: null,
     status: null,
@@ -26,12 +33,23 @@ const props = withDefaults(
 
 const emit = defineEmits<{
   "update:modelValue": [value: string];
+  "update:executionHostValue": [value: string];
   confirm: [];
   close: [];
   pause: [];
   resume: [];
   cancel: [];
 }>();
+
+function onKeydown(event: KeyboardEvent) {
+  if (!props.open || event.key !== "Escape") return;
+  event.preventDefault();
+  event.stopImmediatePropagation();
+  emit("close");
+}
+
+onMounted(() => window.addEventListener("keydown", onKeydown));
+onBeforeUnmount(() => window.removeEventListener("keydown", onKeydown));
 </script>
 
 <template>
@@ -82,6 +100,29 @@ const emit = defineEmits<{
             unchanged.
           </template>
         </p>
+
+        <label v-if="executionHosts.length > 1" class="upscale-dialog__field">
+          <span>Run on</span>
+          <select
+            :value="executionHostValue"
+            :disabled="busy || !!jobState"
+            data-test="upscale-host"
+            @change="
+              emit(
+                'update:executionHostValue',
+                ($event.target as HTMLSelectElement).value,
+              )
+            "
+          >
+            <option
+              v-for="host in executionHosts"
+              :key="host.key"
+              :value="host.key"
+            >
+              {{ host.label }}
+            </option>
+          </select>
+        </label>
 
         <label class="upscale-dialog__field">
           <span>Upscaler</span>
@@ -264,6 +305,9 @@ h2 {
   gap: 7px;
   font-size: 13px;
   font-weight: 650;
+}
+.upscale-dialog__field + .upscale-dialog__field {
+  margin-top: 14px;
 }
 select {
   width: 100%;


### PR DESCRIPTION
## Summary
- dismiss the shared image/video upscale dialog with Escape
- retain upscale actions after saving a remote print locally by routing to a capable copy
- show a Run on host selector only when the same logical media exists on multiple upscale-capable hosts
- preserve per-host filenames and routing, including while a host filter is active

## Verification
- `bunx vitest run --config vitest.config.ts src/views/LibraryView.test.ts ../ui/components/UpscaleDialog.test.ts` (31 passed)
- rendered browser UAT: selected a second host and dismissed the dialog with Escape
- independent peer review approved `ba39c5e6` with no findings
- `bun run check:frontend`: Studio 1561/1561 and Web 1765/1765 passed; Desktop changed slice passed, while the aggregate run hit two pre-existing HostDetailView live-fixture flakes unrelated to this diff