### PR TITLE
fix(licenses): dismiss dialog after legacy acceptance

### DIFF
--- a/changelog.d/license-dialog-auto-dismiss.md
+++ b/changelog.d/license-dialog-auto-dismiss.md
@@ -1,0 +1,4 @@
+- **Dismiss license reviews after acceptance.** Mobile, desktop, and web now
+  close an install-triggered license dialog as soon as an older host accepts
+  and queues the model download, instead of showing “Recording…” until the
+  entire transfer finishes.

--- a/studio/api/licenseAcceptance.ts
+++ b/studio/api/licenseAcceptance.ts
@@ -112,6 +112,58 @@ async function cancelDownload(target: ApiTarget, id: string) {
   }
 }
 
+/** Submit exact pinned terms with a download request and return once the host
+ * has accepted the enqueue. Older hosts expose no record-only endpoint, so
+ * this is also their compatibility seam: consent is recorded as a side effect
+ * of the queued pull, but the dialog must not stay open for the whole transfer.
+ */
+async function startAcceptedDownload(
+  target: ApiTarget,
+  requirement: LicenseRequirement,
+  signal?: AbortSignal,
+): Promise<CreateDownloadResponse> {
+  try {
+    const response = await apiFetchTo(target, "/api/downloads", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      ...(signal ? { signal } : {}),
+      body: JSON.stringify({
+        model: requirement.installModel,
+        accept_licenses: requirement.licenses.map(acceptanceFor),
+      }),
+    });
+    return (await response.json()) as CreateDownloadResponse;
+  } catch (error) {
+    if (error instanceof ApiError) {
+      if (
+        error.status === 409 &&
+        typeof error.body === "object" &&
+        error.body !== null &&
+        typeof (error.body as Record<string, unknown>).id === "string"
+      ) {
+        return error.body as unknown as CreateDownloadResponse;
+      }
+      const current = licenseFromErrorBody(error.body);
+      if (current) {
+        throw new ApiError(error.message, error.status, {
+          ...(error.body as object),
+          license: current,
+        });
+      }
+    }
+    throw error;
+  }
+}
+
+/** Accept on a pre-standalone-route host and dismiss once its pull is queued. */
+export async function acceptAndQueueDownload(
+  target: ApiTarget,
+  requirement: LicenseRequirement,
+  signal?: AbortSignal,
+): Promise<void> {
+  await startAcceptedDownload(target, requirement, signal);
+}
+
 /** Accept exact pinned terms on one host, download the owning bundle there,
  * and resolve only when that host reports the job terminal. */
 export async function acceptAndDownload(
@@ -126,41 +178,7 @@ export async function acceptAndDownload(
     bytesDone: 0,
     bytesTotal: 0,
   });
-  let created: CreateDownloadResponse;
-  try {
-    const response = await apiFetchTo(target, "/api/downloads", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      ...(signal ? { signal } : {}),
-      body: JSON.stringify({
-        model: requirement.installModel,
-        accept_licenses: requirement.licenses.map(acceptanceFor),
-      }),
-    });
-    created = (await response.json()) as CreateDownloadResponse;
-  } catch (error) {
-    if (error instanceof ApiError) {
-      if (
-        error.status === 409 &&
-        typeof error.body === "object" &&
-        error.body !== null &&
-        typeof (error.body as Record<string, unknown>).id === "string"
-      ) {
-        created = error.body as unknown as CreateDownloadResponse;
-      } else {
-        const current = licenseFromErrorBody(error.body);
-        if (current) {
-          throw new ApiError(error.message, error.status, {
-            ...(error.body as object),
-            license: current,
-          });
-        }
-        throw error;
-      }
-    } else {
-      throw error;
-    }
-  }
+  const created = await startAcceptedDownload(target, requirement, signal);
   let missingSnapshots = 0;
   try {
     for (;;) {

--- a/studio/composables/useLicenseAcceptance.test.ts
+++ b/studio/composables/useLicenseAcceptance.test.ts
@@ -44,6 +44,58 @@ afterEach(() => {
 });
 
 describe("runWithLicenseConsent", () => {
+  it("dismisses after an older host queues the accepted download", async () => {
+    const fetch = vi.fn(
+      async (input: string | URL | Request, init?: RequestInit) => {
+        const url = String(input);
+        if (url.endsWith("/api/licenses/accept")) {
+          return Response.json({ error: "not found" }, { status: 404 });
+        }
+        if (url.endsWith("/api/downloads") && init?.method === "POST") {
+          return Response.json({ id: "job-legacy", position: 0 });
+        }
+        if (url.endsWith("/api/downloads")) {
+          return Response.json({
+            active_jobs: [],
+            queued: [],
+            history: [
+              {
+                id: "job-legacy",
+                model: "future-face-adapter",
+                status: "completed",
+                bytes_done: 1,
+                bytes_total: 1,
+              },
+            ],
+          });
+        }
+        throw new Error(`unexpected request: ${url}`);
+      },
+    );
+    vi.stubGlobal("fetch", fetch);
+    const start = vi
+      .fn<() => Promise<string>>()
+      .mockRejectedValueOnce(refusal())
+      .mockRejectedValueOnce(refusal());
+
+    const running = runWithLicenseConsent({
+      hostLabel: "legacy-host",
+      target,
+      installModel: "future-face-adapter",
+      start,
+    });
+    await answerPrompt(true);
+
+    await expect(running).resolves.toEqual({ kind: "accepted" });
+    expect(useLicenseAcceptance().pending.value).toBeNull();
+    expect(
+      fetch.mock.calls.filter(
+        ([input, init]) =>
+          String(input).endsWith("/api/downloads") && !init?.method,
+      ),
+    ).toHaveLength(0);
+  });
+
   it("takes consent and re-drives the caller's own enqueue exactly once", async () => {
     vi.stubGlobal(
       "fetch",

--- a/studio/composables/useLicenseAcceptance.ts
+++ b/studio/composables/useLicenseAcceptance.ts
@@ -2,6 +2,7 @@ import { ref } from "vue";
 import { ApiError, type ApiTarget } from "../api/client";
 import {
   acceptAndDownload,
+  acceptAndQueueDownload,
   recordLicenseAcceptances,
   type LicenseDownloadProgress,
 } from "../api/licenseAcceptance";
@@ -102,6 +103,12 @@ export function useLicenseAcceptance() {
               (cause.status === 404 || cause.status === 405);
             if (!missingRoute) throw cause;
             downloaded = true;
+            await acceptAndQueueDownload(
+              prompt.target,
+              requirement,
+              controller.signal,
+            );
+            continue;
           }
         }
         await acceptAndDownload(


### PR DESCRIPTION
## Summary
- Close install-triggered license reviews once an older host accepts and queues the download, rather than leaving the dialog on “Recording…” until the transfer finishes.
- Share the enqueue implementation while preserving explicit review-and-download progress flows.
- Apply the fix through the common studio acceptance flow used by mobile, desktop, and web.

## Regression coverage
- Added a legacy-host fallback regression that asserts the dialog state clears without polling downloads to completion.
- Verified the new regression fails before the implementation and passes afterward.

## Validation
- [x] Studio: 1,567 tests passed
- [x] Web: 1,765 tests passed and production build passed
- [x] Desktop: 5,607 tests passed and production build passed
- [x] Mobile production build passed
- [x] Architecture, formatting, dead-code, diff, and changelog checks passed
- [x] Independent agent peer review of commit 4cbc21b610f54db5eebd8e4c63335a28d6d84c3e: no findings

## Limitations
Rendered browser and iOS UAT were not performed: browser-control tooling was unavailable and no iOS simulator was booted. The reproduced legacy-host fallback matches the reported “Recording…” symptom; the affected live host was not inspected.