### PR TITLE
fix(mobile): rotating a mesh no longer swipes the gallery

### DIFF
--- a/changelog.d/mobile-mesh-rotate-swipe.md
+++ b/changelog.d/mobile-mesh-rotate-swipe.md
@@ -1,0 +1,4 @@
+- **Rotating a 3D model on iPhone no longer swipes the gallery.** Dragging a mesh
+  to orbit it also armed the viewer's horizontal swipe, so turning a model
+  navigated to the next or previous print instead. A surface that reads drags
+  itself now marks itself `data-gesture="own"` and the gallery leaves it alone.

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -824,6 +824,43 @@ describe("MobileGalleryViewer", () => {
     expect(view.emitted("next")).toHaveLength(1);
   });
 
+  /// Dragging a mesh is how you ROTATE it. The stage arms its swipe on
+  /// `pointerdown.capture`, so it fires before the mesh viewer's own handler
+  /// and a child cannot stop it — orbiting a model sideways navigated the
+  /// gallery out from under the user instead of turning the model.
+  it("rotates a mesh without navigating the gallery", async () => {
+    const meshItem: GalleryImage = {
+      ...image,
+      filename: "chair.glb",
+      format: "glb",
+    };
+    const view = mountViewer(meshItem, { position: 2, total: 4 });
+    await flushPromises();
+    const mesh = view.get("[data-test='gallery-viewer-mesh']");
+
+    // A long horizontal drag that starts on the mesh: far past SWIPE_DISTANCE
+    // and unambiguously horizontal, so nothing but the origin can save it.
+    // Dispatch ON the mesh, as a finger on the model does: the stage still
+    // sees it, because its listener is registered for the capture phase.
+    await mesh.trigger("pointerdown", {
+      pointerId: 21,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 300,
+      clientY: 200,
+    });
+    await mesh.trigger("pointerup", {
+      pointerId: 21,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 90,
+      clientY: 204,
+    });
+
+    expect(view.emitted("next")).toBeUndefined();
+    expect(view.emitted("previous")).toBeUndefined();
+  });
+
   it("navigates horizontally with swipe gestures and ignores vertical drags", async () => {
     const view = mountViewer(image, { position: 2, total: 4 });
     await flushPromises();

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -414,7 +414,15 @@ function isMediaControl(target: EventTarget | null): boolean {
 function isSwipeBlockingControl(target: EventTarget | null): boolean {
   return (
     target instanceof Element &&
-    !!target.closest("button, input, textarea, select, a, [contenteditable='true']")
+    !!target.closest(
+      // `[data-gesture='own']` is the generic opt-out for a surface that
+      // interprets drags itself. The stage arms its swipe on
+      // `pointerdown.capture`, so it runs BEFORE any child handler and a
+      // child cannot stop it — dragging a mesh to rotate it navigated the
+      // gallery instead of turning the model. Any future canvas that owns
+      // its own drag (a pannable map, a curve editor) opts out the same way.
+      "button, input, textarea, select, a, [contenteditable='true'], [data-gesture='own']",
+    )
   );
 }
 

--- a/studio/components/MeshViewer.vue
+++ b/studio/components/MeshViewer.vue
@@ -718,10 +718,15 @@ function onKeydown(event: KeyboardEvent): void {
 </script>
 
 <template>
+  <!-- `data-gesture="own"`: this surface reads drags as camera orbit, so an
+       ancestor must not also read them as a swipe. It pairs with
+       `touch-action: none` below, which only stops the BROWSER's own panning
+       and never a JavaScript pointer handler on a parent. -->
   <div
     ref="root"
     class="mesh-viewer"
     data-test="mesh-viewer"
+    data-gesture="own"
     :data-status="status"
   >
     <img


### PR DESCRIPTION
## The bug

Dragging a 3D model on iPhone to rotate it also navigated to the next or previous print, so a model could not be turned sideways at all.

## Cause

The gallery stage arms its swipe on `@pointerdown.capture` (`MobileGalleryViewer.vue`), which runs **before** any child handler — so the mesh viewer could not stop it with `stopPropagation`, and its `touch-action: none` only suppresses the browser's own panning, never a JavaScript pointer handler on an ancestor.

The stage's swipe-blocking selector listed `button, input, textarea, select, a, [contenteditable]`. A `<canvas>` matched none of them, so every orbit drag past 48px was read as a swipe.

## Fix

Rather than special-casing the mesh viewer inside the gallery, a surface that interprets drags itself now declares `data-gesture="own"`, and the stage's existing predicate honours it. Any future canvas that owns its drags — a pannable map, a curve editor — opts out the same way, with no further gallery changes.

## Test

The regression test drives the pointer sequence **on the mesh element**, as a finger on the model does, and asserts neither `next` nor `previous` is emitted. Verified to fail before the fix and pass after.

## Verification

studio 1566 · desktop mobile+gallery 1067 · web/desktop/mobile builds · all five prettier gates · architecture · knip — all clean.