### PR TITLE
fix(tui): name a restored source image after the print's recorded file

### DIFF
--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -2317,6 +2317,12 @@ pub enum Popup {
     SourceImageInput {
         input: String,
         error: Option<String>,
+        /// The pre-filled path is selected as a whole when the picker
+        /// opens on a row that already has a file: the first typed
+        /// character or Backspace replaces it (typing a new path over a
+        /// restored one must not append to it), Enter keeps it. Cleared
+        /// by the first edit; the renderer shows it reversed.
+        selected: bool,
     },
     /// One File-under editor (Title, Tags, or Collection). Invalid input
     /// stays visible and never reaches a generation request.
@@ -4618,7 +4624,11 @@ impl App {
                     }
                     _ => {}
                 },
-                Some(Popup::SourceImageInput { input, error }) => match key.code {
+                Some(Popup::SourceImageInput {
+                    input,
+                    error,
+                    selected,
+                }) => match key.code {
                     KeyCode::Esc => self.close_popup(),
                     KeyCode::Enter => {
                         // An emptied field clears the source: the way back
@@ -4637,6 +4647,18 @@ impl App {
                                 Err(message) => *error = Some(message),
                             }
                         }
+                    }
+                    // A selected pre-fill is replaced by the first edit.
+                    KeyCode::Char(c) if *selected => {
+                        input.clear();
+                        input.push(c);
+                        *selected = false;
+                        *error = None;
+                    }
+                    KeyCode::Backspace if *selected => {
+                        input.clear();
+                        *selected = false;
+                        *error = None;
                     }
                     KeyCode::Char(c)
                         if input.len() + c.len_utf8()
@@ -6714,10 +6736,16 @@ impl App {
                 let filename = entry.filename();
                 self.generate.source_restore_pending = Some(filename.clone());
                 let host_id = origin.host_id.clone();
+                let recorded_name = name.to_string();
                 let tx = self.bg_tx.clone();
                 self.tokio_handle.spawn(async move {
-                    let outcome =
-                        crate::source_media::restore_source_image(&url, &host_id, &filename).await;
+                    let outcome = crate::source_media::restore_source_image(
+                        &url,
+                        &host_id,
+                        &filename,
+                        Some(&recorded_name),
+                    )
+                    .await;
                     let _ = tx.send(BackgroundEvent::SourceImageRestored { filename, outcome });
                 });
             }
@@ -7437,7 +7465,12 @@ impl App {
                     .source_image_path
                     .clone()
                     .unwrap_or_default();
-                self.popup = Some(Popup::SourceImageInput { input, error: None });
+                let selected = !input.is_empty();
+                self.popup = Some(Popup::SourceImageInput {
+                    input,
+                    error: None,
+                    selected,
+                });
             }
             // File under — three validated one-line editors.
             ParamField::Title | ParamField::Tags | ParamField::Collection => {
@@ -16032,7 +16065,7 @@ mod tests {
 
         app.handle_crossterm_event(key(KeyCode::Enter));
         assert!(
-            matches!(&app.popup, Some(Popup::SourceImageInput { input, error: None }) if input.is_empty()),
+            matches!(&app.popup, Some(Popup::SourceImageInput { input, error: None, .. }) if input.is_empty()),
             "Enter on the Source row opens the picker, got {}",
             app.popup.is_some()
         );
@@ -16352,7 +16385,11 @@ mod tests {
                 "availability": "available",
                 "members": [
                     {"member_id": "mask-1", "role": "mask_image", "display_name": "mask.png", "size_bytes": 3},
-                    {"member_id": "src-1", "role": "source_image", "display_name": "armchair.png", "size_bytes": 8}
+                    // The host's display name is `<role>-<n>` whenever the
+                    // pin kept no usable file name; the print's own recorded
+                    // name must win over it (the live UAT saw
+                    // `source_image-1` on the row).
+                    {"member_id": "src-1", "role": "source_image", "display_name": "source_image-1", "size_bytes": 8}
                 ]
             })))
             .expect(1)
@@ -16366,6 +16403,7 @@ mod tests {
             .await;
 
         let mut app = app_with_remote_print(&server.uri());
+        app.gallery.entries[0].metadata.source_image_name = Some("armchair-cutout.png".into());
         app.load_gallery_into_generate();
         assert_eq!(app.active_view, View::Create);
         assert_eq!(
@@ -16375,13 +16413,17 @@ mod tests {
         );
         assert_eq!(
             app.generate.params.source_image_recall.as_deref(),
-            Some("armchair.png"),
+            Some("armchair-cutout.png"),
             "until the host answers, the row says attach again"
         );
         settle_source_restore(&mut app).await;
 
-        let expected = crate::source_media::cache_path("chair.glb", "armchair.png");
+        let expected = crate::source_media::cache_path("chair.glb", "armchair-cutout.png");
         assert!(expected.starts_with(home.dir.path()), "{expected:?}");
+        assert!(
+            expected.ends_with("chair.glb/armchair-cutout.png"),
+            "the cached file carries the print's recorded name, got {expected:?}"
+        );
         assert_eq!(
             app.generate.params.source_image_path.as_deref(),
             Some(expected.to_string_lossy().as_ref())
@@ -16390,13 +16432,99 @@ mod tests {
         assert_eq!(app.generate.params.source_image_recall, None);
         assert_eq!(
             app.generate.params.display_value(&ParamField::SourceImage),
-            "armchair.png"
+            "armchair-cutout.png",
+            "the Source row shows the recorded name, never the member id"
         );
-        assert!(timeline_has(&app, "Restored source image armchair.png"));
+        assert!(timeline_has(
+            &app,
+            "Restored source image armchair-cutout.png"
+        ));
         // The restored file rides the request as bytes like any picked path.
         let request = crate::backend::build_request(&app.generate.params, "", &None).unwrap();
         assert_eq!(request.source_image.as_deref(), Some(&b"png-bytes"[..]));
-        assert_eq!(request.source_image_name.as_deref(), Some("armchair.png"));
+        assert_eq!(
+            request.source_image_name.as_deref(),
+            Some("armchair-cutout.png")
+        );
+
+        // Reopening the picker on the restored file pre-selects its path, so
+        // a new path typed over it replaces rather than extends it.
+        select_source_row(&mut app);
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        assert!(matches!(
+            &app.popup,
+            Some(Popup::SourceImageInput { input, selected: true, .. })
+                if input == &expected.to_string_lossy().to_string()
+        ));
+        type_text(&mut app, "/nope/missing.png");
+        assert!(
+            matches!(&app.popup, Some(Popup::SourceImageInput { input, selected: false, .. }) if input == "/nope/missing.png"),
+            "typing replaces the pre-selected path, got {:?}",
+            app.popup.as_ref().map(|_| ())
+        );
+        app.handle_crossterm_event(key(KeyCode::Esc));
+    }
+
+    /// Enter on a Source row that already has a file opens the picker with
+    /// that path pre-selected: the first typed character or Backspace
+    /// replaces the whole text, Enter keeps it as-is.
+    #[tokio::test]
+    async fn source_picker_preselects_the_current_path_so_typing_replaces_it() {
+        let mut app = make_settings_test_app();
+        app.models.catalog = mold_core::build_model_catalog(&app.config, None, false);
+        app.generate.params.model = mold_core::manifest::HUNYUAN3D_DEFAULT_MODEL.to_string();
+        app.sync_generate_capabilities();
+        assert!(app.generate.capabilities.supports_source_image);
+        select_source_row(&mut app);
+        let dir = tempfile::tempdir().unwrap();
+        let cat = dir.path().join("cat.png");
+        std::fs::write(&cat, IDENTITY_TEST_PNG).unwrap();
+        let cat_path = cat.to_string_lossy().to_string();
+
+        // Empty field: nothing to select.
+        assert_eq!(app.generate.params.source_image_path, None);
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        assert!(matches!(
+            &app.popup,
+            Some(Popup::SourceImageInput {
+                selected: false,
+                ..
+            })
+        ));
+        app.handle_crossterm_event(key(KeyCode::Esc));
+
+        // Pre-filled field: selected, and Enter accepts it unchanged.
+        app.generate.params.source_image_path = Some(cat_path.clone());
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        assert!(matches!(
+            &app.popup,
+            Some(Popup::SourceImageInput { input, selected: true, .. }) if input == &cat_path
+        ));
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        assert!(app.popup.is_none());
+        assert_eq!(
+            app.generate.params.source_image_path.as_deref(),
+            Some(cat_path.as_str())
+        );
+
+        // Typing replaces the selection instead of appending to it.
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        type_text(&mut app, "/nowhere/dog.png");
+        assert!(
+            matches!(&app.popup, Some(Popup::SourceImageInput { input, selected: false, .. }) if input == "/nowhere/dog.png")
+        );
+        app.handle_crossterm_event(key(KeyCode::Esc));
+
+        // Backspace on a selection empties the field in one stroke; Enter on
+        // the emptied field then clears the source.
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        app.handle_crossterm_event(key(KeyCode::Backspace));
+        assert!(
+            matches!(&app.popup, Some(Popup::SourceImageInput { input, selected: false, .. }) if input.is_empty())
+        );
+        app.handle_crossterm_event(key(KeyCode::Enter));
+        assert!(app.popup.is_none());
+        assert_eq!(app.generate.params.source_image_path, None);
     }
 
     /// An older print the host never retained keeps the attach-again marker

--- a/crates/mold-tui/src/source_media.rs
+++ b/crates/mold-tui/src/source_media.rs
@@ -11,7 +11,7 @@
 
 use std::path::{Path, PathBuf};
 
-use mold_core::RetainedSourceMediaAvailability;
+use mold_core::{RetainedSourceMediaAvailability, RetainedSourceMediaMember};
 
 /// The member role the Source row restores. Other roles (masks, identity
 /// photos, keyframes, audio) have no row to land on in the TUI.
@@ -55,11 +55,10 @@ pub(crate) fn cache_dir() -> PathBuf {
         .join("source-media")
 }
 
-/// Where a restored member lands: `<cache>/<print filename>/<display name>`,
-/// so two prints conditioned on files of the same name never collide and
-/// the file keeps the name the row shows. Both segments are reduced to a
-/// plain file name first; the host's display name is already sanitized, and
-/// this makes sure of it locally.
+/// Where a restored member lands: `<cache>/<print filename>/<file name>`
+/// (the file name from [`restored_file_name`]), so two prints conditioned
+/// on files of the same name never collide and the file keeps the name the
+/// row shows. Both segments are reduced to a plain file name first.
 pub(crate) fn cache_path(print_filename: &str, display_name: &str) -> PathBuf {
     cache_dir()
         .join(file_name_only(print_filename))
@@ -67,6 +66,13 @@ pub(crate) fn cache_path(print_filename: &str, display_name: &str) -> PathBuf {
 }
 
 fn file_name_only(name: &str) -> String {
+    safe_file_name(name).unwrap_or_else(|| "member".to_string())
+}
+
+/// Reduce `name` to one plain file-name segment: the last path component,
+/// with separators and control characters replaced. `None` when nothing
+/// usable is left (empty, `.`, `..`, whitespace only).
+fn safe_file_name(name: &str) -> Option<String> {
     let base = Path::new(name)
         .file_name()
         .map(|part| part.to_string_lossy().to_string())
@@ -81,19 +87,55 @@ fn file_name_only(name: &str) -> String {
             }
         })
         .collect();
-    if cleaned.is_empty() || cleaned == "." || cleaned == ".." {
-        "member".to_string()
+    if cleaned.trim().is_empty() || cleaned == "." || cleaned == ".." {
+        None
     } else {
-        cleaned
+        Some(cleaned)
     }
 }
 
+/// The file name a restored source image is cached under and shown as on
+/// the Source row.
+///
+/// The print's recorded name (`OutputMetadata.source_image_name`, the name
+/// the reuse already shows as "attach again") comes first: it is the name
+/// the user attached. The host's `display_name` is only a fallback because
+/// it degrades to `<role>-<n>` (`source_image-1`) whenever the pin kept no
+/// usable name, and the opaque member id is the last resort. A recorded
+/// name without an extension borrows the member's, so the file still opens
+/// by type. Every candidate is reduced to a safe file name, and one that
+/// reduces to nothing falls through to the next.
+pub(crate) fn restored_file_name(
+    recorded_name: Option<&str>,
+    member: &RetainedSourceMediaMember,
+) -> String {
+    let display = safe_file_name(&member.display_name);
+    if let Some(recorded) = recorded_name.and_then(safe_file_name) {
+        if Path::new(&recorded).extension().is_some() {
+            return recorded;
+        }
+        return match display
+            .as_deref()
+            .and_then(|name| Path::new(name).extension())
+            .and_then(|ext| ext.to_str())
+        {
+            Some(ext) => format!("{recorded}.{ext}"),
+            None => recorded,
+        };
+    }
+    display
+        .or_else(|| safe_file_name(&member.member_id))
+        .unwrap_or_else(|| "member".to_string())
+}
+
 /// Ask `server_url` what it retained for `print_filename` and bring the
-/// source image back into the cache.
+/// source image back into the cache, named by [`restored_file_name`] from
+/// the print's `recorded_name`.
 pub(crate) async fn restore_source_image(
     server_url: &str,
     host_id: &str,
     print_filename: &str,
+    recorded_name: Option<&str>,
 ) -> SourceRestore {
     let api_key = crate::hosts::api_key_for(host_id);
     let client = crate::hosts::client_for(server_url, api_key.as_deref());
@@ -118,7 +160,7 @@ pub(crate) async fn restore_source_image(
         Ok(bytes) => bytes,
         Err(error) => return SourceRestore::Failed(error.to_string()),
     };
-    let target = cache_path(print_filename, &member.display_name);
+    let target = cache_path(print_filename, &restored_file_name(recorded_name, member));
     let write = async {
         if let Some(parent) = target.parent() {
             tokio::fs::create_dir_all(parent).await?;
@@ -147,6 +189,77 @@ mod tests {
         assert!(hostile.ends_with("source-media/etc/x.png"), "{hostile:?}");
         let empty = cache_path("", "..");
         assert!(empty.ends_with("source-media/member/member"), "{empty:?}");
+    }
+
+    fn member(id: &str, display_name: &str) -> RetainedSourceMediaMember {
+        RetainedSourceMediaMember {
+            member_id: id.into(),
+            role: SOURCE_IMAGE_ROLE.into(),
+            display_name: display_name.into(),
+            size_bytes: 8,
+        }
+    }
+
+    /// The print's recorded file name wins; the host's display name is the
+    /// fallback (it is `<role>-<n>` whenever the pin kept no usable name),
+    /// and the opaque id is the last resort.
+    #[test]
+    fn restored_file_name_prefers_the_recorded_name_then_display_then_id() {
+        assert_eq!(
+            restored_file_name(
+                Some("armchair-cutout.png"),
+                &member("src-1", "source_image-1")
+            ),
+            "armchair-cutout.png"
+        );
+        assert_eq!(
+            restored_file_name(None, &member("src-1", "chair.webp")),
+            "chair.webp"
+        );
+        assert_eq!(restored_file_name(None, &member("src-1", "")), "src-1");
+        assert_eq!(
+            restored_file_name(Some("  "), &member("src-1", "   ")),
+            "src-1"
+        );
+        // A recorded name without an extension borrows the member's.
+        assert_eq!(
+            restored_file_name(Some("armchair"), &member("src-1", "source_image-1.png")),
+            "armchair.png"
+        );
+        assert_eq!(
+            restored_file_name(Some("armchair"), &member("src-1", "source_image-1")),
+            "armchair"
+        );
+    }
+
+    /// Whatever name wins, it is reduced to one plain file-name segment.
+    #[test]
+    fn restored_file_name_is_reduced_to_a_safe_file_name() {
+        assert_eq!(
+            restored_file_name(Some("../../etc/passwd\\x.png"), &member("src-1", "a.png")),
+            "passwd_x.png"
+        );
+        // A candidate that reduces to nothing falls through to the next.
+        assert_eq!(
+            restored_file_name(Some(".."), &member("src-1", "chair.png")),
+            "chair.png"
+        );
+        assert_eq!(
+            restored_file_name(Some("evil\nname.png"), &member("src-1", "a.png")),
+            "evil_name.png"
+        );
+        assert_eq!(restored_file_name(None, &member("../id", "../..")), "id");
+        let path = cache_path(
+            "chair.glb",
+            &restored_file_name(
+                Some("/tmp/armchair-cutout.png"),
+                &member("src-1", "source_image-1"),
+            ),
+        );
+        assert!(
+            path.ends_with("source-media/chair.glb/armchair-cutout.png"),
+            "{path:?}"
+        );
     }
 
     #[test]

--- a/crates/mold-tui/src/ui/popup.rs
+++ b/crates/mold-tui/src/ui/popup.rs
@@ -723,13 +723,19 @@ fn render_identity_image_input(frame: &mut Frame, app: &mut App) {
          Checked before it is accepted.",
         input,
         error.as_deref(),
+        false,
     );
 }
 
 /// The Source row's picker: same shape as the identity one, because both
 /// are "one local file path, checked before it is accepted".
 fn render_source_image_input(frame: &mut Frame, app: &mut App) {
-    let Some(Popup::SourceImageInput { input, error }) = &app.popup else {
+    let Some(Popup::SourceImageInput {
+        input,
+        error,
+        selected,
+    }) = &app.popup
+    else {
         return;
     };
     render_path_input(
@@ -740,9 +746,12 @@ fn render_source_image_input(frame: &mut Frame, app: &mut App) {
          Checked before it is accepted.",
         input,
         error.as_deref(),
+        *selected,
     );
 }
 
+/// One-line path editor. `selected` draws the whole text reversed: the
+/// pre-fill is selected as a block, and typing replaces it.
 fn render_path_input(
     frame: &mut Frame,
     theme: &crate::ui::theme::Theme,
@@ -750,6 +759,7 @@ fn render_path_input(
     hint: &str,
     input: &str,
     error: Option<&str>,
+    selected: bool,
 ) {
     let area = centered_rect(frame.area(), 72, 24);
     frame.render_widget(Clear, area);
@@ -770,9 +780,21 @@ fn render_path_input(
             .wrap(Wrap { trim: true }),
         Rect { height: 2, ..inner },
     );
+    let text_style = Style::default().fg(theme.text);
+    let input_line = if selected {
+        Line::from(vec![
+            Span::styled(
+                input.to_string(),
+                text_style.add_modifier(Modifier::REVERSED),
+            ),
+            Span::styled("\u{2588}", text_style),
+        ])
+    } else {
+        Line::from(Span::styled(format!("{input}\u{2588}"), text_style))
+    };
     frame.render_widget(
-        Paragraph::new(format!("{input}\u{2588}"))
-            .style(Style::default().fg(theme.text))
+        Paragraph::new(input_line)
+            .style(text_style)
             .wrap(Wrap { trim: false }),
         Rect {
             y: inner.y + 3,


### PR DESCRIPTION
## What

Two small TUI fixes found by the live Hunyuan3D acceptance pass on main (evidence under `output/verification/hunyuan3d/20260901T222500Z-tui-uat-main/`).

1. **Restored source image name.** After Library `e` (Reuse settings) on a remote mesh print, `source_media::restore_source_image` cached the retained `source_image` member under the host's member `display_name`. The server's `safe_display_name` degrades to `<role>-<n>` (`source_image-1`) whenever the pinned entry kept no usable file name, so the Source row and its header read `source_image-1` while the timeline correctly said "Restored source image armchair-cutout.png from the print's host". The bytes were right; only the name was wrong.

   The cached file is now named by a new `source_media::restored_file_name`, with this precedence: the print's recorded `OutputMetadata.source_image_name` (the same name the reuse path already shows as the recall / "attach again" marker; borrows the member's extension when the recorded name has none) → the member's display name → the member id. Every candidate is reduced to a safe single file-name segment (last path component, separators and control characters replaced), and a candidate that reduces to nothing falls through to the next. The row shows that name via the existing `file_name_of(path)`.

2. **Source path picker pre-selection.** The UAT typed a new path into the picker that opened on the restored file and got `…/armchair-cutout.png/nope/missing.png`, because the popup appended to the pre-fill. `Popup::SourceImageInput` now carries `selected: bool`, set when the picker opens on a non-empty path. The text input has no cursor/selection concept, so the chosen behaviour is: the first typed character or Backspace replaces the whole pre-filled text and clears the selection; Enter keeps the pre-fill unchanged; the renderer draws the selected text with `Modifier::REVERSED` so it reads as a block selection. The Identity photo picker shares the renderer and passes `selected: false` (unchanged behaviour, out of scope here).

## Tests (written first)

- `source_media::tests::restored_file_name_prefers_the_recorded_name_then_display_then_id` — precedence, extension borrowing, blank candidates.
- `source_media::tests::restored_file_name_is_reduced_to_a_safe_file_name` — traversal, backslash, control characters, `..` fall-through, and the resulting `cache_path`.
- `app::tests::reuse_restores_the_retained_source_image_from_the_host` — the mocked host now answers `display_name: "source_image-1"` for a print that recorded `armchair-cutout.png`; asserts the cached path, the Source row label, the timeline line, and the outgoing request's `source_image_name` all say `armchair-cutout.png`, and that reopening the picker pre-selects the restored path so typing replaces it.
- `app::tests::source_picker_preselects_the_current_path_so_typing_replaces_it` — empty field is not selected; pre-fill is selected and Enter keeps it; typing replaces; Backspace empties in one stroke and Enter then clears the source.

## Gates

- `cargo fmt --all -- --check`
- `cargo clippy -p mold-ai-tui --all-targets -- -D warnings`
- `cargo test -p mold-ai-tui -- restored_file_name picker reuse_ cache_path source_row` (19 passed)

Corrects unreleased behaviour, so `skip-changelog`.
