### PR TITLE
fix(desktop): hide the canvas in the Create summary for a canvasless recipe

### DIFF
--- a/desktop/src/components/create/CreateHeader.test.ts
+++ b/desktop/src/components/create/CreateHeader.test.ts
@@ -62,6 +62,90 @@ describe("CreateHeader", () => {
     expect(wrapper.get(".ms-header__summary").text()).toBe("1:1 · 1024×1024 · 4 steps");
   });
 
+  it("omits the aspect and canvas for a canvasless (3-D mesh) recipe, showing octree instead", () => {
+    // A Hunyuan3D recipe renders no pixel canvas: width/height sit at the
+    // recipe's zero default (they describe a poster, not a canvas), so the
+    // old `${aspect} · ${width}×${height} · ${steps} steps` summary read
+    // "1:1 · 0×0 · 5 steps" — nonsense for a mesh. The snapshot's
+    // `canvasless` flag (mirroring the form's own source-of-truth) swaps in
+    // the octree resolution instead.
+    readyLocal();
+    const meshForm = form();
+    meshForm.family = "hunyuan3d";
+    meshForm.width = 0;
+    meshForm.height = 0;
+    meshForm.steps = 5;
+    meshForm.recipeCapabilities = {
+      outputFormats: ["glb"],
+      defaultOutputFormat: "glb",
+      promptMode: "ignored",
+      supportsStrength: false,
+      canvasless: true,
+      mesh: {
+        octree_resolutions: [128, 192, 256, 320, 384],
+        octree_default: 256,
+        threshold: { default: 0.6, min: 0.0, max: 1.0, step: 0.01, mode: "adjustable" },
+        target_faces_min: 100,
+        target_faces_max: 2_000_000,
+        texture: { mode: "hidden", required: false, reason: "not available" },
+      },
+    };
+    const wrapper = mount(CreateHeader, { props: { form: meshForm } });
+    const text = wrapper.get(".ms-header__summary").text();
+    expect(text).not.toContain("0×0");
+    expect(text).not.toContain("1:1");
+    expect(text).toBe("octree 256 · 5 steps");
+  });
+
+  it("uses the form's explicit octree override, not the recipe default, in the mesh summary", () => {
+    readyLocal();
+    const meshForm = form();
+    meshForm.family = "hunyuan3d";
+    meshForm.width = 0;
+    meshForm.height = 0;
+    meshForm.steps = 5;
+    meshForm.mesh.octreeResolution = 192;
+    meshForm.recipeCapabilities = {
+      outputFormats: ["glb"],
+      defaultOutputFormat: "glb",
+      promptMode: "ignored",
+      supportsStrength: false,
+      canvasless: true,
+      mesh: {
+        octree_resolutions: [128, 192, 256, 320, 384],
+        octree_default: 256,
+        threshold: { default: 0.6, min: 0.0, max: 1.0, step: 0.01, mode: "adjustable" },
+        target_faces_min: 100,
+        target_faces_max: 2_000_000,
+        texture: { mode: "hidden", required: false, reason: "not available" },
+      },
+    };
+    const wrapper = mount(CreateHeader, { props: { form: meshForm } });
+    expect(wrapper.get(".ms-header__summary").text()).toBe("octree 192 · 5 steps");
+  });
+
+  it("keeps the aspect and canvas summary unchanged for an ordinary (non-mesh) recipe", () => {
+    // Regression guard: an SDXL-style recipe with no recipeCapabilities
+    // snapshot (or one with canvasless: false) must still summarize as
+    // aspect · dimensions · steps.
+    readyLocal();
+    const sdxlForm = form();
+    sdxlForm.family = "sdxl";
+    sdxlForm.width = 1024;
+    sdxlForm.height = 1024;
+    sdxlForm.steps = 30;
+    sdxlForm.recipeCapabilities = {
+      outputFormats: ["png"],
+      defaultOutputFormat: "png",
+      promptMode: "required",
+      supportsStrength: false,
+      canvasless: false,
+      mesh: null,
+    };
+    const wrapper = mount(CreateHeader, { props: { form: sdxlForm } });
+    expect(wrapper.get(".ms-header__summary").text()).toBe("1:1 · 1024×1024 · 30 steps");
+  });
+
   it("titles a sequence draft and summarizes clips + fps instead of steps", () => {
     readyLocal();
     const draft = useSequenceDraftStore();

--- a/desktop/src/components/create/CreateHeader.vue
+++ b/desktop/src/components/create/CreateHeader.vue
@@ -5,6 +5,7 @@ import { useSequenceDraftStore } from "@studio/stores/sequenceDraft";
 import { validatePrintTitle } from "@studio/lib/libraryOrganization";
 import type { GenerateForm } from "../../lib/generateForm";
 import { outputFamilyLabel } from "@studio/lib/outputShape";
+import { isMeshFamily } from "@studio/lib/legacyRecipeRules";
 import HostChip from "./HostChip.vue";
 
 /**
@@ -69,10 +70,22 @@ function onBlur() {
 
 const summary = computed(() => {
   const { width, height, steps } = props.form;
-  const aspect = outputFamilyLabel(width, height);
   if (isSequence.value) {
+    const aspect = outputFamilyLabel(width, height);
     return `${aspect} · ${width}×${height} · ${draft.clips.length} clips · ${props.form.fps} fps`;
   }
+  // A canvasless recipe (a 3-D mesh) has no aspect or pixel canvas — its
+  // width/height default to 0×0, so the ordinary summary read nonsense like
+  // "1:1 · 0×0 · 5 steps". Show its octree resolution instead, using the
+  // same canvasless predicate the rest of the form relies on (recipe
+  // snapshot first, family fallback for a form restored pre-snapshot).
+  const canvasless = props.form.recipeCapabilities?.canvasless ?? isMeshFamily(props.form.family);
+  if (canvasless) {
+    const octree =
+      props.form.mesh?.octreeResolution ?? props.form.recipeCapabilities?.mesh?.octree_default;
+    return octree != null ? `octree ${octree} · ${steps} steps` : `${steps} steps`;
+  }
+  const aspect = outputFamilyLabel(width, height);
   return `${aspect} · ${width}×${height} · ${steps} steps`;
 });
 </script>


### PR DESCRIPTION
## What

The Create header's summary pill (`desktop/src/components/create/CreateHeader.vue`) built `${aspect} · ${width}×${height} · ${steps} steps` unconditionally. A canvasless recipe (a 3-D mesh, e.g. Hunyuan3D) has no pixel canvas — its width/height sit at the recipe's zero default — so the summary read nonsense like `1:1 · 0×0 · 5 steps`.

## Why

Seen in a live desktop acceptance pass with a Hunyuan3D model selected.

## Fix

The `summary` computed now checks the same canvasless predicate the rest of the form already relies on (`form.recipeCapabilities?.canvasless ?? isMeshFamily(form.family)`). When canvasless, it omits the aspect/canvas segment and shows the mesh's octree resolution instead (form override if set, else the recipe's `mesh.octree_default`), e.g. `octree 256 · 5 steps`. Non-mesh recipes are unaffected.

## Tests (`desktop/src/components/create/CreateHeader.test.ts`)

- `omits the aspect and canvas for a canvasless (3-D mesh) recipe, showing octree instead`
- `uses the form's explicit octree override, not the recipe default, in the mesh summary`
- `keeps the aspect and canvas summary unchanged for an ordinary (non-mesh) recipe`

## Gates run

- `cd desktop && bunx vue-tsc -b` — clean
- `bun run test:desktop` — 454 files / 5873 tests pass
- `cd desktop && bunx prettier --check . ../ui ../studio` — clean
- `bun run check:dead-code` — clean

https://claude.ai/code/session_01HdWxHWD91PBJEx4xyvfEt4