### PR TITLE
fix(desktop): read the whole model contract from the host that has the checkpoint

### DIFF
--- a/desktop/src/components/create/AdvancedSettings.vue
+++ b/desktop/src/components/create/AdvancedSettings.vue
@@ -114,7 +114,16 @@ const props = withDefaults(
   defineProps<{
     form: GenerateForm;
     routingRequest?: Partial<GenerateRoutingRequest> | null | undefined;
-    /** The picked model, used by Reset to restore its defaults. */
+    /**
+     * The row that answers for the CHECKPOINT'S CONTRACT — its advertised
+     * recipe drives every control below, and Reset restores its defaults.
+     *
+     * The parent resolves it from whichever machine has the checkpoint, not
+     * only from the one Create is aimed at: a contract belongs to the
+     * checkpoint and the target will advertise the same one once it has
+     * downloaded it. `null` means no machine has it, and the family rules in
+     * `generationCapabilitiesForFamily` answer instead.
+     */
     selectedModel?: ModelEntry | null;
     upscalers?: ModelEntry[];
     controlAdapters?: Ltx2ControlAdapterInfo[];

--- a/desktop/src/components/create/InspectorPanel.mesh.test.ts
+++ b/desktop/src/components/create/InspectorPanel.mesh.test.ts
@@ -103,8 +103,49 @@ function mountForTargetWithoutModel(model: ModelEntry) {
   form.model = model.name;
   form.family = model.family;
   applyModelDefaults(form, model);
+  // The strength slider and the mask well both render only once a source is
+  // attached, which is exactly the state a Hunyuan3D print is generated in.
+  form.sourceImage = "c291cmNl";
+  form.sourceImageName = "armchair-cutout.png";
   const wrapper = mount(InspectorPanel, { props: { form } });
   return { form, wrapper };
+}
+
+/** The same two machines, with Create aimed at the one that HAS the model. */
+function mountForTargetWithModel(model: ModelEntry) {
+  useModelStore().all = [];
+  readyHost("halcyon", "halcyon");
+  readyHost("plato", "plato");
+  const hostModels = useHostModelsStore();
+  hostModels.byHost.halcyon = { entries: [model], fetchedAt: Date.now(), error: null };
+  hostModels.byHost.plato = { entries: [], fetchedAt: Date.now(), error: null };
+  useAppPrefsStore().settings = { generateTargetHost: "halcyon" } as never;
+
+  const form = reactive(newGenerateForm()) as GenerateForm;
+  form.model = model.name;
+  form.family = model.family;
+  applyModelDefaults(form, model);
+  form.sourceImage = "c291cmNl";
+  form.sourceImageName = "armchair-cutout.png";
+  const wrapper = mount(InspectorPanel, { props: { form } });
+  return { form, wrapper };
+}
+
+/** What the panel offers for the print, as the four leaking controls show it. */
+async function panelContract(wrapper: ReturnType<typeof mount>) {
+  await wrapper.get("[data-test='open-advanced']").trigger("click");
+  await flushPromises();
+  const formatControl = wrapper
+    .findAllComponents({ name: "SegmentedControl" })
+    .find((row) => row.props("label") === "File format");
+  return {
+    strength: wrapper.text().includes("Denoise strength"),
+    mask: wrapper.find("[data-test='source-edit-mask']").exists(),
+    negative: wrapper.find("[data-test='section-negative']").exists(),
+    formats: (formatControl?.props("options") as { value: string }[] | undefined)?.map(
+      (option) => option.value,
+    ),
+  };
 }
 
 beforeEach(() => setActivePinia(createPinia()));
@@ -171,6 +212,84 @@ describe("InspectorPanel — a target host that does not have the model", () => 
     expect(wrapper.findComponent(ShapePicker).exists()).toBe(true);
     expect(wrapper.findComponent(ResolutionSelector).exists()).toBe(true);
     expect(wrapper.find("[data-test='mesh-controls']").exists()).toBe(false);
+  });
+
+  /**
+   * The canvas was only the first control that had to follow the fallback
+   * recipe. Strength, the repaint mask, the negative prompt and the stored
+   * container are asked by `SourceImageWell` and `AdvancedSettings`, which
+   * were still handed the TARGET host's row — so switching machines left a
+   * Denoise slider, an Edit-mask control, a Negative-prompt field and a
+   * png/jpeg/webp picker on a print that has none of them.
+   */
+  it("offers no strength, mask, negative prompt or raster container", async () => {
+    const { wrapper } = mountForTargetWithoutModel(meshModel());
+    await flushPromises();
+    expect(await panelContract(wrapper)).toEqual({
+      strength: false,
+      mask: false,
+      negative: false,
+      formats: ["glb"],
+    });
+  });
+
+  /** The whole point: the panel reads the same wherever Create is aimed. */
+  it("renders the identical contract to the machine that has the model", async () => {
+    const onHost = mountForTargetWithModel(meshModel());
+    await flushPromises();
+    const baseline = await panelContract(onHost.wrapper);
+    onHost.wrapper.unmount();
+    document.body.innerHTML = "";
+    setActivePinia(createPinia());
+
+    const offHost = mountForTargetWithoutModel(meshModel());
+    await flushPromises();
+    expect(await panelContract(offHost.wrapper)).toEqual(baseline);
+    expect(baseline).toEqual({
+      strength: false,
+      mask: false,
+      negative: false,
+      formats: ["glb"],
+    });
+  });
+
+  it("keeps a raster model's strength, mask, negative prompt and formats", async () => {
+    const { wrapper } = mountForTargetWithoutModel(rasterModel());
+    await flushPromises();
+    expect(await panelContract(wrapper)).toEqual({
+      strength: true,
+      mask: true,
+      negative: true,
+      formats: ["png", "jpeg", "webp"],
+    });
+  });
+
+  /**
+   * The family rule is only the answer of LAST resort. Where a machine does
+   * advertise the checkpoint, the panel must read THAT recipe — including
+   * every refusal a family rule would never guess. This checkpoint's own
+   * profile pins one container and refuses strength, the mask and the
+   * negative prompt, none of which follows from `sdxl`.
+   */
+  it("reads the advertised recipe's own refusals, not the family defaults", async () => {
+    const recipe = sdxlRecipe();
+    recipe.capabilities.supports_strength = false;
+    recipe.capabilities.mask = { mode: "hidden", required: false };
+    recipe.capabilities.negative_prompt = { mode: "hidden", required: false };
+    recipe.capabilities.output = {
+      default_format: "jpeg",
+      formats: ["jpeg"],
+      audio_requires_mp4: false,
+    };
+    const model = modelWith("strict-sdxl:fp16", "sdxl", recipe);
+    const { wrapper } = mountForTargetWithoutModel(model);
+    await flushPromises();
+    expect(await panelContract(wrapper)).toEqual({
+      strength: false,
+      mask: false,
+      negative: false,
+      formats: ["jpeg"],
+    });
   });
 });
 

--- a/desktop/src/components/create/InspectorPanel.vue
+++ b/desktop/src/components/create/InspectorPanel.vue
@@ -396,8 +396,16 @@ const selectedPickerModel = computed<ModelEntry | null>(
  * is the authority on it. This only decides who answers when it has none.
  * `selectedModel` remains the answer for questions that really are about the
  * holding machine (its runtime readiness, its on-disk size, its LoRAs).
+ *
+ * EVERY contract question reads this one row, including the ones the child
+ * panels ask. Handing `SourceImageWell` and `AdvancedSettings` the target's
+ * row instead is what left a Denoise slider, an Edit-mask control, a
+ * Negative-prompt field and a `png`/`jpeg`/`webp` picker on a 3-D print after
+ * the canvas itself had already been fixed.
  */
-const contractModel = computed<ModelEntry | null>(() => selectedPickerModel.value);
+const contractModel = computed<ModelEntry | null>(() =>
+  hostModels.contractEntryForTarget(props.form.model, stickyTarget.value),
+);
 
 /**
  * The form's model when no machine has it installed. Restoring a print whose
@@ -796,7 +804,7 @@ function resetSettings() {
       <!-- Source media — primary-form image conditioning; the model dictates
            whether (and how) it renders, exactly like resolutions. -->
       <div v-if="showSourceMedia" class="ms-field" data-test="inspector-source-media">
-        <SourceImageWell :form="form" :selected-model="selectedModel" />
+        <SourceImageWell :form="form" :selected-model="contractModel" />
       </div>
 
       <!-- Identity photo — face conditioning is its own partition, not source
@@ -989,10 +997,10 @@ function resetSettings() {
           v-if="!form.predictDuration"
           :frames="form.frames"
           :fps="form.fps"
-          :model="selectedModel"
+          :model="contractModel"
           :family="form.family"
           :model-name="form.model"
-          :source-image-capability="selectedModel?.source_image ?? form.sourceImageCapability"
+          :source-image-capability="contractModel?.source_image ?? form.sourceImageCapability"
           :routing-request="durationRoutingRequest"
           @update:frames="form.frames = $event"
         />
@@ -1171,7 +1179,7 @@ function resetSettings() {
         v-else-if="advancedExpanded"
         id="desktop-inline-advanced"
         :form="form"
-        :selected-model="selectedModel"
+        :selected-model="contractModel"
         :routing-request="durationRoutingRequest"
         :upscalers="models.upscalers"
         :control-adapters="controlAdapters"

--- a/desktop/src/components/generate/SourceImageWell.vue
+++ b/desktop/src/components/generate/SourceImageWell.vue
@@ -53,8 +53,17 @@ import ReferenceCropModal from "./ReferenceCropModal.vue";
 const props = withDefaults(
   defineProps<{
     form: GenerateForm;
-    /** The picked model row; its advertised contract wins over the form's
-     * snapshot so this component and its mount gate share one derivation. */
+    /**
+     * The row that answers for the CHECKPOINT'S CONTRACT; its advertised
+     * recipe wins over the form's snapshot so this component and its mount
+     * gate share one derivation.
+     *
+     * The parent resolves it from whichever machine has the checkpoint, not
+     * only from the one Create is aimed at — otherwise aiming at a machine
+     * that must download it first put a Denoise slider and an Edit-mask
+     * control on a 3-D print. `null` means no machine has it, and the family
+     * rules answer instead.
+     */
     selectedModel?: ModelEntry | null;
   }>(),
   { selectedModel: null },

--- a/desktop/src/stores/hostModels.test.ts
+++ b/desktop/src/stores/hostModels.test.ts
@@ -292,4 +292,53 @@ describe("hostModels store", () => {
     expect(store.installedEntryForTarget("flux-dev:q8", "hal9000-7680")?.default_steps).toBe(36);
     expect(store.installedEntryForTarget("missing", "hal9000-7680")).toBeNull();
   });
+
+  /**
+   * A checkpoint's advertised contract belongs to the checkpoint. Create
+   * aimed at a machine that must download it first has no row there, and
+   * reading that absence as "this model advertises nothing" is what replaced
+   * a 3-D print's settings with raster ones.
+   */
+  describe("contractEntryForTarget", () => {
+    it("prefers the target host's own row", () => {
+      addExtra("hal9000-7680", "http://hal9000:7680");
+      const store = useHostModelsStore();
+      store.byHost.local = {
+        entries: [model("flux-dev:q8", { default_steps: 20 })],
+        fetchedAt: Date.now(),
+        error: null,
+      };
+      store.byHost["hal9000-7680"] = {
+        entries: [model("flux-dev:q8", { default_steps: 36 })],
+        fetchedAt: Date.now(),
+        error: null,
+      };
+      expect(store.contractEntryForTarget("flux-dev:q8", "hal9000-7680")?.default_steps).toBe(36);
+    });
+
+    it("falls back to a machine that has the checkpoint", () => {
+      addExtra("hal9000-7680", "http://hal9000:7680");
+      addExtra("plato-7680", "http://plato:7680");
+      const store = useHostModelsStore();
+      store.byHost["hal9000-7680"] = {
+        entries: [model("hunyuan3d-mini-turbo:fp16", { default_steps: 5 })],
+        fetchedAt: Date.now(),
+        error: null,
+      };
+      store.byHost["plato-7680"] = { entries: [], fetchedAt: Date.now(), error: null };
+
+      expect(store.installedEntryForTarget("hunyuan3d-mini-turbo:fp16", "plato-7680")).toBeNull();
+      expect(
+        store.contractEntryForTarget("hunyuan3d-mini-turbo:fp16", "plato-7680")?.default_steps,
+      ).toBe(5);
+    });
+
+    it("is null when no machine has it, so the family rules answer", () => {
+      addExtra("plato-7680", "http://plato:7680");
+      const store = useHostModelsStore();
+      store.byHost["plato-7680"] = { entries: [], fetchedAt: Date.now(), error: null };
+      expect(store.contractEntryForTarget("never-downloaded:fp16", "plato-7680")).toBeNull();
+      expect(store.contractEntryForTarget("", "plato-7680")).toBeNull();
+    });
+  });
 });

--- a/desktop/src/stores/hostModels.ts
+++ b/desktop/src/stores/hostModels.ts
@@ -124,6 +124,42 @@ export const useHostModelsStore = defineStore("hostModels", {
         return this.installedOn(targetHostId).find((model) => model.name === name) ?? null;
       };
     },
+    /**
+     * Resolve the row that answers for the CHECKPOINT'S CONTRACT — the
+     * advertised recipe behind the canvas, the prompt mode, strength, the
+     * mask, the negative prompt, the output containers and the mesh block.
+     *
+     * A contract belongs to the checkpoint, not to the machine holding the
+     * file: the target will advertise exactly the same one once it has
+     * downloaded it. So the target's own row wins wherever it exists (two
+     * machines may advertise corrected or aliased metadata, and the one that
+     * will run the job is the authority on it), and any machine that has the
+     * checkpoint answers when it has none. `null` means no machine has it at
+     * all, and only then do the pre-profile family rules answer.
+     *
+     * Runtime questions — readiness, on-disk size, what is loaded — must keep
+     * using {@link installedEntryForTarget}: those really are about the
+     * machine.
+     */
+    contractEntryForTarget(): (name: string, targetHostId: string | null) => ModelEntry | null {
+      return (name, targetHostId) => {
+        if (!name) return null;
+        const onTarget = this.installedEntryForTarget(name, targetHostId);
+        if (onTarget) return onTarget;
+        const primaryEntry = filterRestrictedModels(
+          useModelStore().installed,
+          useHostsStore().capabilities.local,
+        ).find((model) => model.name === name);
+        return (
+          primaryEntry ??
+          this.unionInstalled.find((model) => model.name === name) ??
+          // A downloaded-but-unrunnable row still advertises the checkpoint's
+          // profile; the picker already shows it, so the panel may read it.
+          this.unionDownloaded.find((model) => model.name === name) ??
+          null
+        );
+      };
+    },
     allReadyHostsFetched(state): boolean {
       const hosts = useHostsStore();
       return hosts.all

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -945,7 +945,7 @@ const caps = computed(() =>
     form.pipeline,
     form.guidanceCapabilities,
     form.sourceImageCapability,
-    effectiveGenerationRecipe(selectedEntry.value, form.pipeline),
+    effectiveGenerationRecipe(contractEntry.value, form.pipeline),
   ),
 );
 const formValidationError = computed(
@@ -959,18 +959,18 @@ const formValidationError = computed(
       : resolutionValidationError(
           form.width,
           form.height,
-          selectedEntry.value ?? null,
+          contractEntry.value ?? null,
           form.pipeline,
         )) ??
-    profileStepsValidationError(form.steps, selectedEntry.value, form.pipeline) ??
+    profileStepsValidationError(form.steps, contractEntry.value, form.pipeline) ??
     profileGuidanceValidationError(
       caps.value.fixedGuidance ?? form.guidance,
-      selectedEntry.value,
+      contractEntry.value,
       form.pipeline,
     ) ??
     meshTargetFacesValidationError(form) ??
     (caps.value.supportsVideo
-      ? videoFramesError(form.frames, selectedEntry.value ?? { family: form.family })
+      ? videoFramesError(form.frames, contractEntry.value ?? { family: form.family })
       : null) ??
     (caps.value.supportsVideo ? fpsValidationError(form.fps) : null) ??
     cameraControlValidationError(form) ??
@@ -1211,6 +1211,17 @@ const isSequence = computed(() => draft.output === "sequence");
 const selectedEntry = computed(() =>
   hostModels.installedEntryForTarget(form.model, stickyTarget.value),
 );
+/**
+ * The row that answers for the CHECKPOINT'S CONTRACT, resolved from whichever
+ * machine has it — the same authority the inspector reads, so the canvas, the
+ * submit blocker and the settings panel cannot disagree about the checkpoint
+ * the moment Create is aimed at a machine that must download it first.
+ * `selectedEntry` stays the answer for ROUTING and for the memory estimate,
+ * which really are about the machine that will run the job.
+ */
+const contractEntry = computed(() =>
+  hostModels.contractEntryForTarget(form.model, stickyTarget.value),
+);
 
 let previousStillSource = "";
 let previousStillResolution: SourceResolutionResult | null = null;
@@ -1259,12 +1270,12 @@ function applyDecodedSourceResolution(
   setDimensions(dimensions.width, dimensions.height);
   const resolution = resolveSourceResolution(
     dimensions,
-    selectedEntry.value ?? form.family,
+    contractEntry.value ?? form.family,
     form.pipeline,
   );
   const automaticResolution = resolveDefaultSourceResolution(
     dimensions,
-    selectedEntry.value ?? form.family,
+    contractEntry.value ?? form.family,
     form.pipeline,
   );
   const replaced = base64 !== previous.base64;
@@ -1301,14 +1312,14 @@ watch(
       caps.value.sourceImageMode !== "single"
         ? (form.imageAttachments[0] ?? null)
         : form.sourceImage,
-    () => selectedEntry.value?.name ?? form.model,
+    () => contractEntry.value?.name ?? form.model,
     () => form.pipeline ?? null,
-    () => selectedEntry.value?.generation_profile?.profile_hash ?? null,
-    () => selectedEntry.value?.max_pixels ?? null,
-    () => selectedEntry.value?.max_axis_pixels ?? null,
-    () => selectedEntry.value?.dimension_alignment ?? null,
+    () => contractEntry.value?.generation_profile?.profile_hash ?? null,
+    () => contractEntry.value?.max_pixels ?? null,
+    () => contractEntry.value?.max_axis_pixels ?? null,
+    () => contractEntry.value?.dimension_alignment ?? null,
     () =>
-      selectedEntry.value?.recommended_dimensions
+      contractEntry.value?.recommended_dimensions
         ?.map(({ width, height }) => `${width}x${height}`)
         .join("|") ?? "",
   ],
@@ -1339,14 +1350,14 @@ watch(
 watch(
   [
     () => draft.openingImage?.base64 ?? null,
-    () => selectedEntry.value?.name ?? form.model,
+    () => contractEntry.value?.name ?? form.model,
     () => form.pipeline ?? null,
-    () => selectedEntry.value?.generation_profile?.profile_hash ?? null,
-    () => selectedEntry.value?.max_pixels ?? null,
-    () => selectedEntry.value?.max_axis_pixels ?? null,
-    () => selectedEntry.value?.dimension_alignment ?? null,
+    () => contractEntry.value?.generation_profile?.profile_hash ?? null,
+    () => contractEntry.value?.max_pixels ?? null,
+    () => contractEntry.value?.max_axis_pixels ?? null,
+    () => contractEntry.value?.dimension_alignment ?? null,
     () =>
-      selectedEntry.value?.recommended_dimensions
+      contractEntry.value?.recommended_dimensions
         ?.map(({ width, height }) => `${width}x${height}`)
         .join("|") ?? "",
   ],

--- a/studio/lib/generationCapabilities.test.ts
+++ b/studio/lib/generationCapabilities.test.ts
@@ -528,6 +528,91 @@ describe("prompt mode, strength, and mesh from the advertised recipe", () => {
     expect(caps.mesh).toBeUndefined();
   });
 
+  /**
+   * The canvas was only the first thing the family rule had to answer. A 3-D
+   * engine denoises nothing, repaints nothing, has no unconditional branch to
+   * steer, and stores exactly one container — so with no recipe in hand the
+   * legacy rules must say all four, or the panel offers a Denoise slider, an
+   * Edit-mask control, a Negative-prompt field and a png/jpeg/webp format
+   * picker for a print that is none of those things.
+   */
+  it("refuses strength, mask and a negative prompt for a mesh family with no recipe", () => {
+    const caps = baseGenerationCapabilities(
+      "hunyuan3d",
+      "hunyuan3d-mini-turbo:fp16",
+      null,
+      null,
+      "required",
+      null,
+    );
+    expect(caps.supportsStrength).toBe(false);
+    expect(caps.supportsMask).toBe(false);
+    expect(caps.supportsNegativePrompt).toBe(false);
+  });
+
+  it("stores only the glTF container for a mesh family with no recipe", () => {
+    const caps = baseGenerationCapabilities(
+      "hunyuan3d",
+      "hunyuan3d-mini-turbo:fp16",
+      null,
+      null,
+      "required",
+      null,
+    );
+    expect(caps.outputFormats).toEqual(["glb"]);
+    expect(caps.defaultOutputFormat).toBe("glb");
+  });
+
+  /**
+   * The whole point of the fallback is that a client aimed at a machine
+   * without the checkpoint shows the SAME contract as one aimed at a machine
+   * that has it. Only the advertised mesh block, which nothing can invent,
+   * may differ.
+   */
+  it("agrees with the advertised recipe on every contract the panel renders", () => {
+    const advertised = baseGenerationCapabilities(
+      "hunyuan3d",
+      "hunyuan3d-mini-turbo:fp16",
+      null,
+      null,
+      "required",
+      hunyuan3dRecipe(),
+    );
+    const fallback = baseGenerationCapabilities(
+      "hunyuan3d",
+      "hunyuan3d-mini-turbo:fp16",
+      null,
+      null,
+      "required",
+      null,
+    );
+    for (const key of [
+      "canvasless",
+      "supportsStrength",
+      "supportsMask",
+      "supportsNegativePrompt",
+      "defaultOutputFormat",
+    ] as const) {
+      expect(fallback[key], key).toEqual(advertised[key]);
+    }
+    expect(fallback.outputFormats).toEqual(advertised.outputFormats);
+  });
+
+  it("leaves a raster family's strength, mask, negative and formats alone", () => {
+    const caps = baseGenerationCapabilities(
+      "sdxl",
+      "cyberrealistic-pony:fp16",
+      null,
+      null,
+      null,
+      null,
+    );
+    expect(caps.supportsStrength).toBe(true);
+    expect(caps.supportsMask).toBe(true);
+    expect(caps.supportsNegativePrompt).toBe(true);
+    expect(caps.outputFormats).toEqual(["png", "jpeg", "webp"]);
+  });
+
   it("keeps a raster family's canvas when no recipe is advertised", () => {
     const caps = baseGenerationCapabilities(
       "sdxl",

--- a/studio/lib/generationCapabilities.ts
+++ b/studio/lib/generationCapabilities.ts
@@ -18,6 +18,7 @@ import {
   isMeshFamily,
   isQwenImageEditFamily,
   isWanFamily,
+  LEGACY_MESH_OUTPUT_FORMATS,
   legacyPromptRequirementForFamily,
   legacySupportsStrength,
 } from "./legacyRecipeRules";
@@ -318,6 +319,11 @@ export function baseGenerationCapabilities(
   const h3 = isMinimaxH3Identity(normalized, model);
   const h3Ref2va = h3 && isMinimaxH3Ref2vaModel(model);
   const wan = isWanFamily(normalized);
+  // The pre-profile 3-D rule. It answers ONLY where no recipe is in hand —
+  // a client aimed at a machine that must download the checkpoint first, or
+  // a host that advertises no profile at all — and every question it settles
+  // below is one the advertised recipe would otherwise settle the same way.
+  const mesh = isMeshFamily(normalized);
   const profileCaps = advertisedRecipe?.legacy_adapter
     ? undefined
     : advertisedRecipe?.capabilities;
@@ -367,9 +373,11 @@ export function baseGenerationCapabilities(
       : inferredFixedGuidance;
   const profileControlVisible = (mode: string | undefined) =>
     mode === "adjustable" || mode === "fixed";
-  const legacyOutputFormats = supportsVideo
-    ? ["mp4", "gif", "apng", "webp"]
-    : ["png", "jpeg", "webp"];
+  const legacyOutputFormats = mesh
+    ? LEGACY_MESH_OUTPUT_FORMATS.slice()
+    : supportsVideo
+      ? ["mp4", "gif", "apng", "webp"]
+      : ["png", "jpeg", "webp"];
   return {
     supportsNegativePrompt:
       (profileCaps
@@ -377,7 +385,11 @@ export function baseGenerationCapabilities(
         : advertisedDefault?.supports_negative_prompt) ??
       ((!NO_NEGATIVE_PROMPT_FAMILIES.has(normalized) ||
         isFlux2BaseModel(model)) &&
-        !fixedGuidance),
+        !fixedGuidance &&
+        // A 3-D engine has no unconditional branch a negative prompt could
+        // steer. Its recipe says `ADJUSTABLE_NO_NEGATIVE`, so guidance alone
+        // does not settle it and the family rule must.
+        !mesh),
     guidanceAdjustable: !fixedGuidance,
     fixedGuidance: fixedGuidance
       ? h3
@@ -453,7 +465,7 @@ export function baseGenerationCapabilities(
     // strength — the engine rejects the former and never reads the latter.
     supportsMask: profileCaps
       ? profileControlVisible(profileCaps.mask.mode)
-      : !h3 && !qwenEdit && !flux2Dev && !wan,
+      : !h3 && !qwenEdit && !flux2Dev && !wan && !mesh,
     // A host that sends `supports_strength` is the authority. An older host's
     // recipe never carried it, and its serde default would be `false` — not
     // an assertion that strength is unsupported — so absence falls back to
@@ -469,9 +481,7 @@ export function baseGenerationCapabilities(
     // recipe is in hand, and reading absence as "has a canvas" is what let a
     // Shape and Resolution pair bind to a mesh model's 0 × 0 — a `NaN×NaN px`
     // control under a validation error no user could clear.
-    canvasless: advertisedRecipe
-      ? recipeIsCanvasless(advertisedRecipe)
-      : isMeshFamily(normalized),
+    canvasless: advertisedRecipe ? recipeIsCanvasless(advertisedRecipe) : mesh,
     mesh: profileCaps?.mesh ?? undefined,
     forcesBatchSizeOne: h3 || qwenEdit,
   };

--- a/studio/lib/legacyRecipeRules.ts
+++ b/studio/lib/legacyRecipeRules.ts
@@ -64,8 +64,9 @@ export function isFlux2DevModel(model: string): boolean {
 /**
  * The pre-profile strength rule. Wan pins its conditioning frames exactly,
  * Qwen-Image-Edit and Flux.2 Dev condition through references rather than a
- * denoised source, and H3 has no source-image path at all — none of them
- * read `strength`. Every other family denoises from the source image.
+ * denoised source, H3 has no source-image path at all, and a 3-D family
+ * reconstructs geometry rather than denoising pixels — none of them read
+ * `strength`. Every other family denoises from the source image.
  */
 export function legacySupportsStrength(family: string, model = ""): boolean {
   const normalized = family.trim().toLowerCase();
@@ -73,6 +74,15 @@ export function legacySupportsStrength(family: string, model = ""): boolean {
     !isMinimaxH3Identity(normalized, model) &&
     !isQwenImageEditFamily(normalized) &&
     !isFlux2DevModel(model) &&
-    !isWanFamily(normalized)
+    !isWanFamily(normalized) &&
+    !isMeshFamily(normalized)
   );
 }
+
+/**
+ * The pre-profile container rule for a 3-D family: binary glTF is the only
+ * thing a mesh engine stores, exactly as the advertised recipe's
+ * `output.formats` says. Without it the fallback offered `png`/`jpeg`/`webp`
+ * for a print that has no raster at all.
+ */
+export const LEGACY_MESH_OUTPUT_FORMATS: readonly string[] = ["glb"];


### PR DESCRIPTION
Follow-up to #1547, which fixed only half of the second regression in #1534.

On the live dev app (`main` 0b3aea928) the canvas no longer breaks, but with
`hunyuan3d-mini-turbo:fp16` selected and RUN ON switched to a machine that
does not have it, the settings panel still leaked a Denoise strength slider, a
Mask / Edit-mask control, an Advanced ▸ Negative-prompt textarea, and an
Advanced ▸ Output & seed ▸ File format picker offering `png`/`jpeg`/`webp`
with no `glb` at all. Switching back to the machine that has the model
restored the clean baseline, deterministically.

Two independent causes, both fixed here.

## 1. The child panels were handed the target host's row

`InspectorPanel` resolved a contract row for the controls it owns, but passed
the plain `selectedModel` down. `SourceImageWell` and `AdvancedSettings` each
re-derive their own capabilities from that prop, so on a fallback host they
resolved from a `null` entry and fell back to raster family defaults —
independently of everything the parent had just got right.

Both children now receive the resolved contract row, and the resolution rule
moves out of the component into `hostModels.contractEntryForTarget`, so one
getter answers for every surface:

- the target host's own row wins wherever it exists (two machines may
  advertise corrected or aliased metadata, and the machine that will run the
  job is the authority on it);
- any machine that has the checkpoint answers when the target has no row;
- `null` means no machine has it at all, and only then do the family rules
  answer.

`GenerateView` reads the same getter for its capabilities, its profile
validators (resolution, steps, guidance, frames) and its source-resolution
contract, so the canvas, the submit blocker and the settings panel cannot
disagree about the checkpoint. Routing and the memory estimate deliberately
keep `installedEntryForTarget` — those really are questions about the machine
that will run the job.

## 2. The pre-profile family rules had no 3-D answers

Where no machine has the checkpoint, `baseGenerationCapabilities` falls back
to rules written before the mesh family existed: `legacySupportsStrength` and
the legacy mask rule both said yes, `hunyuan3d` was absent from
`NO_NEGATIVE_PROMPT_FAMILIES`, and the legacy container list was
`png`/`jpeg`/`webp`. A 3-D engine denoises nothing, repaints nothing, has no
unconditional branch a negative prompt could steer, and stores exactly one
container — so the family rule now says all four, and `canvasless` reads from
the same single `mesh` flag rather than repeating the family test.

This half also improves the web and the phone, which share these rules.

## Tests

TDD; each was written first and observed failing.

- `studio/lib/generationCapabilities.test.ts` — a mesh family with no recipe
  refuses strength, the mask and the negative prompt, offers only `glb`, and
  **agrees with the advertised recipe on every contract the panel renders**;
  a raster family keeps strength, mask, negative and its three containers.
- `desktop/src/components/create/InspectorPanel.mesh.test.ts` — mounted
  against a machine without the model, the panel offers no strength, no mask,
  no negative prompt and only `glb`, and renders an **identical contract** to
  the same panel aimed at the machine that has it.
- One test pins cause 1 on its own, since the family rules alone would mask
  it: a checkpoint whose advertised recipe refuses strength, the mask and the
  negative prompt and pins a single container is read correctly on a fallback
  host — an answer no family rule could produce. That test failed until the
  children were given the contract row.
- `desktop/src/stores/hostModels.test.ts` — `contractEntryForTarget` covers
  all three arms: target row preferred, fallback to a machine that has it,
  and null when nobody does.

Gates: `bunx vue-tsc -b`, `bun run test:desktop` (455 files, 5939 tests),
`bun run test:studio` (141 files, 1681 tests), `bun run test:web` (117 files,
1830 tests), `bunx prettier --check . ../ui ../studio`,
`bun run check:dead-code`, `bun run check:architecture` — all clean.

## Note

One contract question is deliberately unchanged.
`legacyPromptRequirementForFamily` still answers `required` for a mesh family
when no machine has the checkpoint, because its documented invariant is that
it never returns `ignored` — no family predating the field lacked a text
encoder. It is unreachable in practice (a checkpoint no machine has cannot be
generated), and correcting it would contradict that invariant, so it is
called out rather than quietly changed.

No `changelog.d/` fragment: the mesh GUI this repairs is unreleased. Carries
`skip-changelog`.

https://claude.ai/code/session_01HdWxHWD91PBJEx4xyvfEt4
