### PR TITLE
chore(mobile): ignore the Android plugin's .gradle cache

### DIFF
--- a/apps/mobile/plugins/android/.gitignore
+++ b/apps/mobile/plugins/android/.gitignore
@@ -1,2 +1,3 @@
 /build
+/.gradle
 /.tauri


### PR DESCRIPTION
Gradle writes `apps/mobile/plugins/android/.gradle` on the first local build of the Tauri Android plugin. The plugin's own `.gitignore` covered `/build` and `/.tauri` but not this directory, so it showed up as untracked after every build. Adds `/.gradle` alongside them.

No user-visible change.

https://claude.ai/code/session_015KVSjWyiCpA1dHW6SKnD6L