### PR TITLE
fix(mobile): read the test print's clock stamp once so the seen-at assertion cannot straddle a second

### DIFF
--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -10447,9 +10447,13 @@ describe("MobileApp gallery", () => {
   });
 
   it("shows New and Upscaled indicators on mobile Library tiles", async () => {
+    // `print.timestamp` is a clock getter; read it ONCE so the seeded
+    // baseline, the served print, and the expected seen-at stamp cannot
+    // straddle a second boundary (the 2026-09-02 iOS CI flake).
+    const stamp = print.timestamp;
     localStorage.setItem(
       "mold.mobile.library-seen-at.v1",
-      JSON.stringify({ "studio-id": print.timestamp - 1 }),
+      JSON.stringify({ "studio-id": stamp - 1 }),
     );
     localStorage.setItem("mold.mobile.library-visited.v1", "true");
     apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
@@ -10459,6 +10463,7 @@ describe("MobileApp gallery", () => {
         return Promise.resolve([
           {
             ...print,
+            timestamp: stamp,
             filename: "new-upscaled.png",
             format: "png",
             metadata: {
@@ -10482,7 +10487,7 @@ describe("MobileApp gallery", () => {
     expect(tile.get("[data-test='new-badge']").text()).toBe("New");
     expect(tile.get("[data-test='upscaled-badge']").text()).toBe("Upscaled");
     expect(JSON.parse(localStorage.getItem("mold.mobile.library-seen-at.v1") ?? "{}")).toEqual({
-      "studio-id": print.timestamp,
+      "studio-id": stamp,
     });
     expect(localStorage.getItem("mold.mobile.library-seen.v1")).toBeNull();
   });

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -10449,7 +10449,9 @@ describe("MobileApp gallery", () => {
   it("shows New and Upscaled indicators on mobile Library tiles", async () => {
     // `print.timestamp` is a clock getter; read it ONCE so the seeded
     // baseline, the served print, and the expected seen-at stamp cannot
-    // straddle a second boundary (the 2026-09-02 iOS CI flake).
+    // straddle a second boundary (the 2026-09-02 iOS CI flake). Freezing is
+    // safe here only because this test makes no submission, so the stamp
+    // need not stay ahead of the clock for age-bounded gallery recovery.
     const stamp = print.timestamp;
     localStorage.setItem(
       "mold.mobile.library-seen-at.v1",


### PR DESCRIPTION
## Summary

The iOS **Mobile frontend** job failed on main once yesterday (run 33666943930):

```
AssertionError: expected { 'studio-id': 1788373547 } to deeply equal { 'studio-id': 1788373548 }
```

`MobileApp.test.ts`'s "shows New and Upscaled indicators on mobile Library tiles" seeded the seen-at baseline, served the print, and asserted the recorded stamp from three separate reads of `print.timestamp`, which is a `Date.now()` getter. A second boundary between any two reads fails the test.

## Fix

Capture the stamp once at the top of the test and use it for the seed, the served print (`timestamp: stamp` after the spread, since the spread copies the getter's value at spread time), and the assertion.

Test-only change; `skip-changelog`.