### PR TITLE
fix(desktop): cfg-split the settings backup permission helper so Windows clippy passes

### DIFF
--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -504,8 +504,8 @@ fn preserve_invalid_document(path: &Path, raw: &str, reason: &str) {
     }
 }
 
-/// Owner-only permissions for the backup (Unix); Windows keeps the app-data
-/// directory's inherited ACL, which is already per-user.
+/// Owner-only permissions for the backup (Unix); elsewhere the app-data
+/// directory's inherited per-user ACL is what protects it.
 #[cfg(unix)]
 fn restrict_to_owner(path: &Path) -> std::io::Result<()> {
     use std::os::unix::fs::PermissionsExt;
@@ -925,6 +925,23 @@ mod tests {
             loaded.notifications,
             "untouched defaults keep their defaults"
         );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn the_invalid_backup_is_owner_only() {
+        // The original may still carry the legacy plaintext `remoteApiKey`,
+        // so the backup gets the same mode as `secrets.json`.
+        use std::os::unix::fs::PermissionsExt;
+        let dir = tempfile::tempdir().unwrap();
+        let path = path_in(&dir);
+        std::fs::write(&path, "not json {").unwrap();
+        load(&path);
+        let mode = std::fs::metadata(invalid_backup_path(&path))
+            .unwrap()
+            .permissions()
+            .mode();
+        assert_eq!(mode & 0o777, 0o600);
     }
 
     #[test]

--- a/desktop/src-tauri/src/settings.rs
+++ b/desktop/src-tauri/src/settings.rs
@@ -492,14 +492,7 @@ fn parse_keeping_readable_keys(mut value: serde_json::Value) -> Loaded {
 /// plaintext `remoteApiKey`.
 fn preserve_invalid_document(path: &Path, raw: &str, reason: &str) {
     let backup = invalid_backup_path(path);
-    let written = std::fs::write(&backup, raw).and_then(|()| {
-        #[cfg(unix)]
-        {
-            use std::os::unix::fs::PermissionsExt;
-            std::fs::set_permissions(&backup, std::fs::Permissions::from_mode(0o600))?;
-        }
-        Ok(())
-    });
+    let written = std::fs::write(&backup, raw).and_then(|()| restrict_to_owner(&backup));
     match written {
         Ok(()) => tracing::warn!(
             "settings.json is invalid ({reason}); using defaults and keeping the original at {}",
@@ -509,6 +502,19 @@ fn preserve_invalid_document(path: &Path, raw: &str, reason: &str) {
             "settings.json is invalid ({reason}); using defaults (could not keep the original: {e})"
         ),
     }
+}
+
+/// Owner-only permissions for the backup (Unix); Windows keeps the app-data
+/// directory's inherited ACL, which is already per-user.
+#[cfg(unix)]
+fn restrict_to_owner(path: &Path) -> std::io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    std::fs::set_permissions(path, std::fs::Permissions::from_mode(0o600))
+}
+
+#[cfg(not(unix))]
+fn restrict_to_owner(_path: &Path) -> std::io::Result<()> {
+    Ok(())
 }
 
 /// Where a document this build cannot parse at all is kept before the next


### PR DESCRIPTION
## Summary

Follow-up to #1577. The Desktop workflow's **Windows (clippy, test)** job failed on main (run 33820692419):

```
error: using `Result.and_then(|x| Ok(y))`, which is more succinctly expressed as `map(|x| y)`
   --> src\settings.rs:495:19
```

The `#[cfg(unix)]` permissions block lived inside an `and_then` closure; on Windows it compiles out and leaves `and_then(|()| Ok(()))`. Moved the permission step into a cfg-split `restrict_to_owner` helper (0600 on Unix, no-op elsewhere) so both targets see the same call shape.

Also on that run, macOS **Native Rust** failed on `engine_boots_authenticates_and_shuts_down` ("engine thread did not exit" within 15 s) — a pre-existing flake (identical failure on main on 2026-09-02, run 33616295687), unrelated to settings. This PR's main push re-runs the Desktop workflow and, with a green Native Rust job, publishes the first nightly carrying the #1577 fix.

Lint-only; `skip-changelog`. `cargo clippy --all-targets -D warnings` and the 36 settings tests pass locally.