### PR TITLE
fix(mdns): bound the peer browser's shutdown by mold, not by the mDNS daemon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -637,6 +637,16 @@ jobs:
           cargo test -p mold-ai-core --features pulid --lib identity
           cargo test -p mold-ai-inference --features pulid --lib identity
           cargo test -p mold-ai-server --features pulid --lib identity
+      # `mdns` is not a default feature and nothing in the workspace turns it
+      # on, so `cargo test/clippy --workspace` never COMPILES mdns.rs — the
+      # module's tests, including the guard against reintroducing the blocking
+      # `recv()` that hung server shutdown (#1581), were dark. The desktop app
+      # enables the feature but is a separate cargo root.
+      - name: Clippy and test the mDNS surface
+        if: env.RUN_RUST_SUITE == 'true'
+        run: |
+          cargo clippy -p mold-ai-server --features mdns --all-targets -- -D warnings
+          cargo test -p mold-ai-server --features mdns --lib mdns
       - name: Record protected gate success
         run: echo "Required Rust and release routes completed successfully."
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,6 +1615,9 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+dependencies = [
+ "getrandom 0.3.4",
+]
 
 [[package]]
 name = "fax"
@@ -1723,6 +1726,7 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
+ "fastrand",
  "futures-core",
  "futures-sink",
  "spin",
@@ -3452,6 +3456,7 @@ dependencies = [
  "cudarc 0.19.8",
  "dirs 5.0.1",
  "filetime",
+ "flume",
  "fs2",
  "futures",
  "futures-core",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1615,9 +1615,6 @@ name = "fastrand"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
-dependencies = [
- "getrandom 0.3.4",
-]
 
 [[package]]
 name = "fax"
@@ -1726,7 +1723,6 @@ version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e139bc46ca777eb5efaf62df0ab8cc5fd400866427e56c68b22e414e53bd3be"
 dependencies = [
- "fastrand",
  "futures-core",
  "futures-sink",
  "spin",

--- a/changelog.d/mdns-browser-bounded-shutdown.md
+++ b/changelog.d/mdns-browser-bounded-shutdown.md
@@ -1,0 +1,7 @@
+- **A server with unusable multicast now stops when asked.** The mDNS peer
+  browser's shutdown joined its worker thread with no bound, and that thread
+  woke only when the mDNS daemon closed its channel. On a host where multicast
+  never works the daemon may never close it, so the server hung instead of
+  finishing shutdown — the desktop app reported that the embedded engine did
+  not stop and that gallery authority remained with the server. Shutdown is
+  now bounded by mold rather than by the daemon.

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -129,6 +129,10 @@ windows-sys = { version = "0.59", features = [
 ] }
 
 [dev-dependencies]
+# The mDNS browse receiver is `flume::Receiver` through mdns-sd's re-export;
+# the bounded-shutdown tests build a channel of the same 0.12 line so the two
+# `Receiver` types unify.
+flume = "0.12"
 # Test-only feature unification lets the server prove its frozen H3 authority
 # against the private loader without exposing that loader on a runnable feature.
 mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.26.0", features = ["h3-private-uat"] }

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -131,8 +131,11 @@ windows-sys = { version = "0.59", features = [
 [dev-dependencies]
 # The mDNS browse receiver is `flume::Receiver` through mdns-sd's re-export;
 # the bounded-shutdown tests build a channel of the same 0.12 line so the two
-# `Receiver` types unify.
-flume = "0.12"
+# `Receiver` types unify. `default-features = false` mirrors how mdns-sd
+# depends on it, so the test channel behaves like the daemon's (flume's
+# default `eventual-fairness` changes receiver wake selection) and the
+# lockfile is untouched.
+flume = { version = "0.12", default-features = false }
 # Test-only feature unification lets the server prove its frozen H3 authority
 # against the private loader without exposing that loader on a runnable feature.
 mold-inference = { path = "../mold-inference", package = "mold-ai-inference", version = "0.26.0", features = ["h3-private-uat"] }

--- a/crates/mold-server/src/lib.rs
+++ b/crates/mold-server/src/lib.rs
@@ -1384,49 +1384,62 @@ pub async fn run_server(
     // driver's `wait_for_work` arm returns, then abort the JoinHandle to ensure
     // the task is cleaned up on the same shutdown path as the HTTP server.
     // Matches the aggregator handle pattern from commit 5e43886.
+    tracing::debug!(step = "mdns-advertise", "awaiting shutdown step");
     #[cfg(feature = "mdns")]
     if let Some(guard) = mdns_guard {
         guard.shutdown();
     }
+    tracing::debug!(step = "mdns-browse", "awaiting shutdown step");
     #[cfg(feature = "mdns")]
     if let Some(guard) = mdns_browser_guard {
         guard.shutdown();
     }
+    tracing::debug!(step = "downloads", "awaiting shutdown step");
     downloads_shutdown.cancel();
     downloads_driver.abort();
     let _ = downloads_driver.await;
+    tracing::debug!(step = "video-upscale", "awaiting shutdown step");
     if let Some(runtime) = video_upscale_dispatcher {
         runtime.shutdown().await;
     }
+    tracing::debug!(step = "idle-evict", "awaiting shutdown step");
     if let Some(handle) = idle_evict_handle {
         handle.abort();
         let _ = handle.await;
     }
     // Server has stopped accepting requests — stop the telemetry aggregator
     // so it doesn't outlive the server loop.
+    tracing::debug!(step = "resources-aggregator", "awaiting shutdown step");
     resources_aggregator.abort();
     let _ = resources_aggregator.await;
 
     // These tasks may be inside spawn_blocking and therefore cannot be safely
     // detached or cancelled. Await their actual completion before returning
     // server authority to an in-process lifecycle owner.
+    tracing::debug!(step = "thumbnail-warmup", "awaiting shutdown step");
     if let Some(handle) = thumbnail_warmup_handle {
         let _ = handle.await;
     }
+    tracing::debug!(step = "gallery-reconcile", "awaiting shutdown step");
     if let Some(handle) = gallery_reconcile_handle {
         let _ = handle.await;
     }
+    tracing::debug!(step = "scheduler-cancel", "awaiting shutdown step");
     scheduler_shutdown.cancel();
+    tracing::debug!(step = "durable-feeder", "awaiting shutdown step");
     if let Some(handle) = durable_feeder_handle {
         let _ = handle.await;
     }
+    tracing::debug!(step = "trash-sweeper", "awaiting shutdown step");
     if let Some(handle) = trash_sweeper_handle {
         // Its token is a child of `scheduler_shutdown`, so the loop exits on
         // the cancel above; a pass already inside `spawn_blocking` finishes.
         let _ = handle.await;
     }
+    tracing::debug!(step = "queue-sweeper", "awaiting shutdown step");
     // Same child-token contract as the trash sweeper.
     let _ = queue_sweeper_handle.await;
+    tracing::debug!(step = "generation-worker", "awaiting shutdown step");
     if let Some(generation_worker_handle) = generation_worker_handle {
         if !uses_cooperative_gpu_dispatch {
             // The CPU/legacy worker predates the coordinator cancellation
@@ -1442,6 +1455,7 @@ pub async fn run_server(
     // and sets the shared flag for any owner finishing a current lease.
     // Joining here makes an in-process server restart incapable of inheriting
     // detached CUDA owner threads or contexts.
+    tracing::debug!(step = "gpu-owners", "awaiting shutdown step");
     let shutdown_pool = gpu_pool.clone();
     let join = tokio::task::spawn_blocking(move || {
         shutdown_pool.workers.shutdown_and_join_all();
@@ -1465,6 +1479,8 @@ pub async fn run_server(
             );
         }
     }
+
+    tracing::debug!("shutdown sequence complete");
 
     if fatal_cuda_error.load(std::sync::atomic::Ordering::SeqCst) {
         anyhow::bail!("fatal CUDA context error; server restart required");

--- a/crates/mold-server/src/mdns.rs
+++ b/crates/mold-server/src/mdns.rs
@@ -401,10 +401,6 @@ pub fn register(bind: &str, port: u16, txt: Vec<(String, String)>) -> Result<Mdn
     Ok(MdnsGuard { daemon, fullname })
 }
 
-/// Start the server's long-lived DNS-SD browser and cache updater.
-///
-/// The background thread tracks resolved and removed services by fullname.
-/// If browsing stops, it marks discovery unavailable and clears cached peers.
 /// Drain browse events into the shared peer cache until the channel closes,
 /// the daemon reports `SearchStopped`, or `stop` is set. Split out of the
 /// thread body so a test can prove the loop leaves on the flag alone, with a
@@ -470,6 +466,10 @@ fn browse_until_stopped(
     }
 }
 
+/// Start the server's long-lived DNS-SD browser and cache updater.
+///
+/// The background thread tracks resolved and removed services by fullname.
+/// If browsing stops, it marks discovery unavailable and clears cached peers.
 pub fn start_browser(
     discovery: Arc<crate::state::DiscoveryState>,
     own_instance_id: Arc<String>,
@@ -482,7 +482,7 @@ pub fn start_browser(
     discovery.set_can_browse(true);
     let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let thread_discovery = discovery.clone();
-    let thread_instance_id = own_instance_id.clone();
+    let thread_instance_id = own_instance_id;
     let thread_stop = stop.clone();
     let thread = std::thread::Builder::new()
         .name("mold-mdns-browser".to_string())

--- a/crates/mold-server/src/mdns.rs
+++ b/crates/mold-server/src/mdns.rs
@@ -48,7 +48,15 @@ pub struct MdnsGuard {
 pub struct MdnsBrowserGuard {
     daemon: ServiceDaemon,
     thread: Option<std::thread::JoinHandle<()>>,
+    stop: Arc<std::sync::atomic::AtomicBool>,
 }
+
+/// How often the browse loop looks up from the channel to notice a stop
+/// request. The browse receiver's sender belongs to the mDNS daemon, so a
+/// blocking `recv()` is only woken by the daemon choosing to close it; on a
+/// host where multicast never works that never happens and the join below
+/// waits forever. Shutdown must be bounded by mold, not by the daemon.
+const BROWSE_STOP_POLL: Duration = Duration::from_millis(250);
 
 impl MdnsGuard {
     /// Unregister the service and shut the daemon down. Best-effort: errors are
@@ -68,6 +76,12 @@ impl MdnsBrowserGuard {
     /// Stop browsing and join the cache updater thread. Best-effort on the
     /// server shutdown path, matching [`MdnsGuard::shutdown`].
     pub fn shutdown(mut self) {
+        // Set BEFORE asking the daemon to stop: the join below is unbounded,
+        // and the flag is the only wake-up that does not depend on the daemon
+        // answering. `stop_browse`/`shutdown` remain the fast path — they
+        // close the channel and the loop leaves immediately — but a daemon
+        // that never answers now costs `BROWSE_STOP_POLL`, not the process.
+        self.stop.store(true, std::sync::atomic::Ordering::SeqCst);
         let _ = self.daemon.stop_browse(SERVICE_TYPE);
         let _ = self.daemon.shutdown();
         if let Some(thread) = self.thread.take() {
@@ -391,6 +405,71 @@ pub fn register(bind: &str, port: u16, txt: Vec<(String, String)>) -> Result<Mdn
 ///
 /// The background thread tracks resolved and removed services by fullname.
 /// If browsing stops, it marks discovery unavailable and clears cached peers.
+/// Drain browse events into the shared peer cache until the channel closes,
+/// the daemon reports `SearchStopped`, or `stop` is set. Split out of the
+/// thread body so a test can prove the loop leaves on the flag alone, with a
+/// live sender and no events — the shape a daemon that never closes its
+/// channel presents on shutdown.
+fn browse_until_stopped(
+    receiver: &mdns_sd::Receiver<ServiceEvent>,
+    discovery: &crate::state::DiscoveryState,
+    own_instance_id: &str,
+    stop: &std::sync::atomic::AtomicBool,
+) {
+    let mut found: BTreeMap<String, mold_core::DiscoveryPeer> = BTreeMap::new();
+    loop {
+        if stop.load(std::sync::atomic::Ordering::SeqCst) {
+            return;
+        }
+        // `is_disconnected` rather than matching flume's error type: the
+        // receiver reaches us through mdns-sd's re-export, and mold does not
+        // otherwise depend on flume.
+        let event = match receiver.recv_timeout(BROWSE_STOP_POLL) {
+            Ok(event) => event,
+            Err(_) if receiver.is_disconnected() && receiver.is_empty() => return,
+            Err(_) => continue,
+        };
+        match event {
+            ServiceEvent::ServiceResolved(info) => {
+                let addresses: Vec<IpAddr> =
+                    info.addresses.iter().map(|a| a.to_ip_addr()).collect();
+                let txt = info
+                    .txt_properties
+                    .iter()
+                    .map(|p| (p.key().to_string(), p.val_str().to_string()))
+                    .collect();
+                let server =
+                    from_service_parts(&info.fullname, &info.host, info.port, addresses, txt);
+                let is_this_machine = server.instance_id.as_deref() == Some(own_instance_id);
+                found.insert(
+                    info.fullname.clone(),
+                    mold_core::DiscoveryPeer {
+                        name: server.name,
+                        url: server.url,
+                        host: server.host,
+                        port: server.port,
+                        version: server.version,
+                        auth_required: server.auth_required,
+                        instance_id: server.instance_id,
+                        is_this_machine,
+                    },
+                );
+            }
+            ServiceEvent::ServiceRemoved(_, fullname) => {
+                found.remove(&fullname);
+            }
+            ServiceEvent::SearchStopped(_) => break,
+            _ => continue,
+        }
+
+        let peers = found.values().cloned().collect();
+        *discovery
+            .peers
+            .write()
+            .unwrap_or_else(|poisoned| poisoned.into_inner()) = peers;
+    }
+}
+
 pub fn start_browser(
     discovery: Arc<crate::state::DiscoveryState>,
     own_instance_id: Arc<String>,
@@ -401,56 +480,19 @@ pub fn start_browser(
         .context("failed to start mDNS discovery browse")?;
 
     discovery.set_can_browse(true);
+    let stop = Arc::new(std::sync::atomic::AtomicBool::new(false));
     let thread_discovery = discovery.clone();
+    let thread_instance_id = own_instance_id.clone();
+    let thread_stop = stop.clone();
     let thread = std::thread::Builder::new()
         .name("mold-mdns-browser".to_string())
         .spawn(move || {
-            let mut found: BTreeMap<String, mold_core::DiscoveryPeer> = BTreeMap::new();
-            while let Ok(event) = receiver.recv() {
-                match event {
-                    ServiceEvent::ServiceResolved(info) => {
-                        let addresses: Vec<IpAddr> =
-                            info.addresses.iter().map(|a| a.to_ip_addr()).collect();
-                        let txt = info
-                            .txt_properties
-                            .iter()
-                            .map(|p| (p.key().to_string(), p.val_str().to_string()))
-                            .collect();
-                        let server = from_service_parts(
-                            &info.fullname,
-                            &info.host,
-                            info.port,
-                            addresses,
-                            txt,
-                        );
-                        let is_this_machine =
-                            server.instance_id.as_deref() == Some(own_instance_id.as_str());
-                        found.insert(
-                            info.fullname.clone(),
-                            mold_core::DiscoveryPeer {
-                                name: server.name,
-                                url: server.url,
-                                host: server.host,
-                                port: server.port,
-                                version: server.version,
-                                auth_required: server.auth_required,
-                                instance_id: server.instance_id,
-                                is_this_machine,
-                            },
-                        );
-                    }
-                    ServiceEvent::ServiceRemoved(_, fullname) => {
-                        found.remove(&fullname);
-                    }
-                    ServiceEvent::SearchStopped(_) => break,
-                    _ => continue,
-                }
-                let peers = found.values().cloned().collect();
-                *thread_discovery
-                    .peers
-                    .write()
-                    .unwrap_or_else(|poisoned| poisoned.into_inner()) = peers;
-            }
+            browse_until_stopped(
+                &receiver,
+                &thread_discovery,
+                &thread_instance_id,
+                &thread_stop,
+            );
             thread_discovery.mark_unavailable();
         });
     let thread = match thread {
@@ -468,6 +510,7 @@ pub fn start_browser(
     Ok(MdnsBrowserGuard {
         daemon,
         thread: Some(thread),
+        stop,
     })
 }
 
@@ -513,6 +556,69 @@ pub fn discover(timeout: Duration) -> Result<Vec<DiscoveredServer>> {
 mod tests {
     use super::*;
     use std::net::{Ipv4Addr, Ipv6Addr};
+    use std::sync::atomic::{AtomicBool, Ordering};
+
+    /// The browse channel's sender belongs to the mDNS daemon. On a host where
+    /// multicast never works the daemon can fail to close it during shutdown,
+    /// and the old blocking `recv()` then parked the browser thread forever —
+    /// `MdnsBrowserGuard::shutdown`'s join never returned, so an embedded
+    /// server never finished stopping. Prove the loop leaves on the flag with
+    /// a LIVE sender and no events.
+    #[test]
+    fn the_browse_loop_stops_on_the_flag_even_when_the_channel_stays_open() {
+        let (sender, receiver) = flume_channel();
+        let discovery = crate::state::DiscoveryState::default();
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let loop_stop = stop.clone();
+        let worker = std::thread::spawn(move || {
+            browse_until_stopped(&receiver, &discovery, "self-id", &loop_stop);
+        });
+
+        // Nothing is ever sent and the sender stays alive for the whole test.
+        std::thread::sleep(BROWSE_STOP_POLL / 2);
+        assert!(!worker.is_finished(), "the loop waits while it may browse");
+        stop.store(true, Ordering::SeqCst);
+
+        let deadline = Instant::now() + BROWSE_STOP_POLL * 8;
+        while !worker.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(
+            worker.is_finished(),
+            "the browse loop must leave within a poll of the stop flag"
+        );
+        worker.join().expect("browse loop thread");
+        drop(sender);
+    }
+
+    /// A daemon that DOES close the channel still ends the loop immediately;
+    /// the flag is the fallback, not the only exit.
+    #[test]
+    fn the_browse_loop_stops_when_the_daemon_closes_the_channel() {
+        let (sender, receiver) = flume_channel();
+        let discovery = crate::state::DiscoveryState::default();
+        let stop = Arc::new(AtomicBool::new(false));
+
+        let worker = std::thread::spawn(move || {
+            browse_until_stopped(&receiver, &discovery, "self-id", &stop);
+        });
+        drop(sender);
+
+        let deadline = Instant::now() + BROWSE_STOP_POLL * 8;
+        while !worker.is_finished() && Instant::now() < deadline {
+            std::thread::sleep(Duration::from_millis(10));
+        }
+        assert!(worker.is_finished(), "a closed channel ends the loop");
+        worker.join().expect("browse loop thread");
+    }
+
+    /// `mdns_sd::Receiver` IS `flume::Receiver` (mdns-sd re-exports it), so a
+    /// test channel comes from flume directly — pinned to the same 0.12 line
+    /// mdns-sd depends on, or the two `Receiver` types would not unify.
+    fn flume_channel() -> (flume::Sender<ServiceEvent>, flume::Receiver<ServiceEvent>) {
+        flume::bounded(8)
+    }
 
     #[test]
     fn is_advertisable_rejects_loopback_and_localhost() {

--- a/desktop/src-tauri/src/server.rs
+++ b/desktop/src-tauri/src/server.rs
@@ -191,12 +191,18 @@ fn start_engine_inner(
                     }
                 }
             }
+            // The runtime drop below waits for every blocking task, so a
+            // single hung `spawn_blocking` parks this thread with the whole
+            // shutdown sequence already logged as complete — silence that
+            // looks identical to a stall inside the server. Name the boundary.
+            tracing::debug!("engine: run_server returned; dropping the runtime");
             // Do not use `shutdown_timeout`: Tokio may detach blocking tasks
             // when that deadline expires. Normal Runtime drop cancels async
             // tasks and waits for every blocking task, so EngineHandle can
             // treat thread exit as proof that no server-owned gallery work
             // survives the authority transfer.
             drop(rt);
+            tracing::debug!("engine: runtime dropped; thread exiting");
         })?;
     Ok(EngineHandle {
         port,

--- a/desktop/src-tauri/tests/engine_boot.rs
+++ b/desktop/src-tauri/tests/engine_boot.rs
@@ -76,6 +76,15 @@ async fn engine_boots_authenticates_and_shuts_down() {
         .unwrap();
     assert!(shutdown.status().is_success());
 
+    // Drop the client — and with it the connection pool — BEFORE waiting on
+    // the thread. Axum's graceful shutdown drains live connections, and this
+    // client's pooled keep-alive connection is one, so holding it here makes
+    // the test the reason the server cannot finish. That is exactly what the
+    // intermittent CI failures were: the whole shutdown sequence ran within
+    // 2 ms of this test giving up and unwinding, never before it.
+    drop(shutdown);
+    drop(client);
+
     // …and reported dead once the thread exits, so the connection state
     // machine knows to restart instead of handing out a dead base URL.
     //

--- a/scripts/ci-local.sh
+++ b/scripts/ci-local.sh
@@ -252,6 +252,10 @@ if wants rust; then
   step "rust: test (full main suite)" cargo test --workspace
   step "rust: optional feature check" \
     cargo check -p mold-ai --features preview,discord,expand,tui,webp,mp4,mdns,pulid
+  step "rust: mDNS clippy" \
+    cargo clippy -p mold-ai-server --features mdns --all-targets -- -D warnings
+  step "rust: mDNS tests" \
+    cargo test -p mold-ai-server --features mdns --lib mdns
   step "rust: MiniMax H3 private foundations" \
     cargo test -p mold-ai-inference --lib --features h3-private-uat minimax_h3
   for bin in h3_artifact_qualification h3_qwen_layer50_capture \


### PR DESCRIPTION
## The bug

`MdnsBrowserGuard::shutdown` (`crates/mold-server/src/mdns.rs`) joins the browse worker thread with no bound. That thread sat in a blocking `recv()` on the browse channel, whose sender belongs to the mDNS daemon — so the only thing that could wake it was the daemon closing the channel. On a host where multicast never works, it may never close, and the join never returns. `run_server` never returns either.

That is user-facing, not just CI: `stop_local_engine` gives the embedded engine 10 s before telling the user *"The embedded engine did not stop within 10s; gallery authority remains with the server."*, and the hard-exit deadline is deliberately off for an embedded server (it would take the whole app down).

## How it surfaced

`engine_boots_authenticates_and_shuts_down` has been failing intermittently on the macOS **Native Rust** job, always at exactly its own bound (main runs 33616295687, 33820692419, 33823114932; PR run 33821746457). Raising the bound to 60 s produced a **60.2 s** failure, which ruled out runner jitter: something genuinely never finishes. Each failure on main skips **Publish nightly update**, which is why the desktop nightly stopped arriving.

The browser join is the only unbounded wait in that shutdown sequence, and the last log line before the stall is consistent with it.

## Fix

The loop polls `recv_timeout(BROWSE_STOP_POLL)` (250 ms) against a stop flag the guard sets *before* asking the daemon to stop. A responsive daemon still ends the loop instantly by closing the channel; an unresponsive one now costs one poll interval instead of the process.

## Tests

- `the_browse_loop_stops_on_the_flag_even_when_the_channel_stays_open` — live sender, no events, flag set. **Verified failing against the old blocking `recv()`** and passing with the fix.
- `the_browse_loop_stops_when_the_daemon_closes_the_channel` — the fast path still ends immediately.

`cargo clippy -p mold-ai-server --features mdns --all-targets -D warnings` and `cargo fmt --all --check` clean. Related: #1580 (test diagnostics that located this).