### PR TITLE
fix(catalog): classify Qwen Image Edit models

### DIFF
--- a/changelog.d/qwen-image-edit-catalog.md
+++ b/changelog.d/qwen-image-edit-catalog.md
@@ -1,0 +1,5 @@
+- **Correct Qwen-Image-Edit catalog routing.** Discoveries from Hugging Face
+  and Civitai now retain the distinct `qwen-image-edit` family through search,
+  installation, sidecar storage, and runtime resolution instead of being
+  misrouted as Qwen-Image
+  ([#1569](https://github.com/utensils/mold/issues/1569)).

--- a/crates/mold-catalog/src/civitai_map.rs
+++ b/crates/mold-catalog/src/civitai_map.rs
@@ -78,6 +78,89 @@ pub fn map_base_model(
     })
 }
 
+/// Refine Civitai's shared Qwen base-model bucket using the model and version
+/// names carried by each result. Civitai exposes both Qwen-Image and
+/// Qwen-Image-Edit under `baseModel=Qwen`; keeping [`map_base_model`] generic
+/// preserves that upstream query while this post-normalization step selects
+/// the runtime family that will be written to the sidecar.
+pub fn refine_family_from_names(
+    family: Family,
+    item_name: &str,
+    version_name: Option<&str>,
+) -> Family {
+    if family == Family::QwenImage
+        && [Some(item_name), version_name]
+            .into_iter()
+            .flatten()
+            .any(|name| looks_like_qwen_image_edit(name) || looks_like_image_edit(name))
+    {
+        Family::QwenImageEdit
+    } else {
+        family
+    }
+}
+
+fn looks_like_qwen_image_edit(value: &str) -> bool {
+    let normalized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>();
+    let words = normalized.split_whitespace().collect::<Vec<_>>();
+    words.iter().enumerate().any(|(index, word)| {
+        let compact_suffix = word.strip_prefix("qwenimageedit");
+        if compact_suffix.is_some_and(|suffix| suffix.chars().all(|ch| ch.is_ascii_digit())) {
+            return true;
+        }
+        if *word != "qwen" {
+            return false;
+        }
+        let mut rest = &words[index + 1..];
+        if rest.first() == Some(&"image") {
+            rest = &rest[1..];
+        }
+        while rest
+            .first()
+            .is_some_and(|word| word.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            rest = &rest[1..];
+        }
+        rest.first() == Some(&"edit")
+    })
+}
+
+fn looks_like_image_edit(value: &str) -> bool {
+    let normalized = value
+        .chars()
+        .map(|ch| {
+            if ch.is_ascii_alphanumeric() {
+                ch.to_ascii_lowercase()
+            } else {
+                ' '
+            }
+        })
+        .collect::<String>();
+    let words = normalized.split_whitespace().collect::<Vec<_>>();
+    words.iter().enumerate().any(|(index, word)| {
+        if *word != "image" {
+            return false;
+        }
+        let mut rest = &words[index + 1..];
+        while rest
+            .first()
+            .is_some_and(|word| word.chars().all(|ch| ch.is_ascii_digit()))
+        {
+            rest = &rest[1..];
+        }
+        rest.first() == Some(&"edit")
+    })
+}
+
 /// Civitai base-model strings we explicitly drop. mold has no engine for
 /// these architectures, so surfacing them in the catalog would just tease
 /// users with un-runnable downloads.
@@ -189,7 +272,7 @@ pub fn supported_for(family: Family, bundling: Bundling, kind: Kind) -> bool {
         // don't inherit checkpoint runnability rules.
         Lora => matches!(
             family,
-            Flux | Flux2 | Sd15 | Sdxl | Sd3 | ZImage | Ltx2 | Wan | QwenImage
+            Flux | Flux2 | Sd15 | Sdxl | Sd3 | ZImage | Ltx2 | Wan | QwenImage | QwenImageEdit
         ),
         Vae | TextEncoder | Tokenizer | Clip => true,
         ControlNet => matches!(family, Sd15 | Sdxl),
@@ -222,5 +305,40 @@ mod tests {
             Kind::Checkpoint
         ));
         assert!(supported_for(Family::Sd3, Bundling::SingleFile, Kind::Lora));
+    }
+
+    #[test]
+    fn qwen_edit_name_refinement_accepts_ecosystem_spellings_without_prefix_matches() {
+        for name in [
+            "Qwen Image Edit",
+            "QWEN_IMAGE_EDIT",
+            "QwenImageEdit2511",
+            "QWEN-EDIT",
+            "Qwen-image_2511_Edit",
+        ] {
+            assert_eq!(
+                refine_family_from_names(Family::QwenImage, name, None),
+                Family::QwenImageEdit,
+                "{name}"
+            );
+        }
+        for name in ["Qwen Image", "Qwen Image Editorial", "Qwen Image Editable"] {
+            assert_eq!(
+                refine_family_from_names(Family::QwenImage, name, None),
+                Family::QwenImage,
+                "{name}"
+            );
+        }
+    }
+
+    #[test]
+    fn qwen_edit_catalog_shapes_are_supported() {
+        for kind in [Kind::Checkpoint, Kind::Lora] {
+            assert!(supported_for(
+                Family::QwenImageEdit,
+                Bundling::SingleFile,
+                kind
+            ));
+        }
     }
 }

--- a/crates/mold-catalog/src/companions.rs
+++ b/crates/mold-catalog/src/companions.rs
@@ -276,7 +276,7 @@ pub static COMPANIONS: &[Companion] = &[
     Companion {
         canonical_name: "qwen-image-runtime",
         kind: Kind::TextEncoder,
-        family_scope: &[Family::QwenImage],
+        family_scope: &[Family::QwenImage, Family::QwenImageEdit],
         source: Source::Hf,
         repo: "Qwen/Qwen-Image",
         files: &[
@@ -422,6 +422,11 @@ pub fn companions_for(
         // FL2VA/Ref2VA component layouts.
         Family::MinimaxH3 => {}
         Family::QwenImage => {
+            push(&mut out, "qwen-image-runtime");
+        }
+        Family::QwenImageEdit => {
+            // The edit DiT is distinct, but its catalog single-file exports
+            // use the same Qwen2.5-VL encoder/tokenizer and VAE runtime bundle.
             push(&mut out, "qwen-image-runtime");
         }
         Family::Wuerstchen => {

--- a/crates/mold-catalog/src/families.rs
+++ b/crates/mold-catalog/src/families.rs
@@ -19,6 +19,7 @@ pub enum Family {
     Wan,
     MinimaxH3,
     QwenImage,
+    QwenImageEdit,
     Wuerstchen,
     Hunyuan3d,
 }
@@ -35,6 +36,7 @@ pub const ALL_FAMILIES: &[Family] = &[
     Family::Wan,
     Family::MinimaxH3,
     Family::QwenImage,
+    Family::QwenImageEdit,
     Family::Wuerstchen,
     Family::Hunyuan3d,
 ];
@@ -73,6 +75,7 @@ impl Family {
             Family::Wan => "wan",
             Family::MinimaxH3 => "minimax-h3",
             Family::QwenImage => "qwen-image",
+            Family::QwenImageEdit => "qwen-image-edit",
             Family::Wuerstchen => "wuerstchen",
             Family::Hunyuan3d => "hunyuan3d",
         }
@@ -98,6 +101,7 @@ impl Family {
             | Family::Sd3
             | Family::ZImage
             | Family::QwenImage
+            | Family::QwenImageEdit
             | Family::Wuerstchen
             | Family::Hunyuan3d => false,
         }
@@ -126,6 +130,7 @@ impl Family {
             | Family::Wan
             | Family::MinimaxH3
             | Family::QwenImage
+            | Family::QwenImageEdit
             | Family::Wuerstchen => false,
         }
     }
@@ -144,6 +149,7 @@ impl Family {
             "wan" => Family::Wan,
             "minimax-h3" | "minimax_h3" | "minimaxh3" => Family::MinimaxH3,
             "qwen-image" => Family::QwenImage,
+            "qwen-image-edit" | "qwen_image_edit" => Family::QwenImageEdit,
             "wuerstchen" => Family::Wuerstchen,
             "hunyuan3d" | "hunyuan-3d" => Family::Hunyuan3d,
             other => return Err(UnknownFamily(other.to_string())),
@@ -187,5 +193,17 @@ mod tests {
             assert!(!family.is_video());
         }
         assert!(active_families().any(|family| family == Family::Sd3));
+    }
+
+    #[test]
+    fn qwen_image_edit_is_a_distinct_raster_family() {
+        for alias in ["qwen-image-edit", "qwen_image_edit"] {
+            let family = Family::from_str(alias).unwrap();
+            assert_eq!(family, Family::QwenImageEdit);
+            assert_eq!(family.as_str(), "qwen-image-edit");
+            assert!(!family.is_video());
+            assert!(!family.is_mesh());
+        }
+        assert!(active_families().any(|family| family == Family::QwenImageEdit));
     }
 }

--- a/crates/mold-catalog/src/hf_seeds.rs
+++ b/crates/mold-catalog/src/hf_seeds.rs
@@ -45,6 +45,7 @@ pub fn seeds_for(family: Family) -> &'static [&'static str] {
         ],
         MinimaxH3 => &["MiniMaxAI/MiniMax-H3", "Comfy-Org/MiniMax-H3"],
         QwenImage => &["Qwen/Qwen-Image"],
+        QwenImageEdit => &["Qwen/Qwen-Image-Edit-2511"],
         Wuerstchen => &["warp-ai/wuerstchen"],
         // Tencent's own releases. `Hunyuan3D-2` carries the 1.1B shape
         // checkpoints and the 2.0 paint stack; `-2mini` the 0.6B tier;

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -1070,10 +1070,15 @@ async fn civitai_fetch_window(
         // below — the response is broader but cards land on screen.
         if trimmed_q.is_none() {
             if let Some(family) = opts.family {
-                for bm in CIVITAI_BASE_MODELS
-                    .iter()
-                    .filter(|bm| matches!(map_base_model(bm), Some((f, _, _)) if f == family))
-                {
+                for bm in CIVITAI_BASE_MODELS.iter().filter(|bm| {
+                    matches!(
+                        map_base_model(bm),
+                        Some((mapped, _, _))
+                            if mapped == family
+                                || (family == Family::QwenImageEdit
+                                    && mapped == Family::QwenImage)
+                    )
+                }) {
                     q.append_pair("baseModels", bm);
                 }
             }
@@ -1186,6 +1191,7 @@ fn hf_family_search_term(family: Family) -> &'static str {
         Family::Wan => "wan2",
         Family::MinimaxH3 => "minimax-h3",
         Family::QwenImage => "qwen-image",
+        Family::QwenImageEdit => "qwen-image-edit",
         Family::Wuerstchen => "wuerstchen",
         Family::Hunyuan3d => "hunyuan3d",
     }
@@ -1452,7 +1458,7 @@ pub fn wan_sub_family_from_id(repo_id: &str) -> Option<String> {
 pub fn family_from_hf(
     repo_id: &str,
     tags: &[String],
-    _pipeline_tag: Option<&str>,
+    pipeline_tag: Option<&str>,
 ) -> Option<(Family, FamilyRole)> {
     let id_lower = repo_id.to_ascii_lowercase();
     let role_for = |id: &str, family: Family| -> FamilyRole {
@@ -1467,6 +1473,17 @@ pub fn family_from_hf(
     // Repo-id substring match — the load-bearing path. HF doesn't
     // expose a canonical "model family" tag, so id-substring + curated
     // seed list is the cleanest signal.
+    let qwen_edit_pipeline = tags.iter().any(|tag| {
+        matches!(
+            tag.to_ascii_lowercase().as_str(),
+            "diffusers:qwenimageeditpipeline" | "diffusers:qwenimageeditpluspipeline"
+        )
+    });
+    let qwen_edit_name =
+        crate::civitai_map::refine_family_from_names(Family::QwenImage, repo_id, None)
+            == Family::QwenImageEdit;
+    let qwen_image_name = id_lower.contains("qwen-image") || id_lower.contains("qwen_image");
+
     let family = if looks_like_minimax_h3(&id_lower) {
         Family::MinimaxH3
     } else if id_lower.contains("flux.2") || id_lower.contains("flux-2") {
@@ -1487,7 +1504,13 @@ pub fn family_from_hf(
         Family::Wan
     } else if id_lower.contains("z-image") || id_lower.contains("zimage") {
         Family::ZImage
-    } else if id_lower.contains("qwen-image") || id_lower.contains("qwen_image") {
+    } else if qwen_edit_name
+        || (qwen_image_name
+            && qwen_edit_pipeline
+            && pipeline_tag.is_none_or(|tag| tag.eq_ignore_ascii_case("image-to-image")))
+    {
+        Family::QwenImageEdit
+    } else if qwen_image_name {
         Family::QwenImage
     } else if id_lower.contains("wuerstchen") {
         Family::Wuerstchen
@@ -1523,6 +1546,8 @@ pub fn family_from_hf(
                     // a repo that tags itself `wan` is claiming the family.
                     "wan" => Some(Family::Wan),
                     "minimax-h3" | "minimax_h3" | "minimaxh3" => Some(Family::MinimaxH3),
+                    "qwen-image-edit" | "qwen_image_edit" => Some(Family::QwenImageEdit),
+                    "qwen-image" | "qwen_image" => Some(Family::QwenImage),
                     _ => continue,
                 }
             };
@@ -1976,6 +2001,7 @@ mod tests {
             (Family::Wan, "wan2"),
             (Family::MinimaxH3, "minimax-h3"),
             (Family::QwenImage, "qwen-image"),
+            (Family::QwenImageEdit, "qwen-image-edit"),
             (Family::Wuerstchen, "wuerstchen"),
             (Family::Hunyuan3d, "hunyuan3d"),
         ];
@@ -2081,6 +2107,38 @@ mod tests {
             result.entries[0].source_id,
             "city96/stable-diffusion-3.5-medium-gguf"
         );
+        server.verify().await;
+    }
+
+    #[tokio::test]
+    async fn hf_qwen_edit_filter_uses_the_specific_upstream_term_and_metadata() {
+        let server = MockServer::start().await;
+        let hits = vec![serde_json::json!({
+            "id": "Qwen/Qwen-Image-2511",
+            "tags": ["diffusers", "diffusers:QwenImageEditPlusPipeline"],
+            "pipeline_tag": "image-to-image"
+        })];
+        Mock::given(method("GET"))
+            .and(path("/api/models"))
+            .and(query_param("search", "qwen-image-edit"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(hits))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let result = hf_search(
+            &server.uri(),
+            &LiveSearchOpts {
+                family: Some(Family::QwenImageEdit),
+                source: Some(Source::Hf),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("Qwen edit family page");
+
+        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.entries[0].family, Family::QwenImageEdit);
         server.verify().await;
     }
 

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -1431,6 +1431,22 @@ fn looks_like_minimax_h3(id_lower: &str) -> bool {
         })
 }
 
+/// Match Qwen as a repository-name token, including the ecosystem's compact
+/// `QwenImage*` spelling, without treating an arbitrary image-edit repository
+/// as Qwen merely because the edit classifier is being evaluated.
+fn looks_like_qwen(id_lower: &str) -> bool {
+    id_lower
+        .split(|ch: char| !ch.is_ascii_alphanumeric())
+        .filter(|word| !word.is_empty())
+        .any(|word| {
+            word.strip_prefix("qwen").is_some_and(|suffix| {
+                suffix.is_empty()
+                    || suffix.chars().all(|ch| ch.is_ascii_digit())
+                    || suffix.starts_with("image")
+            })
+        })
+}
+
 /// Wan's sub-family, inferred from a repo id.
 ///
 /// The HF normalizers pass `sub_family: None` on the grounds that single-file
@@ -1479,10 +1495,14 @@ pub fn family_from_hf(
             "diffusers:qwenimageeditpipeline" | "diffusers:qwenimageeditpluspipeline"
         )
     });
-    let qwen_edit_name =
-        crate::civitai_map::refine_family_from_names(Family::QwenImage, repo_id, None)
+    let qwen_context = looks_like_qwen(&id_lower);
+    let qwen_edit_name = qwen_context
+        && crate::civitai_map::refine_family_from_names(Family::QwenImage, repo_id, None)
             == Family::QwenImageEdit;
-    let qwen_image_name = id_lower.contains("qwen-image") || id_lower.contains("qwen_image");
+    let qwen_image_name = qwen_context
+        && (id_lower.contains("qwen-image")
+            || id_lower.contains("qwen_image")
+            || id_lower.contains("qwenimage"));
 
     let family = if looks_like_minimax_h3(&id_lower) {
         Family::MinimaxH3

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -145,6 +145,8 @@ pub enum LiveSearchError {
     Network(#[from] reqwest::Error),
     #[error("decode: {0}")]
     Decode(#[from] serde_json::Error),
+    #[error("{host} search is still scanning locally-filtered results")]
+    Incomplete { host: &'static str },
     #[error("upstream {host}: HTTP {status} {body}")]
     Upstream {
         host: &'static str,
@@ -423,7 +425,9 @@ const MAX_SEARCH_RETRY_DELAY: Duration = Duration::from_secs(15);
 fn upstream_retry_after(error: &LiveSearchError) -> Option<Duration> {
     match error {
         LiveSearchError::Upstream { retry_after, .. } => *retry_after,
-        _ => None,
+        LiveSearchError::Network(_)
+        | LiveSearchError::Decode(_)
+        | LiveSearchError::Incomplete { .. } => None,
     }
 }
 
@@ -450,7 +454,9 @@ fn parse_retry_after(headers: &reqwest::header::HeaderMap) -> Option<Duration> {
 
 fn retryable_search_error(error: &LiveSearchError) -> bool {
     match error {
-        LiveSearchError::Network(_) | LiveSearchError::Decode(_) => true,
+        LiveSearchError::Network(_)
+        | LiveSearchError::Decode(_)
+        | LiveSearchError::Incomplete { .. } => true,
         LiveSearchError::Upstream { status, .. } => {
             matches!(status, 408 | 425 | 429 | 500..=599)
         }
@@ -494,6 +500,10 @@ fn provider_error(source: Source, error: &LiveSearchError) -> CatalogProviderErr
         Source::Civitai => "Civitai",
     };
     let (code, message) = match error {
+        LiveSearchError::Incomplete { .. } => (
+            Some("scan-incomplete"),
+            format!("{provider} is still scanning matching models. Try again shortly."),
+        ),
         LiveSearchError::Upstream { status: 429, .. } => (
             Some("rate-limited"),
             format!("{provider} is handling too many requests right now. Try again shortly."),
@@ -502,7 +512,11 @@ fn provider_error(source: Source, error: &LiveSearchError) -> CatalogProviderErr
             Some("overloaded"),
             "Civitai is busy right now. Try again in a few seconds.".into(),
         ),
-        _ => (None, format!("{provider} is temporarily unavailable.")),
+        LiveSearchError::Network(_)
+        | LiveSearchError::Decode(_)
+        | LiveSearchError::Upstream { .. } => {
+            (None, format!("{provider} is temporarily unavailable."))
+        }
     };
     CatalogProviderError {
         source,
@@ -969,6 +983,16 @@ async fn civitai_search_paged(
                 );
                 chain.next_page += 1;
                 result = Some(page_result);
+            }
+            if result.is_none() && chain.leftover.is_empty() {
+                // An open cursor is not an empty logical page. Preserve the
+                // cursor and ask the bounded retry driver to resume the scan;
+                // if its own budget is exhausted, callers receive an explicit
+                // retryable provider notice rather than false exhaustion.
+                cache.put_chain(key.clone(), chain);
+                return Err(LiveSearchError::Incomplete {
+                    host: "civitai.com",
+                });
             }
             break;
         }
@@ -1885,6 +1909,56 @@ mod tests {
         }
     }
 
+    struct SparseQwenEditResponder {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Respond for SparseQwenEditResponder {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let is_edit = call == MAX_WINDOW_FETCHES;
+            let name = if is_edit {
+                "Community Qwen Image Edit"
+            } else {
+                "Community Qwen Image"
+            };
+            let version_name = if is_edit { "QwenImageEdit2511" } else { "v1" };
+            let metadata = if is_edit {
+                serde_json::json!({})
+            } else {
+                serde_json::json!({ "nextCursor": format!("c{}", call + 1) })
+            };
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "id": 200_000 + call,
+                    "name": name,
+                    "type": "Checkpoint",
+                    "nsfw": false,
+                    "creator": { "username": "alice" },
+                    "stats": { "downloadCount": 100 },
+                    "tags": [],
+                    "modelVersions": [{
+                        "id": 300_000 + call,
+                        "name": version_name,
+                        "baseModel": "Qwen",
+                        "baseModelType": "Standard",
+                        "files": [{
+                            "id": 400_000 + call,
+                            "name": "model.safetensors",
+                            "sizeKB": 100,
+                            "downloadCount": 1,
+                            "metadata": { "format": "SafeTensor" },
+                            "downloadUrl": "https://civitai.example/model.safetensors",
+                            "hashes": { "SHA256": "deadbeef" }
+                        }],
+                        "images": []
+                    }]
+                }],
+                "metadata": metadata
+            }))
+        }
+    }
+
     fn test_cache() -> LiveCache {
         LiveCache::new(Duration::from_secs(300), 256)
     }
@@ -2471,6 +2545,40 @@ mod tests {
             server.received_requests().await.expect("requests").len(),
             MAX_WINDOW_FETCHES,
             "the partial page must be served from the page cache"
+        );
+    }
+
+    #[tokio::test]
+    async fn civitai_sparse_qwen_edit_scan_does_not_return_a_false_empty_page() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/models"))
+            .respond_with(SparseQwenEditResponder {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            })
+            .mount(&server)
+            .await;
+
+        let result = search_page(
+            &server.uri(),
+            "https://unused.example",
+            &test_cache(),
+            &LiveSearchOpts {
+                family: Some(Family::QwenImageEdit),
+                page_size: 1,
+                source: Some(Source::Civitai),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("bounded scan should resume until the first matching edit row");
+
+        assert_eq!(result.entries.len(), 1);
+        assert_eq!(result.entries[0].family, Family::QwenImageEdit);
+        assert_eq!(
+            server.received_requests().await.expect("requests").len(),
+            MAX_WINDOW_FETCHES + 1,
+            "the retry resumes at the stored cursor rather than restarting"
         );
     }
 

--- a/crates/mold-catalog/src/live.rs
+++ b/crates/mold-catalog/src/live.rs
@@ -984,7 +984,7 @@ async fn civitai_search_paged(
                 chain.next_page += 1;
                 result = Some(page_result);
             }
-            if result.is_none() && chain.leftover.is_empty() {
+            if result.is_none() {
                 // An open cursor is not an empty logical page. Preserve the
                 // cursor and ask the bounded retry driver to resume the scan;
                 // if its own budget is exhausted, callers receive an explicit
@@ -1959,6 +1959,51 @@ mod tests {
         }
     }
 
+    struct SparseDeepPageResponder {
+        calls: std::sync::atomic::AtomicUsize,
+    }
+
+    impl Respond for SparseDeepPageResponder {
+        fn respond(&self, _request: &Request) -> ResponseTemplate {
+            let call = self.calls.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+            let is_edit = call == 0 || call >= MAX_WINDOW_FETCHES;
+            let name = if is_edit {
+                "Community Qwen Image Edit"
+            } else {
+                "Community Qwen Image"
+            };
+            let version_name = if is_edit { "QwenImageEdit2511" } else { "v1" };
+            ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "items": [{
+                    "id": 500_000 + call,
+                    "name": name,
+                    "type": "Checkpoint",
+                    "nsfw": false,
+                    "creator": { "username": "alice" },
+                    "stats": { "downloadCount": 100 },
+                    "tags": [],
+                    "modelVersions": [{
+                        "id": 600_000 + call,
+                        "name": version_name,
+                        "baseModel": "Qwen",
+                        "baseModelType": "Standard",
+                        "files": [{
+                            "id": 700_000 + call,
+                            "name": "model.safetensors",
+                            "sizeKB": 100,
+                            "downloadCount": 1,
+                            "metadata": { "format": "SafeTensor" },
+                            "downloadUrl": "https://civitai.example/model.safetensors",
+                            "hashes": { "SHA256": "deadbeef" }
+                        }],
+                        "images": []
+                    }]
+                }],
+                "metadata": { "nextCursor": format!("c{}", call + 1) }
+            }))
+        }
+    }
+
     fn test_cache() -> LiveCache {
         LiveCache::new(Duration::from_secs(300), 256)
     }
@@ -2579,6 +2624,44 @@ mod tests {
             server.received_requests().await.expect("requests").len(),
             MAX_WINDOW_FETCHES + 1,
             "the retry resumes at the stored cursor rather than restarting"
+        );
+    }
+
+    #[tokio::test]
+    async fn civitai_deep_sparse_scan_does_not_return_empty_mid_intermediate_page() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/models"))
+            .respond_with(SparseDeepPageResponder {
+                calls: std::sync::atomic::AtomicUsize::new(0),
+            })
+            .mount(&server)
+            .await;
+
+        let result = search_page(
+            &server.uri(),
+            "https://unused.example",
+            &test_cache(),
+            &LiveSearchOpts {
+                family: Some(Family::QwenImageEdit),
+                page: 2,
+                page_size: 2,
+                source: Some(Source::Civitai),
+                ..Default::default()
+            },
+        )
+        .await
+        .expect("bounded scan should resume an incomplete intermediate page");
+
+        assert_eq!(result.entries.len(), 2);
+        assert!(result
+            .entries
+            .iter()
+            .all(|entry| entry.family == Family::QwenImageEdit));
+        assert_eq!(
+            server.received_requests().await.expect("requests").len(),
+            MAX_WINDOW_FETCHES + 3,
+            "the retry resumes with the buffered edit row and stored cursor"
         );
     }
 

--- a/crates/mold-catalog/src/normalizer.rs
+++ b/crates/mold-catalog/src/normalizer.rs
@@ -5,7 +5,7 @@
 
 use serde::Deserialize;
 
-use crate::civitai_map::{map_base_model, supported_for};
+use crate::civitai_map::{map_base_model, refine_family_from_names, supported_for};
 use crate::companions::companions_for;
 use crate::entry::{
     Bundling, CatalogEntry, CatalogId, DownloadRecipe, FamilyRole, FileFormat, Kind, LicenseFlags,
@@ -504,6 +504,7 @@ fn from_civitai_version(
     a14b_policy: A14bEmitPolicy,
 ) -> Option<CatalogEntry> {
     let (family, family_role, sub_family) = map_base_model(&version.base_model)?;
+    let family = refine_family_from_names(family, &item.name, version.name.as_deref());
     let file = pick_safetensors(&version.files)?;
     // Drop entries whose Civitai type isn't representable in the catalog
     // (TextualInversion, Hypernetwork, etc.) before doing any further work.

--- a/crates/mold-catalog/src/resolve.rs
+++ b/crates/mold-catalog/src/resolve.rs
@@ -1122,51 +1122,67 @@ mod tests {
     }
 
     #[test]
-    fn qwen_runtime_companion_paths_populated() {
+    fn qwen_and_qwen_edit_runtime_companion_paths_populated() {
         let _lock = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        clear_models_dir_env();
-        let dir = tempfile::tempdir().unwrap();
-        let _home = pin_mold_home(dir.path());
-        let models_dir = dir.path();
-        let primary =
-            models_dir.join("cv-2110043/qwen-image/civitai/2110043/qwenImage_fp8.safetensors");
-        std::fs::create_dir_all(primary.parent().unwrap()).unwrap();
-        std::fs::File::create(&primary).unwrap();
+        for (family, slug, id, filename) in [
+            (
+                Family::QwenImage,
+                "qwen-image",
+                "2110043",
+                "qwenImage_fp8.safetensors",
+            ),
+            (
+                Family::QwenImageEdit,
+                "qwen-image-edit",
+                "2110044",
+                "qwenImageEdit_fp8.safetensors",
+            ),
+        ] {
+            clear_models_dir_env();
+            let dir = tempfile::tempdir().unwrap();
+            let _home = pin_mold_home(dir.path());
+            let models_dir = dir.path();
+            let primary = models_dir.join(format!("cv-{id}/{slug}/civitai/{id}/{filename}"));
+            std::fs::create_dir_all(primary.parent().unwrap()).unwrap();
+            std::fs::File::create(&primary).unwrap();
 
-        let runtime_dir = models_dir.join("qwen-image-runtime");
-        let vae = runtime_dir.join("vae/diffusion_pytorch_model.safetensors");
-        let te = runtime_dir.join("text_encoder/model-00001-of-00004.safetensors");
-        let tok = runtime_dir.join("tokenizer/tokenizer.json");
-        for p in [&vae, &te, &tok] {
-            std::fs::create_dir_all(p.parent().unwrap()).unwrap();
-            std::fs::File::create(p).unwrap();
+            let runtime_dir = models_dir.join("qwen-image-runtime");
+            let vae = runtime_dir.join("vae/diffusion_pytorch_model.safetensors");
+            let te = runtime_dir.join("text_encoder/model-00001-of-00004.safetensors");
+            let tok = runtime_dir.join("tokenizer/tokenizer.json");
+            for p in [&vae, &te, &tok] {
+                std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+                std::fs::File::create(p).unwrap();
+            }
+            let mut config = config_in(models_dir);
+            config.models.insert(
+                "qwen-image-runtime".into(),
+                ModelConfig {
+                    family: Some("companion".into()),
+                    transformer: Some(vae.to_string_lossy().into_owned()),
+                    vae: Some(vae.to_string_lossy().into_owned()),
+                    text_encoder_files: Some(vec![te.to_string_lossy().into_owned()]),
+                    text_tokenizer: Some(tok.to_string_lossy().into_owned()),
+                    ..Default::default()
+                },
+            );
+
+            let mut entry = flux_unet_only_entry(id, filename);
+            entry.family = family;
+            entry.companions = vec!["qwen-image-runtime".into()];
+            let intent = synthesize_intent(&entry, models_dir).unwrap();
+            let cfg = resolve_intent_to_model_config(&format!("cv:{id}"), &intent, &config, FAIL)
+                .unwrap();
+
+            assert_eq!(cfg.transformer.as_deref(), primary.to_str(), "{family}");
+            assert_eq!(cfg.vae.as_deref(), vae.to_str(), "{family}");
+            assert_eq!(
+                cfg.text_encoder_files.as_deref(),
+                Some(vec![te.to_string_lossy().into_owned()].as_slice()),
+                "{family}"
+            );
+            assert_eq!(cfg.text_tokenizer.as_deref(), tok.to_str(), "{family}");
         }
-        let mut config = config_in(models_dir);
-        config.models.insert(
-            "qwen-image-runtime".into(),
-            ModelConfig {
-                family: Some("companion".into()),
-                transformer: Some(vae.to_string_lossy().into_owned()),
-                vae: Some(vae.to_string_lossy().into_owned()),
-                text_encoder_files: Some(vec![te.to_string_lossy().into_owned()]),
-                text_tokenizer: Some(tok.to_string_lossy().into_owned()),
-                ..Default::default()
-            },
-        );
-
-        let mut entry = flux_unet_only_entry("2110043", "qwenImage_fp8.safetensors");
-        entry.family = Family::QwenImage;
-        entry.companions = vec!["qwen-image-runtime".into()];
-        let intent = synthesize_intent(&entry, models_dir).unwrap();
-        let cfg = resolve_intent_to_model_config("cv:2110043", &intent, &config, FAIL).unwrap();
-
-        assert_eq!(cfg.transformer.as_deref(), primary.to_str());
-        assert_eq!(cfg.vae.as_deref(), vae.to_str());
-        assert_eq!(
-            cfg.text_encoder_files.as_deref(),
-            Some(vec![te.to_string_lossy().into_owned()].as_slice())
-        );
-        assert_eq!(cfg.text_tokenizer.as_deref(), tok.to_str());
     }
 
     #[test]

--- a/crates/mold-catalog/src/sidecar.rs
+++ b/crates/mold-catalog/src/sidecar.rs
@@ -518,6 +518,23 @@ mod tests {
     }
 
     #[test]
+    fn sidecar_preserves_qwen_image_edit_as_its_own_runtime_family() {
+        let mut entry = fixture_entry();
+        entry.family = Family::QwenImageEdit;
+        entry.name = "QwenImageEdit2511 community".into();
+        let sidecar = sidecar_from_entry(
+            &entry,
+            "qwen-image-edit/civitai/8001/model.safetensors".into(),
+        );
+
+        assert_eq!(sidecar.family, "qwen-image-edit");
+        assert_eq!(
+            Family::from_str(&sidecar.family).unwrap(),
+            Family::QwenImageEdit
+        );
+    }
+
+    #[test]
     fn installed_h3_sidecar_is_rejected_as_metadata_not_treated_as_a_cache_miss() {
         let root = tempfile::tempdir().unwrap();
         let mut entry = fixture_entry();

--- a/crates/mold-catalog/src/synthesis.rs
+++ b/crates/mold-catalog/src/synthesis.rs
@@ -288,7 +288,7 @@ pub fn family_bundles_vae_unconditionally(family: Family) -> bool {
         | Family::LtxVideo
         | Family::Wan
         | Family::MinimaxH3 => false,
-        Family::QwenImage | Family::Wuerstchen => false,
+        Family::QwenImage | Family::QwenImageEdit | Family::Wuerstchen => false,
         // Hunyuan3D bundles the shape VAE inside the single checkpoint under
         // the `vae.` prefix, unconditionally and across every published tier
         // (2.0, 2.0-turbo, 2.0-mini, 2mv, 2.1). There is nothing to probe for
@@ -462,6 +462,28 @@ mod tests {
         let intent = synthesize_intent(&entry, Path::new("/tmp")).unwrap();
         let names: Vec<&str> = intent.companions.iter().map(|c| c.name.as_str()).collect();
         assert_eq!(names, vec!["qwen-image-runtime"]);
+    }
+
+    #[test]
+    fn synthesize_intent_preserves_qwen_edit_family_and_runtime_companion() {
+        let mut entry = flux_unet_only_entry();
+        entry.id = CatalogId::from("cv:2110044");
+        entry.source_id = "2110044".into();
+        entry.family = Family::QwenImageEdit;
+        entry.download_recipe.files[0].dest =
+            "{family}/civitai/2110044/qwenImageEdit_fp8.safetensors".into();
+
+        let intent = synthesize_intent(&entry, Path::new("/tmp")).unwrap();
+        assert_eq!(intent.family, "qwen-image-edit");
+        assert_eq!(
+            intent
+                .companions
+                .iter()
+                .map(|companion| companion.name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["qwen-image-runtime"]
+        );
+        assert!(!family_bundles_vae_unconditionally(Family::QwenImageEdit));
     }
 
     #[test]

--- a/crates/mold-catalog/tests/companions_lookup.rs
+++ b/crates/mold-catalog/tests/companions_lookup.rs
@@ -210,6 +210,22 @@ fn separated_bundling_has_no_companions() {
 }
 
 #[test]
+fn qwen_edit_single_file_reuses_the_verified_qwen_runtime_bundle() {
+    assert_eq!(
+        companions_for(
+            Family::QwenImageEdit,
+            None,
+            Bundling::SingleFile,
+            Kind::Checkpoint,
+        ),
+        vec!["qwen-image-runtime"]
+    );
+    let runtime = companion_by_name("qwen-image-runtime").expect("qwen runtime");
+    assert!(runtime.family_scope.contains(&Family::QwenImage));
+    assert!(runtime.family_scope.contains(&Family::QwenImageEdit));
+}
+
+#[test]
 fn lora_kind_never_pulls_companions() {
     // LoRAs are self-contained safetensors patches — they are merged into a
     // base model that itself supplies T5/CLIP/VAE. Pulling companions for
@@ -223,6 +239,7 @@ fn lora_kind_never_pulls_companions() {
         Family::ZImage,
         Family::LtxVideo,
         Family::Ltx2,
+        Family::QwenImageEdit,
     ] {
         for bundling in [Bundling::SingleFile, Bundling::Separated] {
             let names = companions_for(family, None, bundling, Kind::Lora);

--- a/crates/mold-catalog/tests/families_roundtrip.rs
+++ b/crates/mold-catalog/tests/families_roundtrip.rs
@@ -27,6 +27,7 @@ fn manifest_strings_are_stable() {
         (Family::Ltx2, "ltx2"),
         (Family::Wan, "wan"),
         (Family::QwenImage, "qwen-image"),
+        (Family::QwenImageEdit, "qwen-image-edit"),
         (Family::Wuerstchen, "wuerstchen"),
     ];
     for (fam, s) in cases {
@@ -36,8 +37,7 @@ fn manifest_strings_are_stable() {
 }
 
 /// The manifest registry is the shipped-model authority; the Models taxonomy
-/// must cover every visible generation family in it. Qwen Image Edit is the
-/// one deliberate presentation merge, sharing the Qwen Image catalog shelf.
+/// must cover every visible generation family in it.
 /// Utility manifests are not generation families and never belong in the
 /// family picker.
 #[test]
@@ -54,7 +54,6 @@ fn catalog_taxonomy_covers_every_visible_generation_manifest_family() {
     let manifest_families = mold_core::manifest::visible_manifests()
         .filter_map(|manifest| {
             let family = match manifest.family.as_str() {
-                "qwen-image-edit" => "qwen-image",
                 family if UTILITY_FAMILIES.contains(&family) => return None,
                 family => family,
             };

--- a/crates/mold-catalog/tests/live_search.rs
+++ b/crates/mold-catalog/tests/live_search.rs
@@ -111,6 +111,37 @@ const ONE_QWEN_CHECKPOINT: &str = r#"{
     "metadata": { "totalPages": 1 }
 }"#;
 
+const ONE_QWEN_EDIT_CHECKPOINT: &str = r#"{
+    "items": [{
+        "id": 9202,
+        "name": "Community Qwen Image Edit",
+        "type": "Checkpoint",
+        "nsfw": false,
+        "creator": { "username": "alice" },
+        "stats": { "downloadCount": 102, "rating": 4.8, "favoriteCount": 12 },
+        "tags": [],
+        "modelVersions": [{
+            "id": 8202,
+            "name": "QWEN_IMAGE_EDIT fp8",
+            "baseModel": "Qwen",
+            "baseModelType": "Standard",
+            "trainedWords": [],
+            "files": [{
+                "id": 1,
+                "name": "qwenImageEdit_fp8.safetensors",
+                "type": "Model",
+                "sizeKB": 19951792,
+                "downloadCount": 1,
+                "metadata": { "format": "SafeTensor" },
+                "downloadUrl": "https://civitai.example/qwen-edit.safetensors",
+                "hashes": { "SHA256": "def456" }
+            }],
+            "images": []
+        }]
+    }],
+    "metadata": { "totalPages": 1 }
+}"#;
+
 fn flux_lora_opts(q: &str) -> LiveSearchOpts {
     LiveSearchOpts {
         q: Some(q.into()),
@@ -262,6 +293,39 @@ async fn family_filter_forwards_as_civitai_base_models_when_no_query() {
         .await
         .unwrap();
     assert_eq!(entries.len(), 1);
+}
+
+#[tokio::test]
+async fn qwen_edit_family_reuses_generic_civitai_bucket_then_filters_locally() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/models"))
+        .and(query_param("baseModels", "Qwen"))
+        .and(query_param("baseModels", "Qwen 2"))
+        .respond_with(ResponseTemplate::new(200).set_body_string(ONE_QWEN_EDIT_CHECKPOINT))
+        .expect(1)
+        .mount(&server)
+        .await;
+
+    let cache = LiveCache::new(Duration::from_secs(300), 64);
+    let opts = LiveSearchOpts {
+        q: None,
+        family: Some(Family::QwenImageEdit),
+        kind: Some(Kind::Checkpoint),
+        source: Some(Source::Civitai),
+        page: 1,
+        page_size: 20,
+        include_nsfw: false,
+        sort: CatalogSort::Downloads,
+        civitai_token: None,
+        hf_token: None,
+    };
+    let entries = search(&server.uri(), "https://hf.unused", &cache, &opts)
+        .await
+        .expect("qwen edit search");
+
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].family, Family::QwenImageEdit);
 }
 
 /// Civitai bug: `query=` + `baseModels=` returns empty first-cursor
@@ -892,6 +956,10 @@ fn family_from_hf_id_substring() {
         ("stabilityai/stable-diffusion-3.5-large", Family::Sd3),
         ("city96/stable-diffusion-3.5-medium-gguf", Family::Sd3),
         ("Tongyi-MAI/Z-Image-Turbo", Family::ZImage),
+        ("Qwen/Qwen-Image-Edit-2511", Family::QwenImageEdit),
+        ("someone/QWEN_IMAGE_EDIT_finetune", Family::QwenImageEdit),
+        ("someone/qwen-image-edit-lightning", Family::QwenImageEdit),
+        ("Qwen/Qwen-Image", Family::QwenImage),
     ];
     for (id, want) in cases {
         let (got, _role) =
@@ -907,6 +975,31 @@ fn family_from_hf_id_substring() {
             family_from_hf(id, &[], None).is_none(),
             "H3 lookalike {id} must not be classified"
         );
+    }
+}
+
+#[test]
+fn family_from_hf_uses_official_qwen_edit_metadata_without_overmatching() {
+    use mold_catalog::entry::FamilyRole;
+
+    let tags = vec!["diffusers:QwenImageEditPlusPipeline".to_string()];
+    let (family, role) = family_from_hf("Qwen/Qwen-Image-2511", &tags, Some("image-to-image"))
+        .expect("official Qwen edit metadata");
+    assert_eq!(family, Family::QwenImageEdit);
+    assert_eq!(role, FamilyRole::Finetune);
+
+    let (_, role) = family_from_hf("Qwen/Qwen-Image-Edit-2511", &tags, Some("image-to-image"))
+        .expect("official seed");
+    assert_eq!(role, FamilyRole::Foundation);
+
+    for id in [
+        "someone/qwen-image-editorial-style",
+        "someone/qwen-image-editable-captioner",
+        "someone/qwen-image",
+    ] {
+        let (family, _) = family_from_hf(id, &[], Some("image-to-image"))
+            .unwrap_or_else(|| panic!("expected generic Qwen family for {id}"));
+        assert_eq!(family, Family::QwenImage, "{id}");
     }
 }
 

--- a/crates/mold-catalog/tests/live_search.rs
+++ b/crates/mold-catalog/tests/live_search.rs
@@ -959,6 +959,7 @@ fn family_from_hf_id_substring() {
         ("Qwen/Qwen-Image-Edit-2511", Family::QwenImageEdit),
         ("someone/QWEN_IMAGE_EDIT_finetune", Family::QwenImageEdit),
         ("someone/qwen-image-edit-lightning", Family::QwenImageEdit),
+        ("someone/QwenImageEdit2511", Family::QwenImageEdit),
         ("Qwen/Qwen-Image", Family::QwenImage),
     ];
     for (id, want) in cases {
@@ -1001,6 +1002,16 @@ fn family_from_hf_uses_official_qwen_edit_metadata_without_overmatching() {
             .unwrap_or_else(|| panic!("expected generic Qwen family for {id}"));
         assert_eq!(family, Family::QwenImage, "{id}");
     }
+
+    assert!(
+        family_from_hf(
+            "someorg/instruct-image-edit-v2",
+            &[],
+            Some("image-to-image")
+        )
+        .is_none(),
+        "a generic image-edit repository has no Qwen context"
+    );
 }
 
 #[test]

--- a/crates/mold-catalog/tests/normalizer_snapshots.rs
+++ b/crates/mold-catalog/tests/normalizer_snapshots.rs
@@ -196,6 +196,103 @@ fn civitai_empty_model_descriptions_fall_back_to_version_description() {
 }
 
 #[test]
+fn civitai_qwen_edit_names_refine_the_generic_base_model_family() {
+    for (item_name, version_name) in [
+        ("Qwen Image Edit portrait", "v1"),
+        ("QWEN_IMAGE_EDIT portrait", "v1"),
+        ("Community checkpoint", "qwen-image-edit-2511 FP8"),
+        ("Community checkpoint", "QwenImageEdit2511"),
+        ("Community checkpoint", "QWEN-EDIT"),
+        ("Community checkpoint", "Qwen-image_2511_Edit"),
+        ("Qwen community checkpoint", "Image Edit 2511"),
+    ] {
+        let item: CivitaiItem = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "name": item_name,
+            "type": "Checkpoint",
+            "nsfw": false,
+            "tags": [],
+            "modelVersions": [{
+                "id": 99,
+                "name": version_name,
+                "baseModel": "Qwen",
+                "baseModelType": "Standard",
+                "files": [{
+                    "id": 7,
+                    "name": "model.safetensors",
+                    "type": "Model",
+                    "sizeKB": 100,
+                    "downloadCount": 0,
+                    "metadata": { "format": "SafeTensor" },
+                    "downloadUrl": "https://civitai.example/model",
+                    "hashes": {}
+                }],
+                "images": []
+            }]
+        }))
+        .expect("parse Civitai fixture");
+
+        let entry = from_civitai(item).expect("normalize Civitai fixture");
+        assert_eq!(
+            entry.family,
+            Family::QwenImageEdit,
+            "{item_name} / {version_name}"
+        );
+        assert_eq!(entry.family.as_str(), "qwen-image-edit");
+        assert_eq!(entry.modality, Modality::Image);
+        assert!(entry.supported);
+        assert_eq!(entry.companions, vec!["qwen-image-runtime"]);
+        assert!(entry.download_recipe.files[0]
+            .dest
+            .starts_with("{family}/civitai/"));
+    }
+}
+
+#[test]
+fn civitai_qwen_names_without_exact_edit_tokens_stay_qwen_image() {
+    for (item_name, version_name) in [
+        ("Qwen Image", "v1"),
+        ("Qwen Image Editorial Style", "v1"),
+        ("Qwen Image Editable Captioner", "v1"),
+        ("Community checkpoint", "Qwen Image Editorial"),
+        ("Community checkpoint", "QwenImageEditable"),
+    ] {
+        let item: CivitaiItem = serde_json::from_value(serde_json::json!({
+            "id": 42,
+            "name": item_name,
+            "type": "Checkpoint",
+            "nsfw": false,
+            "tags": [],
+            "modelVersions": [{
+                "id": 99,
+                "name": version_name,
+                "baseModel": "Qwen 2",
+                "baseModelType": "Standard",
+                "files": [{
+                    "id": 7,
+                    "name": "model.safetensors",
+                    "type": "Model",
+                    "sizeKB": 100,
+                    "downloadCount": 0,
+                    "metadata": { "format": "SafeTensor" },
+                    "downloadUrl": "https://civitai.example/model",
+                    "hashes": {}
+                }],
+                "images": []
+            }]
+        }))
+        .expect("parse Civitai fixture");
+
+        let entry = from_civitai(item).expect("normalize Civitai fixture");
+        assert_eq!(
+            entry.family,
+            Family::QwenImage,
+            "{item_name} / {version_name}"
+        );
+    }
+}
+
+#[test]
 fn civitai_zimage_multifile_version_picks_model_file_not_text_encoder() {
     // cv:2442439 lists Text Encoder, VAE, then Model. The primary recipe
     // must choose the Model file; otherwise mold tries to load Qwen3 text

--- a/crates/mold-inference/src/loader/single_file.rs
+++ b/crates/mold-inference/src/loader/single_file.rs
@@ -330,6 +330,7 @@ mod tests {
             Family::LtxVideo,
             Family::Ltx2,
             Family::QwenImage,
+            Family::QwenImageEdit,
             Family::Wuerstchen,
         ];
 

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -695,6 +695,9 @@ fn live_error_to_install_error(
         LiveSearchError::Decode(e) => mold_core::InstallError::RecipeMalformed(format!(
             "{model_name}: decode upstream payload: {e}"
         )),
+        LiveSearchError::Incomplete { .. } => {
+            mold_core::InstallError::Network(format!("{model_name}: {err}"))
+        }
         LiveSearchError::Upstream { status, body, .. } if *status == 404 => {
             mold_core::InstallError::NotFound(format!(
                 "{model_name}: upstream returned 404 ({})",

--- a/crates/mold-server/src/test_support.rs
+++ b/crates/mold-server/src/test_support.rs
@@ -89,6 +89,12 @@ impl TestApp {
         Self { router }
     }
 
+    pub async fn with_civitai_base(base: impl Into<String>) -> Self {
+        let state = crate::state::AppState::for_tests().with_civitai_base(base);
+        let router = crate::routes::create_router(state);
+        Self { router }
+    }
+
     pub async fn get(&self, uri: &str) -> TestResponse {
         let req = Request::builder().uri(uri).body(Body::empty()).unwrap();
         let resp = self.router.clone().oneshot(req).await.unwrap();

--- a/crates/mold-server/tests/catalog_routes.rs
+++ b/crates/mold-server/tests/catalog_routes.rs
@@ -1,5 +1,7 @@
 use axum::http::StatusCode;
 use mold_server::test_support::TestApp;
+use wiremock::matchers::{method, path, query_param};
+use wiremock::{Mock, MockServer, ResponseTemplate};
 
 #[tokio::test]
 async fn families_endpoint_returns_static_taxonomy() {
@@ -23,6 +25,7 @@ async fn families_endpoint_returns_static_taxonomy() {
         "ltx2",
         "minimax-h3",
         "qwen-image",
+        "qwen-image-edit",
         "wuerstchen",
     ] {
         assert!(
@@ -58,8 +61,59 @@ async fn capabilities_includes_catalog_block() {
         .unwrap()
         .iter()
         .any(|family| family == "sd3"));
+    assert!(v["catalog"]["families"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|family| family == "qwen-image-edit"));
     // The reviewed compact H3 rows are ordinary model identities. Execution
     // availability is advertised by the task/backend capability instead of a
     // family-wide licensing restriction.
     assert_eq!(v["model_access"]["restrictions"], serde_json::json!([]));
+}
+
+#[tokio::test]
+async fn qwen_image_edit_family_filter_is_accepted_and_applied() {
+    let upstream = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path("/api/v1/models"))
+        .and(query_param("baseModels", "Qwen"))
+        .and(query_param("baseModels", "Qwen 2"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "items": [{
+                "id": 1,
+                "name": "QwenImageEdit2511 community",
+                "type": "Checkpoint",
+                "nsfw": false,
+                "modelVersions": [{
+                    "id": 2,
+                    "name": "fp8",
+                    "baseModel": "Qwen",
+                    "baseModelType": "Standard",
+                    "files": [{
+                        "id": 3,
+                        "name": "model.safetensors",
+                        "sizeKB": 100,
+                        "metadata": { "format": "SafeTensor" },
+                        "downloadUrl": "https://civitai.example/model",
+                        "hashes": {}
+                    }],
+                    "images": []
+                }]
+            }],
+            "metadata": { "totalPages": 1 }
+        })))
+        .expect(1)
+        .mount(&upstream)
+        .await;
+
+    let app = TestApp::with_civitai_base(upstream.uri()).await;
+    let response = app
+        .get("/api/catalog/search?family=qwen-image-edit&source=civitai&page=1&page_size=20")
+        .await;
+    assert_eq!(response.status, StatusCode::OK, "{}", response.body);
+    let body: serde_json::Value = serde_json::from_str(&response.body).unwrap();
+    let entries = body["entries"].as_array().expect("entries");
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0]["family"], "qwen-image-edit");
 }


### PR DESCRIPTION
## Summary

- add `qwen-image-edit` as a distinct catalog family across taxonomy, companions, synthesis, resolution, sidecars, and server filters
- classify Hugging Face edit repositories before generic Qwen while anchoring edit heuristics to Qwen context
- keep Civitai's shared Qwen upstream buckets, then refine model/version names using tested ecosystem spellings

## Validation

- `cargo test -p mold-ai-catalog`
- `cargo test -p mold-ai-server --test catalog_routes`
- targeted single-file loader regression
- `cargo clippy -p mold-ai-catalog --all-targets -- -D warnings`
- scoped server clippy and `cargo check --workspace`
- `cargo fmt --all -- --check`
- `cargo run -p mold-ai-core --bin generate_generation_profiles -- --check`
- Claude completed-diff review, including a follow-up review after fixing its HF false-positive finding

No model downloads, inference, image/video generations, or GPU UAT were run.

Closes #1569
