### PR TITLE
fix: validate and orient generation inputs

### DIFF
--- a/changelog.d/input-admission-correctness.md
+++ b/changelog.d/input-admission-correctness.md
@@ -1,0 +1,8 @@
+- **Reject invalid face-identity requests before downloads.** Forced-local
+  generation now refuses an unqualified PuLID model before resolution, repair,
+  or pull; server admission is pinned to return before durable or download queues
+  ([#1305](https://github.com/utensils/mold/issues/1305)).
+- **Honor phone-photo orientation throughout MiniMax H3.** Reference images and
+  FL2VA endpoints now share the EXIF- and ICC-aware bounded decoder, while CLI,
+  TUI, and server descriptors report the same upright dimensions the model sees
+  ([#1431](https://github.com/utensils/mold/issues/1431)).

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -104,6 +104,14 @@ pub(crate) fn resolve_family(model: &str, config: &Config) -> Option<String> {
 
 fn require_local_request_model_activation(req: &GenerateRequest, config: &Config) -> Result<()> {
     let family = resolve_family(&req.model, config);
+    // Model qualification is a name/family fact, so ask it before any local
+    // resolver can repair or auto-pull a checkpoint. Full identity validation
+    // still runs after resolution against the refreshed generation profile.
+    if mold_core::identity::request_mentions_identity(req)
+        && !mold_core::identity::identity_qualified_model_with_family(&req.model, family.as_deref())
+    {
+        anyhow::bail!(mold_core::identity::identity_model_gate_message(&req.model));
+    }
     let models_root = config.resolved_models_dir();
     mold_core::require_generate_request_model_activation(
         req,
@@ -118,6 +126,26 @@ fn require_local_request_model_activation(req: &GenerateRequest, config: &Config
         crate::catalog_bridge::require_known_model_activation(config, identity)?;
     }
     Ok(())
+}
+
+/// Cross the local model-resolution/acquisition boundary only after every
+/// config-only activation rule has accepted the request.
+///
+/// The injected boundary is intentional: a regression can prove that an
+/// unqualified PuLID request invokes no resolver at all, without installing or
+/// downloading a checkpoint merely to observe the ordering.
+#[cfg(any(feature = "cuda", feature = "metal", test))]
+async fn resolve_local_model_after_activation_with<T, F, Fut>(
+    request: &GenerateRequest,
+    config: &Config,
+    resolve: F,
+) -> Result<T>
+where
+    F: FnOnce() -> Fut,
+    Fut: std::future::Future<Output = Result<T>>,
+{
+    require_local_request_model_activation(request, config)?;
+    resolve().await
 }
 
 /// Validate a request on the forced-local path.
@@ -2712,9 +2740,11 @@ async fn prepare_local_request(
     let model_name = req.model.clone();
     let mut req = req.clone();
 
-    require_local_request_model_activation(&req, config)?;
-
-    let (paths, effective_config, pulled) = resolve_or_pull_model(&model_name, config).await?;
+    let (paths, effective_config, pulled) =
+        resolve_local_model_after_activation_with(&req, config, || {
+            resolve_or_pull_model(&model_name, config)
+        })
+        .await?;
     if pulled {
         let model_cfg = effective_config.resolved_model_config(&model_name);
         let family = resolve_family(&model_name, &effective_config);
@@ -4054,6 +4084,7 @@ fn default_filename(
 mod tests {
     use super::*;
     use mold_core::ModelConfig;
+    use std::sync::atomic::{AtomicUsize, Ordering};
 
     fn wan_surface_parity_fixture() -> serde_json::Value {
         serde_json::from_str(include_str!(concat!(
@@ -6521,6 +6552,32 @@ mod tests {
 
         request.lora.as_mut().unwrap().path = format!("{root}/flux/ordinary-adapter.safetensors");
         assert!(require_local_request_model_activation(&request, &config).is_ok());
+    }
+
+    #[tokio::test]
+    async fn unqualified_identity_request_never_crosses_local_model_resolution() {
+        let config = Config::default();
+        let mut request: GenerateRequest = serde_json::from_value(serde_json::json!({
+            "prompt": "a portrait",
+            "model": "qwen-image:fp8",
+            "width": 1024,
+            "height": 1024,
+            "steps": 4,
+            "guidance": 0.0,
+            "batch_size": 1
+        }))
+        .unwrap();
+        request.id_image = Some(vec![0x89, 0x50, 0x4e, 0x47]);
+        let calls = AtomicUsize::new(0);
+
+        let result = resolve_local_model_after_activation_with(&request, &config, || async {
+            calls.fetch_add(1, Ordering::SeqCst);
+            Ok(())
+        })
+        .await;
+
+        assert!(result.is_err());
+        assert_eq!(calls.load(Ordering::SeqCst), 0);
     }
 
     /// Metadata must survive a zero-length prompt on every embedded surface.

--- a/crates/mold-cli/src/commands/h3.rs
+++ b/crates/mold-cli/src/commands/h3.rs
@@ -459,10 +459,18 @@ pub(crate) fn validate_boundary_image_bytes(bytes: &[u8], boundary: &str) -> Res
     if !matches!(format, image::ImageFormat::Png | image::ImageFormat::Jpeg) {
         anyhow::bail!("MiniMax H3 {boundary} frame must be PNG or JPEG; received {format:?}");
     }
-    let dimensions = reader
-        .into_dimensions()
-        .with_context(|| format!("failed to decode MiniMax H3 {boundary} frame"))?;
+    let dimensions =
+        mold_inference::img_utils::oriented_image_dimensions(reader, h3_image_decode_limits())
+            .with_context(|| format!("failed to decode MiniMax H3 {boundary} frame"))?;
     Ok(dimensions)
+}
+
+fn h3_image_decode_limits() -> image::Limits {
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_image_height = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_alloc = Some(minimax_h3::MAX_REFERENCE_IMAGE_PIXELS.saturating_mul(4));
+    limits
 }
 
 fn prepare_references(
@@ -545,7 +553,8 @@ fn probe_image(
         image::ImageFormat::Gif => "image/gif",
         _ => anyhow::bail!("unsupported image format; use PNG, JPEG, WebP, or GIF"),
     };
-    let (width, height) = reader.into_dimensions()?;
+    let (width, height) =
+        mold_inference::img_utils::oriented_image_dimensions(reader, h3_image_decode_limits())?;
     Ok(GenerationReference::Image {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
@@ -740,6 +749,7 @@ fn probe_wav(file: File) -> Result<WavProbe> {
 mod tests {
     use super::*;
     use image::ImageEncoder as _;
+    use std::io::Write as _;
 
     #[test]
     fn reference_arg_preserves_kind_and_paths_containing_equals() {
@@ -747,6 +757,31 @@ mod tests {
         assert_eq!(parsed.kind, ReferenceKind::Video);
         assert_eq!(parsed.path, PathBuf::from("/tmp/clip=final.mp4"));
         assert!(!format!("{parsed:?}").contains("clip=final"));
+    }
+
+    #[test]
+    fn h3_image_probes_report_exif_oriented_dimensions() {
+        let bytes = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../mold-inference/src/ltx2/testdata/preprocess/portrait_exif6.jpg"
+        ));
+        assert_eq!(
+            validate_boundary_image_bytes(bytes, "first").unwrap(),
+            (64, 96)
+        );
+
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(bytes).unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let descriptor = probe_image(file, GenerationReferenceProvenance::default()).unwrap();
+        assert!(matches!(
+            descriptor,
+            GenerationReference::Image {
+                width: 64,
+                height: 96,
+                ..
+            }
+        ));
     }
 
     /// A bare path is the ordered-reference form of the flag, and an image is

--- a/crates/mold-inference/src/img_utils.rs
+++ b/crates/mold-inference/src/img_utils.rs
@@ -168,9 +168,19 @@ pub fn decode_mask_image(
 /// to sRGB (malformed profiles warn and assume sRGB, mirroring upstream
 /// decode.py:164-166).
 pub fn decode_oriented_srgb(bytes: &[u8]) -> Result<RgbImage> {
-    let reader = image::ImageReader::new(Cursor::new(bytes))
+    decode_oriented_srgb_with_limits(bytes, image::Limits::default())
+}
+
+/// [`decode_oriented_srgb`] with caller-supplied decoder limits.
+///
+/// H3 accepts user media through several durable and local entry points. They
+/// all need the same EXIF/ICC semantics without giving up the family's strict
+/// dimension and allocation bounds merely to share this decoder.
+pub fn decode_oriented_srgb_with_limits(bytes: &[u8], limits: image::Limits) -> Result<RgbImage> {
+    let mut reader = image::ImageReader::new(Cursor::new(bytes))
         .with_guessed_format()
         .context("failed to sniff source image format")?;
+    reader.limits(limits);
     let mut decoder = reader
         .into_decoder()
         .context("failed to decode source image")?;
@@ -205,6 +215,36 @@ pub fn decode_oriented_srgb(bytes: &[u8]) -> Result<RgbImage> {
             convert_icc_to_srgb(rgb, &profile, layout)
         }
         _ => rgb,
+    })
+}
+
+/// Read the dimensions the upright decoded pixels will have without
+/// allocating the image.
+///
+/// The reader must already have a format (normally via
+/// `with_guessed_format`). Keeping this beside the decode path means every H3
+/// descriptor agrees with the pixels after EXIF orientation is applied.
+pub fn oriented_image_dimensions<R>(
+    mut reader: image::ImageReader<R>,
+    limits: image::Limits,
+) -> Result<(u32, u32)>
+where
+    R: std::io::BufRead + std::io::Seek,
+{
+    reader.limits(limits);
+    let mut decoder = reader
+        .into_decoder()
+        .context("failed to decode source image")?;
+    let (width, height) = decoder.dimensions();
+    let orientation = decoder
+        .orientation()
+        .unwrap_or(image::metadata::Orientation::NoTransforms);
+    Ok(match orientation {
+        image::metadata::Orientation::Rotate90
+        | image::metadata::Orientation::Rotate270
+        | image::metadata::Orientation::Rotate90FlipH
+        | image::metadata::Orientation::Rotate270FlipH => (height, width),
+        _ => (width, height),
     })
 }
 

--- a/crates/mold-inference/src/minimax_h3/pipeline.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline.rs
@@ -1182,18 +1182,12 @@ fn decode_endpoint(bytes: &[u8]) -> Result<RgbImage> {
         bail!("MiniMax H3 endpoint dimensions {width}x{height} exceed the bounded image contract");
     }
 
-    let mut reader = ImageReader::new(Cursor::new(bytes))
-        .with_guessed_format()
-        .context("unknown endpoint image format")?;
     let mut limits = image::Limits::default();
     limits.max_image_width = Some(MAX_REFERENCE_DIMENSION);
     limits.max_image_height = Some(MAX_REFERENCE_DIMENSION);
     limits.max_alloc = Some(MAX_REFERENCE_IMAGE_PIXELS.saturating_mul(4));
-    reader.limits(limits);
-    Ok(reader
-        .decode()
-        .context("endpoint image decode failed")?
-        .to_rgb8())
+    crate::img_utils::decode_oriented_srgb_with_limits(bytes, limits)
+        .context("endpoint image decode failed")
 }
 
 const PILLOW_RESAMPLE_PRECISION_BITS: u32 = 22;
@@ -1906,6 +1900,13 @@ mod tests {
         let decoded = decode_endpoint(&clamped).unwrap();
         assert_eq!(decoded.width(), 1);
         assert_eq!(decoded.height(), MAX_REFERENCE_DIMENSION);
+    }
+
+    #[test]
+    fn endpoint_decoder_applies_exif_orientation() {
+        let bytes = include_bytes!("../ltx2/testdata/preprocess/portrait_exif6.jpg");
+        let decoded = decode_endpoint(bytes).unwrap();
+        assert_eq!(decoded.dimensions(), (64, 96));
     }
 
     fn png(width: u32, height: u32, color: [u8; 3]) -> Vec<u8> {

--- a/crates/mold-inference/src/reference_media.rs
+++ b/crates/mold-inference/src/reference_media.rs
@@ -7,7 +7,7 @@
 use std::io::{Read, Seek, SeekFrom, Write};
 
 use anyhow::{anyhow, bail, Context, Result};
-use image::{ImageReader, RgbImage};
+use image::RgbImage;
 use sha2::{Digest, Sha256};
 use tempfile::{Builder, NamedTempFile};
 
@@ -44,9 +44,6 @@ pub(crate) fn decode_image_from_binding(
 ) -> Result<RgbImage> {
     let bytes = read_verified_binding(binding, checkpoint)?;
     checkpoint()?;
-    let mut reader = ImageReader::new(std::io::Cursor::new(bytes))
-        .with_guessed_format()
-        .context("unknown reference image format")?;
     let mut limits = image::Limits::default();
     limits.max_image_width = Some(mold_core::minimax_h3::MAX_REFERENCE_DIMENSION);
     limits.max_image_height = Some(mold_core::minimax_h3::MAX_REFERENCE_DIMENSION);
@@ -55,11 +52,8 @@ pub(crate) fn decode_image_from_binding(
             .checked_mul(4)
             .context("reference image decode limit overflowed")?,
     );
-    reader.limits(limits);
-    let image = reader
-        .decode()
-        .context("reference image decode failed")?
-        .to_rgb8();
+    let image = crate::img_utils::decode_oriented_srgb_with_limits(&bytes, limits)
+        .context("reference image decode failed")?;
     checkpoint()?;
     Ok(image)
 }
@@ -493,6 +487,24 @@ mod tests {
 
     fn frame(value: u8) -> RgbImage {
         RgbImage::from_pixel(2, 2, image::Rgb([value, 0, 0]))
+    }
+
+    #[test]
+    fn image_binding_decodes_exif_orientation_upright() {
+        let bytes = include_bytes!("ltx2/testdata/preprocess/portrait_exif6.jpg");
+        let (_staged, binding) = binding(bytes);
+        let decoded = decode_image_from_binding(&binding, &mut || Ok(())).unwrap();
+        assert_eq!(decoded.dimensions(), (64, 96));
+
+        let expected = include_bytes!("ltx2/testdata/preprocess/decoded_portrait_exif6.bin");
+        let mean = decoded
+            .as_raw()
+            .iter()
+            .zip(expected)
+            .map(|(actual, expected)| actual.abs_diff(*expected) as f64)
+            .sum::<f64>()
+            / expected.len() as f64;
+        assert!(mean <= 2.0, "upright pixels drifted: mean-abs {mean}");
     }
 
     #[test]

--- a/crates/mold-server/src/reference_uploads.rs
+++ b/crates/mold-server/src/reference_uploads.rs
@@ -1839,9 +1839,13 @@ fn probe_reference(
                 .ok_or_else(|| unsupported_media(reference, "unknown image format"))?;
             let observed_mime = image_mime(format)
                 .ok_or_else(|| unsupported_media(reference, "unsupported image format"))?;
-            let (observed_width, observed_height) = reader
-                .into_dimensions()
-                .map_err(|error| unsupported_media(reference, error))?;
+            let mut limits = image::Limits::default();
+            limits.max_image_width = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+            limits.max_image_height = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+            limits.max_alloc = Some(minimax_h3::MAX_REFERENCE_IMAGE_PIXELS.saturating_mul(4));
+            let (observed_width, observed_height) =
+                mold_inference::img_utils::oriented_image_dimensions(reader, limits)
+                    .map_err(|error| unsupported_media(reference, error))?;
             require_equal(reference, "mime_type", mime_type.as_str(), observed_mime)?;
             if policy == ReferenceProbePolicy::Strict {
                 require_equal(reference, "width", *width, observed_width)?;
@@ -2625,6 +2629,34 @@ mod tests {
             .write_to(&mut bytes, image::ImageFormat::Png)
             .unwrap();
         bytes.into_inner()
+    }
+
+    #[test]
+    fn reference_probe_canonicalizes_exif_oriented_dimensions() {
+        let bytes = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../mold-inference/src/ltx2/testdata/preprocess/portrait_exif6.jpg"
+        ));
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("portrait.jpg");
+        std::fs::write(&path, bytes).unwrap();
+        let digest = format!("{:x}", Sha256::digest(bytes));
+        let expected = GenerationReference::Image {
+            media: GenerationReferenceAuthority::Descriptor,
+            provenance: GenerationReferenceProvenance {
+                name: Some("portrait.jpg".to_string()),
+                sha256: Some(digest.clone()),
+                crop: None,
+            },
+            mime_type: "image/jpeg".to_string(),
+            width: 64,
+            height: 96,
+        };
+
+        let metadata =
+            probe_reference(&path, &expected, 1, &digest, ReferenceProbePolicy::Strict).unwrap();
+        assert_eq!(metadata.width, Some(64));
+        assert_eq!(metadata.height, Some(96));
     }
 
     fn wav_bytes(sample_rate: u32, channels: u16, sample_count: u32) -> Vec<u8> {

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -13735,6 +13735,46 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn direct_generate_refuses_unqualified_identity_before_queue_or_download() {
+        let (state, mut queue_rx, _gallery_root) = durable_test_state(MockEngine::ready());
+        let journal = state.queue_journal.clone();
+        let app = app_with_state(state.clone());
+        let body = serde_json::json!({
+            "prompt": "a portrait",
+            "model": "qwen-image:fp8",
+            "width": 1024,
+            "height": 1024,
+            "steps": 4,
+            "guidance": 0.0,
+            "batch_size": 1,
+            "output_format": "png",
+            "id_image": "iVBORw0KGgo="
+        });
+
+        let response = app
+            .oneshot(
+                Request::post("/api/generate")
+                    .header("content-type", "application/json")
+                    .body(Body::from(body.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(json_body(response).await["error"]
+            .as_str()
+            .unwrap_or_default()
+            .contains("face-identity"));
+        assert!(journal.list_all().is_empty());
+        assert!(state.job_registry.is_empty());
+        assert!(queue_rx.try_recv().is_err());
+        let downloads = state.downloads.listing().await;
+        assert!(downloads.active.is_none());
+        assert!(downloads.queued.is_empty());
+    }
+
+    #[tokio::test]
     async fn configured_h3_artifact_path_is_rejected_before_queueing() {
         let (state, mut queue_rx, _gallery_root) = durable_test_state(MockEngine::ready());
         spawn_durable_feeder(&state);

--- a/crates/mold-tui/src/h3_references.rs
+++ b/crates/mold-tui/src/h3_references.rs
@@ -325,7 +325,11 @@ fn probe_image(
         image::ImageFormat::Gif => "image/gif",
         _ => anyhow::bail!("unsupported image format; use PNG, JPEG, WebP, or GIF"),
     };
-    let (width, height) = reader.into_dimensions()?;
+    let mut limits = image::Limits::default();
+    limits.max_image_width = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_image_height = Some(minimax_h3::MAX_REFERENCE_DIMENSION);
+    limits.max_alloc = Some(minimax_h3::MAX_REFERENCE_IMAGE_PIXELS.saturating_mul(4));
+    let (width, height) = mold_inference::img_utils::oriented_image_dimensions(reader, limits)?;
     Ok(GenerationReference::Image {
         media: GenerationReferenceAuthority::Descriptor,
         provenance,
@@ -525,6 +529,7 @@ fn probe_wav(file: File) -> Result<WavProbe> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write as _;
 
     fn authenticated_client() -> MoldClient {
         MoldClient::with_api_key("http://127.0.0.1:9", "sekrit".into())
@@ -571,6 +576,26 @@ mod tests {
         assert_eq!(fingerprint.len(), 64);
         assert!(!fingerprint.contains("tmp"));
         assert!(!format!("{references:?}").contains("/tmp"));
+    }
+
+    #[test]
+    fn image_probe_reports_exif_oriented_dimensions() {
+        let bytes = include_bytes!(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/../mold-inference/src/ltx2/testdata/preprocess/portrait_exif6.jpg"
+        ));
+        let mut file = tempfile::tempfile().unwrap();
+        file.write_all(bytes).unwrap();
+        file.seek(SeekFrom::Start(0)).unwrap();
+        let descriptor = probe_image(file, GenerationReferenceProvenance::default()).unwrap();
+        assert!(matches!(
+            descriptor,
+            GenerationReference::Image {
+                width: 64,
+                height: 96,
+                ..
+            }
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- reject unqualified forced-local PuLID requests before model resolution, repair, or download
- pin direct server admission to return 422 without touching durable, job, queue, or download state
- apply bounded EXIF/ICC-aware decoding to MiniMax H3 reference images and FL2VA endpoints
- keep upright dimensions consistent across CLI, TUI, server descriptors, and inference pixels

## Validation

- targeted zero-resolver-call and server no-queue/no-download regressions, including `--features pulid`
- orientation-6 fixture/golden tests across inference reference binding, FL2VA endpoints, CLI, TUI, and server probes
- broader reference-media, H3 pipeline, CLI H3, TUI H3, server reference-upload, EXIF, and ICC test suites
- `cargo clippy -p mold-ai-inference -p mold-ai-server -p mold-ai-tui -p mold-ai --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`
- Claude completed-diff review with no actionable findings

No model downloads, inference, image/video generations, or GPU UAT were run.

Closes #1305
Closes #1431
