### PR TITLE
fix(server): report unobserved generation failures accurately

### DIFF
--- a/changelog.d/disconnected-generation-failure-log.md
+++ b/changelog.d/disconnected-generation-failure-log.md
@@ -1,0 +1,3 @@
+- **Accurate unobserved-generation logs.** A failed or cancelled background generation is no
+  longer reported as a successfully saved output; failures now retain their terminal error in
+  the server log.

--- a/crates/mold-server/src/job_supervisor.rs
+++ b/crates/mold-server/src/job_supervisor.rs
@@ -124,13 +124,14 @@ mod tests {
     use std::sync::Mutex;
 
     #[derive(Clone, Default)]
-    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>, Arc<Notify>);
 
-    struct SharedWriterGuard(Arc<Mutex<Vec<u8>>>);
+    struct SharedWriterGuard(Arc<Mutex<Vec<u8>>>, Arc<Notify>);
 
     impl Write for SharedWriterGuard {
         fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
             self.0.lock().unwrap().extend_from_slice(bytes);
+            self.1.notify_one();
             Ok(bytes.len())
         }
 
@@ -143,7 +144,7 @@ mod tests {
         type Writer = SharedWriterGuard;
 
         fn make_writer(&'a self) -> Self::Writer {
-            SharedWriterGuard(self.0.clone())
+            SharedWriterGuard(self.0.clone(), self.1.clone())
         }
     }
 
@@ -193,11 +194,8 @@ mod tests {
         }
     }
 
-    #[test]
-    fn unobserved_worker_error_logs_the_failure_instead_of_a_saved_output() {
-        let outcome = SupervisedOutcome::Finished(Box::new(Err(
-            "face-identity conditioning failed: no face was detected".to_string(),
-        )));
+    #[tokio::test(flavor = "current_thread")]
+    async fn unobserved_worker_error_logs_the_failure_instead_of_a_saved_output() {
         let writer = SharedWriter::default();
         let subscriber = tracing_subscriber::fmt()
             .without_time()
@@ -205,9 +203,23 @@ mod tests {
             .with_writer(writer.clone())
             .finish();
 
-        tracing::subscriber::with_default(subscriber, || {
-            report_unobserved_completion("job-4", &outcome);
-        });
+        // The detached task stays on this runtime thread, inside the scoped
+        // subscriber, so capture the real failed-delivery reporting path.
+        let _subscriber = tracing::subscriber::set_default(subscriber);
+        let SupervisedJob {
+            result_tx,
+            outcome_rx,
+        } = supervise_job("job-4".to_string(), Arc::new(Notify::new()));
+        drop(outcome_rx);
+        assert!(result_tx
+            .send(Err(
+                "face-identity conditioning failed: no face was detected".to_string(),
+            ))
+            .is_ok());
+
+        tokio::time::timeout(std::time::Duration::from_secs(5), writer.1.notified())
+            .await
+            .expect("the detached supervisor must log the unobserved outcome");
 
         let output = String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
         assert!(output.contains(" WARN "), "expected a warning: {output}");

--- a/crates/mold-server/src/job_supervisor.rs
+++ b/crates/mold-server/src/job_supervisor.rs
@@ -27,6 +27,41 @@ pub enum SupervisedOutcome {
     Cancelled,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum UnobservedCompletion<'a> {
+    Saved,
+    Failed(&'a str),
+    Cancelled,
+}
+
+fn unobserved_completion(outcome: &SupervisedOutcome) -> UnobservedCompletion<'_> {
+    match outcome {
+        SupervisedOutcome::Finished(result) => match result.as_ref() {
+            Ok(_) => UnobservedCompletion::Saved,
+            Err(error) => UnobservedCompletion::Failed(error),
+        },
+        SupervisedOutcome::Cancelled => UnobservedCompletion::Cancelled,
+    }
+}
+
+fn report_unobserved_completion(job_id: &str, outcome: &SupervisedOutcome) {
+    match unobserved_completion(outcome) {
+        UnobservedCompletion::Saved => tracing::info!(
+            job = %job_id,
+            "generation finished without an attached observer; the output was still saved"
+        ),
+        UnobservedCompletion::Failed(error) => tracing::warn!(
+            job = %job_id,
+            %error,
+            "generation failed without an attached observer"
+        ),
+        UnobservedCompletion::Cancelled => tracing::info!(
+            job = %job_id,
+            "generation was cancelled without an attached observer"
+        ),
+    }
+}
+
 /// The two halves a submitting handler needs: the sender that rides along on
 /// the [`crate::state::GenerationJob`], and the receiver the handler awaits.
 pub struct SupervisedJob {
@@ -71,11 +106,8 @@ pub fn supervise_job(job_id: String, cancel: Arc<Notify>) -> SupervisedJob {
             }
         };
 
-        if outcome_tx.send(outcome).is_err() {
-            tracing::info!(
-                job = %job_id,
-                "generation finished after its client disconnected; the output was still saved"
-            );
+        if let Err(outcome) = outcome_tx.send(outcome) {
+            report_unobserved_completion(&job_id, &outcome);
         }
     });
 
@@ -88,6 +120,32 @@ pub fn supervise_job(job_id: String, cancel: Arc<Notify>) -> SupervisedJob {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::io::Write;
+    use std::sync::Mutex;
+
+    #[derive(Clone, Default)]
+    struct SharedWriter(Arc<Mutex<Vec<u8>>>);
+
+    struct SharedWriterGuard(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for SharedWriterGuard {
+        fn write(&mut self, bytes: &[u8]) -> std::io::Result<usize> {
+            self.0.lock().unwrap().extend_from_slice(bytes);
+            Ok(bytes.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'a> tracing_subscriber::fmt::MakeWriter<'a> for SharedWriter {
+        type Writer = SharedWriterGuard;
+
+        fn make_writer(&'a self) -> Self::Writer {
+            SharedWriterGuard(self.0.clone())
+        }
+    }
 
     fn ok_result() -> Result<GenerationJobResult, String> {
         Err("stub".to_string())
@@ -133,6 +191,29 @@ mod tests {
             },
             _ => panic!("expected the worker outcome to reach the handler"),
         }
+    }
+
+    #[test]
+    fn unobserved_worker_error_logs_the_failure_instead_of_a_saved_output() {
+        let outcome = SupervisedOutcome::Finished(Box::new(Err(
+            "face-identity conditioning failed: no face was detected".to_string(),
+        )));
+        let writer = SharedWriter::default();
+        let subscriber = tracing_subscriber::fmt()
+            .without_time()
+            .with_ansi(false)
+            .with_writer(writer.clone())
+            .finish();
+
+        tracing::subscriber::with_default(subscriber, || {
+            report_unobserved_completion("job-4", &outcome);
+        });
+
+        let output = String::from_utf8(writer.0.lock().unwrap().clone()).unwrap();
+        assert!(output.contains(" WARN "), "expected a warning: {output}");
+        assert!(output.contains("generation failed without an attached observer"));
+        assert!(output.contains("error=face-identity conditioning failed: no face was detected"));
+        assert!(!output.contains("output was still saved"));
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary
- distinguish successful, failed, and cancelled unobserved generation outcomes
- preserve the terminal worker error in a warning instead of claiming failed PULID work was saved
- use observer-neutral wording that also covers durable replay/background jobs
- add a tracing regression test and changelog fragment

## Local incident evidence
- job `6e71c124-9cb2-4beb-bfe4-88fc328bd6f2` ran on 2026-09-04 at 23:28 local time
- PULID failed with `no face was detected in the identity image`
- durable settlement held the failure; it was cancelled at 23:31 and is no longer queued
- the detached supervisor incorrectly logged `the output was still saved` because its observer was absent

## Verification
- `nix develop -c cargo test -p mold-ai-server --lib job_supervisor::tests` (4 passed)
- `nix develop -c cargo clippy -p mold-ai-server --lib -- -D warnings`
- `nix develop -c cargo fmt --all -- --check`
- `git diff --check`
- requested sub-agent peer review: clean after resolving two P2 findings

## Broader test note
`nix develop -c cargo test -p mold-ai-server --lib` completed 2,132 tests successfully and exposed 14 unrelated existing/environment-sensitive failures in catalog/model-path fixtures plus one feeder timeout; the focused supervisor suite is green.