### PR TITLE
docs(h3): record CUDA regression and prepare remaining Metal UAT

### DIFF
--- a/docs/qualification/minimax-h3-cuda-post-1604-tests.txt
+++ b/docs/qualification/minimax-h3-cuda-post-1604-tests.txt
@@ -1,0 +1,34 @@
+
+running 29 tests
+test comfy_int8::tests::device_resident_forward_is_bit_identical_to_cpu_staged ... ok
+test comfy_int8::tests::forward_refuses_a_bias_of_the_wrong_shape ... ok
+test comfy_int8::tests::forward_with_bias_is_the_reference_forward_plus_bias_narrowed_once ... ok
+test comfy_int8::tests::forward_without_bias_is_the_reference_forward ... ok
+test comfy_int8::tests::native_biased_forward_matches_portable_reference_plus_bias ... ok
+test comfy_int8::tests::new_on_device_accepts_cpu_storage_and_shares_the_h3_validation ... ok
+test comfy_int8::tests::new_on_device_refuses_a_weight_and_scales_on_different_devices ... ok
+test comfy_int8::tests::the_arm_is_native_only_for_a_compiled_kernel_on_cuda ... ok
+test comfy_int8::tests::the_arm_on_cuda_needs_the_kernel_and_multiple_of_four_extents ... ok
+test minimax_h3::attention::tests::a_chunked_dense_pass_equals_the_unchunked_one ... ok
+test minimax_h3::attention::tests::an_edited_query_chunk_fails_the_frozen_identity ... ok
+test minimax_h3::attention::tests::an_oversized_row_still_yields_a_one_row_chunk ... ok
+test minimax_h3::attention::tests::bounded_dense_execution_matches_direct_f32_reference ... ok
+test minimax_h3::attention::tests::dense_math_is_bounded_to_synthetic_score_shapes ... ok
+test minimax_h3::attention::tests::expected_runtime_identity_rejects_each_crossed_tuple_field ... ok
+test minimax_h3::attention::tests::flash_bf16_cpu_reference_cuda_parity ... ok
+test minimax_h3::attention::tests::flash_contract_mutations_fail_closed_before_tensor_execution ... ok
+test minimax_h3::attention::tests::flash_release_candidate_rejects_non_native_batch ... ok
+test minimax_h3::attention::tests::flash_tensor_strides_are_checked_before_u32_ffi_conversion ... ok
+test minimax_h3::attention::tests::flash_workspace_is_linear_for_released_row_counts ... ok
+test minimax_h3::attention::tests::frozen_plan_mutation_and_tensor_shape_mismatch_are_rejected ... ok
+test minimax_h3::attention::tests::only_the_metal_backend_narrows_the_query_axis ... ok
+test minimax_h3::attention::tests::qualification_telemetry_contains_only_frozen_geometry_and_timing ... ok
+test minimax_h3::attention::tests::release_candidate_build_requires_kernel_target_and_matching_sm89_device ... ok
+test minimax_h3::attention::tests::release_candidate_dispatch_requires_the_current_compiled_build ... ok
+test minimax_h3::attention::tests::released_flash_authority_is_exact_and_never_release_activated ... ok
+test minimax_h3::attention::tests::the_chunked_backend_is_refused_on_every_non_metal_device ... ok
+test minimax_h3::attention::tests::the_metal_authority_freezes_released_production_rows ... ok
+test minimax_h3::attention::tests::the_metal_query_chunk_is_the_score_budget_over_one_row ... ok
+
+test result: ok. 29 passed; 0 failed; 0 ignored; 0 measured; 292 filtered out; finished in 11.37s
+

--- a/docs/qualification/minimax-h3-cuda-post-1604.json
+++ b/docs/qualification/minimax-h3-cuda-post-1604.json
@@ -1,0 +1,104 @@
+{
+  "schema": "mold.minimax-h3.attention-qualification.v1",
+  "decision": "qualified-release-candidate-only",
+  "build": {
+    "schema": "mold.minimax-h3.attention-rc.v2",
+    "identity_sha256": "6158bf6fad87b8c8e36fa9e1b7a798c14ce8e273818ba7859abdfb7c9f212035",
+    "cargo_feature": "h3-flash-attn-rc",
+    "claim_marker": "mold.minimax-h3.attention-rc.kernel-compiled.v1",
+    "kernel_compiled": true,
+    "compiled_compute_capability": [
+      8,
+      9
+    ],
+    "package_version": "0.11.0",
+    "package_source": "git+https://github.com/utensils/candle.git?rev=744ae3b83cfac18db28107a353c449cc9b80d4ec#744ae3b83cfac18db28107a353c449cc9b80d4ec",
+    "kernel": "CandleFlashFwdHdim128Bf16Sm80V011",
+    "mask": "FullNonCausalPacked",
+    "model_contract": {
+      "heads": 56,
+      "head_dim": 128,
+      "dtype": "Bf16"
+    }
+  },
+  "observed_device": {
+    "Cuda": {
+      "compute_capability": [
+        8,
+        9
+      ]
+    }
+  },
+  "authority_identity_sha256": "f573fff4df6893637e5314553af333a88997820b84c4d7e9a6161dd92db4f376",
+  "probe": {
+    "schema": "mold.minimax-h3.attention-rc.v2",
+    "plan_identity_sha256": "ee9a47a22f50412de1297041cb91de50b15297543dbd540ed85f3c41e3240318",
+    "backend": "FlashAttentionV2",
+    "kernel": "CandleFlashFwdHdim128Bf16Sm80V011",
+    "activation": "ReleaseCandidateQualificationOnly",
+    "device": {
+      "Cuda": {
+        "compute_capability": [
+          8,
+          9
+        ]
+      }
+    },
+    "scope": "PackedTransformer",
+    "mask": "FullNonCausalPacked",
+    "dtype": "Bf16",
+    "batch_size": 1,
+    "sequence_rows": 257,
+    "heads": 56,
+    "head_dim": 128,
+    "workspace": {
+      "input_output_tensor_bytes": 14737408,
+      "qkv_compute_bytes": 0,
+      "score_matrix_bytes": 0,
+      "probability_matrix_bytes": 0,
+      "output_compute_bytes": 0,
+      "softmax_lse_bytes": 57568,
+      "peak_auxiliary_bytes_upper_bound": 57568
+    },
+    "elapsed_micros": 10033
+  },
+  "max_absolute_difference": 0.00048828125,
+  "maximum_allowed_difference": 0.02,
+  "qk_swap_max_absolute_difference": 0.04736328,
+  "minimum_qk_swap_difference": 0.02,
+  "planned_shapes": [
+    {
+      "sequence_rows": 37296,
+      "workspace": {
+        "input_output_tensor_bytes": 2138701824,
+        "qkv_compute_bytes": 0,
+        "score_matrix_bytes": 0,
+        "probability_matrix_bytes": 0,
+        "output_compute_bytes": 0,
+        "softmax_lse_bytes": 8354304,
+        "peak_auxiliary_bytes_upper_bound": 8354304
+      }
+    },
+    {
+      "sequence_rows": 107856,
+      "workspace": {
+        "input_output_tensor_bytes": 6184894464,
+        "qkv_compute_bytes": 0,
+        "score_matrix_bytes": 0,
+        "probability_matrix_bytes": 0,
+        "output_compute_bytes": 0,
+        "softmax_lse_bytes": 24159744,
+        "peak_auxiliary_bytes_upper_bound": 24159744
+      }
+    }
+  ],
+  "release_activation": "rejected",
+  "release_requirements": [
+    "MiniMaxH3Authorization",
+    "ReleaseArtifactIncludesKernel",
+    "CrossBackendReproducibilityDecision",
+    "RemainingCudaArchitectureQualification"
+  ],
+  "model_artifacts_accessed": false,
+  "runtime_activated": false
+}

--- a/docs/qualification/minimax-h3-cuda-post-1604.md
+++ b/docs/qualification/minimax-h3-cuda-post-1604.md
@@ -1,0 +1,82 @@
+# H3 CUDA regression after #1604 — 2026-09-05
+
+**PASS: bounded CUDA attention/INT8 validation.** The user released the CUDA
+validation hold after the Metal campaign preparation. Metal UAT remains on
+hold. This run loaded no model, started no service, changed no kernel setting,
+and qualifies neither default-resolution output nor performance.
+
+Source: `d6096446a74b1eeb70e4fdefff69bc57e3bb128b`, based on merged
+`27ed658e` (#1604). The later report-only commits do not change tested source.
+Candle: `744ae3b83cfac18db28107a353c449cc9b80d4ec`.
+Host: HPE/plato, NVIDIA L40S SM89, driver 595.71.05. GPU 3 UUID
+`GPU-6cb1bce8-3699-646a-db9c-c4a9a322a1d9` was selected explicitly.
+Immediately before tests it reported 0% utilization and 765 MiB used by an
+existing service; the local service activity response contained `items: []`.
+Other GPUs had active workloads and were not selected. These timings are
+not an exclusive-host performance measurement.
+
+## Results and retained evidence
+
+- [Unit-test transcript](minimax-h3-cuda-post-1604-tests.txt): **29 passed,
+  zero failed, zero ignored**, 11.37 seconds. Twenty attention tests include
+  BF16 CPU/CUDA parity; nine INT8 tests include native route selection,
+  device-resident versus CPU-staged bit identity, bias and device validation.
+- [Verbatim FlashAttention report](minimax-h3-cuda-post-1604.json): actual
+  CUDA initialization, **257 rows × 56 heads × 128 dimensions**, BF16,
+  `FlashAttentionV2`. Maximum absolute CPU-reference difference
+  **0.00048828125**, below 0.02. Q/K-swap negative-control difference
+  **0.04736328**, above 0.02. Reported kernel time: 10,033 microseconds.
+- The standalone probe fails if CUDA initialization fails; it has no CPU
+  fallback. Some library tests return early if device initialization fails,
+  so their libtest pass count alone is not a no-skip device attestation.
+  The separately retained probe confirms CUDA was usable on the same selected
+  GPU in this run; it does not instrument each library test's initialization.
+- Production row counts 37,296 and 107,856 were **planned only**. The report
+  explicitly records `model_artifacts_accessed: false` and
+  `runtime_activated: false`. Its release-candidate refusal fields describe
+  this synthetic probe's authority, not a new restriction on shipped H3.
+
+The library test build emitted the existing unused re-export warning in
+`minimax_h3/comfy_quant.rs`; both builds completed successfully. No source
+change or warning suppression was introduced for this qualification.
+
+## Reproduction
+
+Both builds ran in the repository Nix devshell with two Cargo jobs and the
+locked, offline dependency graph. The existing task-owned target cache was
+reused; concurrent builds in the main checkout used another target directory.
+From the tested checkout:
+
+```sh
+export CARGO_TARGET_DIR=/home/jamesbrink/.codex/worktrees/20f3/mold/target
+export CUDA_COMPUTE_CAP=89
+nix develop --command cargo test --locked --offline -j 2 \
+  -p mold-ai-candle --features h3,cuda,h3-flash-attn-rc,flash-attn \
+  --lib --no-run
+nix develop --command cargo build --locked --offline -j 2 \
+  -p mold-ai-inference --features dev-bins,h3-cuda \
+  --bin h3_attention_qualification
+export CUDA_VISIBLE_DEVICES=GPU-6cb1bce8-3699-646a-db9c-c4a9a322a1d9
+nix develop --command timeout 120 \
+  "$CARGO_TARGET_DIR/debug/deps/mold_candle-acb893fc96c50408" \
+  minimax_h3::attention::tests comfy_int8::tests --test-threads=1 --nocapture
+nix develop --command timeout 120 \
+  "$CARGO_TARGET_DIR/debug/h3_attention_qualification"
+```
+
+The libtest filename is the one emitted by this build; another toolchain or
+feature graph may emit a different suffix. Hashes of the executed binaries:
+
+| Binary | SHA-256 |
+| --- | --- |
+| `mold_candle-acb893fc96c50408` | `f086d2ef32fa3fcf6bc0d72fb21308edfe8ce9b32273cb30ea1a1a18d371b9e8` |
+| `h3_attention_qualification` | `08f6ba7d3aa2cc52118eec9449ade2effe66548936ffc66a1e569f76974374bb` |
+
+## Remaining scope
+
+The [Metal/default-resolution campaign](minimax-h3-metal-next-campaign.md)
+still needs recovered verified allocation/watchdog instrumentation, exact
+request budgets, frozen input fixtures, paired full-render evidence and
+visual/audio review. This bounded CUDA pass closes the kernel regression
+check for the tested source only. It does not close #1164/#1542, lift the
+Metal hold, promote `CorrectnessOnly`, or claim a 48 GiB default-resolution fit.

--- a/docs/qualification/minimax-h3-metal-memory.md
+++ b/docs/qualification/minimax-h3-metal-memory.md
@@ -240,7 +240,8 @@ occurred. The separate qualification process and reservation were released.
 
 PR #1604 merged as `27ed658e`. The [next campaign plan](minimax-h3-metal-next-campaign.md)
 tracks default-resolution and broader FL2VA evidence, exact phase accounting,
-and launch/cleanup gates. GPU execution is on hold during that preparation.
+and launch/cleanup gates. Metal GPU execution remains on hold. The subsequently authorized
+[bounded CUDA follow-up](minimax-h3-cuda-post-1604.md) passed on the merged code.
 
 - Complete per-phase runtime measurements for the intended Turbo/default shape; the small base admission budget above is established.
 - Extend the completed reduced-size conditioner, DiT and VAE evidence to

--- a/docs/qualification/minimax-h3-metal-memory.md
+++ b/docs/qualification/minimax-h3-metal-memory.md
@@ -238,6 +238,10 @@ occurred. The separate qualification process and reservation were released.
 
 ## Remaining acceptance
 
+PR #1604 merged as `27ed658e`. The [next campaign plan](minimax-h3-metal-next-campaign.md)
+tracks default-resolution and broader FL2VA evidence, exact phase accounting,
+and launch/cleanup gates. GPU execution is on hold during that preparation.
+
 - Complete per-phase runtime measurements for the intended Turbo/default shape; the small base admission budget above is established.
 - Extend the completed reduced-size conditioner, DiT and VAE evidence to
   default-resolution requests under the same safety controls.

--- a/docs/qualification/minimax-h3-metal-next-campaign.md
+++ b/docs/qualification/minimax-h3-metal-next-campaign.md
@@ -1,0 +1,204 @@
+# H3 Metal next campaign: default resolution and FL2VA coverage
+
+Preparation status: **READY FOR UAT planning; execution ON HOLD**.
+Audited 2026-09-05 against merged `27ed658e` (PR #1604), Candle
+`744ae3b83cfac18db28107a353c449cc9b80d4ec`. This document records no new
+hardware result and authorizes no launch. The current user hold includes
+GPU device creation, model-free GPU tests, model loads, upstream inference,
+pressure tests, and UAT on both Metal and CUDA. CPU review and preparation
+may continue. No kernel setting or service change is required by this plan.
+
+## Acceptance audit
+
+| Item | Current evidence | Remaining evidence |
+| --- | --- | --- |
+| #1164 Metal execution and dispatch | Shipped Metal admission, portable quantization, streamed Qwen; #1604 merged attention/INT8 lifetime fixes and owned local execution | Verify exact campaign binary identity; do not reopen implemented dispatch work |
+| #1542 compact memory fit | Phase accounting exists; disk size is not residency; 256-square guarded render fits | Exact Turbo/default request phase budgets and measured phase peaks on 48 GiB hardware |
+| Conditioned FL2VA | First-frame Turbo 4-step, 256×256, 107 frames, seed 42; local/server identical MP4 | Default 1344×768 **and 124 frames**; base last-frame/two-endpoint coverage where advertised |
+| CUDA preservation | Real attention/INT8 tests, no-skip FlashAttention probe, matching reduced-size video/audio | Paired default/broader fixtures at the campaign revision |
+| Quality | Reduced-size SSIM 0.988634, PSNR 37.762865 dB, audio correlation 0.973562 | Default-resolution visual review and audio listening, plus numerical comparison |
+| Tier / issue completion | Metal remains `CorrectnessOnly`; both issues open | Separate memory, correctness and performance conclusions; no automatic promotion or closure |
+
+Issue bodies still say #1604 is open and fixes are unmerged. Those historical
+checkboxes are superseded by `27ed658e`; they are not new implementation
+requirements. No issue was edited during this preparation. The conditional
+GGUF proposal in #1542 remains conditional: investigate a new layout only if
+measured phase residency cannot fit safely. This campaign does not touch
+Candle VAE #1040, Wan #1059/#1094, or LTX #1462.
+
+The retained measurements, binary limitations, hashes and source references
+remain in [the previous campaign](minimax-h3-metal-memory.md). Its 8 GiB
+allocation ceiling and 7,757,168,640-byte highest sample apply to the small
+request only. Neither number is a default-resolution bound.
+
+## Freeze the paired request matrix
+
+All rows use batch one, 24 fps, seed 42, explicit width/height/frame count,
+MP4 with audio, and no expansion or prompt rewriting. Retain the literal
+prompt, PNG bytes and SHA-256, normalized conditioning identity, exact model
+and adapter revisions, resolved guidance/shift/sigma ladder, and canonical
+request JSON. Reuse the old gradient/source and prompt for row A only if the
+retained bytes are available; otherwise name a new fixture, never claim a
+reproduction. For other rows freeze one scenic image and one distinct last
+frame once; Metal and CUDA consume identical bytes. Do not infer the canvas
+from a source image: that intentionally selects a different aspect-derived
+size in the CLI.
+
+| Order / case | Model tag suffix (`minimax-h3-fl2va:`) | Canvas / frames | Conditioning / purpose |
+| --- | --- | --- | --- |
+| A / smoke-replay | `comfy-pruned-int8-turbo-4step-768p` | 256×256 / 107 | First frame; revalidate guard and exact-current local/server identity |
+| B / intermediate | same | 768×768 / 107 | First frame; phase scaling and decoder checkpoint before default size |
+| C / default | same | 1344×768 / 124 | First frame; actual default canvas and duration, Metal/CUDA pair |
+| D / base-first | `comfy-pruned-int8` | 1344×768 / 124 | First frame; base schedule and quality independently of Turbo |
+| E / base-last | same base | 768×768 / 107 | Last frame; only if current profile accepts this mode |
+| F / base-both | same base | 768×768 / 107 | First and last frames; endpoint overlap and conditioning cost |
+| G / long | original Turbo tag | 768×768 / 345 | First frame; duration scaling, only after a separate safe budget decision |
+
+Turbo 4-step is **five terminal-inclusive sigma points / four evaluations**;
+base defaults to 21 points / 20 evaluations. Resolve defaults from the exact
+model profile, recording the resolved values; never transplant another
+Turbo tier's flow shift. Last-only or two-endpoint refusal from a current
+profile is a retained contract result, not permission to bypass it. Broader
+FL2VA does not imply Ref2VA or other Turbo adapters were qualified.
+
+Run cold process cases first. A warm server repeat is separately labeled:
+`QwenConditioningCached` is not a conditioner load/encode measurement.
+After each case, inspect its measurements before considering the next.
+Do not launch all rows as a batch. Default-resolution fit is not a claim
+that the maximum-duration default canvas fits.
+
+## Exact accounting to capture before and during every case
+
+Before allocating model tensors, retain the actual prepared request's
+`H3FactoryTargetBudgetInput`, frozen plan/factory identity and the resolved
+Qwen placement. Export the **existing authority**, not a separately
+reimplemented formula. `private_server.rs::private_h3_unified_target_peak_bytes`
+computes `max(device_bytes + host_bytes)` across these budget prefixes:
+
+```text
+reference_decode, reference_preprocess, reference_visual_encode,
+reference_audio_encode, vae_load, qwen_encode, qwen_transfer,
+condition_encode, noise_allocation, transformer_load, denoise,
+visual_decode, audio_decode, waveform_transfer, mux
+```
+
+For each prefix preserve the exact `_phase_device_bytes` and
+`_phase_host_bytes`, checked sum, applicability and binding maximum. Keep
+inapplicable reference phases explicit. Metal's zero separate host increment
+means host cost is already included; it does not mean host residency is zero.
+Also retain all fields from `public_runtime_bounds_for_shape`, adapter
+resident charge, packed video/audio/condition rows, Qwen pre-merge patch
+rows and merged text pads. A 256-square **base** budget cannot price row C's
+Turbo adapter or 124-frame sequence.
+
+Record one machine-readable row at each phase entry/exit, each streamed
+Qwen layer/DiT block boundary, each decoder chunk, and every allocation
+high-water change. Required columns:
+
+```text
+case_id, request_sha256, executable_sha256, monotonic_ns, phase,
+event, iteration, allocated_native_bytes, native_peak_bytes,
+requested_allocation_bytes, allocator_ceiling_bytes,
+process_resident_bytes, process_peak_resident_bytes,
+host_available_bytes, swap_used_bytes, kernel_pressure,
+budget_device_bytes, budget_host_bytes, phase_complete, error
+```
+
+Use the runtime's `H3PipelinePhase` names, including `QwenLoad`,
+`QwenEncode`, `VaeLoad`, `VisualConditionEncode`, `NoiseAllocation`,
+`TransformerLoad`, `Denoise`/`TransformerBlock`, `VisualDecode`,
+`AudioDecode`, `VideoEncode`, `Mux`, `Staged`, `Complete`. Attribute attention
+and FFN transients inside the denoise phase separately. Transfer-only budget
+phases need explicit measurement boundaries even where there is no matching
+pipeline enum. Preserve nested phase membership instead of attributing a
+chunk twice. Synchronize phase boundaries before reporting completed-device
+residency; label sampled RSS/high-water values as samples. Report absolute
+native peaks and changes from the phase-entry baseline separately.
+
+Do not add process RSS to native Metal allocation to claim physical unified
+use: they may overlap. Do not subtract consecutive process-lifetime RSS
+high-water marks and call the result a phase peak. Native allocation peak,
+process RSS, system headroom, calculated admission and retained post-call
+allocation answer different questions and must stay separate.
+
+**Instrumentation gap:** the retained allocator/watchdog modifications were
+unshipped, and are not reproducible from main alone. Recover and hash their
+exact sources/binary or prepare a separately reviewed qualification build.
+The existing `private_runtime_observer.rs` process attestation is Linux/CUDA
+shaped and `process_peak_resident_bytes` reads `/proc/self/status`; do not
+claim its observation schema is Metal evidence or fabricate CUDA fields.
+Use a clearly separate qualification report for macOS. This document adds
+no production accounting formula, new layout, or launcher.
+
+## Fail-closed launch and cleanup gates (after the hold is released)
+
+1. Confirm explicit release of the user hold, exclusive host ownership via
+   `/tmp/mold-metal-qualification.lock`, no competing GPU work, and the exact
+   binary/source/instrumentation/checkpoint identities. Use an isolated
+   `MOLD_HOME`, output directory and process group; do not change the existing
+   server. Missing lock ownership or missing evidence directory refuses launch.
+2. Prove the recovered allocator ceiling and external watchdog with test
+   doubles before any model run: over-ceiling allocation, failed/stale memory
+   sample, pressure change, swap growth, missing child, cancellation and
+   cleanup paths. An environment variable alone is not proof a binary has
+   a pre-allocation ceiling. No working verified ceiling means **no launch**.
+3. Read the native automatic wired limit and effective capacity; never change
+   them to make a case pass. Require normal pressure and at least the previous
+   24 GiB available baseline. For larger cases additionally require the
+   prepared unified peak to fit below current availability minus a 12 GiB
+   host floor and below effective device headroom. Reserve that exact grant;
+   do not infer it from checkpoint file sizes or enlarge it after refusal.
+4. Derive and record a separate native-allocation ceiling from current
+   capacity/headroom and the measured phase plan, retaining the host floor.
+   Reject a case whose safe ceiling cannot cover its planned device phase.
+   Keep the previous 8 GiB ceiling for row A; do not reuse it blindly for C.
+   The independent watchdog samples at most every 250 ms, aborts below 12 GiB
+   available, on non-normal pressure or more than 256 MiB swap growth, and
+   fails closed on a missing/invalid/stale sample. These campaign limits are
+   tighter than the built-in 8 GiB/2 GiB cooperative guard.
+5. Freeze a per-case wall-clock deadline before launch. A watchdog failure
+   or missing allocation event stream cancels the isolated child; enforce
+   a bounded shutdown deadline and terminate only that owned process group
+   if cooperative cancellation does not settle. Record abnormal exits and
+   incomplete commands as failures, never resumable successful evidence.
+6. In every exit path, reap the child, confirm the owned process group has
+   no descendants, retain stdout/stderr/request/telemetry and refusal facts,
+   stop its sampler, and release only this attempt's reservation and lock.
+   Verify pressure and swap after settlement. Preserve partial media as
+   failed artifacts; never silently retry, shrink, change steps or clear a
+   stale lock that may belong to a live process.
+
+## CUDA and output comparison gates
+
+After the hold ends, qualify the exact campaign revision on one idle SM89
+GPU. Keep the native CUDA INT8 and FlashAttention routes. The bounded tests
+are `minimax_h3::attention::tests` and `comfy_int8::tests` in `mold-ai-candle`
+with `h3,cuda,h3-flash-attn-rc,flash-attn`; build the
+`h3_attention_qualification` binary from `mold-ai-inference` with
+`dev-bins,h3-cuda`. Require actual CUDA device creation, nonzero probe rows
+and no skips. These are **deferred GPU commands**, not hold-safe tests.
+
+Pair rows A–F on the same source revision, checkpoint/adapter and request;
+row G requires its own capacity decision on both hosts. Retain decoded frame
+count, dimensions, fps, duration, audio sample rate/channels, decode errors,
+finite/sample-clipping checks, whole-video and per-frame PSNR/SSIM, aligned
+zero-lag audio correlation/RMS difference, sampled frames and a human
+`Visual:` and `Audio:` assessment. Report alignment method and both original
+stream lengths; no trimming to conceal duration drift. Exact local/server
+byte equality is useful but does not replace cross-backend comparison.
+Historical 256-square metrics are observations, not universal thresholds.
+Document any acceptance threshold before inspecting new results; a failure
+or unreviewed result cannot promote Metal beyond `CorrectnessOnly`.
+
+## Hold-safe preparation result and handoff
+
+This audit found no demonstrated additional production fix: the known
+lifetime/dispatch fixes are merged. Only documentation changes are prepared.
+No GPU was initialized, model loaded, upstream inference run, service changed,
+pressure test started or kernel setting modified in this task.
+
+The next operator needs: recovered verified instrumentation and watchdog;
+exact per-case allocation-free budgets; frozen input fixtures; explicit hold
+release and exclusive host availability; then sequential phase measurements,
+paired CUDA media and visual/listening review. Until those exist, report
+**READY FOR UAT preparation, not qualified and not cleared to launch**.

--- a/docs/qualification/minimax-h3-metal-next-campaign.md
+++ b/docs/qualification/minimax-h3-metal-next-campaign.md
@@ -3,10 +3,10 @@
 Preparation status: **READY FOR UAT planning; execution ON HOLD**.
 Audited 2026-09-05 against merged `27ed658e` (PR #1604), Candle
 `744ae3b83cfac18db28107a353c449cc9b80d4ec`. This document records no new
-hardware result and authorizes no launch. The current user hold includes
-GPU device creation, model-free GPU tests, model loads, upstream inference,
-pressure tests, and UAT on both Metal and CUDA. CPU review and preparation
-may continue. No kernel setting or service change is required by this plan.
+hardware result and authorizes no launch. The user subsequently released bounded H3 CUDA validation; its completed
+results are in [the CUDA follow-up](minimax-h3-cuda-post-1604.md). Metal GPU
+device creation, tests, model loads, upstream inference, pressure tests and
+UAT remain on hold. CPU review and preparation may continue. No kernel setting or service change is required by this plan.
 
 ## Acceptance audit
 
@@ -170,13 +170,15 @@ no production accounting formula, new layout, or launcher.
 
 ## CUDA and output comparison gates
 
-After the hold ends, qualify the exact campaign revision on one idle SM89
-GPU. Keep the native CUDA INT8 and FlashAttention routes. The bounded tests
+Bounded checks at `d6096446` completed after the user released CUDA
+validation; the linked follow-up retains their results. For a later runtime
+revision, qualify that exact campaign revision on one idle SM89 GPU. Keep the native CUDA INT8 and FlashAttention routes. The bounded tests
 are `minimax_h3::attention::tests` and `comfy_int8::tests` in `mold-ai-candle`
 with `h3,cuda,h3-flash-attn-rc,flash-attn`; build the
 `h3_attention_qualification` binary from `mold-ai-inference` with
 `dev-bins,h3-cuda`. Require actual CUDA device creation, nonzero probe rows
-and no skips. These are **deferred GPU commands**, not hold-safe tests.
+and no skips. These are GPU tests, not hold-safe CPU checks. Their completed run does not
+authorize the separate paired full-render campaign.
 
 Pair rows A–F on the same source revision, checkpoint/adapter and request;
 row G requires its own capacity decision on both hosts. Retain decoded frame
@@ -194,8 +196,10 @@ or unreviewed result cannot promote Metal beyond `CorrectnessOnly`.
 
 This audit found no demonstrated additional production fix: the known
 lifetime/dispatch fixes are merged. Only documentation changes are prepared.
-No GPU was initialized, model loaded, upstream inference run, service changed,
-pressure test started or kernel setting modified in this task.
+The initial preparation initialized no GPU. Subsequently authorized bounded
+CUDA validation completed as recorded in the linked follow-up; no model was
+loaded, upstream inference run, service changed, pressure test started or
+kernel setting modified.
 
 The next operator needs: recovered verified instrumentation and watchdog;
 exact per-case allocation-free budgets; frozen input fixtures; explicit hold

--- a/docs/qualification/minimax-h3-metal-next-campaign.md
+++ b/docs/qualification/minimax-h3-metal-next-campaign.md
@@ -47,12 +47,12 @@ size in the CLI.
 | Order / case | Model tag suffix (`minimax-h3-fl2va:`) | Canvas / frames | Conditioning / purpose |
 | --- | --- | --- | --- |
 | A / smoke-replay | `comfy-pruned-int8-turbo-4step-768p` | 256×256 / 107 | First frame; revalidate guard and exact-current local/server identity |
-| B / intermediate | same | 768×768 / 107 | First frame; phase scaling and decoder checkpoint before default size |
-| C / default | same | 1344×768 / 124 | First frame; actual default canvas and duration, Metal/CUDA pair |
+| B / intermediate | `comfy-pruned-int8-turbo-4step-768p` | 768×768 / 107 | First frame; phase scaling and decoder checkpoint before default size |
+| C / default | `comfy-pruned-int8-turbo-4step-768p` | 1344×768 / 124 | First frame; actual default canvas and duration, Metal/CUDA pair |
 | D / base-first | `comfy-pruned-int8` | 1344×768 / 124 | First frame; base schedule and quality independently of Turbo |
-| E / base-last | same base | 768×768 / 107 | Last frame; only if current profile accepts this mode |
-| F / base-both | same base | 768×768 / 107 | First and last frames; endpoint overlap and conditioning cost |
-| G / long | original Turbo tag | 768×768 / 345 | First frame; duration scaling, only after a separate safe budget decision |
+| E / base-last | `comfy-pruned-int8` | 768×768 / 107 | Last frame; only if current profile accepts this mode |
+| F / base-both | `comfy-pruned-int8` | 768×768 / 107 | First and last frames; endpoint overlap and conditioning cost |
+| G / long | `comfy-pruned-int8-turbo-4step-768p` | 768×768 / 345 | First frame; duration scaling, only after a separate safe budget decision |
 
 Turbo 4-step is **five terminal-inclusive sigma points / four evaluations**;
 base defaults to 21 points / 20 evaluations. Resolve defaults from the exact
@@ -84,10 +84,14 @@ visual_decode, audio_decode, waveform_transfer, mux
 
 For each prefix preserve the exact `_phase_device_bytes` and
 `_phase_host_bytes`, checked sum, applicability and binding maximum. Keep
-inapplicable reference phases explicit. Metal's zero separate host increment
-means host cost is already included; it does not mean host residency is zero.
-Also retain all fields from `public_runtime_bounds_for_shape`, adapter
-resident charge, packed video/audio/condition rows, Qwen pre-merge patch
+inapplicable reference phases explicit. These per-phase host fields remain
+separate and can be nonzero on Metal: preserve every host and device value
+before summing. Only the final Metal owner grant projects the maximum combined
+phase sum into unified device bytes with a zero **additional** host claim
+(`private_server.rs::owner_fence_budget_preserves_cuda_and_projects_metal_unified_memory`).
+That owner projection must never overwrite the phase report's host columns or
+be interpreted as zero host residency. Also retain all fields from
+`public_runtime_bounds_for_shape`, adapter resident charge, packed video/audio/condition rows, Qwen pre-merge patch
 rows and merged text pads. A 256-square **base** budget cannot price row C's
 Turbo adapter or 124-frame sequence.
 


### PR DESCRIPTION
PR #1604 fixed the known H3 Metal memory lifetimes and local dispatch, but default-resolution and broader FL2VA qualification remain open. This adds the next campaign's request matrix, exact phase-accounting requirements, and fail-closed launch/cleanup gates, including the missing unshipped instrumentation needed before Metal UAT.

Retains fresh bounded CUDA evidence from the merged runtime source: 29 attention/INT8 tests passed and the real-device 257-row FlashAttention probe measured maximum CPU-reference error 0.00048828125 (limit 0.02). Raw JSON, test transcript, binary hashes and reproduction commands distinguish this kernel check from full-model qualification. Metal UAT remains on hold; no capability promotion or issue closure is proposed.

Validation: bounded CUDA tests/probe on L40S SM89, report/link checks, Candle single-identity contract, H3 attention release contract and `git diff --check`. Independent final subagent review found no actionable issues and verified raw evidence, hashes, matrix and source references. Documentation/evidence only; no production code changed.

Refs #1164, #1542. Follow-up to #1604.
