### PR TITLE
fix(desktop): label APNG outputs as clips

### DIFF
--- a/changelog.d/desktop-apng-library-clip.md
+++ b/changelog.d/desktop-apng-library-clip.md
@@ -1,0 +1,1 @@
+- **Label APNG outputs as clips.** The desktop Library now gives APNG animations the same clip badge and media handling as other generated videos.

--- a/desktop/src/lib/gallery/media.test.ts
+++ b/desktop/src/lib/gallery/media.test.ts
@@ -9,6 +9,8 @@ import {
   fullSizeMediaUrl,
   galleryFilenameOfPath,
   galleryMediaPath,
+  isClipItem,
+  isVideoItem,
   isThumbnailPath,
   mediaMimeType,
   prepareNativeThumbnail,
@@ -16,6 +18,27 @@ import {
   thumbnailFilenameOfPath,
   thumbnailTier,
 } from "./media";
+
+const galleryItem = (filename: string, format: "png" | "apng") =>
+  ({
+    filename,
+    format,
+    metadata: {},
+  }) as Parameters<typeof isVideoItem>[0];
+
+describe("isVideoItem", () => {
+  it("keeps APNG clips out of video-only playback and processing paths", () => {
+    expect(isVideoItem(galleryItem("generated.png", "apng"))).toBe(false);
+    expect(isVideoItem(galleryItem("generated.apng", "png"))).toBe(false);
+  });
+});
+
+describe("isClipItem", () => {
+  it("classifies APNG outputs as clips from either their format or extension", () => {
+    expect(isClipItem(galleryItem("generated.png", "apng"))).toBe(true);
+    expect(isClipItem(galleryItem("generated.apng", "png"))).toBe(true);
+  });
+});
 
 vi.mock("../api/client", async (importOriginal) => ({
   ...(await importOriginal<typeof import("../api/client")>()),

--- a/desktop/src/lib/gallery/media.ts
+++ b/desktop/src/lib/gallery/media.ts
@@ -529,12 +529,24 @@ export const galleryMediaPath = (
       : `${mediaPath(filename)}${fromTrash ? "?view=trash" : ""}`;
 
 /**
- * Whether a gallery print is a video. The single source of truth shared by
- * the grid's ▶ badge, the store's Images/Video kind filter, and the chip
- * counts — so they can never disagree.
+ * Whether a gallery print can enter the desktop's video playback and
+ * processing paths. Animated image containers use `isClipItem` instead:
+ * APNG bytes are not valid input for `<video>` or framewise video upscale.
  */
 export const isVideoItem = (item: GalleryImage): boolean =>
-  item.format === "mp4" || item.filename.endsWith(".mp4") || !!item.metadata.video_frames;
+  item.format === "mp4" ||
+  item.filename.toLowerCase().endsWith(".mp4") ||
+  !!item.metadata.video_frames;
+
+/**
+ * Whether a gallery print belongs to the Library's motion/clip class. This
+ * drives its clip badge, Video filter, and counts without opting animated
+ * image containers into video-only playback or processing.
+ */
+export const isClipItem = (item: GalleryImage): boolean => {
+  const filename = item.filename.toLowerCase();
+  return isVideoItem(item) || item.format === "apng" || filename.endsWith(".apng");
+};
 
 /**
  * Whether a gallery print is an audio-only artifact (LTX-2 text-to-audio).

--- a/desktop/src/stores/gallery.ts
+++ b/desktop/src/stores/gallery.ts
@@ -7,8 +7,8 @@ import {
   evictMedia,
   galleryMediaPath,
   isAudioItem,
+  isClipItem,
   isMeshItem,
-  isVideoItem,
   type GallerySource,
 } from "../lib/gallery/media";
 import { ipc } from "../lib/ipc";
@@ -690,7 +690,7 @@ export const useGalleryStore = defineStore("gallery", {
             // a mesh or an audio print as an image.
             if (isMeshItem(e.item)) return mediaKind === "mesh";
             if (isAudioItem(e.item)) return mediaKind === "audio";
-            if (isVideoItem(e.item)) return mediaKind === "video";
+            if (isClipItem(e.item)) return mediaKind === "video";
             return mediaKind === "image";
           });
         }
@@ -795,7 +795,7 @@ export const useGalleryStore = defineStore("gallery", {
       for (const e of entries) {
         if (isMeshItem(e.item)) mesh++;
         else if (isAudioItem(e.item)) audio++;
-        else if (isVideoItem(e.item)) video++;
+        else if (isClipItem(e.item)) video++;
       }
       return {
         all: entries.length,

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -1149,6 +1149,26 @@ describe("LibraryView header + NEW badges", () => {
     wrapper.unmount();
   });
 
+  it("badges an APNG output as a clip without frame metadata", async () => {
+    const { wrapper } = await mountView(undefined, (gallery) => {
+      const first = gallery.buckets.local?.items[0];
+      if (first) {
+        first.filename = "animated-output.png";
+        first.format = "apng";
+        first.metadata = {
+          ...first.metadata,
+          frames: null,
+          fps: null,
+          video_frames: null,
+          video_fps: null,
+        };
+      }
+    });
+
+    expect(wrapper.get('[data-test="media-kind-badge"]').text()).toBe("clip");
+    wrapper.unmount();
+  });
+
   it("badges a mesh tile with the 3-D word", async () => {
     const { wrapper } = await mountView(undefined, (gallery) => {
       const first = gallery.buckets.local?.items[0];

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -41,6 +41,7 @@ import {
   fetchGalleryMediaBytes,
   galleryMediaPath,
   isAudioItem,
+  isClipItem,
   isMeshItem,
   isVideoItem,
   prepareNativeThumbnail,
@@ -1754,7 +1755,7 @@ interface TileModel {
   canOrganize: boolean;
   availability: string;
   purgeAt: number | null;
-  video: boolean;
+  clip: boolean;
   audio: boolean;
   mesh: boolean;
   /** The mock's word badge: "clip 5s" / "3-D" / "audio", "" for a still. */
@@ -1775,11 +1776,11 @@ interface TileModel {
  */
 function mediaKindBadge(
   item: GalleryImage,
-  kind: { video: boolean; audio: boolean; mesh: boolean },
+  kind: { clip: boolean; audio: boolean; mesh: boolean },
 ): string {
   if (kind.mesh) return "3-D";
   if (kind.audio) return "audio";
-  if (!kind.video) return "";
+  if (!kind.clip) return "";
   const frames = item.metadata.frames ?? item.metadata.video_frames ?? null;
   const fps = item.metadata.fps ?? item.metadata.video_fps ?? null;
   if (!frames || !fps || fps <= 0) return "clip";
@@ -1801,7 +1802,7 @@ const tileModels = computed<TileModel[]>(() => {
     // Imported predicates, not the view's local aliases: `useVirtualizer`
     // evaluates `rows` (and so this computed) synchronously during setup,
     // before the aliases declared further down are initialized.
-    const video = isVideoItem(item);
+    const clip = isClipItem(item);
     const mesh = isMeshItem(item);
     const audio = isAudioItem(item);
     models[i] = {
@@ -1815,10 +1816,10 @@ const tileModels = computed<TileModel[]>(() => {
         !trash && gallery.allLocationsOf(entry).some((l) => organizeCapable(l.sourceKey)),
       availability: entry.availableOn.map((s) => s.label).join(" · "),
       purgeAt: org.purgeAt,
-      video,
+      clip,
       audio,
       mesh,
-      kindBadge: mediaKindBadge(item, { video, audio, mesh }),
+      kindBadge: mediaKindBadge(item, { clip, audio, mesh }),
       upscaled: isUpscaledImage(item),
       mediaPath: galleryMediaPath(item.filename, source, true, item.trashed_at != null),
       // The tile is always a still thumbnail now; a local clip's poster comes


### PR DESCRIPTION
## Summary
- classify APNG Library entries as clips from their explicit format or `.apng` extension
- keep Library clip classification separate from `<video>`, source-video, and framewise-upscale compatibility
- keep the clip badge, Video filter, and media counts on the same Library predicate
- add contract and rendered Library regression coverage

## Validation
- `nix develop -c bun run test:desktop` (500 files, 6,734 tests)
- `nix develop -c bun run build:desktop`
- `nix develop -c bun run check:architecture`
- `nix develop -c bunx prettier --check desktop/src/lib/gallery/media.ts desktop/src/lib/gallery/media.test.ts desktop/src/stores/gallery.ts desktop/src/views/LibraryView.vue desktop/src/views/LibraryView.test.ts`
- `bash scripts/release/check-changelog-fragments.sh <base> HEAD`