### PR TITLE
feat(website): add consent-based Google Analytics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -222,3 +222,13 @@ this machine; status is read-only, set/reset require explicit root invocation.
 user path. Shared DevicePanel reads optional host telemetry; remote clients have
 no kernel mutation control. See `website/guide/metal-memory.md` and the reviewed
 `docs/metal-memory-policy-plan.md` for contracts and validation limits.
+
+## Public website analytics
+
+`website/.vitepress/theme/analytics.mjs` owns the consent-gated GA4 integration
+(`G-RG6PPTGX2T`), restricted to `https://utensils.io/mold/`. Never import it into
+Studio or the apps. The layout component owns the visitor choice and sends one
+explicit page view after VitePress navigation. Keep GA enhanced-measurement
+browser-history page views OFF to avoid duplicates; search, form, and video
+measurement are also off. `bun run verify` in `website/` runs consent and
+navigation tests. Update `website/privacy.md` when this behavior changes.

--- a/README.md
+++ b/README.md
@@ -213,3 +213,7 @@ weights require separate acceptance and are limited to non-commercial research
 use.
 
 Model checksums are verified when files are downloaded. Complete installed models queue and switch without full checksum scans, including after restart. To check existing bytes explicitly, run `mold info MODEL --verify`. Normal loading still checks file sizes and formats; it does not guarantee detection of same-size corruption.
+
+The [public website privacy policy](https://utensils.io/mold/privacy) describes
+optional Google Analytics on the documentation website. Analytics loads only with
+visitor consent; this integration is not included in Mold apps or servers.

--- a/changelog.d/website-google-analytics.md
+++ b/changelog.d/website-google-analytics.md
@@ -1,0 +1,3 @@
+- **Optional website analytics.** The public documentation website now offers
+  consent-based Google Analytics with a persistent preference control and an
+  updated privacy disclosure. Mold apps and servers contain no new analytics.

--- a/website/.vitepress/theme/analytics-choice.vue
+++ b/website/.vitepress/theme/analytics-choice.vue
@@ -1,0 +1,107 @@
+<script setup>
+import { nextTick, onMounted, onUnmounted, ref } from 'vue'
+import { useRouter } from 'vitepress'
+import { createAnalytics } from './analytics.mjs'
+
+const router = useRouter()
+const visible = ref(false)
+let analytics
+let previousAfterRouteChange
+let afterRouteChange
+
+onMounted(() => {
+  analytics = createAnalytics(window)
+  visible.value = !analytics.choice()
+  analytics.start()
+  previousAfterRouteChange = router.onAfterRouteChange
+  afterRouteChange = async (to) => {
+    await previousAfterRouteChange?.(to)
+    await nextTick()
+    analytics.pageView()
+  }
+  router.onAfterRouteChange = afterRouteChange
+})
+onUnmounted(() => {
+  if (router.onAfterRouteChange === afterRouteChange) {
+    router.onAfterRouteChange = previousAfterRouteChange
+  }
+})
+function choose(accepted) {
+  const wasEnabled = analytics.choice() === 'granted'
+  analytics.choose(accepted)
+  visible.value = false
+  // Stop already-loaded automatic measurement listeners after withdrawal.
+  if (wasEnabled && !accepted) window.location.reload()
+}
+</script>
+
+<template>
+  <div
+    v-if="visible"
+    class="analytics-choice"
+    role="region"
+    aria-label="Website analytics"
+  >
+    <p>
+      Allow Google Analytics to measure visits and use of this website?
+      <a href="/mold/privacy#website-analytics">Privacy details</a>
+    </p>
+    <div class="analytics-actions">
+      <button type="button" @click="choose(false)">Decline</button>
+      <button type="button" @click="choose(true)">Allow analytics</button>
+    </div>
+  </div>
+  <button
+    v-else
+    class="analytics-settings"
+    type="button"
+    @click="visible = true"
+  >
+    Analytics preferences
+  </button>
+</template>
+
+<style scoped>
+.analytics-choice {
+  position: fixed;
+  z-index: 50;
+  bottom: 16px;
+  left: 16px;
+  right: 16px;
+  max-width: 480px;
+  padding: 16px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 12px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-1);
+  box-shadow: var(--vp-shadow-3);
+  font-size: 14px;
+  line-height: 1.6;
+}
+.analytics-choice a {
+  color: var(--vp-c-brand-1);
+  text-decoration: underline;
+}
+.analytics-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  margin-top: 12px;
+}
+.analytics-actions button {
+  padding: 6px 14px;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  font-weight: 500;
+}
+.analytics-actions button:hover {
+  background: var(--vp-c-bg-soft);
+}
+.analytics-settings {
+  display: block;
+  margin: 12px auto;
+  color: var(--vp-c-text-2);
+  font-size: 12px;
+  text-decoration: underline;
+}
+</style>

--- a/website/.vitepress/theme/analytics.mjs
+++ b/website/.vitepress/theme/analytics.mjs
@@ -1,0 +1,89 @@
+// Public documentation only. The apps and embedded Studio never import this.
+export const measurementId = 'G-RG6PPTGX2T'
+const storageKey = 'mold.website.analytics'
+
+function cleanUrl(value) {
+  try {
+    const url = new URL(value)
+    return url.origin + url.pathname
+  } catch {
+    return ''
+  }
+}
+
+export function createAnalytics(win) {
+  let selected
+  let loaded = false
+  let previousPage = cleanUrl(win.document.referrer)
+  const eligible = () =>
+    win.location.origin === 'https://utensils.io' &&
+    win.location.pathname.startsWith('/mold/')
+  function choice() {
+    if (selected !== undefined) return selected
+    try {
+      const saved = win.localStorage.getItem(storageKey)
+      if (saved === 'granted' || saved === 'denied') selected = saved
+    } catch {
+      // Storage may be disabled. Consent still works for the current page.
+    }
+    return selected
+  }
+  function gtag() {
+    win.dataLayer.push(arguments)
+  }
+  function pageView() {
+    if (!eligible() || choice() !== 'granted' || !loaded) return
+    const page = cleanUrl(win.location.href)
+    gtag('set', { page_location: page, page_referrer: previousPage })
+    gtag('event', 'page_view', {
+      page_location: page,
+      page_title: win.document.title,
+      page_referrer: previousPage,
+    })
+    previousPage = page
+  }
+  function start() {
+    if (!eligible() || choice() !== 'granted' || loaded) return
+    loaded = true
+    win.dataLayer = win.dataLayer || []
+    win.gtag = gtag
+    win[`ga-disable-${measurementId}`] = false
+    gtag('consent', 'default', {
+      analytics_storage: 'granted',
+      ad_storage: 'denied',
+      ad_user_data: 'denied',
+      ad_personalization: 'denied',
+    })
+    gtag('js', new Date())
+    gtag('config', measurementId, {
+      send_page_view: false,
+      allow_google_signals: false,
+      allow_ad_personalization_signals: false,
+      cookie_path: '/mold/',
+      cookie_domain: 'utensils.io',
+      cookie_prefix: 'mold',
+      page_location: cleanUrl(win.location.href),
+      page_referrer: previousPage,
+    })
+    const script = win.document.createElement('script')
+    script.async = true
+    script.src = `https://www.googletagmanager.com/gtag/js?id=${measurementId}`
+    win.document.head.appendChild(script)
+    pageView()
+  }
+  function choose(accepted) {
+    selected = accepted ? 'granted' : 'denied'
+    try {
+      win.localStorage.setItem(storageKey, selected)
+    } catch {
+      // Keep the choice in memory if persistent storage is unavailable.
+    }
+    if (loaded) {
+      win[`ga-disable-${measurementId}`] = !accepted
+      gtag('consent', 'update', { analytics_storage: selected })
+    } else if (accepted) {
+      start()
+    }
+  }
+  return { choice, choose, start, pageView }
+}

--- a/website/.vitepress/theme/index.ts
+++ b/website/.vitepress/theme/index.ts
@@ -1,6 +1,7 @@
 import DefaultTheme from 'vitepress/theme'
 import { h } from 'vue'
 import SupportStrip from './support-strip.vue'
+import AnalyticsChoice from './analytics-choice.vue'
 import './style.css'
 
 export default {
@@ -8,6 +9,7 @@ export default {
   Layout() {
     return h(DefaultTheme.Layout, null, {
       'home-hero-info-after': () => h(SupportStrip),
+      'layout-bottom': () => h(AnalyticsChoice),
     })
   },
 }

--- a/website/package.json
+++ b/website/package.json
@@ -8,7 +8,7 @@
     "preview": "vitepress preview",
     "fmt": "prettier --write .",
     "fmt:check": "prettier --check .",
-    "verify": "bun run scripts/verify-docs.mjs"
+    "verify": "bun run scripts/verify-docs.mjs && bun test scripts/analytics.test.mjs"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.0",

--- a/website/privacy.md
+++ b/website/privacy.md
@@ -1,13 +1,42 @@
 # Privacy Policy
 
-**Effective July 21, 2026**
+**Effective September 6, 2026**
 
-This policy describes how the open-source Mold project handles information in
+This policy describes how the open-source Mold project handles information on its public website and in
 the Mold apps that link to it: the mobile app for iPhone, iPad, and Android,
 and the desktop app for macOS, Linux, and Windows. Each is a client for Mold
 servers that you choose and control. The Mold project does not operate a
 central account service, hosted generation service, advertising network, or
 analytics service for these apps.
+
+## Website analytics
+
+The public website at [utensils.io/mold](https://utensils.io/mold/) uses
+Google Analytics only after you select **Allow analytics**. Declining leaves
+Google Analytics unloaded. You can change your choice using **Analytics
+preferences** at the bottom of any website page. We store this preference in
+local storage in your browser.
+
+When enabled, Google Analytics measures page visits, traffic sources, scrolls,
+outbound link clicks, and file-download clicks, along with browser/device
+information and approximate geographic information derived from your connection.
+It uses cookies scoped to this website to distinguish visits. We use these
+reports to understand which documentation is useful and how visitors find Mold.
+We disable Google signals and advertising personalization, do not enable form or
+site-search measurement, and remove query strings and fragments from the page
+URLs and referrers we explicitly send. Outbound and download measurements may
+include the destination link URL.
+
+Google processes this website analytics data under
+[Google's privacy policy](https://policies.google.com/privacy). See also
+[how Google uses information from sites that use its services](https://policies.google.com/technologies/partner-sites).
+Withdrawing your choice stops future analytics collection after the page reloads;
+it does not erase data already collected. You can remove existing cookies and
+saved preferences through your browser's site-data settings.
+
+This website analytics integration does not collect Mold prompts, generated
+media, server API keys, or usage of the CLI, desktop, mobile, or self-hosted
+Studio apps.
 
 ## Information the apps store on your device
 
@@ -43,7 +72,7 @@ not receive this server traffic merely because you use the app.
 
 ## Third-party services
 
-Mold has no advertising or tracking SDKs. A Mold server may contact model
+The Mold apps have no advertising or tracking SDKs. A Mold server may contact model
 catalogs such as [Hugging Face](https://huggingface.co/privacy) and
 [Civitai](https://civitai.com/content/privacy) when you browse or download
 models. Those requests originate from the server and are governed by the
@@ -83,7 +112,7 @@ knowingly collect personal information from children through its apps.
 
 ## Changes to this policy
 
-We may update this policy when the app's data practices change. The effective
+We may update this policy when the website or apps' data practices change. The effective
 date at the top identifies the current version.
 
 ## Contact

--- a/website/scripts/analytics.test.mjs
+++ b/website/scripts/analytics.test.mjs
@@ -1,0 +1,105 @@
+import { test } from 'node:test'
+import assert from 'node:assert/strict'
+import {
+  createAnalytics,
+  measurementId,
+} from '../.vitepress/theme/analytics.mjs'
+
+function fixture(url = 'https://utensils.io/mold/') {
+  const events = [],
+    scripts = [],
+    stored = new Map()
+  const win = {
+    location: new URL(url),
+    localStorage: {
+      getItem: (k) => stored.get(k),
+      setItem: (k, v) => stored.set(k, v),
+    },
+    document: {
+      title: 'mold',
+      referrer: 'https://example.com/?private=value',
+      createElement: () => ({}),
+      head: { appendChild: (s) => scripts.push(s) },
+    },
+    dataLayer: events,
+  }
+  return { win, events, scripts, stored, analytics: createAnalytics(win) }
+}
+
+test('no Google script or events before consent, including rejection', () => {
+  const f = fixture()
+  f.analytics.start()
+  f.analytics.pageView()
+  f.analytics.choose(false)
+  assert.equal(f.scripts.length, 0)
+  assert.equal(f.events.length, 0)
+  assert.equal(f.analytics.choice(), 'denied')
+})
+
+test('accept loads once and records one sanitized page view per navigation', () => {
+  const f = fixture('https://utensils.io/mold/?secret=value#fragment')
+  f.analytics.choose(true)
+  f.analytics.start()
+  assert.equal(f.scripts.length, 1)
+  assert.match(f.scripts[0].src, new RegExp(measurementId))
+  const events = f.events.map((e) => Array.from(e))
+  assert.equal(events[0][0], 'consent')
+  assert.equal(events[0][2].ad_storage, 'denied')
+  const config = events.find((e) => e[0] === 'config')[2]
+  assert.equal(config.send_page_view, false)
+  assert.equal(config.allow_google_signals, false)
+  assert.equal(config.cookie_path, '/mold/')
+  let views = events.filter((e) => e[1] === 'page_view')
+  assert.equal(views.length, 1)
+  assert.equal(views[0][2].page_location, 'https://utensils.io/mold/')
+  assert.equal(views[0][2].page_referrer, 'https://example.com/')
+  f.win.location = new URL('https://utensils.io/mold/guide/?secret=value')
+  f.win.document.title = 'Guide | mold'
+  f.analytics.pageView()
+  views = f.events.map((e) => Array.from(e)).filter((e) => e[1] === 'page_view')
+  assert.equal(views.length, 2)
+  assert.equal(views[1][2].page_title, 'Guide | mold')
+  assert.equal(views[1][2].page_referrer, 'https://utensils.io/mold/')
+})
+
+test('saved acceptance starts tracking; withdrawal disables subsequent events', () => {
+  const f = fixture()
+  f.stored.set('mold.website.analytics', 'granted')
+  f.analytics.start()
+  assert.equal(f.scripts.length, 1)
+  f.analytics.choose(false)
+  assert.equal(f.win[`ga-disable-${measurementId}`], true)
+  const count = f.events.length
+  f.analytics.pageView()
+  assert.equal(f.events.length, count)
+})
+
+test('development, previews, and other utensils sites never load analytics', () => {
+  for (const url of [
+    'http://localhost:5173/mold/',
+    'https://utensils.io/other/',
+    'https://example.com/mold/',
+  ]) {
+    const f = fixture(url)
+    f.analytics.choose(true)
+    f.analytics.pageView()
+    assert.equal(f.scripts.length, 0)
+    assert.equal(f.events.length, 0)
+  }
+})
+
+test('unavailable storage does not break the website or consent choice', () => {
+  const f = fixture()
+  f.win.localStorage = {
+    getItem() {
+      throw Error('blocked')
+    },
+    setItem() {
+      throw Error('blocked')
+    },
+  }
+  assert.doesNotThrow(() => f.analytics.start())
+  f.analytics.choose(true)
+  assert.equal(f.analytics.choice(), 'granted')
+  assert.equal(f.scripts.length, 1)
+})


### PR DESCRIPTION
The public documentation site needs its own traffic reports. Add GA4 property `Mold — utensils.io/mold` / web stream `G-RG6PPTGX2T`, with Google scripts loaded only after a visitor accepts analytics and a persistent preference control for changing that choice.

The integration is restricted to production `https://utensils.io/mold/`. It records explicit VitePress page views, strips page/referrer query strings and fragments, disables advertising signals, and scopes cookies to `/mold/`. The Google stream has history-based automatic page views, search, form, and video measurement disabled; scrolls, outbound clicks, and downloads remain enabled. Update the public privacy disclosure and developer documentation. No app/server analytics is added.

Validation:
- Five tests cover default/rejected consent, one-time loading, sanitized navigation events, saved consent/withdrawal, production scoping, and unavailable browser storage; wired into the existing docs CI verification command.
- `bun run verify`, `bun run fmt:check`, and `bun run build` passed in `website/`.
- Chrome: desktop and iPhone 12 Pro (390×844) consent controls render; decline, reopen, allow, and documentation navigation work. Console has no messages.
- After merge, verify the GitHub Pages deployment and GA realtime receipt from the live website.
