### PR TITLE
fix(web,desktop): stop losing and stalling auto-chained long clips

### DIFF
--- a/changelog.d/auto-chain-recovery-gaps.md
+++ b/changelog.d/auto-chain-recovery-gaps.md
@@ -1,0 +1,11 @@
+- **A long clip survives a page reload again.** Reloading the browser while
+  the machine was rendering a long clip reported "server progress lost" while
+  the machine happily carried on stitching it. The page now picks the same
+  render back up where it left off
+  ([#1621](https://github.com/utensils/mold/issues/1621)).
+- **A clip paused by a restart now says so and stops.** When a machine parks a
+  long clip at shutdown it keeps every finished piece, ready to resume — but
+  the desktop app sat on that row forever, checking every few seconds and never
+  saying anything. It now tells you the clip is paused and points you at
+  Resume in the queue
+  ([#1622](https://github.com/utensils/mold/issues/1622)).

--- a/desktop/src/lib/generationRecovery.test.ts
+++ b/desktop/src/lib/generationRecovery.test.ts
@@ -1512,30 +1512,19 @@ describe("reconcileInterruptedGenerationJobs", () => {
 
   /**
    * Graceful shutdown parks a long clip's chain job as `paused`, keeping its
-   * manifest, completed clips, and tail cache so it can be resumed. Recovery
-   * must HOLD such a job — naming the parking — rather than settling it as
-   * failed or interrupted, which would abandon work the host still has.
+   * manifest, source media, completed clips and tail cache so it can be
+   * resumed. That is a decision waiting on a PERSON — unlike `queued` and
+   * `running` it never resolves on its own — so recovery must stop polling
+   * and hand it back, rather than looping every 4s forever around a row that
+   * can never settle (#1622).
    */
-  it("holds a chain the host parked at shutdown instead of failing it", async () => {
+  it("hands back a chain the host parked at shutdown instead of polling it forever", async () => {
     const job = makeJob({ id: "chain-5" });
     let chainCalls = 0;
-    // What the job looked like at the top of each poll — the parked label is
-    // written between polls, so sampling here is what proves it was held
-    // rather than settled.
-    const seen: Array<{ stage: string | null; status: string; error?: string | null }> = [];
     apiJsonTo.mockImplementation((_target: unknown, path: string) => {
       if (path === "/api/chain-jobs/chain-5") {
         chainCalls += 1;
-        seen.push({ stage: job.stage ?? null, status: job.status, error: job.error });
-        return Promise.resolve(
-          chainCalls <= 2
-            ? { id: "chain-5", state: "paused", finalizes: [] }
-            : {
-                id: "chain-5",
-                state: "completed",
-                finalizes: [{ output: "parked clip.mp4", at_unix_ms: 1, stage_seeds: [] }],
-              },
-        );
+        return Promise.resolve({ id: "chain-5", state: "paused", finalizes: [] });
       }
       if (path === "/api/gallery") return Promise.resolve([]);
       return Promise.reject(new Error(`Unexpected path ${path}`));
@@ -1543,17 +1532,17 @@ describe("reconcileInterruptedGenerationJobs", () => {
     const opts = options({ chain: true });
     await reconcileInterruptedGenerationJobs([job], opts);
 
-    // Parked for two polls: still live, never failed, and named as parked.
-    expect(chainCalls).toBe(3);
-    expect(seen[1]?.stage).toContain("Paused after restart");
-    expect(seen[2]?.stage).toContain("Paused after restart");
-    for (const sample of seen) {
-      expect(sample.status).not.toBe("error");
-      expect(sample.error).toBeFalsy();
-    }
-    // And it still settles on the print the host was holding for it.
-    expect(job.status).toBe("complete");
-    expect(job.result?.filename).toBe("parked clip.mp4");
+    // Asked once and stopped, rather than spinning on an unchanging answer.
+    expect(chainCalls).toBe(1);
+    expect(job.stage).toBeNull();
+    expect(job.error).toContain("paused this clip when it restarted");
+    // Advisory, not a failure: the work is intact and resumable.
+    expect(job.interrupted).toBe(true);
+    expect(job.retainedByHost).toBe(true);
+    // The id is released so this dead row stops suppressing the host's own
+    // fleet row — the row that carries Resume.
+    expect(job.id).toBe("");
+    expect(job.recoveredJobId).toBe("chain-5");
   });
 
   it("finds only the id-less one-shot shim created with the interrupted submission", async () => {

--- a/desktop/src/lib/generationRecovery.ts
+++ b/desktop/src/lib/generationRecovery.ts
@@ -476,6 +476,20 @@ function settleUnreconciled(job: Job, message: string): void {
   }
 }
 
+/**
+ * Settle a job the host deliberately PARKED and is holding for a decision.
+ *
+ * Like `settleUnreconciled` this is advisory rather than a failure — the work
+ * is intact on the host — but the cause is known, so it says so. Releasing the
+ * server id matters twice over here: it stops this dead row from suppressing
+ * the host's own fleet row, and that row is the one carrying **Resume**.
+ */
+function settleParked(job: Job, message: string): void {
+  settleUnreconciled(job, message);
+  // The host did not merely stop answering; it told us it kept the work.
+  job.retainedByHost = true;
+}
+
 function settleCompleted(job: Job, complete: CompleteEvent, opts: GenerationRecoveryOptions): void {
   job.result = metadataOnlyResult(complete);
   job.visualSeed = String(complete.seed_used);
@@ -642,14 +656,23 @@ async function reconcileJob(job: Job, opts: GenerationRecoveryOptions): Promise<
         });
         transportRetries = 0;
         if (settledExternally(job) || !isActive()) return;
-        if (
-          detail &&
-          (detail.state === "queued" || detail.state === "running" || detail.state === "paused")
-        ) {
-          job.stage =
-            detail.state === "paused"
-              ? `Paused after restart on ${opts.hostLabel}`
-              : `Developing on ${opts.hostLabel}`;
+        // A parked chain is waiting on a PERSON, not on the host. Graceful
+        // shutdown journals the manifest, source media, finished clips and
+        // tail cache precisely so it can be resumed, and nothing changes
+        // until someone says so — polling it is an unbounded 4s loop around
+        // a row that can never settle (#1622). Hand it back instead: the
+        // release below un-suppresses the host's own fleet row, which is
+        // where Resume lives.
+        if (detail?.state === "paused") {
+          settleParked(
+            job,
+            `${opts.hostLabel} paused this clip when it restarted. ` +
+              `Resume it from the queue to finish the render.`,
+          );
+          return;
+        }
+        if (detail && (detail.state === "queued" || detail.state === "running")) {
+          job.stage = `Developing on ${opts.hostLabel}`;
           await sleep(interval);
           continue;
         }

--- a/web/src/composables/useGenerateStream.test.ts
+++ b/web/src/composables/useGenerateStream.test.ts
@@ -454,6 +454,57 @@ describe("loadPersistedJobs dead-letters running rows on rehydrate", () => {
     expect(loaded.jobs[0].progress.stage).toBe("Denoising");
   });
 
+  it("keeps a reloaded auto-chained clip running for its own chain stream", () => {
+    // A long clip the host had to split runs as a durable chain job. Its id
+    // is persisted, the job outlives the page, and the host keeps rendering
+    // and stitching — so a reload that announced "server progress lost" was
+    // reporting a failure that had not happened (#1621).
+    const raw = persistedPayload([
+      persisted({
+        id: "long-clip",
+        chain: {
+          stageCount: 3,
+          currentStage: 2,
+          estimatedTotalFrames: 291,
+          jobId: "chain-9",
+        },
+      }),
+    ]);
+
+    const loaded = __testing__.loadPersistedState(raw);
+
+    expect(loaded.canvasErrorJobId).toBeNull();
+    expect(loaded.jobs[0]).toMatchObject({
+      id: "long-clip",
+      state: "running",
+      error: null,
+      detached: true,
+      settledAt: null,
+    });
+  });
+
+  it("still dead-letters a chain row that never got its job id", () => {
+    // The chain block exists from the moment the row is created; only the id
+    // proves the host admitted it. Without one there is nothing to re-attach
+    // to, so the ordinary dead-letter is the honest answer.
+    const raw = persistedPayload([
+      persisted({
+        id: "never-admitted",
+        chain: {
+          stageCount: 3,
+          currentStage: 0,
+          estimatedTotalFrames: 291,
+          jobId: null,
+        },
+      }),
+    ]);
+
+    const loaded = __testing__.loadPersistedState(raw);
+
+    expect(loaded.canvasErrorJobId).toBe("never-admitted");
+    expect(loaded.jobs[0]).toMatchObject({ state: "error", detached: false });
+  });
+
   it("does not give settled persisted failures canvas authority", () => {
     const raw = persistedPayload([
       persisted({ id: "old-error", state: "error", error: "old failure" }),

--- a/web/src/composables/useGenerateStream.ts
+++ b/web/src/composables/useGenerateStream.ts
@@ -591,9 +591,12 @@ function loadPersistedState(raw: string | null): LoadedJobsState {
         // A row whose server id is known is NOT dead-lettered on boot: the
         // server may still be rendering it, and the queue reconciler can
         // prove that either way. Only a row that never received its queued
-        // frame has nothing to reconcile against.
+        // frame has nothing to reconcile against. An auto-chained long clip
+        // is durable in the same way — its identity is the chain job, which
+        // this boot re-subscribes to (#1621).
         !persisted.serverId &&
         !persisted.durableBatch &&
+        !persisted.chain?.jobId &&
         (!newestZombie || persisted.startedAt > newestZombie.startedAt)
       ) {
         newestZombie = persisted;
@@ -607,7 +610,9 @@ function loadPersistedState(raw: string | null): LoadedJobsState {
       // settled that way before the reload.
       const detached =
         (p.state === "running" &&
-          (Boolean(p.serverId) || Boolean(p.durableBatch))) ||
+          (Boolean(p.serverId) ||
+            Boolean(p.durableBatch) ||
+            Boolean(p.chain?.jobId))) ||
         p.detached === true;
       const wasZombie = p.state === "running" && !detached;
       const state: Job["state"] = wasZombie ? "error" : p.state;
@@ -971,6 +976,7 @@ export const __testing__ = {
   reconcileDurableHost,
   handleDurableEvent,
   resetDurableLifecycleForTests,
+  recoverAutoChainJobs,
 };
 
 function createJobRecord(
@@ -1037,6 +1043,7 @@ const durableCancellations = new Map<string, Promise<void>>();
 const durableGallerySnapshots = new Map<string, Promise<GalleryImage[]>>();
 const durableGalleryRows = new Map<string, GalleryImage>();
 let durableRecoveryStarted = false;
+let autoChainRecoveryStarted = false;
 let durableWakeListenersInstalled = false;
 
 function routeSignature(route: HostRoute): string {
@@ -1917,6 +1924,49 @@ function ensureDurableEventSession(route: HostRoute): void {
   });
 }
 
+/**
+ * Re-subscribe to every auto-chained long clip this browser left running.
+ *
+ * A chain job is durable on the host: it survives the page, and a graceful
+ * shutdown parks it rather than dropping it. The id rides `chain.jobId`
+ * through localStorage, so a reload can pick the same stream back up instead
+ * of telling the user their render failed while the machine is still
+ * stitching it (#1621). Without this, relaxing the boot dead-letter would
+ * only trade a false failure for a row that runs forever.
+ *
+ * A row whose machine this browser no longer knows about keeps the honest
+ * detached ending: nothing here can reach it to ask.
+ */
+function recoverAutoChainJobs(): void {
+  if (autoChainRecoveryStarted) return;
+  autoChainRecoveryStarted = true;
+  for (const job of jobs.value) {
+    const chainJobId = job.chain?.jobId;
+    if (!chainJobId || job.state !== "running" || job.durableBatch) continue;
+    const target = routeForDetachedJob(job);
+    const hostId = job.hostId ?? ORIGIN_HOST_ID;
+    if (hostId !== ORIGIN_HOST_ID && !target) {
+      settleDetachedJob(job.id, "That machine is no longer connected.");
+      continue;
+    }
+    const route: HostRoute = {
+      hostId,
+      label: job.hostLabel ?? hostId,
+      target: target ?? { baseUrl: "" },
+    };
+    job.streamStarted = true;
+    void attachAutoChainJob(job, chainJobId, route, job.controller, (err) => {
+      // The host is unreachable or no longer holds the job. This is the
+      // detached ending, not a failure of the render: the machine may well
+      // still be working, and the print lands in the Library either way.
+      settleDetachedJob(
+        job.id,
+        err.message ?? "Lost contact with that machine.",
+      );
+    });
+  }
+}
+
 function recoverDurableLifecycle(): void {
   if (durableRecoveryStarted) return;
   durableRecoveryStarted = true;
@@ -1997,6 +2047,7 @@ function resetDurableLifecycleForTests(): void {
   durableGallerySnapshots.clear();
   durableGalleryRows.clear();
   durableRecoveryStarted = false;
+  autoChainRecoveryStarted = false;
 }
 
 function submitJobs(
@@ -2043,6 +2094,25 @@ async function followAutoChainJob(
     return;
   }
   if (job.chain) job.chain.jobId = jobId;
+  await attachAutoChainJob(job, jobId, route, controller, onError);
+}
+
+/**
+ * Follow an EXISTING chain job's event stream to settlement.
+ *
+ * Split out from the creation above because a chain job outlives the page
+ * that started it: the id is persisted, so a reload can subscribe to the same
+ * stream instead of dead-lettering work the host is still doing (#1621). The
+ * server replays the job's frames on subscribe, so a reattached stream
+ * reconstructs stage progress rather than resuming mid-count.
+ */
+async function attachAutoChainJob(
+  job: Job,
+  jobId: string,
+  route: HostRoute | null,
+  controller: AbortController,
+  onError: (err: { kind: "http" | "network"; message?: string }) => void,
+): Promise<void> {
   let live = emptyChainJobLive();
   let settled = false;
   const settle = (run: () => void) => {
@@ -2399,6 +2469,7 @@ export function useGenerateStream(
   onHeld?: (job: Job) => void,
 ): UseGenerateStream {
   recoverDurableLifecycle();
+  recoverAutoChainJobs();
   installDurableWakeListeners();
   // Per-call: register the optional `onComplete` listener and tear it
   // down when the calling component unmounts so navigating away from


### PR DESCRIPTION
Closes #1621. Closes #1622.

Two pre-existing gaps on the auto-chain path — what a clip does when its length
exceeds the checkpoint's single-pass size, so the host splits it into clips and
stitches them. Both were found while peer-reviewing #1619 and deliberately left
out of it: neither was a regression of that PR, and it was already 232 files.

Verified against `main` before filing — `useGenerateStream.ts` changed by 15
lines of comment in #1619, and `generationRecovery.ts` not at all.

## #1621 — web lost a running long clip on reload

Reload the page mid-render and the card flipped to `error` with "page reloaded
— server progress lost", while the machine carried on rendering and stitching.

`loadPersistedState` dead-letters a persisted `running` row unless it has a
durable identity, testing `serverId` and `durableBatch`. An auto-chain has
neither — its identity is `chain.jobId`, which `PersistedJob` **was already
persisting**. The guard just never consulted it.

The fix is two halves, and the second is the important one:

1. `chain.jobId` now counts as a durable identity, so the row is not
   dead-lettered and loads `detached`.
2. Boot re-subscribes to the chain job's own event stream. `attachAutoChainJob`
   is split out of `followAutoChainJob` (creation vs. following), and
   `recoverAutoChainJobs` runs once per boot beside `recoverDurableLifecycle`.

Without (2), relaxing the guard would only have traded a false failure for a row
that runs forever with nothing reconciling it. A row whose machine this browser
no longer knows about keeps the honest detached ending — nothing here can reach
it to ask.

## #1622 — desktop polled a restart-parked chain forever

Graceful shutdown parks a chain as `paused`, keeping its manifest, source media,
finished clips and tail cache so it can be resumed. `reconcileJobOnce` lumped
`paused` in with `queued` and `running`: set a stage, sleep 4s, loop. But those
two resolve on their own and `paused` never does — it is waiting on a **person**.
The row could never settle and the poll never stopped.

It now settles as advisory rather than a failure (`interrupted`,
`retainedByHost` — the host explicitly said it kept the work), names the
parking, and releases the server id. That release matters twice: it stops the
dead local row from suppressing the host's own fleet row, and that row is
exactly where the **Resume** action added in #1619 lives. So the settle points
at an affordance that already exists rather than inventing a second one.

## Tests

- web: a persisted chain row with a `jobId` stays `running` and `detached`; one
  whose `jobId` is still `null` (the host never admitted it) is still
  dead-lettered, because there is nothing to reattach to.
- desktop: the parked chain is asked **once**, settles advisory-not-failed, and
  releases its id — replacing a test that asserted the old forever-poll.

## Gates

studio 1677 · web 1755 · desktop 6263 · `vue-tsc -b` both shells · knip ·
architecture · prettier ×3.
