### PR TITLE
refactor(studio): centralize API error parsing

### DIFF
--- a/studio/api/client.test.ts
+++ b/studio/api/client.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
 import {
+  ApiError,
   IncompatibleHostError,
   apiFetchTo,
   conditionalApiJsonTo,
@@ -7,6 +8,25 @@ import {
 } from "./client";
 
 afterEach(() => vi.unstubAllGlobals());
+
+const failureReaders = [
+  {
+    name: "ordinary",
+    read: () =>
+      apiFetchTo(
+        { baseUrl: "http://failure-test:7680", apiKey: null },
+        "/api/status",
+      ),
+  },
+  {
+    name: "conditional",
+    read: () =>
+      conditionalApiJsonTo(
+        { baseUrl: "http://failure-test:7680", apiKey: null },
+        "/api/gallery",
+      ),
+  },
+] as const;
 
 describe("target-explicit Studio API", () => {
   it("keeps durable API keys in headers and out of URLs", async () => {
@@ -33,6 +53,56 @@ describe("target-explicit Studio API", () => {
       IncompatibleHostError,
     );
   });
+
+  it.each(failureReaders)(
+    "preserves structured HTTP errors for $name requests",
+    async ({ read }) => {
+      const body = { error: "invalid request", code: "INVALID_REQUEST" };
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response(JSON.stringify(body), {
+            status: 422,
+            statusText: "Unprocessable Content",
+            headers: { "content-type": "application/json" },
+          }),
+        ),
+      );
+
+      await expect(read()).rejects.toEqual(
+        expect.objectContaining<ApiError>({
+          name: "ApiError",
+          message: "invalid request",
+          status: 422,
+          body,
+        }),
+      );
+    },
+  );
+
+  it.each(failureReaders)(
+    "falls back to status text for non-JSON $name failures",
+    async ({ read }) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue(
+          new Response("bad gateway", {
+            status: 502,
+            statusText: "Bad Gateway",
+          }),
+        ),
+      );
+
+      await expect(read()).rejects.toEqual(
+        expect.objectContaining<ApiError>({
+          name: "ApiError",
+          message: "Bad Gateway",
+          status: 502,
+          body: null,
+        }),
+      );
+    },
+  );
 
   it("reuses an unchanged gallery snapshot on 304", async () => {
     const rows = [{ filename: "cat.png" }];

--- a/studio/api/client.ts
+++ b/studio/api/client.ts
@@ -32,6 +32,20 @@ export function apiHeaders(target: ApiTarget, extra?: HeadersInit): Headers {
   return headers;
 }
 
+async function throwApiError(response: Response): Promise<never> {
+  let body: unknown = null;
+  try {
+    body = await response.clone().json();
+  } catch {
+    // Non-JSON failures still retain their HTTP status and status text.
+  }
+  const detail =
+    typeof body === "object" && body !== null && "error" in body
+      ? String((body as { error: unknown }).error)
+      : response.statusText;
+  throw new ApiError(detail, response.status, body);
+}
+
 export async function apiFetchTo(
   target: ApiTarget,
   path: string,
@@ -41,19 +55,7 @@ export async function apiFetchTo(
     ...init,
     headers: apiHeaders(target, init.headers),
   });
-  if (!response.ok) {
-    let body: unknown = null;
-    try {
-      body = await response.clone().json();
-    } catch {
-      // Non-JSON failures still retain their HTTP status and status text.
-    }
-    const detail =
-      typeof body === "object" && body !== null && "error" in body
-        ? String((body as { error: unknown }).error)
-        : response.statusText;
-    throw new ApiError(detail, response.status, body);
-  }
+  if (!response.ok) await throwApiError(response);
   return response;
 }
 
@@ -89,19 +91,7 @@ export async function conditionalApiJsonTo<T>(
     headers,
   });
   if (response.status === 304 && cached) return cached.value as T;
-  if (!response.ok) {
-    let body: unknown = null;
-    try {
-      body = await response.clone().json();
-    } catch {
-      // Preserve non-JSON failures below.
-    }
-    const detail =
-      typeof body === "object" && body !== null && "error" in body
-        ? String((body as { error: unknown }).error)
-        : response.statusText;
-    throw new ApiError(detail, response.status, body);
-  }
+  if (!response.ok) await throwApiError(response);
   const value = (await response.json()) as T;
   const etag = response.headers.get("ETag");
   if (etag) conditionalJsonCache.set(key, { etag, value });


### PR DESCRIPTION
## Summary

- replace the two duplicate HTTP failure parsers in the shared Studio API client with one private `throwApiError` path
- keep ordinary requests and conditional ETag requests aligned on `ApiError` status, body, and message behavior
- add characterization coverage for structured JSON errors and non-JSON status-text fallback on both request paths

## Reduction

Hand-written, non-test production source only:

- `studio/api/client.ts`: **140 → 130 lines** (**-10 lines**, 7.1% smaller)
- reproducible command: `git diff --numstat origin/main..HEAD -- studio/api/client.ts`
- result: `16  26  studio/api/client.ts` (**net -10**)

Structural reduction: two independent 12-line failure-parsing blocks now route through one helper, removing the duplicate JSON-body parsing and `ApiError` construction path.

Tests are reported separately and excluded from the production reduction:

- `studio/api/client.test.ts`: `70  0` (**+70 test lines**)
- no generated, vendor, lock, or formatting-only files changed

## Behavior preservation

The characterization tests were added and passed before the production extraction. They pin both callers to the same behavior:

- JSON `{ error, code }` responses retain the server message, HTTP status, and parsed body
- non-JSON failures retain `null` body and fall back to `Response.statusText`
- existing API-key header and ETag/304 identity behavior remains covered

## Validation

- `nix develop -c bunx vitest run --config studio/vitest.config.ts studio/api/client.test.ts` — 1 file, 7 tests passed
- `nix develop -c ./scripts/ci-local.sh web` — architecture, dead-code, Studio formatting, web formatting, 1,707 Studio tests, 1,759 web tests, web typecheck/build, and 6,364 desktop tests passed
- `nix develop -c bash -lc 'cd desktop && bun run fmt:check && bun run build && bun run build:mobile && bunx vitest run src/mobile && bunx prettier --check "src/mobile/**/*.{ts,vue,css}" vite.mobile.config.ts index.mobile.html'` — desktop/mobile formatting, desktop build, mobile build, and 1,118 mobile tests passed
- `git diff --check` — passed
