### PR TITLE
fix(mobile): center controls and route Auto prompt tools

### DIFF
--- a/changelog.d/mobile-segment-centering.md
+++ b/changelog.d/mobile-segment-centering.md
@@ -1,2 +1,5 @@
 - **Centered mobile button labels.** Vertically center segmented controls, including
   Still picture, Short clip, and 3-D object, while preserving enlarged text and touch targets.
+- **Auto prompt tools use reachable machines.** Expand and Remix now follow Auto
+  and Most capable routing and can use an installed expander on a peer. The
+  generation destination stays separate, and retries preserve both machines.

--- a/changelog.d/mobile-segment-centering.md
+++ b/changelog.d/mobile-segment-centering.md
@@ -1,0 +1,2 @@
+- **Centered mobile button labels.** Vertically center segmented controls, including
+  Still picture, Short clip, and 3-D object, while preserving enlarged text and touch targets.

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -3358,7 +3358,7 @@ describe("MobileApp generation queue", () => {
     await flushPromises();
 
     expect(wrapper.get("[data-test='mobile-prepared-expansion']").text()).toContain(
-      "Host selection changed from Studio to Render",
+      "Host selection changed from Auto to Render",
     );
   });
 
@@ -11457,6 +11457,176 @@ describe("MobileApp automatic generation routing", () => {
     expect(admissionTargets()[0]).toEqual(target);
   });
 
+  it.each([
+    ["auto", "expand", true],
+    ["auto", "remix", true],
+    ["capable", "expand", true],
+    ["capable", "remix", true],
+    ["auto", "expand", false],
+    ["auto", "remix", false],
+  ] as const)(
+    "%s %s chooses a peer expander (preferred configured: %s)",
+    async (policy, tool, configured) => {
+      twoHosts();
+      localStorage.setItem("mold.mobile.generate-target.v1", policy);
+      fleetApi({ renderModels: [] });
+      const baseApi = apiJsonTo.getMockImplementation()!;
+      apiJsonTo.mockImplementation((route, path, init) =>
+        path === "/api/capabilities"
+          ? Promise.resolve({
+              ...durableQueueCapabilities,
+              expand: {
+                configured: route.baseUrl === renderTarget.baseUrl || configured,
+                model_present: route.baseUrl === renderTarget.baseUrl,
+              },
+            })
+          : baseApi(route, path, init),
+      );
+      wrapper = mountMobileApp();
+      await flushPromises();
+      await fieldControl("Prompt").setValue("a lighthouse in rain");
+      await wrapper.get(`[data-test='mobile-prompt-${tool}']`).trigger("click");
+      await flushPromises();
+      const call = (tool === "expand" ? expandPrompt : remixPrompt).mock.calls[0]!;
+      expect(call.at(-1)).toEqual(renderTarget);
+      expect(wrapper.text()).not.toContain("will not fall back");
+    },
+  );
+
+  it.each([1, 2])(
+    "keeps Batch %s generation on its original host after peer expansion",
+    async (count) => {
+      twoHosts();
+      fleetApi({ renderModels: [] });
+      const baseApi = apiJsonTo.getMockImplementation()!;
+      apiJsonTo.mockImplementation((route, path, init) =>
+        path === "/api/capabilities"
+          ? Promise.resolve({
+              ...durableQueueCapabilities,
+              expand: {
+                configured: true,
+                model_present: route.baseUrl === renderTarget.baseUrl,
+              },
+            })
+          : baseApi(route, path, init),
+      );
+      wrapper = mountMobileApp();
+      await flushPromises();
+      if (count === 2) await wrapper.get("[data-test='mobile-batch-increment']").trigger("click");
+      await fieldControl("Prompt").setValue("a lighthouse in rain");
+      await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+      await flushPromises();
+      expect(expandPrompt.mock.calls[0]!.at(-1)).toEqual(renderTarget);
+      await wrapper
+        .get(
+          count === 1
+            ? "[data-test='mobile-develop-button']"
+            : "[data-test='mobile-develop-prepared']",
+        )
+        .trigger("click");
+      await flushPromises();
+      expect(admissionTargets()).toHaveLength(1);
+      expect(admissionTargets()[0]).toEqual(target);
+      expect(admittedRequests()).toHaveLength(count);
+    },
+  );
+
+  it("does not generate on an old Auto route after changing a completed rewrite to Most capable", async () => {
+    twoHosts();
+    fleetApi({});
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("a lighthouse");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-generate-host']").setValue("capable");
+    await flushPromises();
+    expect(wrapper.get("[data-test='mobile-quick-expansion-stale']").text()).toContain(
+      "Host selection changed from Auto to Most capable",
+    );
+    await wrapper.get("[data-test='mobile-develop-button']").trigger("click");
+    await flushPromises();
+    expect(admissionTargets()).toHaveLength(0);
+  });
+
+  it("rejects a late expansion result after the routing policy changes", async () => {
+    twoHosts();
+    fleetApi({});
+    let finish!: (value: { expanded: string[] }) => void;
+    expandPrompt.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          finish = resolve;
+        }),
+    );
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("original lighthouse");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    await wrapper.get("[data-test='mobile-generate-host']").setValue("capable");
+    await flushPromises();
+    finish({ expanded: ["late rewritten lighthouse"] });
+    await flushPromises();
+    expect((fieldControl("Prompt").element as HTMLTextAreaElement).value).toBe(
+      "original lighthouse",
+    );
+    expect(wrapper.text()).toContain("changed while expansion was running");
+  });
+
+  it("Auto expansion ignores an unreachable browsed machine", async () => {
+    twoHosts();
+    const saved = JSON.parse(localStorage.getItem("mold.mobile.hosts.v1")!);
+    saved.push({ id: "peer-id", name: "Peer", baseUrl: "http://peer:7680", instanceId: "peer-id" });
+    localStorage.setItem("mold.mobile.hosts.v1", JSON.stringify(saved));
+    fleetApi({});
+    const baseApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((route, path, init) => {
+      if (route.baseUrl === target.baseUrl) return Promise.reject(new Error("offline"));
+      if (path === "/api/status" && route.baseUrl === "http://peer:7680")
+        return Promise.resolve({ ...status, instance_id: "peer-id", hostname: "peer" });
+      if (path === "/api/capabilities")
+        return Promise.resolve({
+          ...durableQueueCapabilities,
+          expand: { configured: true, model_present: true },
+        });
+      return baseApi(route, path, init);
+    });
+    wrapper = mountMobileApp();
+    await flushPromises();
+    expect(wrapper.get(".mobile-header .host-chip").text()).toBe("Auto");
+    await fieldControl("Prompt").setValue("a lighthouse in rain");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    expect(expandPrompt).toHaveBeenCalledOnce();
+    expect(expandPrompt.mock.calls[0]!.at(-1)).not.toEqual(target);
+    expect(wrapper.text()).not.toContain("will not fall back");
+  });
+
+  it("pinned expansion keeps its selected machine even when a peer has the expander", async () => {
+    twoHosts();
+    fleetApi({});
+    localStorage.setItem("mold.mobile.generate-target.v1", "studio-id");
+    const baseApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((route, path, init) =>
+      path === "/api/capabilities"
+        ? Promise.resolve({
+            ...durableQueueCapabilities,
+            expand: {
+              configured: true,
+              model_present: route.baseUrl === renderTarget.baseUrl,
+            },
+          })
+        : baseApi(route, path, init),
+    );
+    wrapper = mountMobileApp();
+    await flushPromises();
+    await fieldControl("Prompt").setValue("a lighthouse in rain");
+    await wrapper.get("[data-test='mobile-prompt-expand']").trigger("click");
+    await flushPromises();
+    expect(expandPrompt.mock.calls[0]!.at(-1)).toEqual(target);
+  });
+
   it("offers Auto and Most capable once two machines are reachable", async () => {
     twoHosts();
     fleetApi({});
@@ -12913,10 +13083,9 @@ describe("MobileApp Create File under", () => {
   });
 
   it("gives every prepared Batch N sibling the same dropped outcome, once", async () => {
-    // Prepared work never re-routes: it freezes the BROWSED machine at
-    // preparation and develops there, which under an automatic policy need not
-    // be a machine the candidate-set gate spoke for. Browsing Render while
-    // Studio keeps the group visible is exactly that seam.
+    // Auto chooses Render for preparation; reviewed work then keeps that route.
+    // Studio still makes filing visible across the candidate set.
+    autoWinner(filerTarget.baseUrl);
     localStorage.setItem("mold.mobile.selected-host.v1", "render-id");
     await openFleetCreate();
 

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -274,7 +274,7 @@ import { meshStatsLabel } from "@studio/lib/meshControls";
 import type { MeshExportGeometryCapabilities } from "@studio/lib/meshExport";
 import { isMobileMeshResult, meshResultBlob } from "./meshResult";
 import { parseMissingExpandModel } from "../lib/expandErrors";
-import { resolveExpansionRoute } from "@studio/lib/expansionRouting";
+import { expansionPolicyForSelection, resolveExpansionRoute } from "@studio/lib/expansionRouting";
 import {
   expansionPullJobMatchesModel,
   resolveExpansionPullStatus,
@@ -287,6 +287,7 @@ import {
   createPreparedExpansionBatch,
   preparedExpansionStaleReasons,
   quickExpansionStaleReasons,
+  hostSelectionLabel,
   validateExpandedPrompts,
   type PreparedExpansionBatch as PreparedExpansionBatchState,
   type PreparedExpansionInputs,
@@ -634,6 +635,7 @@ interface MobileRemixReviewState {
   conditioningFingerprint: string;
   selectedHostPolicy: string | null;
   route: HostRoute;
+  expansionRoute?: HostRoute;
   variants: MobileRemixReviewVariant[];
   requestToken: number;
 }
@@ -1393,6 +1395,9 @@ const generateTarget = computed(() =>
     selectedHostId.value,
   ),
 );
+const promptToolHostPolicy = computed(() =>
+  generateTarget.value === AUTO_TARGET_ID ? null : generateTarget.value,
+);
 const automaticRouting = computed(
   () => autoRoutingAvailable.value && isAutomaticTarget(generateTarget.value),
 );
@@ -1634,6 +1639,7 @@ const selectedRoute = computed<HostRoute | null>(() => {
  * ready machine while dropping the previous route/download authority. Reviewed
  * multi-variation batches deliberately keep their original frozen route. */
 function carryQuickTransformToHost(hostId: string): void {
+  if (automaticRouting.value) return;
   const snapshot = quickExpansionSnapshot.value;
   const host = hosts.value.find((candidate) => candidate.id === hostId);
   if (
@@ -1651,7 +1657,7 @@ function carryQuickTransformToHost(hostId: string): void {
   }
   quickExpansionSnapshot.value = {
     ...snapshot,
-    selectedHostPolicy: hostId,
+    selectedHostPolicy: promptToolHostPolicy.value,
     route: routeForMobileHost(host),
   };
   if (expansionRecovery.value?.route.hostId !== hostId) clearExpansionRecovery();
@@ -1710,7 +1716,7 @@ const preparedStaleReasons = computed(() => {
         }
       : {}),
     stylePreset: form.stylePreset || null,
-    selectedHostPolicy: selectedHostId.value || null,
+    selectedHostPolicy: promptToolHostPolicy.value,
     readyHostIds: new Set(hosts.value.filter((host) => host.online).map((host) => host.id)),
     hostLabels: new Map(hosts.value.map((host) => [host.id, host.name])),
     modelLabels: new Map(models.value.map((model) => [model.name, modelLabel(model.name)])),
@@ -1737,12 +1743,12 @@ const preparedStaleReasons = computed(() => {
 const quickStaleReasons = computed(() => {
   const snapshot = quickExpansionSnapshot.value;
   if (!snapshot) return [];
-  return quickExpansionStaleReasons(snapshot, {
+  const reasons = quickExpansionStaleReasons(snapshot, {
     expandedPrompt: form.prompt,
     model: form.model,
     family: form.family,
     task: expansionTaskForRequest(form.family, buildRequest(form)),
-    selectedHostPolicy: selectedHostId.value || null,
+    selectedHostPolicy: promptToolHostPolicy.value,
     readyHostIds: new Set(hosts.value.filter((host) => host.online).map((host) => host.id)),
     hostLabels: new Map(hosts.value.map((host) => [host.id, host.name])),
     modelLabels: new Map(models.value.map((model) => [model.name, modelLabel(model.name)])),
@@ -1757,6 +1763,13 @@ const quickStaleReasons = computed(() => {
       ]),
     ),
   });
+  if (snapshot.selectedHostPolicy !== promptToolHostPolicy.value) {
+    const labels = new Map(hosts.value.map((host) => [host.id, host.name]));
+    reasons.push(
+      `Host selection changed from ${hostSelectionLabel(snapshot.selectedHostPolicy, labels)} to ${hostSelectionLabel(promptToolHostPolicy.value, labels)}.`,
+    );
+  }
+  return reasons;
 });
 const remixStaleReasons = computed(() => {
   const review = remixReview.value;
@@ -1775,7 +1788,7 @@ const remixStaleReasons = computed(() => {
     reasons.push("Conditioning media changed after this remix was prepared.");
   if ((form.stylePreset || null) !== review.stylePreset)
     reasons.push("Style changed after this remix was prepared.");
-  if (selectedHostId.value !== review.selectedHostPolicy)
+  if (promptToolHostPolicy.value !== review.selectedHostPolicy)
     reasons.push("Selected machine changed after this remix was prepared.");
   if (JSON.stringify(remixDimensions.value) !== JSON.stringify(review.dimensions))
     reasons.push("Remix dimensions changed after these variants were prepared.");
@@ -5320,7 +5333,7 @@ function expansionInputs(count: number): PreparedExpansionInputs {
     context: expansionContextForRequest(form.family, request, promptRecipeFromForm(form)),
     requestedCount: count,
     stylePreset: form.stylePreset || null,
-    selectedHostPolicy: selectedHostId.value || null,
+    selectedHostPolicy: promptToolHostPolicy.value,
   };
 }
 
@@ -5357,7 +5370,7 @@ function remixInputs(sourceKind: RemixSourceKind = remixSource.value): {
       task: currentExpansionTask.value,
       requestedCount: DEFAULT_REMIX_VARIATIONS,
       stylePreset: form.stylePreset || null,
-      selectedHostPolicy: selectedHostId.value || null,
+      selectedHostPolicy: promptToolHostPolicy.value,
     },
     remix,
     visiblePrompt: form.prompt,
@@ -5368,34 +5381,61 @@ function sameFrozenHost(route: HostRoute, host: MobileHost | undefined): boolean
   return mobileHostMatchesRoute(route, host);
 }
 
-/**
- * The host prompt expansion runs on (shared policy, issue #1162 §5).
- *
- * iPhone pins exactly ONE machine, so the candidate list is that machine and
- * the answer is always the generation route — including when it lacks the
- * expander, where the existing 422 → pull recovery still owns the outcome.
- * The call is shaped so mobile Auto / Most capable (#1163) can hand a real
- * candidate list and ranker here without moving the policy.
- */
-function expansionRouteFor(route: HostRoute): HostRoute {
-  const capability = expandCapabilities[route.hostId];
+interface MobilePromptToolRoutes {
+  route: HostRoute;
+  expansionRoute: HostRoute;
+}
+
+function promptToolProvenance(
+  route: HostRoute,
+  expansionRoute: HostRoute,
+): { expansionRoute?: HostRoute } {
+  return route.hostId === expansionRoute.hostId
+    ? {}
+    : {
+        expansionRoute: { ...expansionRoute, target: { ...expansionRoute.target } },
+      };
+}
+
+/** Resolve a fresh prompt tool request using the active generation policy.
+ * Explicit recovery routes bypass this selection and retain their authority. */
+function currentPromptToolRoutes(): MobilePromptToolRoutes | null {
+  if (!automaticRouting.value) {
+    const host = hosts.value.find((candidate) => candidate.id === generateTarget.value);
+    const route = host ? routeForMobileHost(host) : selectedRoute.value;
+    return route ? { route, expansionRoute: route } : null;
+  }
+  const generationHost = provisionalAutomaticHost(form.model, form.family);
+  const generationRoute = generationHost ? routeForMobileHost(generationHost) : null;
   const decision = resolveExpansionRoute(
-    { kind: "pinned", hostId: route.hostId },
-    { hostId: route.hostId },
-    [
-      {
-        hostId: route.hostId,
+    expansionPolicyForSelection(generateTarget.value, { auto: AUTO_TARGET_ID }),
+    generationHost && expandCapabilities[generationHost.id]?.configured !== false
+      ? generationRoute
+      : null,
+    routingHosts.value.map((host) => {
+      const capability = expandCapabilities[host.id];
+      return {
+        hostId: host.id,
         ready: true,
         ...(capability
           ? { modelPresent: capability.model_present, configured: capability.configured }
           : {}),
-      },
-    ],
-    () => null,
+      };
+    }),
+    (ids) => {
+      const views = routingHosts.value.filter((host) => ids.includes(host.id)).map(routingHostView);
+      const chosen =
+        generateTarget.value === CAPABLE_TARGET_ID
+          ? pickMostCapableHost(views, null, { lowestIdWins: true })
+          : pickAutoHost(views, { lowestIdWins: true });
+      return chosen?.id ?? null;
+    },
   );
-  if (decision.kind !== "reroute") return route;
-  const host = hosts.value.find((candidate) => candidate.id === decision.hostId);
-  return host ? routeForMobileHost(host) : route;
+  if (!generationRoute) return null;
+  if (decision.kind !== "reroute")
+    return { route: generationRoute, expansionRoute: generationRoute };
+  const host = routingHosts.value.find((candidate) => candidate.id === decision.hostId);
+  return host ? { route: generationRoute, expansionRoute: routeForMobileHost(host) } : null;
 }
 
 interface ReplacementFocusOwnership {
@@ -5469,6 +5509,7 @@ function setExpansionFailure(
   requestToken: number,
   replacePrepared: boolean,
   remix: MobileRemixRecoveryPayload | null = null,
+  generationRoute: HostRoute = route,
 ): string {
   const message = error instanceof Error ? error.message : String(error);
   const missingModel = parseMissingExpandModel(message);
@@ -5481,6 +5522,7 @@ function setExpansionFailure(
       model: missingModel,
       inputs,
       route,
+      generationRoute,
       requestToken,
       replacePrepared,
       remix,
@@ -5492,6 +5534,14 @@ function setExpansionFailure(
 }
 
 function recoveryStaleReason(recovery: MobileExpansionRecoveryRecord): string | null {
+  if (
+    !sameFrozenHost(
+      recovery.generationRoute,
+      hosts.value.find((host) => host.id === recovery.generationRoute.hostId),
+    )
+  ) {
+    return `${recovery.generationRoute.label}'s generation connection changed.`;
+  }
   const currentRemix = recovery.remix
     ? mobileRemixRecoveryPayload(recovery.remix.sourceKind)
     : null;
@@ -5550,6 +5600,7 @@ function commitExpandedPrompts(
   requestToken: number,
   replacePrepared: boolean,
   focus: ReplacementFocusOwnership,
+  expansionRoute: HostRoute = route,
 ): void {
   // One result answers a Batch-1 request and is also what a prompt-ignoring
   // recipe returns for any requested count, so the count actually received
@@ -5570,6 +5621,7 @@ function commitExpandedPrompts(
       stylePreset: inputs.stylePreset,
       selectedHostPolicy: inputs.selectedHostPolicy,
       route: { ...route, target: { ...route.target } },
+      ...promptToolProvenance(route, expansionRoute),
     };
     // Bake-and-clear: the rewrite absorbed the style (the server received it
     // as a directive), so the chip clears here — leaving it lit would apply
@@ -5584,7 +5636,10 @@ function commitExpandedPrompts(
     if (replacePrepared) restoreReplacementFocus(focus, "prompt");
     return;
   }
-  preparedBatch.value = createPreparedExpansionBatch(inputs, route, prompts, requestToken);
+  preparedBatch.value = {
+    ...createPreparedExpansionBatch(inputs, route, prompts, requestToken),
+    ...promptToolProvenance(route, expansionRoute),
+  };
   remixUndo.value = null;
   appliedRemix.value = null;
   quickExpansionSnapshot.value = null;
@@ -5607,36 +5662,42 @@ function refusePromptTransform(): boolean {
 
 async function expandForCurrentBatch(
   replacePrepared = false,
-  routeOverride: HostRoute | null = null,
+  routeOverride: MobilePromptToolRoutes | null = null,
 ): Promise<void> {
   if (refusePromptTransform()) return;
   const count = effectiveBatchSize.value;
   const inputs = expansionInputs(count);
-  const host = routeOverride
-    ? hosts.value.find((candidate) => candidate.id === routeOverride.hostId)
-    : selectedHost.value;
-  const route = routeOverride ?? selectedRoute.value;
+  const routes = routeOverride ?? currentPromptToolRoutes();
+  const route = routes?.route;
+  const expandOn = routes?.expansionRoute;
+  const host = route ? hosts.value.find((candidate) => candidate.id === route.hostId) : undefined;
   const replacementFocus = captureReplacementFocus(replacePrepared);
   if (
     !inputs.sourcePrompt ||
     !inputs.model ||
     !host ||
     !route ||
+    !expandOn ||
     expansionRunning.value ||
     (preparedBatch.value && count === 1 && !replacePrepared)
   ) {
     return;
   }
-  if (!sameFrozenHost(route, host)) {
+  if (
+    !sameFrozenHost(route, host) ||
+    !sameFrozenHost(
+      expandOn,
+      hosts.value.find((host) => host.id === expandOn.hostId),
+    )
+  ) {
     expansionError.value = `${route.label} isn't reachable with the frozen connection. Expansion will not fall back.`;
     return;
   }
-  if (expandCapabilities[route.hostId]?.configured === false) {
+  if (expandCapabilities[expandOn.hostId]?.configured === false) {
     expansionError.value = `Prompt expansion isn't configured on ${route.label}. Configure that host before retrying.`;
     clearExpansionRecovery();
     return;
   }
-  const expandOn = expansionRouteFor(route);
 
   clearExpansionRecovery();
   submissionAttempts.invalidate();
@@ -5673,16 +5734,36 @@ async function expandForCurrentBatch(
       current.requestedCount !== inputs.requestedCount ||
       current.stylePreset !== inputs.stylePreset ||
       current.selectedHostPolicy !== inputs.selectedHostPolicy ||
-      !sameFrozenHost(route, currentHost)
+      !sameFrozenHost(route, currentHost) ||
+      !sameFrozenHost(
+        expandOn,
+        hosts.value.find((host) => host.id === expandOn.hostId),
+      )
     ) {
       expansionError.value =
         "The prompt, model, style, Batch, or host changed while expansion was running. Expand again with the current inputs.";
       return;
     }
-    commitExpandedPrompts(inputs, route, prompts, token, replacePrepared, replacementFocus);
+    commitExpandedPrompts(
+      inputs,
+      route,
+      prompts,
+      token,
+      replacePrepared,
+      replacementFocus,
+      expandOn,
+    );
   } catch (error) {
     if (!preparationGuard.isCurrent(token)) return;
-    expansionError.value = setExpansionFailure(error, inputs, route, token, replacePrepared);
+    expansionError.value = setExpansionFailure(
+      error,
+      inputs,
+      expandOn,
+      token,
+      replacePrepared,
+      null,
+      route,
+    );
   } finally {
     if (!unmounted && preparationGuard.isCurrent(token)) expansionRunning.value = false;
   }
@@ -5695,6 +5776,7 @@ function commitRemixReview(
   route: HostRoute,
   variants: ReturnType<typeof validateRemixVariants>,
   requestToken: number,
+  expansionRoute: HostRoute = route,
 ): void {
   remixReview.value = {
     sourcePrompt: remix.sourcePrompt,
@@ -5709,6 +5791,7 @@ function commitRemixReview(
     conditioningFingerprint: remix.conditioningFingerprint,
     selectedHostPolicy: prepared.selectedHostPolicy,
     route: { ...route, target: { ...route.target } },
+    ...promptToolProvenance(route, expansionRoute),
     variants: variants.map((variant, index) => ({
       id: `remix-${requestToken}-${index + 1}`,
       prompt: variant.prompt,
@@ -5721,17 +5804,20 @@ function commitRemixReview(
 }
 
 async function remixCurrent(
-  routeOverride: HostRoute | null = null,
+  routeOverride: MobilePromptToolRoutes | null = null,
   replacePrepared = false,
 ): Promise<void> {
   if (refusePromptTransform()) return;
   const { prepared, remix, visiblePrompt } = remixInputs();
-  const route = routeOverride ?? selectedRoute.value;
+  const routes = routeOverride ?? currentPromptToolRoutes();
+  const route = routes?.route;
+  const expandOn = routes?.expansionRoute;
   const host = route ? hosts.value.find((candidate) => candidate.id === route.hostId) : undefined;
   if (
     !prepared.sourcePrompt ||
     !prepared.model ||
     !route ||
+    !expandOn ||
     !host ||
     remix.dimensions.length === 0 ||
     expansionRunning.value ||
@@ -5739,11 +5825,17 @@ async function remixCurrent(
   ) {
     return;
   }
-  if (!sameFrozenHost(route, host)) {
+  if (
+    !sameFrozenHost(route, host) ||
+    !sameFrozenHost(
+      expandOn,
+      hosts.value.find((host) => host.id === expandOn.hostId),
+    )
+  ) {
     expansionError.value = `${route.label} isn't reachable with the frozen connection. Remix will not fall back.`;
     return;
   }
-  if (expandCapabilities[route.hostId]?.configured === false) {
+  if (expandCapabilities[expandOn.hostId]?.configured === false) {
     expansionError.value = `Prompt tools aren't configured on ${route.label}. Configure that host before retrying.`;
     clearExpansionRecovery();
     return;
@@ -5768,7 +5860,7 @@ async function remixCurrent(
         ...(styleDirective ? { style: styleDirective } : {}),
         dimensions: [...remix.dimensions],
       },
-      route.target,
+      expandOn.target,
     );
     if (!preparationGuard.isCurrent(token)) return;
     if (
@@ -5784,23 +5876,28 @@ async function remixCurrent(
     if (
       JSON.stringify(current.prepared) !== JSON.stringify(prepared) ||
       JSON.stringify(current.remix) !== JSON.stringify(remix) ||
-      !sameFrozenHost(route, currentHost)
+      !sameFrozenHost(route, currentHost) ||
+      !sameFrozenHost(
+        expandOn,
+        hosts.value.find((host) => host.id === expandOn.hostId),
+      )
     ) {
       expansionError.value =
         "The prompt, model, conditioning, dimensions, style, or host changed while Remix was running. Remix again with the current inputs.";
       return;
     }
-    commitRemixReview(prepared, remix, visiblePrompt, route, variants, token);
+    commitRemixReview(prepared, remix, visiblePrompt, route, variants, token, expandOn);
     if (replacePrepared) preparedBatch.value = null;
   } catch (error) {
     if (!preparationGuard.isCurrent(token)) return;
     expansionError.value = setExpansionFailure(
       error,
       prepared,
-      route,
+      expandOn,
       token,
       replacePrepared,
       remix,
+      route,
     )
       .replaceAll("Expansion", "Remix")
       .replaceAll("expansion", "remix");
@@ -5813,14 +5910,24 @@ function replacePreparedPrompts(useFrozenRoute: boolean): void {
   const batch = preparedBatch.value;
   if (!batch) return;
   if (batch.kind !== "remix") {
-    void expandForCurrentBatch(true, useFrozenRoute ? batch.route : null);
+    void expandForCurrentBatch(
+      true,
+      useFrozenRoute
+        ? { route: batch.route, expansionRoute: batch.expansionRoute ?? batch.route }
+        : null,
+    );
     return;
   }
   remixSource.value = batch.sourceKind ?? "current";
   remixDimensions.value = [
     ...(batch.dimensions ?? defaultRemixDimensions(batch.task, Boolean(batch.stylePreset))),
   ];
-  void remixCurrent(useFrozenRoute ? batch.route : null, true);
+  void remixCurrent(
+    useFrozenRoute
+      ? { route: batch.route, expansionRoute: batch.expansionRoute ?? batch.route }
+      : null,
+    true,
+  );
 }
 
 function toggleRemixVariant(id: string): void {
@@ -5869,6 +5976,7 @@ function applyRemixSelection(): void {
       stylePreset: review.stylePreset,
       selectedHostPolicy: review.selectedHostPolicy,
       route: { ...review.route, target: { ...review.route.target } },
+      ...promptToolProvenance(review.route, review.expansionRoute ?? review.route),
     };
     appliedRemix.value = {
       prompt: selected[0]!.prompt.trim(),
@@ -5904,6 +6012,7 @@ function applyRemixSelection(): void {
     review.requestToken,
   );
   Object.assign(preparedBatch.value, {
+    ...promptToolProvenance(review.route, review.expansionRoute ?? review.route),
     remixVariantDimensions: selected.map((variant) => [...variant.dimensions]),
   });
   remixUndo.value = null;
@@ -6277,9 +6386,10 @@ async function retryExpansionAfterPull(): Promise<void> {
           dimensions: [...recovery.remix.dimensions],
         },
         form.prompt,
-        { ...recovery.route, target: { ...recovery.route.target } },
+        { ...recovery.generationRoute, target: { ...recovery.generationRoute.target } },
         variants,
         recovery.requestToken,
+        recovery.route,
       );
       if (recovery.replacePrepared) preparedBatch.value = null;
     } else {
@@ -6288,11 +6398,12 @@ async function retryExpansionAfterPull(): Promise<void> {
       const prompts = validateExpandedPrompts(response.expanded, recovery.inputs.requestedCount);
       commitExpandedPrompts(
         { ...recovery.inputs },
-        { ...recovery.route, target: { ...recovery.route.target } },
+        { ...recovery.generationRoute, target: { ...recovery.generationRoute.target } },
         prompts,
         recovery.requestToken,
         recovery.replacePrepared,
         focus,
+        recovery.route,
       );
     }
   } catch (error) {

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -5777,6 +5777,7 @@ button:disabled {
   flex-wrap: wrap;
 }
 .mobile-surface .ms-seg .ms-seg__btn {
+  justify-content: center;
   min-width: 0;
   min-height: 44px;
   height: auto;

--- a/desktop/src/mobile/mobileExpansionRecovery.test.ts
+++ b/desktop/src/mobile/mobileExpansionRecovery.test.ts
@@ -24,6 +24,29 @@ const route: HostRoute = {
 };
 
 describe("mobile expansion recovery", () => {
+  it("keeps the generation authority separate from the expander and immutable", () => {
+    const generationRoute = {
+      ...route,
+      hostId: "render",
+      target: { baseUrl: "https://render.test", apiKey: "render-key" },
+    };
+    const recovery = createMobileExpansionRecovery({
+      id: 1,
+      leaseId: "lease",
+      model: "qwen3-expand:q8",
+      inputs,
+      route,
+      generationRoute,
+      requestToken: 1,
+      replacePrepared: false,
+    });
+    generationRoute.target.baseUrl = "https://replacement.test";
+    expect(recovery.route).toEqual(route);
+    expect(recovery.host.id).toBe(route.hostId);
+    expect(recovery.generationRoute.target.baseUrl).toBe("https://render.test");
+    expect(Object.isFrozen(recovery.generationRoute.target)).toBe(true);
+  });
+
   it("deep-snapshots inputs and derives its pull host only from the frozen route", () => {
     const mutableInputs = { ...inputs };
     const mutableRoute = { ...route, target: { ...route.target } };

--- a/desktop/src/mobile/mobileExpansionRecovery.ts
+++ b/desktop/src/mobile/mobileExpansionRecovery.ts
@@ -10,6 +10,7 @@ export interface MobileExpansionRecoveryRecord {
   readonly model: string;
   readonly inputs: Readonly<PreparedExpansionInputs>;
   readonly route: Readonly<HostRoute>;
+  readonly generationRoute: Readonly<HostRoute>;
   readonly host: Readonly<MobileHost>;
   readonly requestToken: number;
   readonly replacePrepared: boolean;
@@ -30,6 +31,7 @@ interface MobileExpansionRecoveryDraft {
   model: string;
   inputs: PreparedExpansionInputs;
   route: HostRoute;
+  generationRoute?: HostRoute;
   requestToken: number;
   replacePrepared: boolean;
   remix?: MobileRemixRecoveryPayload | null;
@@ -68,6 +70,10 @@ export function createMobileExpansionRecovery(
     model: draft.model,
     inputs,
     route,
+    generationRoute: Object.freeze({
+      ...(draft.generationRoute ?? route),
+      target: Object.freeze({ ...(draft.generationRoute ?? route).target }),
+    }),
     host,
     requestToken: draft.requestToken,
     replacePrepared: draft.replacePrepared,

--- a/docs/design/mobile-redesign-plan.md
+++ b/docs/design/mobile-redesign-plan.md
@@ -237,3 +237,9 @@ Bound video/mesh, favorite, and ordered-image marker glyphs to 18px inside their
 ### Gallery entry destination
 
 Native visual testing found that Choose from gallery opened Local file. Source/edit-target and first/last-frame gallery actions now declare Gallery as the initial tab and restore it on each reopen; generic ordered-reference addition keeps its file-first default. The simulator verifies Gallery → Local file → Done → Choose from gallery returns to Gallery with real host thumbnails. 98 focused tests, formatting, native rebuild, and independent review pass. No generation was launched for this UI check.
+
+### Final TestFlight prompt-tool routing follow-up
+
+Auto and Most capable now resolve fresh Expand and Remix requests across reachable machines instead of using the browsed machine. The shared expansion policy can select a peer with the expander installed while generation remains on its separately captured route. Frozen refreshes and missing-model recovery preserve both authorities. Automatic browsing does not move prepared work, explicit pinning retains quick-result portability, and policy changes are named before stale work can submit.
+
+Validation covers offline browsed hosts with reachable peers, both automatic policies and prompt tools, unavailable expander configuration, pinned behavior, separate generation destinations for Batch 1 and Batch N, immutable recovery, and policy changes during and after expansion. Mobile regression tests, production build/typecheck, architecture, formatting, and independent review pass. This check used local fixtures without generation.


### PR DESCRIPTION
Mobile Auto displayed the fleet policy but Expand still used the browsed machine; an offline browsed host therefore produced a frozen-connection error even with reachable peers. Remix also bypassed expansion routing.

Fresh Expand and Remix requests now resolve the active policy using the shared expander policy and generation rankers. A peer may rewrite the prompt while generation remains on its captured destination. Frozen refreshes and missing-model recovery retain both authorities, and changing the routing policy rejects late responses. This also includes the final segmented-button centering fix.

Validation: full mobile regression suite, mobile production build/typecheck, architecture and formatting checks; independent peer review. Mounted tests cover unreachable browsed hosts, Auto/Most capable peer expansion, disabled expander configuration, pinned behavior, policy changes during requests, and generation staying on its original host after peer expansion. Local fixtures only; no generations launched.

Follow-up to #1628 from TestFlight feedback.
