### PR TITLE
fix(studio): preserve Hunyuan3D prompt and PBR controls

### DIFF
--- a/changelog.d/mobile-mesh-capability-controls.md
+++ b/changelog.d/mobile-mesh-capability-controls.md
@@ -1,0 +1,4 @@
+- **Restore Hunyuan3D 2.1 prompt and PBR controls.** Accept its advertised mesh
+  roundtrip workflow without discarding the rest of the model profile, so the
+  apps keep descriptions optional and expose supported Color / PBR settings
+  ([#1651](https://github.com/utensils/mold/pull/1651)).

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -520,10 +520,10 @@ function serveProfiledRasterModel(): void {
   });
 }
 
-function serveMeshModel(): void {
+function serveMeshModel(entry: ModelEntry = meshModel): void {
   const base = apiJsonTo.getMockImplementation()!;
   apiJsonTo.mockImplementation((callTarget: unknown, path: string, init?: RequestInit) => {
-    if (path === "/api/models") return Promise.resolve([meshModel]);
+    if (path === "/api/models") return Promise.resolve([entry]);
     if (path === "/api/capabilities") {
       return Promise.resolve({
         ...durableQueueCapabilities,
@@ -5729,6 +5729,32 @@ describe("MobileApp generation queue", () => {
     form.sourceImageName = "armchair.png";
     await flushPromises();
     expect(wrapper.get("#mobile-prompt").isVisible()).toBe(false);
+    expect(
+      wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("keeps Hunyuan3D 2.1 promptless and exposes PBR when roundtrip is advertised", async () => {
+    const entry = structuredClone(meshModel);
+    entry.name = "hunyuan3d-2.1:fp16";
+    const mesh = entry.generation_profile!.recipes[0]!.capabilities.mesh!;
+    mesh.workflow_modes = ["image_to_mesh", "text_to_mesh", "mesh_roundtrip", "mesh_texture"];
+    mesh.texture = { mode: "adjustable", required: false };
+    serveMeshModel(entry);
+    wrapper = mountMobileApp();
+    await flushPromises();
+    const form = wrapper.getComponent(MobileLoraControls).props("form") as GenerateForm;
+    form.prompt = "";
+    form.sourceImage = PNG_1170x2532;
+    form.sourceImageName = "teapot.png";
+    await flushPromises();
+    expect(wrapper.get("#mobile-prompt").isVisible()).toBe(false);
+    expect(
+      wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
+    ).toBeUndefined();
+    expect(wrapper.get("[data-test='mobile-mesh-materials']").text()).toContain("Color / PBR");
+    await wrapper.get("[data-test='mobile-mesh-texture-toggle']").trigger("click");
+    expect(form.mesh.texture).toBe(true);
     expect(
       wrapper.get("[data-test='mobile-develop-button']").attributes("disabled"),
     ).toBeUndefined();

--- a/desktop/src/mobile/MobileSharedParams.test.ts
+++ b/desktop/src/mobile/MobileSharedParams.test.ts
@@ -373,6 +373,7 @@ describe("MobileSharedParams mesh controls", () => {
 
   it("exposes color PBR on the primary form and serializes the advertised texture size", async () => {
     const recipe = hunyuan3dRecipe();
+    recipe.capabilities.mesh!.workflow_modes = ["image_to_mesh", "mesh_roundtrip", "mesh_texture"];
     recipe.capabilities.mesh!.texture = { mode: "adjustable", required: false };
     recipe.capabilities.mesh!.texture_resolutions = [1024, 2048, 4096];
     recipe.capabilities.mesh!.texture_default_resolution = 2048;

--- a/studio/lib/generationProfile.test.ts
+++ b/studio/lib/generationProfile.test.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
 import { describe, expect, it } from "vitest";
 import {
   advertisedGenerationProfile,
@@ -16,6 +18,29 @@ import {
   type GenerationRecipeProfile,
 } from "./generationProfile";
 import { hunyuan3dRecipe, sdxlRecipe } from "./generationProfile.testFixtures";
+
+it("accepts every generation profile emitted by the Rust registry", () => {
+  let directory = process.cwd();
+  const relative = "docs/generated/generation-profiles-v1.json";
+  while (!existsSync(resolve(directory, relative))) {
+    const parent = dirname(directory);
+    if (parent === directory) throw new Error(`Missing ${relative}`);
+    directory = parent;
+  }
+  const registry = JSON.parse(
+    readFileSync(resolve(directory, relative), "utf8"),
+  );
+  expect(registry.profiles.length).toBeGreaterThan(0);
+  for (const { models, profile } of registry.profiles) {
+    expect(
+      advertisedGenerationProfile({
+        family: models[0].family,
+        generation_profile: profile,
+      }),
+      profile.profile_id,
+    ).not.toBeNull();
+  }
+});
 
 function profileModel(): GenerationProfileModel {
   const recipe = (
@@ -585,6 +610,24 @@ describe("prompt, strength, and mesh contract", () => {
     const unknownWorkflow = structuredClone(complete);
     (caps(unknownWorkflow).mesh as LooseCaps).workflow_modes = ["magic_mesh"];
     expect(advertisedGenerationProfile(modelWith(unknownWorkflow))).toBeNull();
+  });
+
+  it("preserves Hunyuan3D 2.1 prompt and PBR authority with mesh roundtrip", () => {
+    const recipe = hunyuan3dRecipe();
+    const mesh = caps(recipe).mesh as LooseCaps;
+    mesh.workflow_modes = [
+      "image_to_mesh",
+      "text_to_mesh",
+      "mesh_roundtrip",
+      "mesh_texture",
+    ];
+    mesh.texture = { mode: "adjustable", required: false };
+    const model = modelWith(recipe);
+    const resolved = effectiveGenerationRecipe(model);
+    expect(resolved).toEqual(recipe);
+    expect(resolved?.capabilities.prompt?.mode).toBe("ignored");
+    expect(resolved?.capabilities.mesh?.texture.mode).toBe("adjustable");
+    expect(recipeIsCanvasless(resolved)).toBe(true);
   });
 
   it("retains PBR and prompt contracts on hosts with the old hidden matting placeholder", () => {

--- a/studio/lib/generationProfile.ts
+++ b/studio/lib/generationProfile.ts
@@ -12,6 +12,7 @@ import type {
   FloatControl,
   ProfileAspectGroup,
   ProfileFpsControl,
+  MeshWorkflowMode,
   PromptCapabilitiesProfile,
   ResolutionProfile,
   TemporalProfile,
@@ -435,6 +436,14 @@ function isPromptCapabilities(
  * default outside it, or a non-integer entry, is a contract this client
  * could only misrender.
  */
+const MESH_WORKFLOW_MODES = {
+  image_to_mesh: true,
+  multiview_to_mesh: true,
+  mesh_roundtrip: true,
+  mesh_texture: true,
+  text_to_mesh: true,
+} satisfies Record<MeshWorkflowMode, true>;
+
 function isMeshCapabilities(value: unknown): value is MeshCapabilitiesProfile {
   if (!isRecord(value)) return false;
   const { octree_resolutions, octree_default, target_faces_min } = value;
@@ -482,13 +491,10 @@ function isMeshCapabilities(value: unknown): value is MeshCapabilitiesProfile {
     (workflowModes === undefined ||
       (Array.isArray(workflowModes) &&
         new Set(workflowModes).size === workflowModes.length &&
-        workflowModes.every((mode) =>
-          [
-            "image_to_mesh",
-            "multiview_to_mesh",
-            "mesh_texture",
-            "text_to_mesh",
-          ].includes(String(mode)),
+        workflowModes.every(
+          (mode) =>
+            typeof mode === "string" &&
+            Object.hasOwn(MESH_WORKFLOW_MODES, mode),
         )))
   );
 }


### PR DESCRIPTION
Hunyuan3D 2.1 profiles advertise `mesh_roundtrip`, but the shared client validator omitted it. Rejecting the entire profile made mobile demand a prompt and hide PBR despite the server advertising an ignored prompt and material controls.

Accept the complete generated workflow enum through an exhaustive typed table. Keep unknown workflows and malformed profiles rejected. This restores the profile's prompt, canvasless and PBR authority on iOS, Android, web and desktop without adding a model-specific override.

Validation: the mounted mobile regression fails against the old validator and passes with this fix; primary PBR controls preserve texture settings on the request. Every Rust-generated profile now has a client acceptance contract test. Local 390×844 component render verifies optional description, working PBR toggle, GLB/texture request fields and no overflow or page errors. Independent review is clear. No real generations or remote-server changes.
