### PR TITLE
refactor(desktop): consolidate RunPod mutation lifecycle

### DIFF
--- a/desktop/src/stores/runpod.test.ts
+++ b/desktop/src/stores/runpod.test.ts
@@ -11,6 +11,9 @@ const runpodOverview = vi.fn().mockResolvedValue({
   networkVolumes: [],
 });
 const runpodDelete = vi.fn();
+const runpodNetworkVolumeCreate = vi.fn();
+const runpodNetworkVolumeUpdate = vi.fn();
+const runpodNetworkVolumeDelete = vi.fn();
 const disconnectHost = vi.fn();
 const forgetRemoteHost = vi.fn();
 const appSettingsGet = vi.fn();
@@ -28,6 +31,9 @@ vi.mock("../lib/ipc", () => ({
     runpodOverview: (...args: unknown[]) => runpodOverview(...args),
     runpodCreate: vi.fn().mockRejectedValue(new Error("GPU is unavailable for Pod creation")),
     runpodDelete: (...args: unknown[]) => runpodDelete(...args),
+    runpodNetworkVolumeCreate: (...args: unknown[]) => runpodNetworkVolumeCreate(...args),
+    runpodNetworkVolumeUpdate: (...args: unknown[]) => runpodNetworkVolumeUpdate(...args),
+    runpodNetworkVolumeDelete: (...args: unknown[]) => runpodNetworkVolumeDelete(...args),
     forgetRemoteHost: (...args: unknown[]) => forgetRemoteHost(...args),
     appSettingsGet: (...args: unknown[]) => appSettingsGet(...args),
   },
@@ -44,6 +50,9 @@ describe("RunPod operation errors", () => {
     setActivePinia(createPinia());
     runpodOverview.mockClear();
     runpodDelete.mockReset().mockResolvedValue(undefined);
+    runpodNetworkVolumeCreate.mockReset().mockResolvedValue({ id: "volume-created" });
+    runpodNetworkVolumeUpdate.mockReset().mockResolvedValue({ id: "volume-updated" });
+    runpodNetworkVolumeDelete.mockReset().mockResolvedValue(undefined);
     disconnectHost.mockReset().mockResolvedValue(undefined);
     forgetRemoteHost.mockReset().mockResolvedValue([]);
     appSettingsGet.mockReset().mockResolvedValue({ savedHosts: [] });
@@ -60,6 +69,40 @@ describe("RunPod operation errors", () => {
 
     store.clearOperationError();
     expect(store.operationError).toBeNull();
+  });
+
+  it("keeps volume mutations busy through refresh and returns their IPC result", async () => {
+    const store = useRunPodStore();
+
+    const creating = store.createNetworkVolume({ name: "models" } as never);
+
+    expect(store.mutating).toBe("volume:create");
+    expect(store.operationError).toBeNull();
+    await expect(creating).resolves.toEqual({ id: "volume-created" });
+    expect(store.mutating).toBeNull();
+    expect(runpodOverview).toHaveBeenCalledOnce();
+
+    const updating = store.updateNetworkVolume({ id: "volume-created" } as never);
+
+    expect(store.mutating).toBe("volume:update:volume-created");
+    await expect(updating).resolves.toEqual({ id: "volume-updated" });
+    expect(store.mutating).toBeNull();
+    expect(runpodOverview).toHaveBeenCalledTimes(2);
+  });
+
+  it("records volume mutation failures and always clears the busy state", async () => {
+    runpodNetworkVolumeDelete.mockRejectedValueOnce(new Error("volume is attached"));
+    const store = useRunPodStore();
+    store.operationError = "old failure";
+
+    const deleting = store.deleteNetworkVolume("volume-123");
+
+    expect(store.mutating).toBe("volume:delete:volume-123");
+    expect(store.operationError).toBeNull();
+    await expect(deleting).rejects.toThrow("volume is attached");
+    expect(store.operationError).toContain("volume is attached");
+    expect(store.mutating).toBeNull();
+    expect(runpodOverview).not.toHaveBeenCalled();
   });
 
   it("disconnects the deleted pod's Mold host so its download queue is retired", async () => {

--- a/desktop/src/stores/runpod.ts
+++ b/desktop/src/stores/runpod.ts
@@ -12,6 +12,30 @@ import {
 } from "../lib/runpod";
 import { useHostsStore } from "./hosts";
 
+interface RunPodMutationState {
+  mutating: string | null;
+  operationError: string | null;
+}
+
+async function runMutation<T>(
+  state: RunPodMutationState,
+  mutation: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  state.mutating = mutation;
+  state.operationError = null;
+  try {
+    return await operation();
+  } catch (error) {
+    state.operationError = friendlyRunPodError(
+      error instanceof Error ? error.message : String(error),
+    );
+    throw error;
+  } finally {
+    state.mutating = null;
+  }
+}
+
 export const useRunPodStore = defineStore("runpod", {
   state: () => ({
     overview: emptyRunPodOverview() as RunPodOverview,
@@ -58,71 +82,33 @@ export const useRunPodStore = defineStore("runpod", {
       this.loaded = true;
     },
     async create(input: RunPodCreateInput) {
-      this.mutating = "create";
-      this.operationError = null;
-      try {
+      return runMutation(this, "create", async () => {
         await ipc.runpodCreate(input);
         await this.load();
-      } catch (error) {
-        this.operationError = friendlyRunPodError(
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      } finally {
-        this.mutating = null;
-      }
+      });
     },
     async createNetworkVolume(input: RunPodNetworkVolumeCreateInput) {
-      this.mutating = "volume:create";
-      this.operationError = null;
-      try {
+      return runMutation(this, "volume:create", async () => {
         const volume = await ipc.runpodNetworkVolumeCreate(input);
         await this.load();
         return volume;
-      } catch (error) {
-        this.operationError = friendlyRunPodError(
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      } finally {
-        this.mutating = null;
-      }
+      });
     },
     async updateNetworkVolume(input: RunPodNetworkVolumeUpdateInput) {
-      this.mutating = `volume:update:${input.id}`;
-      this.operationError = null;
-      try {
+      return runMutation(this, `volume:update:${input.id}`, async () => {
         const volume = await ipc.runpodNetworkVolumeUpdate(input);
         await this.load();
         return volume;
-      } catch (error) {
-        this.operationError = friendlyRunPodError(
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      } finally {
-        this.mutating = null;
-      }
+      });
     },
     async deleteNetworkVolume(id: string) {
-      this.mutating = `volume:delete:${id}`;
-      this.operationError = null;
-      try {
+      return runMutation(this, `volume:delete:${id}`, async () => {
         await ipc.runpodNetworkVolumeDelete(id);
         await this.load();
-      } catch (error) {
-        this.operationError = friendlyRunPodError(
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      } finally {
-        this.mutating = null;
-      }
+      });
     },
     async act(action: "start" | "stop" | "delete", id: string) {
-      this.mutating = `${action}:${id}`;
-      this.operationError = null;
-      try {
+      return runMutation(this, `${action}:${id}`, async () => {
         if (action === "start") await ipc.runpodStart(id);
         else if (action === "stop") await ipc.runpodStop(id);
         else {
@@ -169,14 +155,7 @@ export const useRunPodStore = defineStore("runpod", {
           }
         }
         await this.load();
-      } catch (error) {
-        this.operationError = friendlyRunPodError(
-          error instanceof Error ? error.message : String(error),
-        );
-        throw error;
-      } finally {
-        this.mutating = null;
-      }
+      });
     },
     clearOperationError() {
       this.operationError = null;


### PR DESCRIPTION
Five RunPod mutations repeated the same busy-state and error-handling lifecycle. Consolidate that plumbing in a private typed helper, keeping action-specific IPC calls, refreshes, return values, and sequential pod-host cleanup intact.

GitHub validation completed for `d807fdd660490e934ddd2768d9c9508f25f11760`: **6 successful checks, 12 skipped, 0 failed, 0 pending**. Desktop formatting/tests/typecheck/build and Android APK build, Android 35 instrumentation, Android 36 smoke, and Android 28 public Downloads acceptance all passed. The PR is ready for review and has not been merged.

Production reduction: `desktop/src/stores/runpod.ts` shrinks from **185 to 164 lines**, with **34 additions / 55 deletions (net -21)**. Five lifecycle copies become one. Tests separately add 43 lines; no generated, vendor, dependency, lockfile, or documentation changes.

Reproduce against the starting upstream commit:
```sh
git diff --numstat eec63f37e925a20566c9f29512c1bde539834408..HEAD -- desktop/src/stores/runpod.ts
git show eec63f37e925a20566c9f29512c1bde539834408:desktop/src/stores/runpod.ts | wc -l
wc -l desktop/src/stores/runpod.ts
git diff --numstat eec63f37e925a20566c9f29512c1bde539834408..HEAD -- desktop/src/stores/runpod.test.ts
```

Behavior evidence: all seven existing store tests passed before editing. Two additional characterization tests passed on the original implementation and after consolidation (9/9), covering volume results, busy-state cleanup, error replacement, and failure without refresh. Existing tests cover persistent operation errors, failed deletion, saved aliases, sequential cleanup, and partial-cleanup warnings.

Local validation passed:
```sh
nix develop -c sh -c 'cd desktop && bunx vitest run src/stores/runpod.test.ts'
nix develop -c bunx prettier --check desktop/src/stores/runpod.ts desktop/src/stores/runpod.test.ts
nix develop -c ./scripts/ci-local.sh web
nix develop -c sh -c 'cd desktop && bun run fmt:check && bun run build && bun run build:mobile'
nix develop -c sh -c 'bash scripts/tests/ios-release-assets.sh && bash scripts/tests/ios-testflight-distribution.sh && bash scripts/tests/ios-sim-pick.sh'
SKIP_CHANGELOG=true bash scripts/release/check-changelog-fragments.sh eec63f37e925a20566c9f29512c1bde539834408 HEAD
git diff --check
```

The frontend gate passed architecture, dead-code analysis, formatting, 1,713 Studio tests, 1,839 web tests, 6,437 desktop tests, and the web typechecked build. Desktop/mobile typechecked builds and iOS asset/distribution/simulator contracts passed. Build chunk-size/import advisories and test fixture DNS/abort diagnostics are non-fatal under repository CI policy. Rust/native and docs gates are outside this two-file TypeScript scope. No live billable RunPod operations were performed; IPC is mocked in tests. `skip-changelog` applies because this is an internal behavior-preserving refactor.
