### PR TITLE
fix(studio): hide pixel canvas controls for 3-D across surfaces

### DIFF
--- a/changelog.d/mesh-canvas-control-parity.md
+++ b/changelog.d/mesh-canvas-control-parity.md
@@ -1,0 +1,2 @@
+### Fixed
+- Keep 3-D object generation free of image aspect-ratio, pixel-resolution, and source-fit controls on web, desktop, iOS, Android, and the terminal UI even when a model's generation profile is unavailable.

--- a/changelog.d/mesh-canvas-control-parity.md
+++ b/changelog.d/mesh-canvas-control-parity.md
@@ -1,2 +1,1 @@
-### Fixed
-- Keep 3-D object generation free of image aspect-ratio, pixel-resolution, and source-fit controls on web, desktop, iOS, Android, and the terminal UI even when a model's generation profile is unavailable.
+- **Hide irrelevant pixel controls for 3-D objects.** Keep mesh generation free of image aspect-ratio, pixel-resolution, and source-fit controls on web, desktop, iOS, Android, and the terminal UI even when a model's generation profile is unavailable.

--- a/crates/mold-tui/src/model_info.rs
+++ b/crates/mold-tui/src/model_info.rs
@@ -47,6 +47,8 @@ pub struct ModelCapabilities {
     /// family-only catalog (no profile) offers no mesh rows at all rather
     /// than inventing bounds the server might not honour.
     pub mesh: Option<mold_core::MeshCapabilitiesProfile>,
+    /// No pixel size control, even while optional mesh capabilities are unavailable.
+    pub canvasless: bool,
     /// The ordered reference-image contract the selected recipe advertises
     /// (`capabilities.reference_images`), copied verbatim. `Some` is what
     /// shows the References row; `None` means this model has no reference
@@ -136,6 +138,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         };
@@ -159,6 +162,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: Some(Scheduler::Ddim),
         },
@@ -180,6 +184,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: Some(Scheduler::Ddim),
         },
@@ -201,6 +206,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -222,6 +228,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -243,6 +250,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -271,6 +279,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -292,6 +301,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -313,6 +323,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -334,6 +345,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -355,6 +367,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -376,6 +389,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: true,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -405,6 +419,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: true,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -433,6 +448,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: true,
             reference_images: None,
             default_scheduler: None,
         },
@@ -454,6 +470,7 @@ pub fn capabilities_for_family(family: &str) -> ModelCapabilities {
             supports_video_upscale: false,
             supports_flow_shift: false,
             mesh: None,
+            canvasless: false,
             reference_images: None,
             default_scheduler: None,
         },
@@ -610,6 +627,9 @@ pub fn apply_recipe_capabilities(
     recipe: Option<&mold_core::GenerationCapabilitiesProfile>,
 ) {
     caps.mesh = recipe.and_then(|recipe| recipe.mesh.clone());
+    if let Some(recipe) = recipe {
+        caps.canvasless = recipe.mesh.is_some();
+    }
     // `reference_images` is `Option` on the wire and its ABSENCE means an
     // older server — one whose flux2-dev and qwen-image-edit references still
     // work. So a profile that does not carry the block leaves

--- a/crates/mold-tui/src/ui/create_form.rs
+++ b/crates/mold-tui/src/ui/create_form.rs
@@ -301,9 +301,9 @@ pub fn visible_rows(caps: &ModelCapabilities, adv: &AdvancedState) -> Vec<Create
     let mut rows = vec![CreateRow::Field(ParamField::Model)];
     // A mesh recipe has no canvas (its profile's resolution domain is
     // `None`, and the request's width/height are ignored), so a Size row
-    // would offer a knob that changes nothing. The mesh block is the one
-    // capability signal the form carries for that recipe.
-    if caps.mesh.is_none() {
+    // would offer a knob that changes nothing, including before the
+    // optional mesh-controls profile has arrived.
+    if !caps.canvasless {
         rows.push(CreateRow::Field(ParamField::Size));
     }
     rows.extend([
@@ -1268,7 +1268,7 @@ mod tests {
 
         let family_only = capabilities_for_family("hunyuan3d");
         assert!(family_only.mesh.is_none());
-        assert!(visible_rows(&family_only, &AdvancedState::default())
+        assert!(!visible_rows(&family_only, &AdvancedState::default())
             .contains(&CreateRow::Field(ParamField::Size)));
 
         let catalog = mold_core::build_model_catalog(&Config::default(), None, false);

--- a/desktop/src/components/create/InspectorPanel.test.ts
+++ b/desktop/src/components/create/InspectorPanel.test.ts
@@ -57,6 +57,26 @@ function formFor(family: string): GenerateForm {
 }
 
 describe("InspectorPanel — layout", () => {
+  it("hides raster controls when a mesh model has no usable profile", () => {
+    const form = formFor("hunyuan3d");
+    form.model = "hunyuan3d-2.1:fp16";
+    form.width = 1024;
+    form.height = 1024;
+    useModelStore().all = [
+      {
+        name: form.model,
+        family: form.family,
+        downloaded: true,
+        default_width: 1024,
+        default_height: 1024,
+      } as ModelEntry,
+    ];
+    const wrapper = mount(InspectorPanel, { props: { form } });
+    expect(wrapper.findComponent(ShapePicker).exists()).toBe(false);
+    expect(wrapper.findComponent(ResolutionSelector).exists()).toBe(false);
+    wrapper.unmount();
+  });
+
   it("disables ineffective distilled guidance and re-enables a guided recipe", async () => {
     const form = formFor("ltx2");
     form.model = "ltx-2.3-22b-distilled:fp8";

--- a/desktop/src/components/generate/SourceImageWell.mesh.test.ts
+++ b/desktop/src/components/generate/SourceImageWell.mesh.test.ts
@@ -56,18 +56,22 @@ beforeEach(() => setActivePinia(createPinia()));
 afterEach(() => (document.body.innerHTML = ""));
 
 describe("SourceImageWell — canvasless 3-D recipes", () => {
-  it("offers no source fit, strength or mask for an attached mesh source", async () => {
-    const selectedModel = modelWith("hunyuan3d-mini-turbo:fp16", "hunyuan3d", hunyuan3dRecipe());
-    const wrapper = mount(SourceImageWell, {
-      props: { form: formFor("hunyuan3d", selectedModel.name), selectedModel },
-      attachTo: document.body,
-    });
-    await flushPromises();
-    expect(wrapper.find("[data-test='source-media-wells']").exists()).toBe(true);
-    expect(wrapper.find("[data-test='source-fit-policy']").exists()).toBe(false);
-    expect(wrapper.vm.maskAvailable).toBe(false);
-    expect(wrapper.text()).not.toContain("Prompt strength");
-  });
+  it.each([true, false])(
+    "offers no source fit, strength or mask with advertised profile %s",
+    async (advertised) => {
+      const selectedModel = modelWith("hunyuan3d-mini-turbo:fp16", "hunyuan3d", hunyuan3dRecipe());
+      if (!advertised) delete selectedModel.generation_profile;
+      const wrapper = mount(SourceImageWell, {
+        props: { form: formFor("hunyuan3d", selectedModel.name), selectedModel },
+        attachTo: document.body,
+      });
+      await flushPromises();
+      expect(wrapper.find("[data-test='source-media-wells']").exists()).toBe(true);
+      expect(wrapper.find("[data-test='source-fit-policy']").exists()).toBe(false);
+      expect(wrapper.vm.maskAvailable).toBe(false);
+      expect(wrapper.text()).not.toContain("Prompt strength");
+    },
+  );
 
   it("keeps source fit, strength and the mask for a raster recipe", async () => {
     const selectedModel = modelWith("sdxl-base:fp16", "sdxl", sdxlRecipe());

--- a/desktop/src/lib/generateForm.mesh.test.ts
+++ b/desktop/src/lib/generateForm.mesh.test.ts
@@ -73,6 +73,25 @@ function meshForm() {
 }
 
 describe("selecting a Hunyuan3D recipe", () => {
+  it("keeps a missing-profile mesh request canvasless without inventing mesh features", () => {
+    const model = hunyuanModel();
+    delete model.generation_profile;
+    const form = newGenerateForm();
+    form.model = model.name;
+    form.family = model.family;
+    applyModelDefaults(form, model);
+    expect(form.outputFormat).toBe("glb");
+    expect([form.width, form.height]).toEqual([0, 0]);
+    form.sourceImage = "c291cmNl";
+    form.maskImage = "bWFzaw==";
+    form.sourceFit = { mode: "crop-fill" };
+    const request = buildRequest(form);
+    expect(request).toMatchObject({ width: 0, height: 0, output_format: "glb" });
+    expect(request).not.toHaveProperty("source_fit");
+    expect(request).not.toHaveProperty("mask_image");
+    expect(request).not.toHaveProperty("mesh");
+  });
+
   it("pins glb, takes the recipe's zero canvas, and snapshots the mesh controls", () => {
     const form = meshForm();
     expect(form.outputFormat).toBe("glb");

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -384,7 +384,7 @@ describe("MobileResolutionPicker", () => {
         family: meshModel.family,
         model: {
           ...meshModel,
-          generation_profile: undefined,
+          generation_profile: null,
           default_width: 1024,
           default_height: 1024,
         },

--- a/desktop/src/mobile/MobileResolutionPicker.test.ts
+++ b/desktop/src/mobile/MobileResolutionPicker.test.ts
@@ -377,6 +377,26 @@ describe("MobileResolutionPicker", () => {
    * correct rather than malformed input. Blocking on `width < 1` here would
    * disable Develop for every 3-D print.
    */
+
+  it("hides raster controls for a mesh model with no usable profile and stale dimensions", () => {
+    const wrapper = mount(MobileResolutionPicker, {
+      props: {
+        family: meshModel.family,
+        model: {
+          ...meshModel,
+          generation_profile: undefined,
+          default_width: 1024,
+          default_height: 1024,
+        },
+        width: 1024,
+        height: 1024,
+      },
+    });
+    expect(wrapper.find(".mobile-resolution-picker").exists()).toBe(false);
+    expect(wrapper.emitted("validity-change")).toEqual([[true]]);
+    wrapper.unmount();
+  });
+
   it("renders nothing and stays valid on a canvasless recipe", () => {
     const wrapper = mount(MobileResolutionPicker, {
       props: {

--- a/studio/lib/generationProfile.test.ts
+++ b/studio/lib/generationProfile.test.ts
@@ -392,8 +392,8 @@ describe("output format gate", () => {
   it("accepts the canvasless GLB contract a 3-D family advertises", () => {
     // `OUTPUT_FORMATS` is a runtime GATE, not a type: a missing format makes
     // `isOutputCapabilities` reject the whole profile, and the model then
-    // renders with the legacy raster fallback — canvas controls and PNG
-    // output — instead of the contract the server actually sent. Nothing
+    // loses the advertised mesh controls to the conservative legacy
+    // fallback instead of using the contract the server sent. Nothing
     // fails loudly, which is why this is asserted rather than reviewed.
     const model = profileModel();
     const set = model.generation_profile as GenerationProfileSet;
@@ -687,6 +687,26 @@ describe("prompt, strength, and mesh contract", () => {
     expect(legacy("flux", "flux-dev:q8")?.capabilities.mesh).toBeUndefined();
     expect(legacy("flux", "flux-dev:q8")?.legacy_adapter).toBe(true);
   });
+});
+
+describe("mesh profile fallback", () => {
+  it.each([undefined, { schema_version: 999 }])(
+    "never invents a canvas for an unavailable profile (%j)",
+    (generation_profile) => {
+      const recipe = effectiveGenerationRecipe({
+        name: "hunyuan3d-2.1:fp16",
+        family: "hunyuan3d",
+        default_width: 1024,
+        default_height: 1024,
+        generation_profile,
+      } as GenerationProfileModel);
+      expect(recipe?.legacy_adapter).toBe(true);
+      expect(recipeIsCanvasless(recipe)).toBe(true);
+      expect(recipe?.defaults).toMatchObject({ width: 0, height: 0 });
+      expect(recipe?.resolution.aspect_groups).toEqual([]);
+      expect(recipe?.capabilities.mesh).toBeUndefined();
+    },
+  );
 });
 
 describe("recipeIsCanvasless", () => {

--- a/studio/lib/generationProfile.ts
+++ b/studio/lib/generationProfile.ts
@@ -19,6 +19,7 @@ import type {
   WanRecipeCapabilitiesProfile,
 } from "./generated/generationProfileV1";
 import {
+  isMeshFamily,
   legacyPromptRequirementForFamily,
   legacySupportsStrength,
 } from "./legacyRecipeRules";
@@ -708,6 +709,7 @@ function legacyRecipe(
   pipeline?: string | null,
 ): GenerationRecipeProfile {
   const family = model.family.trim().toLowerCase();
+  const canvasless = isMeshFamily(family);
   const alignment = positiveInteger(model.dimension_alignment, 16);
   const refining =
     family === "ltx2" &&
@@ -782,8 +784,12 @@ function legacyRecipe(
     label: "Default",
     request_selector: {},
     defaults: {
-      width: positiveInteger(model.default_width, Math.max(64, alignment)),
-      height: positiveInteger(model.default_height, Math.max(64, alignment)),
+      width: canvasless
+        ? 0
+        : positiveInteger(model.default_width, Math.max(64, alignment)),
+      height: canvasless
+        ? 0
+        : positiveInteger(model.default_height, Math.max(64, alignment)),
       steps: positiveInteger(model.default_steps, 20),
       guidance: Number.isFinite(model.default_guidance)
         ? Number(model.default_guidance)
@@ -793,15 +799,24 @@ function legacyRecipe(
         : {}),
       ...(model.default_fps !== undefined ? { fps: model.default_fps } : {}),
     },
-    resolution: {
-      domain: "dynamic",
-      alignment,
-      min_width: Math.max(64, alignment),
-      min_height: Math.max(64, alignment),
-      max_pixels: maxPixels,
-      max_axis_pixels: maxAxisPixels,
-      aspect_groups: aspectGroups,
-    },
+    resolution: canvasless
+      ? {
+          domain: "none",
+          alignment: 1,
+          min_width: 0,
+          min_height: 0,
+          max_pixels: 0,
+          aspect_groups: [],
+        }
+      : {
+          domain: "dynamic",
+          alignment,
+          min_width: Math.max(64, alignment),
+          min_height: Math.max(64, alignment),
+          max_pixels: maxPixels,
+          max_axis_pixels: maxAxisPixels,
+          aspect_groups: aspectGroups,
+        },
     steps: {
       default: positiveInteger(model.default_steps, 20),
       min: 1,
@@ -842,12 +857,14 @@ function legacyRecipe(
       lora: { mode: "hidden", max_count: 0 },
       controlnet: { mode: "hidden", max_count: 0 },
       output: {
-        default_format:
-          family === "ltx2" || family === "ltx-video" || family === "wan"
+        default_format: canvasless
+          ? "glb"
+          : family === "ltx2" || family === "ltx-video" || family === "wan"
             ? "mp4"
             : "png",
-        formats:
-          family === "ltx2" || family === "ltx-video" || family === "wan"
+        formats: canvasless
+          ? ["glb"]
+          : family === "ltx2" || family === "ltx-video" || family === "wan"
             ? ["mp4", "gif", "apng", "webp"]
             : ["png", "jpeg", "webp"],
         audio_requires_mp4: family === "ltx2",
@@ -864,7 +881,8 @@ function legacyRecipe(
       // that resolves through the recipe gets the same answer it would have
       // computed from the family. `legacy_adapter` still marks this object
       // as the client talking, for callers that must tell a host's answer
-      // from a fallback. No legacy host has a mesh family.
+      // from a fallback. An absent or rejected mesh profile still has no
+      // pixel canvas; optional mesh features remain unadvertised.
       prompt: { mode: legacyPromptRequirementForFamily(family) },
       supports_strength: legacySupportsStrength(family, model.name ?? ""),
     },

--- a/web/src/components/create/ControlsAside.test.ts
+++ b/web/src/components/create/ControlsAside.test.ts
@@ -53,6 +53,29 @@ function factory(overrides: Partial<GenerateFormState> = {}, family = "flux") {
 }
 
 describe("ControlsAside", () => {
+  it("hides raster controls when a mesh model has no usable profile", () => {
+    const wrapper = mount(ControlsAside, {
+      props: {
+        family: "hunyuan3d",
+        advCount: 0,
+        modelValue: baseForm({
+          model: "hunyuan3d-2.1:fp16",
+          width: 1024,
+          height: 1024,
+        }),
+        model: {
+          name: "hunyuan3d-2.1:fp16",
+          family: "hunyuan3d",
+          default_width: 1024,
+          default_height: 1024,
+        } as ModelInfoExtended,
+      },
+    });
+    expect(wrapper.findComponent(ShapePicker).exists()).toBe(false);
+    expect(wrapper.findComponent(ResolutionSelector).exists()).toBe(false);
+    wrapper.unmount();
+  });
+
   beforeEach(() => {
     setActivePinia(createPinia());
     localStorage.clear();

--- a/web/src/components/create/SourceMediaPanel.test.ts
+++ b/web/src/components/create/SourceMediaPanel.test.ts
@@ -190,6 +190,32 @@ describe("SourceMediaPanel — per-model source-image contract (#772)", () => {
 });
 
 describe("SourceMediaPanel — source fit", () => {
+  it("does not fit a mesh source to a pixel canvas when the profile is unavailable", () => {
+    const wrapper = factory(
+      "hunyuan3d",
+      {
+        model: "hunyuan3d-2.1:fp16",
+        imageAttachments: [
+          { kind: "upload", filename: "source.png", base64: "AA" },
+        ],
+      },
+      {
+        models: [
+          {
+            name: "hunyuan3d-2.1:fp16",
+            family: "hunyuan3d",
+            source_image: "required",
+            default_width: 1024,
+            default_height: 1024,
+          },
+        ],
+      },
+    );
+    expect(wrapper.text()).toContain("source.png");
+    expect(wrapper.find("[aria-label='Fit to canvas']").exists()).toBe(false);
+    wrapper.unmount();
+  });
+
   it("offers all five source-fit policies once an image is attached", () => {
     const wrapper = factory("sdxl", {
       imageAttachments: [


### PR DESCRIPTION
## Problem and change
A Hunyuan3D model with a missing or rejected generation profile fell back to an image recipe, exposing Shape, pixel Resolution, and Source fit despite producing a mesh. The shared fallback now declares no pixel canvas, zero dimensions, and GLB output. Advertised profiles remain authoritative; optional mesh and PBR capabilities are not invented.

Desktop, web, and the shared iOS/Android UI consume this correction. The terminal UI also hides Size before optional mesh capabilities are available. Valid mesh detail and texture-resolution controls remain intact.

## Validation
- Independent peer review completed, findings addressed.
- Mounted desktop/web/mobile regressions cover stale raster dimensions and unavailable profiles; source wells omit raster fit controls.
- Request regression checks zero dimensions, GLB, and omission of source_fit, mask_image, and unadvertised mesh fields.
- Local browser component interaction: image → 3-D → image hides and restores pixel controls with no runtime errors.
- Local suites: 1,717 Studio, 1,841 web, and 6,446 desktop tests passed. One Library timing failure in the first desktop run passed in isolation and in the complete rerun.
- Web, desktop, and mobile production builds passed; formatting and changelog policy passed.
- Rust: terminal canvasless-row regression and all 30 model-capability tests passed with Rust 1.93 and Apple clang/SDK.

CI note: the first Android API 36 smoke attempt was blocked by an emulator “System UI isn’t responding” dialog (retained in the run’s android-app-smoke artifact). API 35 passed. The failed job passed on retry on the unchanged head, including API 36; no app assertion or test was weakened.
