### PR TITLE
feat(library): add bulk local saving across clients

### DIFF
--- a/changelog.d/library-bulk-save.md
+++ b/changelog.d/library-bulk-save.md
@@ -1,0 +1,1 @@
+- Add bulk local saving to desktop and mobile Library selections and bulk downloads to web, with progress and partial-failure reporting. Desktop skips existing local copies and exposes save/export in the selection context menu; web also exposes removal from the current collection.

--- a/desktop/src/components/library/BulkBar.test.ts
+++ b/desktop/src/components/library/BulkBar.test.ts
@@ -175,3 +175,19 @@ describe("BulkBar export progress", () => {
     expect(wrapper.get("[data-test='bulk-export']").text()).toBe("Export…");
   });
 });
+
+describe("bulk local saving", () => {
+  it("uses eligibility independently of the selection count and exposes progress", async () => {
+    const wrapper = mountBar({ localSave: true, localSaveCount: 2 });
+    await wrapper.get("[data-test='bulk-save-locally']").trigger("click");
+    expect(wrapper.emitted("saveLocally")).toHaveLength(1);
+    await wrapper.setProps({ savingLocally: true, localSaveProgress: "Saving 1 of 2…" });
+    expect(wrapper.get("[data-test='bulk-save-locally']").text()).toBe("Saving 1 of 2…");
+    expect(wrapper.get("[data-test='bulk-save-locally']").attributes("disabled")).toBeDefined();
+    await wrapper.setProps({ savingLocally: false, localSaveCount: 0 });
+    expect(wrapper.get("[data-test='bulk-save-locally']").attributes("disabled")).toBeDefined();
+    await wrapper.setProps({ scope: "trash", localSaveCount: 2 });
+    expect(wrapper.find("[data-test='bulk-save-locally']").exists()).toBe(false);
+    wrapper.unmount();
+  });
+});

--- a/desktop/src/components/library/BulkBar.vue
+++ b/desktop/src/components/library/BulkBar.vue
@@ -41,6 +41,10 @@ const props = withDefaults(
     /** An export batch is running — the Export button says so and stands
      *  down. Separate from `busy` so it never borrows the delete wording. */
     exporting?: boolean;
+    localSave?: boolean;
+    localSaveCount?: number;
+    savingLocally?: boolean;
+    localSaveProgress?: string;
     collections?: readonly MergedCollection[];
     /** Slugs every selected print is in. */
     collectionSelected?: readonly string[];
@@ -64,6 +68,10 @@ const props = withDefaults(
     confirming: false,
     busy: false,
     exporting: false,
+    localSave: false,
+    localSaveCount: 0,
+    savingLocally: false,
+    localSaveProgress: "",
     collections: () => [],
     collectionSelected: () => [],
     collectionMixed: () => [],
@@ -81,6 +89,7 @@ const emit = defineEmits<{
   clear: [];
   exit: [];
   export: [];
+  saveLocally: [];
   favorite: [value: boolean];
   trash: [];
   /** Hard delete (non-trash hosts): first press arms, second deletes. */
@@ -296,6 +305,21 @@ defineExpose({ openCollections, openTags, closePopovers });
           Remove from album
         </button>
       </template>
+      <button
+        v-if="localSave"
+        type="button"
+        class="ms-bb"
+        :disabled="!localSaveCount || busy || savingLocally"
+        :title="
+          localSaveCount
+            ? `Save ${localSaveCount} remote prints to this device's Library`
+            : 'Selected prints are already local or cannot be saved locally'
+        "
+        data-test="bulk-save-locally"
+        @click="emit('saveLocally')"
+      >
+        {{ savingLocally ? localSaveProgress || "Saving…" : "Save locally" }}
+      </button>
       <button
         type="button"
         class="ms-bb"

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -12451,6 +12451,112 @@ describe("MobileApp Library organization", () => {
     expect(wrapper?.find("[data-test='mobile-library-chip-tag']").exists()).toBe(false);
   });
 
+  it("disables native bulk save for legacy OBJ and retains original GLB saving", async () => {
+    installLibraryApi();
+    const baseApi = apiJsonTo.getMockImplementation()!;
+    apiJsonTo.mockImplementation((route, path, init) =>
+      path === "/api/gallery"
+        ? Promise.resolve([
+            libraryPrint("legacy.obj", nowSecs + 5, { format: "obj" }),
+            libraryPrint("original.glb", nowSecs + 4, { format: "glb" }),
+          ])
+        : baseApi(route, path, init),
+    );
+    await openLibrary();
+    await wrapper?.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tiles = wrapper!.findAll("[data-test='gallery-item']");
+    await tiles
+      .find((tile) => tile.attributes("aria-label")?.includes("legacy.obj"))!
+      .trigger("click");
+    expect(wrapper?.get("[data-test='mobile-gallery-save']").attributes("disabled")).toBeDefined();
+    await tiles
+      .find((tile) => tile.attributes("aria-label")?.includes("original.glb"))!
+      .trigger("click");
+    await wrapper?.get("[data-test='mobile-gallery-save']").trigger("click");
+    await flushPromises();
+    expect(invoke).toHaveBeenCalledWith(
+      "save_export_to_mold_folder",
+      expect.objectContaining({
+        url: `${target.baseUrl}/api/gallery/export/original.glb`,
+        apiKey: target.apiKey,
+        filename: "original.glb",
+        request: { format: "glb" },
+      }),
+    );
+    expect(
+      invoke.mock.calls.filter(([command]) => command === "save_export_to_mold_folder"),
+    ).toHaveLength(1);
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "Saved 1 of 1",
+    );
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "1 selected print has no supported local-save format",
+    );
+  });
+
+  it("does not publish an old batch outcome after selection changes during saving", async () => {
+    installLibraryApi();
+    await openLibrary();
+    await wrapper?.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tiles = wrapper!.findAll("[data-test='gallery-item']");
+    await tiles[0]!.trigger("click");
+    let finishSave!: () => void;
+    invoke.mockImplementation((command: string) =>
+      command === "save_image_to_photos"
+        ? new Promise<void>((resolve) => {
+            finishSave = resolve;
+          })
+        : Promise.resolve(null),
+    );
+    await wrapper?.get("[data-test='mobile-gallery-save']").trigger("click");
+    await flushPromises();
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "Saving 1 of 1",
+    );
+    await tiles[1]!.trigger("click");
+    finishSave();
+    await flushPromises();
+    expect(wrapper?.find("[data-test='mobile-gallery-save-status']").exists()).toBe(false);
+    expect(
+      wrapper?.get("[data-test='mobile-gallery-save']").attributes("disabled"),
+    ).toBeUndefined();
+  });
+
+  it("saves selected originals locally and reports a partial failure", async () => {
+    installLibraryApi();
+    await openLibrary();
+    await wrapper?.get("[data-test='mobile-gallery-select']").trigger("click");
+    const tiles = wrapper!.findAll("[data-test='gallery-item']");
+    await tiles[0]!.trigger("click");
+    await tiles[1]!.trigger("click");
+    apiFetchTo.mockImplementation(async () => new Response(new Blob(["original"])));
+    let count = 0;
+    invoke.mockImplementation(async (command: string) => {
+      if (command === "save_image_to_photos" && ++count === 1)
+        throw new Error("Photos unavailable");
+      return null;
+    });
+    await wrapper?.get("[data-test='mobile-gallery-save']").trigger("click");
+    await flushPromises();
+    expect(count).toBe(2);
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "Saved 1 of 2",
+    );
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "Photos unavailable",
+    );
+    await tiles[0]!.trigger("click");
+    expect(wrapper?.find("[data-test='mobile-gallery-save-status']").exists()).toBe(false);
+    await wrapper?.get("[data-test='mobile-gallery-save']").trigger("click");
+    await flushPromises();
+    expect(wrapper?.get("[data-test='mobile-gallery-save-status']").text()).toContain(
+      "Saved 1 of 1",
+    );
+    await wrapper?.get("[data-test='mobile-gallery-select']").trigger("click");
+    await wrapper?.get("[data-test='mobile-gallery-select']").trigger("click");
+    expect(wrapper?.find("[data-test='mobile-gallery-save-status']").exists()).toBe(false);
+  });
+
   it("fans a bulk favorite out through /api/gallery/organize", async () => {
     installLibraryApi();
     await openLibrary();

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -9670,6 +9670,72 @@ async function setCollectionMembershipFor(
 
 // ── Select-mode bulk actions ───────────────────────────────────────────────
 
+const gallerySaveBusy = ref(false);
+const gallerySaveStatus = ref("");
+let gallerySaveSelectionVersion = 0;
+watch(
+  [gallerySelection, gallerySelectMode],
+  () => {
+    gallerySaveSelectionVersion++;
+    if (!gallerySaveBusy.value) gallerySaveStatus.value = "";
+  },
+  { flush: "sync" },
+);
+const gallerySaveTargets = computed(() =>
+  selectedRepresentatives().filter(
+    (print) =>
+      isStillImageFile(print.filename) ||
+      isVideoItem(print) ||
+      print.filename.toLowerCase().endsWith(".glb"),
+  ),
+);
+async function saveSelectedGalleryPrints(): Promise<void> {
+  if (gallerySaveBusy.value || !gallerySaveTargets.value.length) return;
+  const targets = [...gallerySaveTargets.value];
+  const skipped = gallerySelection.value.size - targets.length;
+  const selectionVersion = gallerySaveSelectionVersion;
+  gallerySaveBusy.value = true;
+  let saved = 0;
+  let firstError = "";
+  try {
+    for (const [index, print] of targets.entries()) {
+      gallerySaveStatus.value = `Saving ${index + 1} of ${targets.length}…`;
+      try {
+        if (isMeshItem(print)) {
+          await invoke("save_export_to_mold_folder", {
+            url: `${print.target.baseUrl}/api/gallery/export/${encodeURIComponent(print.filename)}`,
+            apiKey: print.target.apiKey,
+            request: { format: "glb" },
+            filename: print.filename,
+            reuseKey: `${print.target.baseUrl}\n${print.filename}\n${JSON.stringify({ format: "glb" })}`,
+          });
+        } else if (isVideoItem(print)) {
+          const url = await streamableMediaUrl(galleryMediaPath(print.filename, "host"), {
+            target: print.target,
+            cacheKey: print.cacheKey,
+            allowLegacyBlob: false,
+          });
+          await invoke("save_video_to_photos", { url });
+        } else {
+          const response = await apiFetchTo(print.target, galleryMediaPath(print.filename, "host"));
+          await invoke("save_image_to_photos", {
+            dataB64: await blobToBase64(await response.blob()),
+          });
+        }
+        saved++;
+      } catch (error) {
+        firstError ||= `${print.filename}: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    }
+    gallerySaveStatus.value =
+      selectionVersion === gallerySaveSelectionVersion
+        ? `Saved ${saved} of ${targets.length}.${skipped ? ` ${skipped} selected ${skipped === 1 ? "print has" : "prints have"} no supported local-save format.` : ""} Photos and videos go to Photos; meshes go to the Mold folder.${firstError ? ` ${firstError}` : ""}`
+        : "";
+  } finally {
+    gallerySaveBusy.value = false;
+  }
+}
+
 async function favoriteSelected(): Promise<void> {
   if (organizationBusy.value || gallerySelection.value.size === 0) return;
   galleryDeleteConfirming.value = false;
@@ -12903,6 +12969,19 @@ function onMobileQueueRowAction(row: MobileActivityRow, action: string): void {
               Remove
             </button>
           </template>
+          <button
+            v-if="!galleryDeleteConfirming && libraryScope !== 'trash'"
+            type="button"
+            :disabled="!gallerySaveTargets.length || gallerySaveBusy"
+            title="Save selected photos and videos to Photos, and GLB meshes to the Mold folder"
+            data-test="mobile-gallery-save"
+            @click="saveSelectedGalleryPrints"
+          >
+            {{ gallerySaveBusy ? "Saving…" : "Save locally" }}
+          </button>
+          <span v-if="gallerySaveStatus" role="status" data-test="mobile-gallery-save-status">{{
+            gallerySaveStatus
+          }}</span>
           <button
             v-if="
               !galleryDeleteConfirming && libraryScope !== 'trash' && singleSelectedUpscalePrint

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -8,6 +8,7 @@ const { apiFetchTo, localGalleryDelete, localGalleryList } = vi.hoisted(() => ({
   localGalleryDelete: vi.fn().mockResolvedValue(undefined),
   localGalleryList: vi.fn(),
 }));
+const nativeSave = vi.hoisted(() => ({ enabled: false, save: vi.fn() }));
 const retainedInventoryMock = vi.hoisted(() => vi.fn());
 vi.mock("@studio/api/gallerySourceMedia", async (importOriginal) => {
   const actual = await importOriginal<typeof import("@studio/api/gallerySourceMedia")>();
@@ -54,12 +55,12 @@ vi.mock("../lib/api/client", () => ({
   currentTarget: () => ({ baseUrl: "http://x", apiKey: null }),
 }));
 vi.mock("../lib/ipc", () => ({
-  inTauri: () => false,
+  inTauri: () => nativeSave.enabled,
   ipc: {
     localGalleryDelete,
     localGalleryList,
     revealOutputFile: vi.fn(),
-    saveOutputBytes: vi.fn(),
+    saveOutputBytes: nativeSave.save,
   },
 }));
 
@@ -183,6 +184,8 @@ async function mountView(
 }
 
 beforeEach(() => {
+  nativeSave.enabled = false;
+  nativeSave.save.mockReset();
   clearSessionScrollForTests();
   vi.clearAllMocks();
   localStorage.clear();
@@ -1339,6 +1342,35 @@ describe("scope counts and Escape in a text field", () => {
     window.dispatchEvent(handled);
     await flushPromises();
     expect(wrapper.findComponent({ name: "Lightbox" }).exists()).toBe(true);
+    wrapper.unmount();
+  });
+});
+
+describe("Library bulk local saving", () => {
+  it("skips local prints, retains source metadata, and continues after failure", async () => {
+    const remote = { ...prints[0]!, filename: "remote.png" };
+    const { wrapper, gallery } = await mountView(remote, (store) => {
+      store.buckets["plato-7680"]!.items.push({ ...remote, filename: "second.mp4" });
+    });
+    nativeSave.enabled = true;
+    const refresh = vi.spyOn(gallery, "refreshHost").mockResolvedValue(undefined);
+    apiFetchTo.mockImplementation(async () => new Response(new Blob(["original"])));
+    nativeSave.save
+      .mockRejectedValueOnce(new Error("disk full"))
+      .mockResolvedValueOnce("saved.mp4");
+    window.dispatchEvent(new Event("mold:library-select-all"));
+    await flushPromises();
+    expect(wrapper.find("[data-test='bulk-save-locally']").exists()).toBe(true);
+    await wrapper.get("[data-test='bulk-save-locally']").trigger("click");
+    await flushPromises();
+    expect(nativeSave.save).toHaveBeenCalledTimes(2);
+    expect(nativeSave.save.mock.calls.map((args) => args[0]).sort()).toEqual([
+      "remote.png",
+      "second.mp4",
+    ]);
+    expect(nativeSave.save.mock.calls[0]![2]).toEqual(remote.metadata);
+    expect(refresh).toHaveBeenCalledWith("local");
+    expect(wrapper.get("[data-test='bulk-save-locally']").attributes("disabled")).toBeUndefined();
     wrapper.unmount();
   });
 });

--- a/desktop/src/views/LibraryView.vue
+++ b/desktop/src/views/LibraryView.vue
@@ -287,19 +287,49 @@ async function fetchItemBase64(entry: MergedPrint): Promise<string> {
   return readGalleryMediaBase64(entry, gallery);
 }
 
+const localSaveBusy = ref(false);
+const localSaveProgress = ref("");
 async function saveToThisMac(entry: MergedPrint) {
+  await saveSelectedLocally([entry]);
+}
+
+async function saveSelectedLocally(selection: MergedPrint[]) {
+  if (localSaveBusy.value) return;
+  const targets = selection.filter(canSaveLocally);
+  if (!targets.length) return;
+  localSaveBusy.value = true;
+  let saved = 0;
+  const failures: string[] = [];
   try {
-    // The origin row's metadata rides along so the local DB row matches the
-    // origin exactly — videos embed nothing in the file itself.
-    const saved = await ipc.saveOutputBytes(
-      entry.item.filename,
-      await fetchItemBase64(entry),
-      entry.item.metadata,
+    for (const [index, entry] of targets.entries()) {
+      localSaveProgress.value = `Saving ${index + 1} of ${targets.length}…`;
+      try {
+        await ipc.saveOutputBytes(
+          entry.item.filename,
+          await fetchItemBase64(entry),
+          entry.item.metadata,
+        );
+        saved++;
+      } catch (error) {
+        failures.push(
+          `${entry.item.filename}: ${error instanceof Error ? error.message : String(error)}`,
+        );
+      }
+    }
+    if (saved) await gallery.refreshHost("local");
+    const description =
+      failures[0] ??
+      (selection.length > targets.length
+        ? `${selection.length - targets.length} prints already local or unavailable for local saving.`
+        : "");
+    toasts.push(
+      `Saved locally ${saved} of ${targets.length} prints`,
+      failures.length ? "error" : "info",
+      description ? { description } : {},
     );
-    toasts.push(`Saved locally — ${saved}`);
-    void gallery.refreshHost("local");
-  } catch (err) {
-    toasts.push(err instanceof Error ? err.message : String(err), "error");
+  } finally {
+    localSaveBusy.value = false;
+    localSaveProgress.value = "";
   }
 }
 
@@ -1148,7 +1178,7 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
   const favorite = isFavorite(entry);
   const trashable = entryTrashCapable(entry);
   if (selectedForBulk) {
-    const targets = selectedEntries.value;
+    const targets = [...selectedEntries.value];
     const allFavourite = targets.every(isFavorite);
     const allOrganizable = targets.every(canOrganizeEntry);
     const allTrashable = targets.every(entryTrashCapable);
@@ -1175,6 +1205,16 @@ function tileMenu(entry: MergedPrint): MenuEntry[] {
             { separator: true } as MenuEntry,
           ]
         : []),
+      {
+        label: localSaveProgress.value || `Save ${targets.filter(canSaveLocally).length} locally`,
+        disabled: localSaveBusy.value || !targets.some(canSaveLocally),
+        action: () => void saveSelectedLocally(targets),
+      },
+      {
+        label: exportBusy.value ? "Exporting…" : `Export ${bulkCount} selected…`,
+        disabled: exportBusy.value,
+        action: () => void exportSelected(targets),
+      },
       {
         label: allTrashable
           ? `Move ${bulkCount} selected to trash`
@@ -2791,6 +2831,10 @@ onUnmounted(() => {
       :confirming="confirmingBulkDelete"
       :busy="bulkDeleting || organizeBusy"
       :exporting="exportBusy"
+      :local-save="inTauri()"
+      :local-save-count="selectedEntries.filter(canSaveLocally).length"
+      :saving-locally="localSaveBusy"
+      :local-save-progress="localSaveProgress"
       :collections="gallery.mergedCollections"
       :collection-selected="selectionOrganization.collectionsAll"
       :collection-mixed="selectionOrganization.collectionsSome"
@@ -2803,7 +2847,8 @@ onUnmounted(() => {
       @select-all="selectAllInFilter"
       @clear="clearBulkSelection"
       @exit="setSelectMode(false)"
-      @export="exportSelected(selectedEntries)"
+      @export="exportSelected([...selectedEntries])"
+      @save-locally="saveSelectedLocally([...selectedEntries])"
       @favorite="(value) => setFavorite(selectedEntries, value)"
       @trash="deleteSelectedPrints"
       @update:confirming="confirmingBulkDelete = $event"

--- a/web/src/pages/LibraryPage.organization.test.ts
+++ b/web/src/pages/LibraryPage.organization.test.ts
@@ -9,6 +9,12 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { defineComponent } from "vue";
 import { createPinia, setActivePinia } from "pinia";
+import { fetchGalleryBlob } from "../lib/galleryMedia";
+import { downloadVideoExport } from "@studio/lib/videoExport";
+vi.mock("@studio/lib/videoExport", async (original) => ({
+  ...(await original<typeof import("@studio/lib/videoExport")>()),
+  downloadVideoExport: vi.fn(),
+}));
 import LibraryPage from "./LibraryPage.vue";
 import {
   requestConfirm,
@@ -642,6 +648,28 @@ describe("Trash-aware deletes in Prints", () => {
     expect(wrapper.get("[data-test='grid-names']").text()).toBe(
       "old.png,smurf.png",
     );
+  });
+
+  it("downloads a frozen selection and continues after a failed print", async () => {
+    const wrapper = mountPage();
+    await flushPromises();
+    await wrapper.get("[data-test='gallery-select']").trigger("click");
+    await wrapper.get("[data-test='grid-select-first']").trigger("click");
+    await wrapper.get("[data-test='grid-select-second']").trigger("click");
+    vi.mocked(fetchGalleryBlob)
+      .mockRejectedValueOnce(new Error("offline"))
+      .mockResolvedValueOnce(new Blob(["original"]));
+    await wrapper.get("[data-test='bulk-download']").trigger("click");
+    await flushPromises();
+    expect(fetchGalleryBlob).toHaveBeenCalledTimes(2);
+    expect(downloadVideoExport).toHaveBeenCalledTimes(1);
+    expect(
+      wrapper.get("[data-test='bulk-download']").attributes("disabled"),
+    ).toBeUndefined();
+    expect(JSON.stringify(useNotifications().toasts)).toContain(
+      "Started 1 of 2 downloads",
+    );
+    wrapper.unmount();
   });
 
   it("bulk Trash is undoable and commits through the bulk trash route", async () => {

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -60,6 +60,8 @@ import {
 } from "@studio/lib/libraryOrganization";
 import { defaultSourceFitPolicy } from "@studio/lib/sourceFit";
 import { blobToBase64 } from "../lib/base64";
+import { downloadVideoExport } from "@studio/lib/videoExport";
+import { downloadFilename } from "../lib/libraryOrganization";
 import { fetchGalleryBlob } from "../lib/galleryMedia";
 import {
   requestConfirm,
@@ -1131,10 +1133,14 @@ const selectedEntries = computed(() =>
     .filter((e): e is HostGalleryImage => !!e),
 );
 const selectionCopies = computed(() => copiesOfKeys([...selection.value]));
-const selectionOrganizes = computed(() =>
-  selectionCopies.value.some((copy) =>
-    hostOrganizes(snapshots.value, copy.hostId),
-  ),
+const selectionOrganizes = computed(
+  () =>
+    selectedEntries.value.length > 0 &&
+    selectedEntries.value.every((entry) =>
+      copiesOfKeys([keyOf(entry)]).some((copy) =>
+        hostOrganizes(snapshots.value, copy.hostId),
+      ),
+    ),
 );
 const selectionTrashes = computed(
   () =>
@@ -1194,6 +1200,39 @@ const lightboxCollectionRows = computed(() =>
 const selectionHostsLabel = computed(() =>
   [...new Set(selectionCopies.value.map((c) => c.hostLabel))].join(" · "),
 );
+
+const downloadBusy = ref(false);
+const downloadProgress = ref("");
+async function downloadSelected() {
+  if (downloadBusy.value || !selectedEntries.value.length) return;
+  const targets = [...selectedEntries.value];
+  downloadBusy.value = true;
+  let downloaded = 0;
+  let firstError = "";
+  try {
+    for (const [index, entry] of targets.entries()) {
+      downloadProgress.value = `Downloading ${index + 1} of ${targets.length}…`;
+      try {
+        const host = hostById(entry.hostId);
+        if (!host) throw new Error("The media host is no longer connected.");
+        downloadVideoExport(
+          await fetchGalleryBlob(host, entry.filename),
+          downloadFilename(entry),
+        );
+        downloaded++;
+      } catch (error) {
+        firstError ||= `${entry.filename}: ${error instanceof Error ? error.message : String(error)}`;
+      }
+    }
+    toast(
+      firstError ? "error" : "success",
+      `Started ${downloaded} of ${targets.length} downloads.${firstError ? ` ${firstError}` : " Your browser may ask you to allow multiple downloads."}`,
+    );
+  } finally {
+    downloadBusy.value = false;
+    downloadProgress.value = "";
+  }
+}
 
 function bulkFavorite() {
   const favorite = !selectionAllFavorite.value;
@@ -3076,6 +3115,25 @@ onBeforeUnmount(() => {
           </template>
 
           <template v-else>
+            <button
+              type="button"
+              class="gal__bar-btn"
+              :disabled="selection.size === 0 || downloadBusy"
+              data-test="bulk-download"
+              @click="downloadSelected"
+            >
+              {{ downloadBusy ? downloadProgress : "Download" }}
+            </button>
+            <button
+              v-if="currentCollection"
+              type="button"
+              class="gal__bar-btn"
+              :disabled="selection.size === 0 || !selectionOrganizes"
+              data-test="bulk-remove-from-collection"
+              @click="removeSelectedFromCollection"
+            >
+              Remove from collection
+            </button>
             <template v-if="canOrganize">
               <Popover
                 :open="bulkCollectionsOpen"


### PR DESCRIPTION
Library selections could organize or delete prints, but desktop only offered Save locally for individual prints and web/mobile had no bulk save action. This adds bulk saving through each surface's existing authenticated media path, with sequential processing, progress, and partial-failure reporting.

- Desktop saves remote originals and metadata into the local Library, skips existing local copies, and exposes save/export in selection context menus.
- Web downloads selected originals and exposes removal from the current collection. Organization actions require every selected logical print to have a capable host.
- iOS/Android save selected images and videos to Photos and original GLBs to the Mold folder; audio and legacy OBJ remain unsupported by the native save action.

Validation:
- Independent subagent peer review approved the final diff with no remaining actionable findings. Fixed unsupported OBJ eligibility and stale results after selection changes, including during an in-flight save; regression tests cover both.
- 1,715 Studio tests, 1,840 web tests, and all 6,445 desktop-suite tests passed. The desktop suite passed with `--maxWorkers=4` after two album/tag timing failures in the unbounded run. Local Node 26 required `NODE_OPTIONS=--no-experimental-webstorage` for happy-dom storage compatibility.
- Desktop, web, and mobile frontend builds; Library regression tests cover skipping local copies, original metadata, partial failures, and busy states.
- Playwright: six selected web prints produce six downloads; responsive checks at 1440×1000 and 390×844, plus desktop toolbar progress rendering.
- Hosted CI passed on `9a5b0d6d`, including web, desktop/mobile frontend, Android 35 app/instrumentation, Android 36 app smoke, and Android 28 public Downloads acceptance. Android passed on retry after an initial hidden-WebView CDP touch timeout.
- Interactive bulk saving on physical devices remains unverified: the existing Android test helper's `--apk true` invocation is rejected by the installed Tauri CLI, and no emulator was running.

No generations or deployment changes.
