### PR TITLE
fix(studio): unify library and 3-D workflows and restore durable media

### DIFF
--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -9,3 +9,4 @@
   reload workflow capabilities or reset the selected workflow and inputs.
 - Align desktop 3-D Studio with the shared toolbar, canvas, and inspector design. Add Auto and Most capable routing that keeps every workflow stage on one eligible machine, retains the workflow owner for progress and results, and avoids reloading unchanged result media.
 - Center the web queue's failed-job dismiss icon in its touch target and vertically align it with wrapped error text.
+- Fix text-to-mesh admission rejecting its own future-image validation placeholder as invalid PNG/JPEG, while keeping that placeholder out of the durable request.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -8,3 +8,4 @@
 - **Stable 3-D Studio drafts.** Routine machine telemetry updates no longer
   reload workflow capabilities or reset the selected workflow and inputs.
 - Align desktop 3-D Studio with the shared toolbar, canvas, and inspector design. Add Auto and Most capable routing that keeps every workflow stage on one eligible machine, retains the workflow owner for progress and results, and avoids reloading unchanged result media.
+- Center the web queue's failed-job dismiss icon in its touch target and vertically align it with wrapped error text.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -2,3 +2,6 @@
   Reuse settings, inspector actions wrap within the panel, and mirrored prints
   recover retained source media from another known copy's host before reporting
   it unavailable.
+- **Visible video sound control.** Create and Library show a persistent Sound
+  on/off toggle, remember mute across videos and app launches, and synchronize
+  with native player controls while playback continues to loop.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -7,3 +7,4 @@
   with native player controls while playback continues to loop.
 - **Stable 3-D Studio drafts.** Routine machine telemetry updates no longer
   reload workflow capabilities or reset the selected workflow and inputs.
+- Align desktop 3-D Studio with the shared toolbar, canvas, and inspector design. Add Auto and Most capable routing that keeps every workflow stage on one eligible machine, retains the workflow owner for progress and results, and avoids reloading unchanged result media.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -5,3 +5,5 @@
 - **Visible video sound control.** Create and Library show a persistent Sound
   on/off toggle, remember mute across videos and app launches, and synchronize
   with native player controls while playback continues to loop.
+- **Stable 3-D Studio drafts.** Routine machine telemetry updates no longer
+  reload workflow capabilities or reset the selected workflow and inputs.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -10,3 +10,5 @@
 - Align desktop 3-D Studio with the shared toolbar, canvas, and inspector design. Add Auto and Most capable routing that keeps every workflow stage on one eligible machine, retains the workflow owner for progress and results, and avoids reloading unchanged result media.
 - Center the web queue's failed-job dismiss icon in its touch target and vertically align it with wrapped error text.
 - Fix text-to-mesh admission rejecting its own future-image validation placeholder as invalid PNG/JPEG, while keeping that placeholder out of the durable request.
+- Reuse Generate's filtered style pickers and shared switches in 3-D Studio, make the desktop settings rail resizable with its existing saved-width controls, and bring web workflow routing and mode controls into parity.
+- Restore queued generation settings from the single-job detail endpoint across desktop, web, and mobile, including durable jobs parked after a server restart. Selecting workflow history restores its authored controls without letting polling overwrite edits.

--- a/changelog.d/desktop-library-cleanup.md
+++ b/changelog.d/desktop-library-cleanup.md
@@ -1,0 +1,4 @@
+- **Desktop Library reuse and layout.** Video playback's context menu now offers
+  Reuse settings, inspector actions wrap within the panel, and mirrored prints
+  recover retained source media from another known copy's host before reporting
+  it unavailable.

--- a/crates/mold-server/src/routes_mesh_workflows.rs
+++ b/crates/mold-server/src/routes_mesh_workflows.rs
@@ -126,20 +126,38 @@ fn load_detail(state: &AppState, id: &str) -> Result<MeshWorkflowJobDetail, ApiE
     detail_from_rows(row, stages)
 }
 
-async fn validate_stage_model(
-    state: &AppState,
+// Only the validation clone receives a stand-in. The durable request stays
+// source-free until the image stage publishes its real PNG.
+fn stage_validation_request(
     request: &mold_core::GenerateRequest,
     workflow_mode: Option<MeshWorkflowMode>,
-) -> Result<(), ApiError> {
-    let family = crate::routes::require_server_model_activation(state, &request.model).await?;
+) -> Result<mold_core::GenerateRequest, ApiError> {
     let mut validation_request = request.clone();
     if workflow_mode == Some(MeshWorkflowMode::TextToMesh)
         && validation_request.source_image.is_none()
     {
         // The preceding durable image stage supplies this field. Validation
         // still needs to exercise the Hunyuan3D image-conditioned recipe.
-        validation_request.source_image = Some(vec![0]);
+        validation_request.source_image = Some({
+            let mut png = std::io::Cursor::new(Vec::new());
+            image::DynamicImage::new_rgb8(1, 1)
+                .write_to(&mut png, image::ImageFormat::Png)
+                .map_err(|error| {
+                    ApiError::internal(format!("workflow validation image: {error}"))
+                })?;
+            png.into_inner()
+        });
     }
+    Ok(validation_request)
+}
+
+async fn validate_stage_model(
+    state: &AppState,
+    request: &mold_core::GenerateRequest,
+    workflow_mode: Option<MeshWorkflowMode>,
+) -> Result<(), ApiError> {
+    let family = crate::routes::require_server_model_activation(state, &request.model).await?;
+    let validation_request = stage_validation_request(request, workflow_mode)?;
     crate::routes::validate_generate_request(
         &validation_request,
         family.as_deref(),
@@ -672,6 +690,36 @@ pub(crate) async fn delete_mesh_workflow(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn text_to_mesh_validates_future_image_without_persisting_placeholder() {
+        let request: mold_core::GenerateRequest = serde_json::from_value(serde_json::json!({
+            "model": "hunyuan3d-mini-turbo:fp16", "prompt": "", "width": 0,
+            "height": 0, "steps": 5, "guidance": 5.0, "output_format": "glb"
+        }))
+        .unwrap();
+        let validation =
+            stage_validation_request(&request, Some(MeshWorkflowMode::TextToMesh)).unwrap();
+        let image = image::load_from_memory(validation.source_image.as_ref().unwrap()).unwrap();
+        assert_eq!((image.width(), image.height()), (1, 1));
+        crate::routes::validate_generate_request(
+            &validation,
+            Some("hunyuan3d"),
+            mold_core::ReferenceForm::Admitted,
+        )
+        .unwrap();
+        assert!(request.source_image.is_none());
+        let mut invalid = request.clone();
+        invalid.source_image = Some(vec![0]);
+        let unchanged =
+            stage_validation_request(&invalid, Some(MeshWorkflowMode::TextToMesh)).unwrap();
+        assert!(crate::routes::validate_generate_request(
+            &unchanged,
+            Some("hunyuan3d"),
+            mold_core::ReferenceForm::Admitted
+        )
+        .is_err());
+    }
 
     #[test]
     fn detail_projection_keeps_execution_identity_and_mode() {

--- a/desktop/src/components/create/HostChip.test.ts
+++ b/desktop/src/components/create/HostChip.test.ts
@@ -184,3 +184,21 @@ describe("HostChip", () => {
     expect(menu()).toBeNull();
   });
 });
+
+it("supports an independent workflow pick without changing image routing preferences", async () => {
+  readyLocal();
+  const prefs = useAppPrefsStore();
+  const update = vi.spyOn(prefs, "update");
+  const wrapper = mount(HostChip, {
+    props: { modelValue: null, alwaysShowRouting: true },
+    attachTo: document.body,
+  });
+  mounted.push(wrapper);
+  await wrapper.get("[data-test=host-chip]").trigger("click");
+  option("capable").click();
+  await flushPromises();
+  expect(wrapper.emitted("update:modelValue")).toEqual([["capable"]]);
+  expect(update).not.toHaveBeenCalled();
+  await wrapper.setProps({ disabled: true });
+  expect(wrapper.get("[data-test=host-chip]").attributes("disabled")).toBeDefined();
+});

--- a/desktop/src/components/create/HostChip.vue
+++ b/desktop/src/components/create/HostChip.vue
@@ -13,12 +13,26 @@ import { useHostsStore, type HostView } from "../../stores/hosts";
  * same persisted `generateTargetHost` contract as always. With one host it
  * is a plain status label; there is nothing to choose between.
  */
+const props = defineProps<{
+  /** A controlled workflow pick; omitted retains New image's persisted setting. */
+  modelValue?: string | null;
+  disabled?: boolean;
+  alwaysShowRouting?: boolean;
+}>();
+const emit = defineEmits<{ "update:modelValue": [value: string | null] }>();
 const hosts = useHostsStore();
+const interactive = computed(() => hosts.multiHost || props.alwaysShowRouting);
 const prefs = useAppPrefsStore();
 
 /** Current routing pick; a persisted host that's gone reads as Auto. */
 const target = computed(
-  () => normalizeTargetHost(prefs.settings?.generateTargetHost ?? null, hosts.all) ?? "auto",
+  () =>
+    normalizeTargetHost(
+      props.modelValue !== undefined
+        ? props.modelValue
+        : (prefs.settings?.generateTargetHost ?? null),
+      hosts.all,
+    ) ?? "auto",
 );
 
 const targetHost = computed(() =>
@@ -30,7 +44,7 @@ const targetHost = computed(() =>
 /** The chip names the pick, not just the primary: sticky host → its label. */
 const chipHost = computed(() => targetHost.value ?? hosts.primaryHost ?? null);
 const chipLabel = computed(() => {
-  if (target.value === "auto" && hosts.multiHost) return "Auto";
+  if (target.value === "auto" && interactive.value) return "Auto";
   if (target.value === "capable") return "Most capable";
   return chipHost.value?.label ?? "This device";
 });
@@ -53,7 +67,10 @@ const chipStatus = computed(() => {
 });
 
 function pick(id: string) {
-  void prefs.update({ generateTargetHost: id === "auto" ? null : id });
+  if (props.disabled) return;
+  const value = id === "auto" ? null : id;
+  if (props.modelValue !== undefined) emit("update:modelValue", value);
+  else void prefs.update({ generateTargetHost: value });
   popoverOpen.value = false;
 }
 
@@ -75,7 +92,7 @@ function hostLine(host: HostView): string {
  */
 const popoverOpen = ref(false);
 function toggle() {
-  if (hosts.multiHost) popoverOpen.value = !popoverOpen.value;
+  if (interactive.value && !props.disabled) popoverOpen.value = !popoverOpen.value;
 }
 </script>
 
@@ -90,13 +107,14 @@ function toggle() {
       <button
         type="button"
         data-test="host-chip"
+        :disabled="disabled"
         class="ms-hostchip__chip"
-        :class="{ 'ms-hostchip__chip--button': hosts.multiHost }"
-        :aria-expanded="hosts.multiHost ? popoverOpen : undefined"
-        :aria-haspopup="hosts.multiHost ? 'menu' : undefined"
-        :tabindex="hosts.multiHost ? 0 : -1"
+        :class="{ 'ms-hostchip__chip--button': interactive }"
+        :aria-expanded="interactive ? popoverOpen : undefined"
+        :aria-haspopup="interactive ? 'menu' : undefined"
+        :tabindex="interactive ? 0 : -1"
         :title="
-          hosts.multiHost
+          interactive
             ? 'Where it runs — Auto picks whichever machine has the style'
             : 'Where it runs'
         "
@@ -107,7 +125,7 @@ function toggle() {
           :class="chipReady ? 'ms-hostchip__dot--ready' : 'ms-hostchip__dot--wait'"
         />
         {{ chipLabel }} · {{ chipStatus }}
-        <Icon v-if="hosts.multiHost" name="chevron-down" :size="12" class="ms-hostchip__chev" />
+        <Icon v-if="interactive" name="chevron-down" :size="12" class="ms-hostchip__chev" />
       </button>
     </template>
     <div data-test="host-menu" role="menu" aria-label="Where it runs" class="ms-hostchip__menu">

--- a/desktop/src/components/gallery/AuthedMedia.test.ts
+++ b/desktop/src/components/gallery/AuthedMedia.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 import AuthedMedia from "./AuthedMedia.vue";
 import { authedMediaUrl, fullSizeMediaUrl } from "../../lib/gallery/media";
 
@@ -12,6 +13,7 @@ vi.mock("../../lib/gallery/media", async (importOriginal) => ({
 }));
 
 beforeEach(() => {
+  setActivePinia(createPinia());
   vi.clearAllMocks();
   vi.mocked(authedMediaUrl).mockResolvedValue("blob:video");
   vi.mocked(fullSizeMediaUrl).mockResolvedValue("http://remote/media?ticket=one-use");

--- a/desktop/src/components/gallery/AuthedMedia.vue
+++ b/desktop/src/components/gallery/AuthedMedia.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import { useVideoPlaybackStore } from "../../stores/videoPlayback";
 import MeshViewer from "@studio/components/MeshViewer.vue";
 import { computed, onMounted, onUnmounted, ref, watch } from "vue";
 import {
@@ -55,6 +56,8 @@ const props = withDefaults(
     priority: "visible",
   },
 );
+
+const videoPlayback = useVideoPlaybackStore();
 
 const src = ref<string | null>(null);
 const failed = ref(false);
@@ -231,6 +234,9 @@ onUnmounted(() => {
   <video
     v-if="video && src"
     :src="src"
+    :muted="videoPlayback.muted"
+    :volume="videoPlayback.volume"
+    @volumechange="videoPlayback.syncFromPlayer"
     class="h-full w-full object-contain"
     :controls="controls"
     loop

--- a/desktop/src/components/gallery/Lightbox.test.ts
+++ b/desktop/src/components/gallery/Lightbox.test.ts
@@ -301,6 +301,22 @@ describe("Lightbox metadata panel", () => {
   });
 });
 
+describe("Lightbox playback context menu", () => {
+  it("routes video settings reuse through the owner", async () => {
+    const wrapper = mountLightbox({ ...item, filename: "clip.mp4", format: "mp4" }, true);
+    await wrapper.get('[data-test="lightbox-media"]').trigger("contextmenu");
+    const menu = useContextMenuStore();
+    const reuse = menu.entries.find(
+      (entry) => !("separator" in entry) && entry.label === "Reuse settings",
+    );
+    expect(reuse).toBeDefined();
+    menu.activate(reuse!);
+    expect(wrapper.emitted("reuse")).toHaveLength(1);
+    expect(useComposerStore().prefill).toBeNull();
+    wrapper.unmount();
+  });
+});
+
 describe("Lightbox a11y", () => {
   it("is a labelled modal dialog", () => {
     const wrapper = mountLightbox();
@@ -663,6 +679,7 @@ describe("Lightbox in the Trash", () => {
     expect(wrapper.find("[data-test='lightbox-use-source']").exists()).toBe(false);
     await wrapper.vm.$nextTick();
     expect(openMenu(wrapper)).not.toContain("Use as source");
+    expect(openMenu(wrapper)).not.toContain("Reuse settings");
     // The trash's own actions are untouched.
     expect(wrapper.find("[data-test='lightbox-restore']").exists()).toBe(true);
     expect(wrapper.find("[data-test='lightbox-delete-forever']").exists()).toBe(true);
@@ -676,6 +693,7 @@ describe("Lightbox in the Trash", () => {
     expect(wrapper.find("[data-test='lightbox-use-source']").exists()).toBe(false);
     await wrapper.vm.$nextTick();
     expect(openMenu(wrapper)).not.toContain("Use as source");
+    expect(openMenu(wrapper)).not.toContain("Reuse settings");
     wrapper.unmount();
   });
 });

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -360,6 +360,10 @@ function imageMenu(): MenuEntry[] {
       ? []
       : [
           {
+            label: "Reuse settings",
+            action: primaryAction,
+          },
+          {
             label: "Use as source",
             disabled: props.audio || props.mesh,
             action: () => emit("useSource"),
@@ -962,7 +966,7 @@ async function performVideoExport(options: VideoExportOptions) {
 
         <!-- the secondary actions -->
         <div class="mt-auto flex flex-col gap-2 pt-2">
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button
               v-if="!fromTrash"
               type="button"
@@ -1025,7 +1029,7 @@ async function performVideoExport(options: VideoExportOptions) {
               {{ generationAssetLabel(asset) }}
             </button>
           </div>
-          <div class="flex gap-2">
+          <div class="flex flex-wrap gap-2">
             <button
               v-if="canExportVideo"
               type="button"

--- a/desktop/src/components/gallery/Lightbox.vue
+++ b/desktop/src/components/gallery/Lightbox.vue
@@ -4,6 +4,7 @@ import { useOverlayStack } from "@ui/lib/overlayStack";
 import Icon from "@ui/components/Icon.vue";
 import VideoExportDialog from "@ui/components/VideoExportDialog.vue";
 import MeshExportDialog from "@ui/components/MeshExportDialog.vue";
+import VideoSoundToggle from "./VideoSoundToggle.vue";
 import AuthedMedia from "./AuthedMedia.vue";
 import CollectionPicker from "../library/CollectionPicker.vue";
 import TagEditor from "../library/TagEditor.vue";
@@ -636,6 +637,7 @@ async function performVideoExport(options: VideoExportOptions) {
         <Icon name="reuse" :size="13" />
         Use these settings
       </button>
+      <VideoSoundToggle v-if="video" />
       <button
         ref="closeBtn"
         type="button"

--- a/desktop/src/components/gallery/VideoSoundToggle.test.ts
+++ b/desktop/src/components/gallery/VideoSoundToggle.test.ts
@@ -18,6 +18,22 @@ beforeEach(() => {
 });
 
 describe("video sound preference", () => {
+  it("does not persist unchanged volume events from mounted players", () => {
+    const store = useVideoPlaybackStore();
+    const write = vi.spyOn(localStorage, "setItem");
+    try {
+      const event = { currentTarget: { muted: false, volume: 1 } } as unknown as Event;
+      for (let tile = 0; tile < 1000; tile++) store.syncFromPlayer(event);
+      expect(write).not.toHaveBeenCalled();
+      store.setMuted(true);
+      expect(write).toHaveBeenCalledTimes(1);
+      store.setMuted(true);
+      expect(write).toHaveBeenCalledTimes(1);
+    } finally {
+      write.mockRestore();
+    }
+  });
+
   it("keeps both controls and a looping player in sync, and remembers mute for the next launch", async () => {
     const first = mount(VideoSoundToggle);
     const second = mount(VideoSoundToggle);

--- a/desktop/src/components/gallery/VideoSoundToggle.test.ts
+++ b/desktop/src/components/gallery/VideoSoundToggle.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { flushPromises, mount } from "@vue/test-utils";
+import { installMemoryLocalStorage } from "../../lib/testSupport/memoryLocalStorage";
+import { useVideoPlaybackStore, VIDEO_MUTED_STORAGE_KEY } from "../../stores/videoPlayback";
+import VideoSoundToggle from "./VideoSoundToggle.vue";
+import AuthedMedia from "./AuthedMedia.vue";
+
+vi.mock("../../lib/gallery/media", async (original) => ({
+  ...(await original<typeof import("../../lib/gallery/media")>()),
+  fullSizeMediaUrl: vi.fn().mockResolvedValue("blob:clip"),
+}));
+
+installMemoryLocalStorage();
+beforeEach(() => {
+  localStorage.removeItem(VIDEO_MUTED_STORAGE_KEY);
+  setActivePinia(createPinia());
+});
+
+describe("video sound preference", () => {
+  it("keeps both controls and a looping player in sync, and remembers mute for the next launch", async () => {
+    const first = mount(VideoSoundToggle);
+    const second = mount(VideoSoundToggle);
+    const player = mount(AuthedMedia, {
+      props: { path: "/api/gallery/image/clip.mp4", video: true },
+    });
+    await flushPromises();
+    const video = player.get("video").element as HTMLVideoElement;
+    expect(first.text()).toBe("Sound on");
+    await first.trigger("click");
+    expect(second.text()).toBe("Sound off");
+    expect(second.attributes("aria-pressed")).toBe("true");
+    expect(video.muted).toBe(true);
+    expect(video.loop).toBe(true);
+    expect(localStorage.getItem(VIDEO_MUTED_STORAGE_KEY)).toBe("true");
+    setActivePinia(createPinia());
+    expect(useVideoPlaybackStore().muted).toBe(true);
+    first.unmount();
+    second.unmount();
+    player.unmount();
+  });
+
+  it("reflects native player sound changes and can unmute a zero-volume player", async () => {
+    const toggle = mount(VideoSoundToggle);
+    const player = mount(AuthedMedia, {
+      props: { path: "/api/gallery/image/clip.mp4", video: true },
+    });
+    await flushPromises();
+    const video = player.get("video").element as HTMLVideoElement;
+    video.volume = 0;
+    await player.get("video").trigger("volumechange");
+    expect(toggle.text()).toBe("Sound off");
+    await toggle.trigger("click");
+    expect(video.volume).toBe(1);
+    expect(video.muted).toBe(false);
+    video.muted = true;
+    await player.get("video").trigger("volumechange");
+    expect(toggle.text()).toBe("Sound off");
+    video.muted = false;
+    await player.get("video").trigger("volumechange");
+    expect(toggle.text()).toBe("Sound on");
+    toggle.unmount();
+    player.unmount();
+  });
+});

--- a/desktop/src/components/gallery/VideoSoundToggle.vue
+++ b/desktop/src/components/gallery/VideoSoundToggle.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { useVideoPlaybackStore } from "../../stores/videoPlayback";
+
+const playback = useVideoPlaybackStore();
+</script>
+
+<template>
+  <button
+    type="button"
+    class="ms-toolbar-button shrink-0"
+    data-test="video-sound-toggle"
+    aria-label="Mute video playback"
+    :aria-pressed="playback.muted"
+    :title="playback.muted ? 'Unmute videos' : 'Mute videos'"
+    @click.stop="playback.toggleSound()"
+  >
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="1.7"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M11 5 6 9H3v6h3l5 4V5Z" />
+      <path v-if="playback.muted" d="m16 9 6 6m0-6-6 6" />
+      <path v-else d="M15 8a6 6 0 0 1 0 8m3-11a10 10 0 0 1 0 14" />
+    </svg>
+    {{ playback.muted ? "Sound off" : "Sound on" }}
+  </button>
+</template>

--- a/desktop/src/composables/useReuseStillPrint.ts
+++ b/desktop/src/composables/useReuseStillPrint.ts
@@ -3,18 +3,17 @@ import {
   retainedSourceMediaDisclosure,
   retainedSourceMediaInventory,
 } from "@studio/api/gallerySourceMedia";
-import { useComposerStore } from "../stores/composer";
+import { useComposerStore, type RetainedSourceReuseHandoff } from "../stores/composer";
 import { useGalleryStore, type MergedPrint } from "../stores/gallery";
 import { useToastStore } from "../stores/toasts";
 
 /**
- * "Use these settings again" for a STILL print: the full metadata prefill plus
+ * "Use these settings again" for a print: the full metadata prefill plus
  * the print's own retained-source authority, asked of the producing host.
  *
  * The Lightbox and the Create view's Recent tab promise the same thing, so
  * they run the same routine — the only per-surface part is what happens after
- * (the Lightbox navigates; Recent is already on the canvas). A sequence print
- * belongs to `composer.setSequence` and never reaches here.
+ * (the Lightbox navigates; Recent is already on the canvas).
  */
 export function useReuseStillPrint() {
   const composer = useComposerStore();
@@ -39,31 +38,49 @@ export function useReuseStillPrint() {
         settledAtMs: entry.item.timestamp * 1000,
       },
     });
-    if (!target) return;
-    // Always ask — the host is the only authority on what it retained, and the
-    // metadata under-reports inline video/audio/mask bytes. But a text-to-image
-    // print's archive entry resolves with no pins, which the server can only
-    // report as `unavailable_legacy`, so an UNAVAILABLE answer is toasted only
-    // when the print's own metadata says conditioning bytes were shipped.
-    void retainedSourceMediaInventory(entry.item.filename, target)
-      .then((inventory) => {
-        if (
-          !composer.setRetainedSourceIfCurrent(retainedVersion, {
-            filename: entry.item.filename,
-            origin: target,
-            inventory,
-          })
-        ) {
-          return;
+    // The merged Library prefers a local output mirror, but mirroring the
+    // output does not copy the producing host's private source-media archive.
+    // Ask every known copy before disclosing an unavailable inventory, and
+    // retain the exact filename and host that actually own the source bytes.
+    const locations = [
+      { sourceKey: entry.sourceKey, filename: entry.item.filename },
+      ...gallery.locationsOf(entry),
+    ].filter(
+      (location, index, all) =>
+        all.findIndex(
+          (other) => other.sourceKey === location.sourceKey && other.filename === location.filename,
+        ) === index,
+    );
+    void (async () => {
+      let unavailable: RetainedSourceReuseHandoff | null = null;
+      for (const location of locations) {
+        if (!composer.isRetainedSourceCurrent(retainedVersion)) return;
+        const origin = gallery.targetOfOrNull(location.sourceKey);
+        if (!origin) continue;
+        try {
+          const inventory = await retainedSourceMediaInventory(location.filename, origin);
+          if (!composer.isRetainedSourceCurrent(retainedVersion)) return;
+          const handoff = { filename: location.filename, origin, inventory };
+          if (inventory.availability === "available") {
+            composer.setRetainedSourceIfCurrent(retainedVersion, handoff);
+            return;
+          }
+          // Prefer a concrete archive/auth failure over a mirror's lack of
+          // private pins when no reachable copy can restore the media.
+          if (!unavailable || unavailable.inventory.availability === "unavailable_legacy") {
+            unavailable = handoff;
+          }
+        } catch {
+          // One unreachable copy must not hide a reachable source archive.
+          // The established local stash/gallery-name restore stays live.
         }
-        const disclosure = retainedSourceMediaDisclosable(entry.item.metadata)
-          ? retainedSourceMediaDisclosure(inventory.availability)
-          : null;
-        if (disclosure) toasts.push(disclosure, "error");
-      })
-      // The established local stash/gallery-name restore stays live. A
-      // transport failure inspecting the additive endpoint must not turn a
-      // previously working reuse into a dead end.
-      .catch(() => {});
+      }
+      if (!unavailable || !composer.setRetainedSourceIfCurrent(retainedVersion, unavailable))
+        return;
+      const disclosure = retainedSourceMediaDisclosable(entry.item.metadata)
+        ? retainedSourceMediaDisclosure(unavailable.inventory.availability)
+        : null;
+      if (disclosure) toasts.push(disclosure, "error");
+    })();
   };
 }

--- a/desktop/src/mobile/MobileApp.vue
+++ b/desktop/src/mobile/MobileApp.vue
@@ -3242,7 +3242,9 @@ async function openMobileLiveWork(row: FleetActiveWork): Promise<void> {
       }
       await verifyAuthority();
       if (epoch !== mobileLiveWorkSelectionEpoch) return;
-      const selection = selectedQueueGeneration<OutputMetadata>(queue.entries, row.id);
+      const entry = await findQueueEntryById(target, row.id);
+      if (epoch !== mobileLiveWorkSelectionEpoch) return;
+      const selection = selectedQueueGeneration<OutputMetadata>(entry ? [entry] : [], row.id);
       if (!selection) {
         setGenerationStatus("This host cannot restore settings for that generation.", true);
         return;

--- a/desktop/src/stores/hosts.ts
+++ b/desktop/src/stores/hosts.ts
@@ -649,8 +649,13 @@ export const useHostsStore = defineStore("hosts", {
      * forgotten) falls back to Auto — the selector already displays it as
      * Auto, and a stale persisted id must never wedge every Generate click.
      */
-    resolveRoute(selection: string | null, modelName: string | null = null): HostRoute | null {
+    resolveRoute(
+      selection: string | null,
+      modelName: string | null = null,
+      eligibleHostIds?: readonly string[],
+    ): HostRoute | null {
       const routable = this.all
+        .filter((host) => !eligibleHostIds || eligibleHostIds.includes(host.id))
         .filter((host) => {
           const telemetry = this.telemetry[host.id];
           if (telemetry?.devices != null)

--- a/desktop/src/stores/videoPlayback.ts
+++ b/desktop/src/stores/videoPlayback.ts
@@ -1,0 +1,35 @@
+import { defineStore } from "pinia";
+
+export const VIDEO_MUTED_STORAGE_KEY = "mold.video-playback.muted.v1";
+
+function savedMuted(): boolean {
+  try {
+    return localStorage.getItem(VIDEO_MUTED_STORAGE_KEY) === "true";
+  } catch {
+    return false;
+  }
+}
+
+/** One sound preference for Create and Library, independent of generation audio. */
+export const useVideoPlaybackStore = defineStore("videoPlayback", {
+  state: () => ({ muted: savedMuted(), volume: 1 }),
+  actions: {
+    setMuted(muted: boolean) {
+      this.muted = muted;
+      try {
+        localStorage.setItem(VIDEO_MUTED_STORAGE_KEY, String(muted));
+      } catch {
+        // Playback still works when storage is unavailable.
+      }
+    },
+    toggleSound() {
+      if (this.muted && this.volume === 0) this.volume = 1;
+      this.setMuted(!this.muted);
+    },
+    syncFromPlayer(event: Event) {
+      const video = event.currentTarget as HTMLVideoElement;
+      this.volume = video.volume;
+      this.setMuted(video.muted || video.volume === 0);
+    },
+  },
+});

--- a/desktop/src/stores/videoPlayback.ts
+++ b/desktop/src/stores/videoPlayback.ts
@@ -15,6 +15,7 @@ export const useVideoPlaybackStore = defineStore("videoPlayback", {
   state: () => ({ muted: savedMuted(), volume: 1 }),
   actions: {
     setMuted(muted: boolean) {
+      if (this.muted === muted) return;
       this.muted = muted;
       try {
         localStorage.setItem(VIDEO_MUTED_STORAGE_KEY, String(muted));

--- a/desktop/src/views/GenerateView.layout.test.ts
+++ b/desktop/src/views/GenerateView.layout.test.ts
@@ -95,7 +95,7 @@ describe("GenerateView layout", () => {
       expect(tagFor(viewSource, "preview-frame")).toContain("[container-type:inline-size]");
       expect(tagFor(viewSource, "preview-frame")).toContain("[container-name:preview-frame]");
       expect(viewSource).toMatch(
-        /@container preview-frame \(max-width: \d+px\) \{\s*\.caption-action--word \{\s*display: none;/,
+        /@container preview-frame \(max-width: \d+px\) \{\s*\.caption-action--word(?:,\s*\.caption-meta--video)? \{\s*display: none;/,
       );
     });
 

--- a/desktop/src/views/GenerateView.variations.test.ts
+++ b/desktop/src/views/GenerateView.variations.test.ts
@@ -288,3 +288,25 @@ describe("GenerateView — where Make 4 variations is offered", () => {
     expect(document.querySelector("[data-test='canvas-variations']")).toBeNull();
   });
 });
+
+describe("GenerateView video sound", () => {
+  it("keeps a visible caption toggle while autoplay and looping stay enabled", async () => {
+    await mountWithAPrint(false);
+    finishPrint({ video_frames: 97 }).resultUrl = "blob:video";
+    await flushPromises();
+    const toggle = document.querySelector<HTMLButtonElement>(
+      "[data-test='canvas-caption'] [data-test='video-sound-toggle']",
+    )!;
+    const video = document.querySelector<HTMLVideoElement>("[data-test='preview-frame'] video")!;
+    expect(toggle).not.toBeNull();
+    expect(video.autoplay).toBe(true);
+    expect(video.loop).toBe(true);
+    toggle.click();
+    await flushPromises();
+    expect(toggle.textContent).toContain("Sound off");
+    expect(video.muted).toBe(true);
+    toggle.click();
+    await flushPromises();
+    expect(video.muted).toBe(false);
+  });
+});

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import VideoSoundToggle from "../components/gallery/VideoSoundToggle.vue";
+import { useVideoPlaybackStore } from "../stores/videoPlayback";
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 import {
   dropTargetAtPosition,
@@ -278,6 +280,7 @@ const models = useModelStore();
 const composer = useComposerStore();
 const toasts = useToastStore();
 const ui = useUiStore();
+const videoPlayback = useVideoPlaybackStore();
 const contextMenu = useContextMenuStore();
 const videoExportJob = ref<Job | null>(null);
 const videoExportBusy = ref(false);
@@ -4339,6 +4342,9 @@ onBeforeUnmount(() => {
                 <video
                   v-else-if="job?.resultUrl && job.result?.video_frames"
                   :src="job.resultUrl"
+                  :muted="videoPlayback.muted"
+                  :volume="videoPlayback.volume"
+                  @volumechange="videoPlayback.syncFromPlayer"
                   class="absolute inset-0 h-full w-full object-contain"
                   autoplay
                   loop
@@ -4440,10 +4446,12 @@ onBeforeUnmount(() => {
                   <span
                     v-if="captionMeta"
                     data-test="generation-caption-meta"
+                    :class="{ 'caption-meta--video': job?.result?.video_frames }"
                     class="shrink-0 font-mono text-micro text-fg-dim whitespace-nowrap"
                   >
                     {{ captionMeta }}
                   </span>
+                  <VideoSoundToggle v-if="job?.resultUrl && job.result?.video_frames" />
                   <template v-if="job && job.status === 'complete'">
                     <span class="h-4 w-px shrink-0 bg-border" aria-hidden="true" />
                     <button
@@ -4726,7 +4734,8 @@ onBeforeUnmount(() => {
    with no scroll and no cue. Below that width the word actions stand down and
    the ... menu, which carries every one of them, answers instead. */
 @container preview-frame (max-width: 440px) {
-  .caption-action--word {
+  .caption-action--word,
+  .caption-meta--video {
     display: none;
   }
 }

--- a/desktop/src/views/LibraryView.test.ts
+++ b/desktop/src/views/LibraryView.test.ts
@@ -1007,6 +1007,93 @@ describe("LibraryView Use these settings retained source media", () => {
     wrapper.unmount();
   });
 
+  it.each(["legacy", "offline"])(
+    "restores the producing host's source media when the preferred local mirror is %s",
+    async (state) => {
+      const video: GalleryImage = {
+        ...prints[0]!,
+        filename: "mirrored-ltx.mp4",
+        format: "mp4",
+        metadata: { ...prints[0]!.metadata, seed: 9, source_image_sha256: "a".repeat(64) },
+      };
+      const inventory = {
+        availability: "available" as const,
+        members: [
+          {
+            member_id: "m".repeat(64),
+            role: "source_image",
+            display_name: "city.png",
+            size_bytes: 3,
+          },
+        ],
+      };
+      if (state === "offline") retainedInventoryMock.mockRejectedValueOnce(new Error("offline"));
+      else
+        retainedInventoryMock.mockResolvedValueOnce({
+          availability: "unavailable_legacy",
+          members: [],
+        });
+      retainedInventoryMock.mockResolvedValueOnce(inventory);
+      const { wrapper } = await mountView(
+        video,
+        (gallery) => {
+          gallery.buckets.local!.items = [video];
+        },
+        "/library",
+        true,
+      );
+      const before = useToastStore().items.length;
+      await reuseFromContextMenu(wrapper);
+      expect(retainedInventoryMock).toHaveBeenCalledWith(video.filename, {
+        baseUrl: "http://127.0.0.1:7680",
+        apiKey: "local-key",
+      });
+      expect(retainedInventoryMock).toHaveBeenCalledWith(video.filename, plato);
+      expect(useComposerStore().retainedSource).toEqual({
+        filename: video.filename,
+        origin: plato,
+        inventory,
+      });
+      expect(useToastStore().items.length).toBe(before);
+      wrapper.unmount();
+    },
+  );
+
+  it("ignores an older print's inventory after a new composer restore", async () => {
+    const video: GalleryImage = {
+      ...prints[0]!,
+      filename: "mirrored-ltx.mp4",
+      format: "mp4",
+      metadata: { ...prints[0]!.metadata, seed: 9, source_image_sha256: "a".repeat(64) },
+    };
+    let resolveInventory!: (inventory: unknown) => void;
+    retainedInventoryMock.mockImplementationOnce(
+      () =>
+        new Promise((resolve) => {
+          resolveInventory = resolve;
+        }),
+    );
+    const { wrapper } = await mountView(
+      video,
+      (gallery) => {
+        gallery.buckets.local!.items = [video];
+      },
+      "/library",
+      true,
+    );
+    await reuseFromContextMenu(wrapper);
+    const composer = useComposerStore();
+    composer.set({ metadata: prints[1]!.metadata });
+    const before = useToastStore().items.length;
+    resolveInventory({ availability: "unavailable_legacy", members: [] });
+    await flushPromises();
+    expect(retainedInventoryMock).toHaveBeenCalledTimes(1);
+    expect(composer.retainedSource).toBeNull();
+    expect(composer.prefill).toEqual({ metadata: prints[1]!.metadata });
+    expect(useToastStore().items.length).toBe(before);
+    wrapper.unmount();
+  });
+
   it("discloses the auth state when the origin host refuses the probe", async () => {
     // The one case the "connect this machine with an API key" sentence is
     // about: a host that enforces keys, reached with none. The shared probe

--- a/desktop/src/views/MeshWorkflowView.test.ts
+++ b/desktop/src/views/MeshWorkflowView.test.ts
@@ -77,6 +77,46 @@ describe("MeshWorkflowView host routing", () => {
     expect(wrapper.find("[data-test='mesh-studio']").exists()).toBe(true);
     wrapper.unmount();
   });
+  it("refreshes newly ready hosts without refetching on telemetry changes", async () => {
+    const wrapper = mountView();
+    await flushPromises();
+    const hosts = useHostsStore();
+    const inventory = useHostModelsStore();
+    vi.mocked(inventory.refresh).mockClear();
+    hosts.extras[0]!.status = "connecting";
+    await flushPromises();
+    vi.mocked(inventory.refresh).mockClear();
+    hosts.extras[0]!.status = "ready";
+    await flushPromises();
+    expect(inventory.refresh).toHaveBeenCalledTimes(1);
+    hosts.telemetry["renderbox-7680"] = {
+      queueDepth: 2,
+      queueCapacity: 8,
+      version: null,
+      gpuInfo: { name: "CUDA", backend: "cuda", vram_total_mb: 96000, vram_used_mb: 1000 },
+    };
+    await flushPromises();
+    expect(inventory.refresh).toHaveBeenCalledTimes(1);
+    wrapper.unmount();
+  });
+
+  it("retains cached styles while their host reconnects", async () => {
+    const wrapper = mountView();
+    const inventory = useHostModelsStore();
+    const row = { name: "mesh", family: "hunyuan3d", downloaded: true };
+    inventory.byHost["renderbox-7680"] = {
+      entries: [row] as never,
+      fetchedAt: Date.now(),
+      error: null,
+    };
+    wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "renderbox-7680");
+    await flushPromises();
+    useHostsStore().extras[0]!.status = "connecting";
+    await flushPromises();
+    expect(wrapper.findComponent(MeshWorkflowStudio).props("availableModels")).toEqual([row]);
+    wrapper.unmount();
+  });
+
   it("filters complete workflows before Auto and Most capable rank machines", async () => {
     const wrapper = mountView();
     const hosts = useHostsStore();

--- a/desktop/src/views/MeshWorkflowView.test.ts
+++ b/desktop/src/views/MeshWorkflowView.test.ts
@@ -4,7 +4,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@studio/components/MeshWorkflowStudio.vue", () => ({
   default: {
-    props: ["target"],
+    props: ["target", "resolveTarget", "availableModels", "desktop", "hostLabel"],
     template: `
       <div data-test="mesh-studio">
         <span data-test="target-url">{{ target.baseUrl }}</span>
@@ -19,6 +19,9 @@ vi.mock("../lib/ipc", () => ({
   ipc: {},
 }));
 
+import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
+import HostChip from "../components/create/HostChip.vue";
+import { useHostModelsStore } from "../stores/hostModels";
 import MeshWorkflowView from "./MeshWorkflowView.vue";
 import { useConnectionStore } from "../stores/connection";
 import { useHostsStore } from "../stores/hosts";
@@ -43,6 +46,7 @@ function mountView() {
     error: null,
     instanceId: "renderbox-instance",
   });
+  vi.spyOn(useHostModelsStore(), "refresh").mockResolvedValue(undefined);
   return mount(MeshWorkflowView, { global: { plugins: [pinia] } });
 }
 
@@ -54,13 +58,8 @@ describe("MeshWorkflowView host routing", () => {
     await flushPromises();
 
     expect(wrapper.get("[data-test='target-url']").text()).toBe("http://127.0.0.1:49152");
-    const picker = wrapper.get("[data-test='mesh-workflow-host']");
-    expect(picker.findAll("option").map((option) => option.text())).toEqual([
-      "This device · ready",
-      "Render box · ready",
-    ]);
-
-    await picker.setValue("renderbox-7680");
+    wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "renderbox-7680");
+    await flushPromises();
 
     expect(wrapper.get("[data-test='target-url']").text()).toBe("http://renderbox:7680");
     expect(wrapper.get("[data-test='target-key']").text()).toBe("remote-secret");
@@ -69,15 +68,72 @@ describe("MeshWorkflowView host routing", () => {
   it("keeps an unavailable pinned machine visible instead of silently rerouting", async () => {
     const wrapper = mountView();
     const hosts = useHostsStore();
-    await wrapper.get("[data-test='mesh-workflow-host']").setValue("renderbox-7680");
+    wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "renderbox-7680");
+    await flushPromises();
     hosts.extras[0]!.status = "connecting";
     await flushPromises();
 
-    expect(wrapper.get("[data-test='mesh-workflow-host']").element).toHaveProperty(
-      "value",
-      "renderbox-7680",
-    );
-    expect(wrapper.text()).toContain("Render box is reconnecting");
-    expect(wrapper.find("[data-test='mesh-studio']").exists()).toBe(false);
+    expect(wrapper.get("[data-test='target-url']").text()).toBe("http://renderbox:7680");
+    expect(wrapper.find("[data-test='mesh-studio']").exists()).toBe(true);
+    wrapper.unmount();
+  });
+  it("filters complete workflows before Auto and Most capable rank machines", async () => {
+    const wrapper = mountView();
+    const hosts = useHostsStore();
+    const inventory = useHostModelsStore();
+    const mesh = {
+      name: "hunyuan3d",
+      family: "hunyuan3d",
+      downloaded: true,
+      generation_profile: {
+        default_recipe_id: "shape",
+        recipes: [
+          {
+            id: "shape",
+            capabilities: {
+              mesh: { workflow_modes: ["text_to_mesh"] },
+            },
+          },
+        ],
+      },
+    };
+    const image = { name: "z-image", family: "z-image", modality: "image", downloaded: true };
+    for (const host of hosts.all)
+      inventory.byHost[host.id] = {
+        entries: [mesh, image] as never,
+        fetchedAt: Date.now(),
+        error: null,
+      };
+    hosts.telemetry.local = {
+      queueDepth: 0,
+      queueCapacity: 8,
+      version: null,
+      gpuInfo: { name: "Apple", backend: "metal", vram_total_mb: 64000, vram_used_mb: 0 },
+    };
+    hosts.telemetry["renderbox-7680"] = {
+      queueDepth: 5,
+      queueCapacity: 8,
+      version: null,
+      gpuInfo: { name: "CUDA", backend: "cuda", vram_total_mb: 96000, vram_used_mb: 0 },
+    };
+    await flushPromises();
+    const resolve = wrapper.findComponent(MeshWorkflowStudio).props("resolveTarget")!;
+    const request = {
+      mode: "text_to_mesh" as const,
+      meshModel: mesh.name,
+      imageModel: image.name,
+      texture: false,
+      delight: false,
+    };
+    expect((await resolve(request)).target.baseUrl).toBe("http://127.0.0.1:49152");
+    wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "capable");
+    await flushPromises();
+    expect((await resolve(request)).target.baseUrl).toBe("http://renderbox:7680");
+    inventory.byHost["renderbox-7680"]!.entries = [mesh] as never;
+    expect((await resolve(request)).target.baseUrl).toBe("http://127.0.0.1:49152");
+    wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "renderbox-7680");
+    await flushPromises();
+    await expect(resolve(request)).rejects.toThrow("Render box cannot run all");
+    wrapper.unmount();
   });
 });

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -7,11 +7,37 @@ import {
   type MeshWorkflowRequirements,
   type MeshWorkflowRoute,
 } from "@studio/lib/meshWorkflowRouting";
+import ModelPicker from "../components/create/ModelPicker.vue";
+import PanelResizeHandle from "../components/shell/PanelResizeHandle.vue";
+import { useAppPrefsStore } from "../stores/appPrefs";
+import { dragWidth } from "../lib/panelResize";
+import type { ModelEntry } from "../lib/api/types";
 import HostChip from "../components/create/HostChip.vue";
 import { useHostsStore } from "../stores/hosts";
 import { useHostModelsStore } from "../stores/hostModels";
 
 const hosts = useHostsStore();
+const prefs = useAppPrefsStore();
+const draftWidth = ref<number | null>(null);
+const inspectorWidth = computed(() => draftWidth.value ?? prefs.generateParamsWidth);
+function resizeInspector(dx: number) {
+  draftWidth.value = dragWidth("generateParams", prefs.generateParamsWidth, dx, "left");
+}
+async function commitInspector() {
+  if (draftWidth.value !== null) await prefs.update({ generateParamsWidth: draftWidth.value });
+  draftWidth.value = null;
+}
+function resetInspector() {
+  draftWidth.value = null;
+  void prefs.update({ generateParamsWidth: null });
+}
+function pickerModels(filtered: WorkflowModel[]): ModelEntry[] {
+  const names = new Set(filtered.map((model) => model.name));
+  const rows = new Map<string, ModelEntry>();
+  for (const snapshot of Object.values(inventory.byHost))
+    for (const model of snapshot.entries) if (names.has(model.name)) rows.set(model.name, model);
+  return [...rows.values()];
+}
 const inventory = useHostModelsStore();
 const routing = ref<string | null>(null);
 const browseHostId = ref("");
@@ -81,11 +107,48 @@ async function resolveTarget(requirements: MeshWorkflowRequirements): Promise<Me
   <MeshWorkflowStudio
     v-if="target"
     :target="target"
+    :style="{ '--mesh-inspector-width': inspectorWidth + 'px' }"
     :available-models="availableModels"
     :resolve-target="resolveTarget"
     :host-label="selectedHost?.label ?? ''"
     desktop
   >
+    <template #inspector-resize>
+      <PanelResizeHandle
+        class="mesh-inspector-resize"
+        :style="{ right: inspectorWidth - 2 + 'px' }"
+        label="Resize 3-D settings"
+        @resize="resizeInspector"
+        @commit="commitInspector"
+        @reset="resetInspector"
+      />
+    </template>
+    <template #mesh-picker="{ models, selected, select, disabled }">
+      <div class="mesh-style-field">
+        <span class="ms-group-label">3-D style</span>
+        <ModelPicker
+          :models="pickerModels(models)"
+          :selected="pickerModels(models).find((m) => m.name === selected) ?? null"
+          :disabled-reason="disabled ? () => 'Preparing workflow' : null"
+          kicker="3-D object styles"
+          browse-target="/models?type=mesh"
+          @pick="(model) => select(model.name)"
+        />
+      </div>
+    </template>
+    <template #image-picker="{ models, selected, select, disabled }">
+      <div class="mesh-style-field">
+        <span class="ms-group-label">Picture style</span>
+        <ModelPicker
+          :models="pickerModels(models)"
+          :selected="pickerModels(models).find((m) => m.name === selected) ?? null"
+          :disabled-reason="disabled ? () => 'Preparing workflow' : null"
+          kicker="Still picture styles"
+          browse-target="/models?type=image"
+          @pick="(model) => select(model.name)"
+        />
+      </div>
+    </template>
     <template #machine="{ busy }">
       <HostChip v-model="routing" :disabled="busy" always-show-routing />
     </template>
@@ -97,6 +160,18 @@ async function resolveTarget(requirements: MeshWorkflowRequirements): Promise<Me
 </template>
 
 <style scoped>
+.mesh-inspector-resize {
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  z-index: 10;
+}
+.mesh-style-field {
+  display: grid;
+  gap: 8px;
+  min-width: 0;
+}
+
 .mesh-workflow-unavailable {
   display: grid;
   place-content: center;

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -1,51 +1,98 @@
 <script setup lang="ts">
-import { computed, ref, watch } from "vue";
+import { computed, onMounted, ref, watch } from "vue";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
-import MeshWorkflowHostPicker from "@studio/components/MeshWorkflowHostPicker.vue";
+import { meshWorkflowModes, type WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
+import {
+  supportsMeshWorkflow,
+  type MeshWorkflowRequirements,
+  type MeshWorkflowRoute,
+} from "@studio/lib/meshWorkflowRouting";
+import HostChip from "../components/create/HostChip.vue";
 import { useHostsStore } from "../stores/hosts";
+import { useHostModelsStore } from "../stores/hostModels";
 
 const hosts = useHostsStore();
-const selectedHostId = ref("");
+const inventory = useHostModelsStore();
+const routing = ref<string | null>(null);
+const browseHostId = ref("");
 const selectedHost = computed(
-  () => hosts.all.find((host) => host.id === selectedHostId.value) ?? null,
+  () => hosts.all.find((host) => host.id === browseHostId.value) ?? null,
 );
 const target = computed(() => {
   const host = selectedHost.value;
-  if (!host?.baseUrl || (host.status !== "ready" && !host.stale)) return null;
-  return { baseUrl: host.baseUrl, apiKey: host.apiKey };
+  return host?.baseUrl ? { baseUrl: host.baseUrl, apiKey: host.apiKey } : null;
 });
-
+// Telemetry never changes the browsing machine or remounts the draft.
 watch(
   () => hosts.all.map((host) => host.id).join("|"),
   () => {
-    if (selectedHost.value) return;
-    selectedHostId.value = hosts.primaryHost?.id ?? hosts.all[0]?.id ?? "";
+    if (!selectedHost.value) browseHostId.value = hosts.primaryHost?.id ?? hosts.all[0]?.id ?? "";
   },
   { immediate: true },
 );
+watch(routing, (value) => {
+  if (value && value !== "capable") browseHostId.value = value;
+});
+onMounted(() => void inventory.refresh());
 
-function hostStatus(): string {
-  const host = selectedHost.value;
-  if (!host) return "The selected machine is no longer connected.";
-  if (host.stale || host.status === "connecting")
-    return `${host.label} is reconnecting. Its workflows stay on that machine.`;
-  return `${host.label} is unavailable. Its workflows stay on that machine.`;
+const availableModels = computed(() => {
+  const byName = new Map<string, WorkflowModel>();
+  for (const host of hosts.all) {
+    if (routing.value && routing.value !== "capable" && host.id !== routing.value) continue;
+    if (host.status !== "ready" || host.stale) continue;
+    for (const model of inventory.byHost[host.id]?.entries ?? []) {
+      if (!model.downloaded || model.runtime_available === false) continue;
+      const existing = byName.get(model.name);
+      if (!existing || meshWorkflowModes(model).length > meshWorkflowModes(existing).length)
+        byName.set(model.name, model);
+    }
+  }
+  return [...byName.values()];
+});
+
+async function resolveTarget(requirements: MeshWorkflowRequirements): Promise<MeshWorkflowRoute> {
+  await inventory.refresh(true);
+  const eligible = hosts.all
+    .filter(
+      (host) =>
+        host.status === "ready" &&
+        !host.stale &&
+        !inventory.byHost[host.id]?.error &&
+        supportsMeshWorkflow(inventory.byHost[host.id]?.entries ?? [], requirements),
+    )
+    .map((host) => host.id);
+  const route = hosts.resolveRoute(routing.value, requirements.meshModel, eligible);
+  if (!route) {
+    const label =
+      routing.value && routing.value !== "capable"
+        ? hosts.all.find((host) => host.id === routing.value)?.label
+        : null;
+    throw new Error(
+      label
+        ? `${label} cannot run all the selected 3-D stages. Connect it and check its installed styles, or choose Auto.`
+        : "No ready machine can run all the selected 3-D stages. Choose styles installed together on one machine.",
+    );
+  }
+  return { target: route.target, label: route.label };
 }
 </script>
 
 <template>
   <MeshWorkflowStudio
     v-if="target"
-    :key="`${selectedHostId}:${target.baseUrl}:${target.apiKey ?? ''}`"
     :target="target"
+    :available-models="availableModels"
+    :resolve-target="resolveTarget"
+    :host-label="selectedHost?.label ?? ''"
+    desktop
   >
-    <template #machine>
-      <MeshWorkflowHostPicker v-model="selectedHostId" :hosts="hosts.all" />
+    <template #machine="{ busy }">
+      <HostChip v-model="routing" :disabled="busy" always-show-routing />
     </template>
   </MeshWorkflowStudio>
   <div v-else class="mesh-workflow-unavailable text-fg-dim">
-    <MeshWorkflowHostPicker v-model="selectedHostId" :hosts="hosts.all" />
-    <p>{{ hostStatus() }}</p>
+    <HostChip v-model="routing" always-show-routing />
+    <p>Connect a machine to make a 3-D object.</p>
   </div>
 </template>
 

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { computed, onMounted, ref, watch } from "vue";
+import { computed, ref, watch } from "vue";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
 import { meshWorkflowModes, type WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import {
@@ -59,13 +59,23 @@ watch(
 watch(routing, (value) => {
   if (value && value !== "capable") browseHostId.value = value;
 });
-onMounted(() => void inventory.refresh());
+// Connections become ready after the view mounts on a cold launch. Refresh
+// only when that authority set changes, never on queue/GPU telemetry ticks.
+watch(
+  () =>
+    JSON.stringify(
+      hosts.all
+        .filter((host) => host.status === "ready" && !host.stale)
+        .map((host) => [host.id, host.baseUrl, host.apiKey]),
+    ),
+  () => void inventory.refresh(),
+  { immediate: true },
+);
 
 const availableModels = computed(() => {
   const byName = new Map<string, WorkflowModel>();
   for (const host of hosts.all) {
     if (routing.value && routing.value !== "capable" && host.id !== routing.value) continue;
-    if (host.status !== "ready" || host.stale) continue;
     for (const model of inventory.byHost[host.id]?.entries ?? []) {
       if (!model.downloaded || model.runtime_available === false) continue;
       const existing = byName.get(model.name);

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -284,3 +284,28 @@ inside their owning frame, speak the lexicon, and keep copy terse and emoji-free
 Pausing the job that is already running: an in-flight denoise cannot be
 suspended, so the active card's pause holds the queue after the current
 image and says so.
+
+## 3-D Studio workflows
+
+The 3-D Studio uses the desktop shell's 40px view toolbar, a full-height result
+canvas, and the standard 300px inspector on the right. **From words**, **Rebuild**,
+and **Add texture** are the shared segmented control; only workflows supported
+by the connected machines appear. Workflow inputs belong together in the
+inspector, including the description or source files, with **Generate** at its
+foot. Use **3-D style** and **Picture style** for the two style pickers. The
+result and its stage progress occupy the canvas, without a separate landing-page
+heading or oversized cards.
+
+The existing **Where it runs** chip is the last toolbar control. **Auto** chooses
+the least-busy eligible machine; **Most capable** chooses its strongest eligible
+GPU. Eligibility covers every selected stage and style on one machine, including
+optional texture and lighting removal. A named machine is a pin, never a hint.
+Routing is resolved when Generate is pressed, before source uploads. The
+accepted job's machine remains visible beside its history selector; inspecting,
+resuming, cancelling, and downloading the result stay attached to that owner.
+
+Routine telemetry and polling must preserve the draft, focus, selected history
+entry, and viewer camera. Only a changed URL or credential refreshes the browsing
+context. Progress polling updates stage state in place, and a result's bytes are
+loaded once per output identity. At narrow widths, toolbar controls may wrap;
+the canvas and inspector retain independent scrolling.

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -288,11 +288,16 @@ image and says so.
 ## 3-D Studio workflows
 
 The 3-D Studio uses the desktop shell's 40px view toolbar, a full-height result
-canvas, and the standard 300px inspector on the right. **From words**, **Rebuild**,
+canvas, and the standard inspector on the right (300px by default, resizable
+280–480px with Generate's shared handle, width setting, keyboard controls, and
+double-click reset). **From words**, **Rebuild**,
 and **Add texture** are the shared segmented control; only workflows supported
 by the connected machines appear. Workflow inputs belong together in the
 inspector, including the description or source files, with **Generate** at its
-foot. Use **3-D style** and **Picture style** for the two style pickers. The
+foot. Use **3-D style** and **Picture style** for the two style pickers. Reuse
+Generate's model picker with filtered candidates, including its search, family
+groups, availability, and friendly labels; do not build a second selector.
+Use the shared switches and inspector typography for stage settings. The
 result and its stage progress occupy the canvas, without a separate landing-page
 heading or oversized cards.
 

--- a/docs/qualification/desktop-library-cleanup-2026-09-08.md
+++ b/docs/qualification/desktop-library-cleanup-2026-09-08.md
@@ -6,7 +6,7 @@ Implementation: `b5462fa1` (admission) and `49cb683e` (shared UI and queue resto
 
 Real inference ran on Plato GPU 3 (L40S), using an isolated server at loopback port 7689, a separate durable home/output directory, and the installed model files. The test binary was built from `9ec27747` plus the admission fix later committed as `b5462fa1`, with CUDA, cuDNN, preview, mesh-texture, mesh-matting, and mesh-delight enabled. Existing accepted licenses were copied into the isolated home. Production service and existing paused jobs were untouched.
 
-Browser UAT exercised the actual desktop MeshWorkflowView, web MeshWorkflowPage, and mobile MobileApp through local Vite servers. Desktop native APIs were replaced by the browser harness; this is not a packaged Tauri or physical iPhone/Android qualification.
+Browser UAT exercised the actual desktop MeshWorkflowView, web MeshWorkflowPage, and mobile MobileApp through local Vite servers. The initial desktop browser harness replaced native APIs. Follow-up UAT used the actual macOS development binary in a separate test bundle with WKWebView and native IPC. Physical iPhone/Android hardware and release installer delivery are not part of this qualification.
 
 ## Real workflows
 
@@ -27,7 +27,7 @@ Desktop rendered the textured fox with 304,062 triangles. Web and mobile rendere
 ## Interaction and regression checks
 
 - Desktop style pickers are the same components as Generate, filtered by workflow mode and image/mesh capability.
-- Mouse resize, keyboard resize, saved preference updates, and double-click reset passed in the desktop browser harness. Actual OS preference persistence uses the existing app preference store and was not exercised through a packaged app.
+- Mouse resize, keyboard resize, saved preference updates, and double-click reset passed in the desktop browser harness. Follow-up native keyboard resizing changed the saved preference from 480 to 460 pixels and persisted it to the native settings file.
 - Telemetry refresh preserves draft text and focus; unchanged results are not fetched repeatedly.
 - Web uses its existing Create picker, shared segmented mode control and switches, and Auto/Most capable routing constrained to a host supporting every stage.
 - Web 390×844 layout has no horizontal overflow. Mobile connects to Plato, lists generated outputs, and opens the shared mesh viewer.
@@ -40,6 +40,16 @@ Desktop rendered the textured fox with 304,062 triangles. Web and mobile rendere
 
 Local screenshots, API receipts, downloaded GLBs, and harness scripts are retained under `/tmp/mold-library-cleanup/`. The isolated remote output is under `/home/jamesbrink/.local/share/mold-cleanup-uat/output`.
 
-## Remaining observation
+## Native follow-up and progress verification
 
-During the texture run, the queue preview continued reporting “Unwrapping mesh” while a debugger stack showed paint denoising on the GPU. It later advanced to upscaling and completed in about nine minutes. This qualification proves successful output, not accurate intermediate paint progress; the stale progress observation remains unresolved. The production paused jobs were not resumed as part of this test.
+The actual NYC LTX video `mold-ltx-2.5-22b-dev-int8-conv-1788888568154.mp4` was opened in the native Library. Its playback context menu offered Reuse settings; that action restored the original `mold-z-image-turbo-q8-1788888016740.png` source without the missing-media warning. The persistent Sound off control synchronized with the native player and remained muted in Generate. Inspector actions fit inside the panel. The native mesh viewer rendered the first textured fox successfully.
+
+A fourth workflow was submitted through the native file pickers and Generate button to the isolated Plato endpoint: `d53b958c-6a41-4220-8b2c-6a03143f8346`. It completed with a 12,482,632-byte textured GLB, SHA-256 `c6f7d7ba2e365e1c0e7590f98bf82ecfb9e809c9e3f8382ff6b9f3b86adc5f3f`.
+
+The first run had an apparent stale “Unwrapping mesh” observation while a later debugger stack showed denoising. To resolve the uncertainty, the fourth run used temporary event logging in the isolated build only. Unwrapping completed in 88 seconds; the API and native queue then reported “Generating PBR views” with steps 1–15, followed by decode, upscale, bake, fill, and GLB publication. Denoising took 371 seconds. The earlier discrepancy was not reproduced; no paint-progress source change was needed. Test logging is not included in this branch. Production paused jobs were not resumed by this UAT.
+
+Native development reload exposed a separate inventory timing issue: 3-D Studio mounted before host readiness did not refresh its model inventory later. The ready-authority watcher now refreshes only on connection/authority changes, not telemetry; cached styles remain available while reconnecting. Regression tests cover both behaviors.
+
+## Independent review
+
+Claude Sonnet reviewed the full branch and found no critical/high issues. Its valid redundant localStorage-write finding was fixed in `b0e0f508`, with regression coverage. Queue-detail error handling and workflow-owner cancel/resume tests were also added. The appearance picker deliberately accepts PNG/JPEG, matching server admission. Claude's follow-up review found no actionable issues in that fix.

--- a/docs/qualification/desktop-library-cleanup-2026-09-08.md
+++ b/docs/qualification/desktop-library-cleanup-2026-09-08.md
@@ -1,0 +1,45 @@
+# 3-D Studio cleanup UAT — 2026-09-08
+
+Implementation: `b5462fa1` (admission) and `49cb683e` (shared UI and queue restoration), on `fix/desktop-library-cleanup`. No PR or production deployment.
+
+## Environment
+
+Real inference ran on Plato GPU 3 (L40S), using an isolated server at loopback port 7689, a separate durable home/output directory, and the installed model files. The test binary was built from `9ec27747` plus the admission fix later committed as `b5462fa1`, with CUDA, cuDNN, preview, mesh-texture, mesh-matting, and mesh-delight enabled. Existing accepted licenses were copied into the isolated home. Production service and existing paused jobs were untouched.
+
+Browser UAT exercised the actual desktop MeshWorkflowView, web MeshWorkflowPage, and mobile MobileApp through local Vite servers. Desktop native APIs were replaced by the browser harness; this is not a packaged Tauri or physical iPhone/Android qualification.
+
+## Real workflows
+
+| Surface / operation | Durable workflow ID | Result |
+| --- | --- | --- |
+| Desktop From words | `81afaf06-7afd-4fa5-9d51-2b93ce366242` | Z-Image Turbo image → Hunyuan3D mini turbo geometry; completed, 7,166,532-byte GLB |
+| Desktop Add texture | `bc1259bc-32ed-4a18-b27f-ccdec1875967` | Generated mesh and PNG → matting → delight → paint → finalize; completed, 12,197,164-byte GLB with two embedded textures |
+| Web Rebuild / Most capable | `424aa4e7-e747-485a-9005-45bec784464d` | Hunyuan3D 2.1 Shape VAE round trip; completed, 7,076,676-byte GLB |
+
+SHA-256 of downloaded outputs:
+
+- Geometry: `bb19628968388e9e93d74d1ffef11bc1a15ce10bc44514289fa3092f5c184c50`
+- Texture: `c241414968dfc043c45b8b3b8a62d38c3202d513fc37cefb3f9d555cacf2d1a8`
+- Rebuild: `9d2906ed556ebd8a47ceaa7f81478ffcdc1c4f5bd486e7b100d4515051090454`
+
+Desktop rendered the textured fox with 304,062 triangles. Web and mobile rendered the rebuilt fox with 299,638 triangles. No JavaScript page errors occurred. Completed geometry history survived an isolated-server restart.
+
+## Interaction and regression checks
+
+- Desktop style pickers are the same components as Generate, filtered by workflow mode and image/mesh capability.
+- Mouse resize, keyboard resize, saved preference updates, and double-click reset passed in the desktop browser harness. Actual OS preference persistence uses the existing app preference store and was not exercised through a packaged app.
+- Telemetry refresh preserves draft text and focus; unchanged results are not fetched repeatedly.
+- Web uses its existing Create picker, shared segmented mode control and switches, and Auto/Most capable routing constrained to a host supporting every stage.
+- Web 390×844 layout has no horizontal overflow. Mobile connects to Plato, lists generated outputs, and opens the shared mesh viewer.
+- Production inspection confirmed the two reported paused jobs were recovered ordinary generation jobs after the 11:30 service shutdown, not newly admitted workflows. Their single-job endpoints retained metadata that payload-free listings omit. Shared queue restoration now fetches that detail on desktop, web, and mobile.
+- The PNG/JPEG rejection came from a one-byte future-image admission placeholder. The fix uses valid image bytes only in the validation clone and does not persist a fake source.
+
+## Checks
+
+`NODE_OPTIONS=--no-experimental-webstorage bun run check:frontend` passed: 1,725 Studio, 1,844 web, and 6,470 desktop/mobile tests, architecture checks, and desktop/web production builds. The mobile production build passed separately. The final history attachment-clear adjustment passed its five component tests. The Rust admission regression passed with Rust 1.93 and the system Clang linker.
+
+Local screenshots, API receipts, downloaded GLBs, and harness scripts are retained under `/tmp/mold-library-cleanup/`. The isolated remote output is under `/home/jamesbrink/.local/share/mold-cleanup-uat/output`.
+
+## Remaining observation
+
+During the texture run, the queue preview continued reporting “Unwrapping mesh” while a debugger stack showed paint denoising on the GPU. It later advanced to upscaling and completed in about nine minutes. This qualification proves successful output, not accurate intermediate paint progress; the stale progress observation remains unresolved. The production paused jobs were not resumed as part of this test.

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -103,6 +103,7 @@ try {
     // child-process stdout buffer before the app smoke test even starts.
     shell("screencap", "-p", "/sdcard/mold-boot-launcher-anr.png");
     run("pull", "/sdcard/mold-boot-launcher-anr.png", output + "/boot-launcher-anr.png");
+    shell("rm", "-f", "/sdcard/mold-boot-launcher-anr.png");
     shell("am", "force-stop", "com.android.launcher3");
   }
   shell("am", "start", "-n", "com.utensils.mold/.MainActivity");

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -99,10 +99,10 @@ try {
     !bootAnr.includes("com.utensils.mold")
   ) {
     writeFileSync(output + "/boot-launcher-anr.txt", bootAnr);
-    writeFileSync(
-      output + "/boot-launcher-anr.png",
-      execFileSync(adb, ["-s", serial, "exec-out", "screencap", "-p"]),
-    );
+    // Pull the PNG as a file: full-resolution screenshots can exceed the
+    // child-process stdout buffer before the app smoke test even starts.
+    shell("screencap", "-p", "/sdcard/mold-boot-launcher-anr.png");
+    run("pull", "/sdcard/mold-boot-launcher-anr.png", output + "/boot-launcher-anr.png");
     shell("am", "force-stop", "com.android.launcher3");
   }
   shell("am", "start", "-n", "com.utensils.mold/.MainActivity");

--- a/studio/api/queuePlan.test.ts
+++ b/studio/api/queuePlan.test.ts
@@ -334,6 +334,41 @@ describe("queue plan contract", () => {
     ]);
   });
 
+  it.each([404, 405, 401, 500])(
+    "handles detail endpoint status %s without hiding server failures",
+    async (status) => {
+      const row = {
+        id: "wanted",
+        model: "flux-dev:q8",
+        state: "paused",
+        started_at_unix_ms: 1,
+        position: 0,
+      };
+      vi.stubGlobal(
+        "fetch",
+        vi
+          .fn()
+          .mockResolvedValueOnce(Response.json({ queue_capacity: 1 }))
+          .mockResolvedValueOnce(
+            Response.json({
+              entries: [row],
+              page: { limit: 1, offset: 0, returned: 1 },
+            }),
+          )
+          .mockResolvedValueOnce(
+            Response.json({ error: "detail unavailable" }, { status }),
+          ),
+      );
+      const result = findQueueEntryById(
+        { baseUrl: "https://gpu.example", apiKey: "secret" },
+        "wanted",
+      );
+      if (status === 404 || status === 405)
+        await expect(result).resolves.toMatchObject(row);
+      else await expect(result).rejects.toMatchObject({ status });
+    },
+  );
+
   it("reads one queue job with persisted settings and retry authority", async () => {
     const fetchMock = vi.fn().mockResolvedValue(
       Response.json({

--- a/studio/api/queuePlan.test.ts
+++ b/studio/api/queuePlan.test.ts
@@ -309,6 +309,11 @@ describe("queue plan contract", () => {
           entries: [row("wanted")],
           page: { limit: 1, offset: 1, returned: 1 },
         }),
+      )
+      .mockResolvedValueOnce(
+        Response.json({
+          job: { ...row("wanted"), metadata: { prompt: "restored" } },
+        }),
       );
     vi.stubGlobal("fetch", fetchMock);
 
@@ -317,11 +322,15 @@ describe("queue plan contract", () => {
         { baseUrl: "https://gpu.example", apiKey: "secret" },
         "wanted",
       ),
-    ).resolves.toMatchObject({ id: "wanted" });
+    ).resolves.toMatchObject({
+      id: "wanted",
+      metadata: { prompt: "restored" },
+    });
     expect(fetchMock.mock.calls.map(([url]) => url)).toEqual([
       "https://gpu.example/api/status",
       "https://gpu.example/api/queue?limit=1",
       "https://gpu.example/api/queue?limit=1&cursor=next",
+      "https://gpu.example/api/queue/wanted",
     ]);
   });
 

--- a/studio/api/queuePlan.ts
+++ b/studio/api/queuePlan.ts
@@ -1,4 +1,5 @@
 import {
+  ApiError,
   IncompatibleHostError,
   apiFetchTo,
   apiJsonTo,
@@ -348,7 +349,23 @@ export async function findQueueEntryById(
       listing.entries,
       listing.live_only_entries ?? [],
     ).find((entry) => entry.id === id);
-    if (match) return match;
+    if (match) {
+      // Listings deliberately omit durable request settings. Opening one row
+      // must read its bounded detail before handing it to any Create surface.
+      if (match.metadata == null) {
+        try {
+          return (await getQueueJob(target, id)).job;
+        } catch (error) {
+          // Compatibility with hosts that predate the single-job endpoint.
+          if (
+            !(error instanceof ApiError) ||
+            ![404, 405].includes(error.status)
+          )
+            throw error;
+        }
+      }
+      return match;
+    }
     const cursor = listing.page?.next_cursor;
     const limit = listing.page?.limit;
     if (!cursor || !limit) return null;

--- a/studio/components/MeshWorkflowHostPicker.vue
+++ b/studio/components/MeshWorkflowHostPicker.vue
@@ -7,6 +7,8 @@ defineProps<{
     stale?: boolean;
   }>;
   modelValue: string;
+  automatic?: boolean;
+  disabled?: boolean;
 }>();
 
 const emit = defineEmits<{ "update:modelValue": [id: string] }>();
@@ -17,12 +19,17 @@ const emit = defineEmits<{ "update:modelValue": [id: string] }>();
     Run workflow on
     <select
       :value="modelValue"
+      :disabled="disabled"
       data-test="mesh-workflow-host"
       aria-label="3-D workflow machine"
       @change="
         emit('update:modelValue', ($event.target as HTMLSelectElement).value)
       "
     >
+      <option v-if="automatic" value="auto">Auto · least busy</option>
+      <option v-if="automatic" value="capable">
+        Most capable · strongest GPU
+      </option>
       <option
         v-for="host in hosts"
         :key="host.id"

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -236,3 +236,41 @@ it("restores a selected workflow's settings without overwriting edits on progres
     vi.useRealTimers();
   }
 });
+
+it.each([
+  ["running", "Cancel", "cancelMeshWorkflow"],
+  ["paused", "Resume", "resumeMeshWorkflow"],
+] as const)(
+  "sends %s workflow controls to the resolved owner",
+  async (state, label, action) => {
+    const api = await import("../api/meshWorkflows");
+    vi.clearAllMocks();
+    vi.mocked(api.getMeshWorkflow).mockResolvedValue({
+      id: "workflow-1",
+      state,
+      mode: "text_to_mesh",
+      stages: [],
+    } as never);
+    const owner = { baseUrl: "http://plato-uat:7689", apiKey: null };
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://browse-host:7680", apiKey: null },
+        resolveTarget: async () => ({ target: owner, label: "Plato UAT" }),
+      },
+    });
+    try {
+      await flushPromises();
+      await wrapper.get("textarea").setValue("A wooden fox");
+      await wrapper.get("form").trigger("submit");
+      await flushPromises();
+      await wrapper
+        .findAll("button")
+        .find((button) => button.text() === label)!
+        .trigger("click");
+      await flushPromises();
+      expect(api[action]).toHaveBeenCalledWith(owner, "workflow-1");
+    } finally {
+      wrapper.unmount();
+    }
+  },
+);

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -196,3 +196,43 @@ it("retains unchanged result media across progress polls and stops polling on un
     vi.useRealTimers();
   }
 });
+
+it("restores a selected workflow's settings without overwriting edits on progress polls", async () => {
+  const { getMeshWorkflow } = await import("../api/meshWorkflows");
+  vi.useFakeTimers();
+  listMeshWorkflows.mockResolvedValue({
+    jobs: [{ id: "saved", mode: "text_to_mesh", state: "running" }] as never,
+  });
+  vi.mocked(getMeshWorkflow).mockResolvedValue({
+    id: "saved",
+    mode: "text_to_mesh",
+    state: "running",
+    stages: [],
+    request: {
+      mode: "text_to_mesh",
+      image_request: {
+        model: "z-image-turbo:q8",
+        prompt: "A saved wooden fox",
+      },
+      mesh_request: {
+        model: "hunyuan3d-mini-turbo:fp16",
+        mesh: { texture: false },
+      },
+    },
+  } as never);
+  const wrapper = mount(MeshWorkflowStudio, {
+    props: { target: { baseUrl: "http://local:7680", apiKey: null } },
+  });
+  try {
+    await flushPromises();
+    await wrapper.get('[aria-label="Previous 3-D workflow"]').setValue("saved");
+    await flushPromises();
+    expect(wrapper.get("textarea").element.value).toBe("A saved wooden fox");
+    await wrapper.get("textarea").setValue("An edited fox");
+    await vi.advanceTimersByTimeAsync(750);
+    expect(wrapper.get("textarea").element.value).toBe("An edited fox");
+  } finally {
+    wrapper.unmount();
+    vi.useRealTimers();
+  }
+});

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -111,3 +111,19 @@ describe("MeshWorkflowStudio feature-aware PBR authoring", () => {
     expect(request.mesh_request.mesh).toBeUndefined();
   });
 });
+
+it("preserves the draft when telemetry recreates an equivalent target", async () => {
+  const target = { baseUrl: "http://metal-host:7680", apiKey: null };
+  const wrapper = mount(MeshWorkflowStudio, { props: { target } });
+  await flushPromises();
+  await wrapper.get("textarea").setValue("A brass telescope");
+  const calls = listMeshWorkflows.mock.calls.length;
+  for (let tick = 0; tick < 3; tick++) {
+    await wrapper.setProps({ target: { ...target } });
+    await flushPromises();
+  }
+  expect(listMeshWorkflows.mock.calls.length).toBe(calls);
+  expect(wrapper.get("textarea").element.value).toBe("A brass telescope");
+  expect(wrapper.text()).not.toContain("Loading workflow capabilities");
+  wrapper.unmount();
+});

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -127,3 +127,72 @@ it("preserves the draft when telemetry recreates an equivalent target", async ()
   expect(wrapper.text()).not.toContain("Loading workflow capabilities");
   wrapper.unmount();
 });
+
+it("submits and reads workflow history on the resolved owner", async () => {
+  const target = { baseUrl: "http://remote:7680", apiKey: "remote-key" };
+  const resolveTarget = vi.fn(async () => ({ target, label: "Render box" }));
+  const wrapper = mount(MeshWorkflowStudio, {
+    props: {
+      target: { baseUrl: "http://local:7680", apiKey: null },
+      resolveTarget,
+    },
+  });
+  await flushPromises();
+  await wrapper.get("textarea").setValue("A brass telescope");
+  await wrapper.get("form").trigger("submit");
+  await flushPromises();
+  expect(resolveTarget).toHaveBeenCalledWith(
+    expect.objectContaining({
+      mode: "text_to_mesh",
+      imageModel: "z-image-turbo:q8",
+    }),
+  );
+  expect(createMeshWorkflow).toHaveBeenCalledWith(target, expect.any(Object));
+  expect(listMeshWorkflows).toHaveBeenLastCalledWith(target);
+  wrapper.unmount();
+});
+
+it("retains unchanged result media across progress polls and stops polling on unmount", async () => {
+  const { getMeshWorkflow } = await import("../api/meshWorkflows");
+  const { apiFetchTo } = await import("../api/client");
+  vi.clearAllMocks();
+  vi.useFakeTimers();
+  vi.mocked(getMeshWorkflow).mockResolvedValue({
+    id: "workflow-1",
+    state: "running",
+    mode: "text_to_mesh",
+    stages: [],
+    output_filename: "result.glb",
+  } as never);
+  vi.mocked(apiFetchTo).mockImplementation(
+    async () => new Response(new Uint8Array([1])),
+  );
+  const createUrl = vi
+    .spyOn(URL, "createObjectURL")
+    .mockReturnValue("blob:result");
+  const revokeUrl = vi
+    .spyOn(URL, "revokeObjectURL")
+    .mockImplementation(() => {});
+  const wrapper = mount(MeshWorkflowStudio, {
+    props: { target: { baseUrl: "http://local:7680", apiKey: null } },
+  });
+  try {
+    await flushPromises();
+    await wrapper.get("textarea").setValue("A brass telescope");
+    await wrapper.get("form").trigger("submit");
+    await flushPromises();
+    expect(apiFetchTo).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(750);
+    await flushPromises();
+    expect(getMeshWorkflow).toHaveBeenCalledTimes(2);
+    expect(apiFetchTo).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(getMeshWorkflow).toHaveBeenCalledTimes(2);
+  } finally {
+    wrapper.unmount();
+    createUrl.mockRestore();
+    revokeUrl.mockRestore();
+    vi.useRealTimers();
+  }
+});

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import type {
   MeshWorkflowRequirements,
@@ -9,6 +10,7 @@ import type {
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "../api/client";
 import {
   cancelMeshWorkflow,
+  type CreateMeshWorkflowRequest,
   createMeshWorkflow,
   deleteMeshWorkflow,
   getMeshWorkflow,
@@ -172,7 +174,7 @@ async function refreshJobs(): Promise<void> {
     jobs.value = listing.jobs;
 }
 
-async function refreshSelected(): Promise<void> {
+async function refreshSelected(restoreDraft = false): Promise<void> {
   clearPoll();
   const epoch = ++selectionEpoch;
   const id = selectedId.value;
@@ -186,12 +188,37 @@ async function refreshSelected(): Promise<void> {
     const result = await getMeshWorkflow<WorkflowGenerateRequest>(target, id);
     if (epoch !== selectionEpoch) return;
     detail.value = result;
+    if (restoreDraft && result?.request) restoreWorkflowDraft(result.request);
     await loadResult();
   } catch (cause) {
     if (epoch === selectionEpoch)
       error.value = cause instanceof Error ? cause.message : String(cause);
   } finally {
     if (epoch === selectionEpoch) schedulePoll();
+  }
+}
+
+function restoreWorkflowDraft(
+  request: CreateMeshWorkflowRequest<WorkflowGenerateRequest>,
+): void {
+  // History is a different request; never carry another workflow's attachments.
+  meshFile.value = null;
+  appearanceFile.value = null;
+  mode.value = request.mode;
+  const mesh =
+    request.mode === "text_to_mesh"
+      ? request.mesh_request
+      : request.mode === "mesh_texture"
+        ? request.texture_request
+        : request.roundtrip_request;
+  meshModelName.value = mesh.model;
+  texture.value =
+    request.mode === "mesh_texture" || mesh.mesh?.texture === true;
+  textureResolution.value = mesh.mesh?.texture_resolution ?? 2048;
+  delight.value = mesh.mesh?.delight === true;
+  if (request.mode === "text_to_mesh") {
+    prompt.value = request.image_request.prompt;
+    imageModelName.value = request.image_request.model;
   }
 }
 
@@ -518,7 +545,7 @@ watch(meshModelName, () => {
 });
 watch(selectedId, () => {
   revokeResult();
-  void refreshSelected();
+  void refreshSelected(true);
 });
 watch(
   [() => props.target.baseUrl, () => props.target.apiKey],
@@ -587,56 +614,47 @@ onBeforeUnmount(() => {
     <p v-if="loading">Loading workflow capabilities…</p>
 
     <div v-else class="mesh-studio__grid">
+      <slot name="inspector-resize" />
       <form class="mesh-studio__composer" @submit.prevent="submit">
         <fieldset class="mesh-studio__fields" :disabled="busy">
-          <span v-if="desktop" class="ms-group-label">Settings</span>
-          <div
-            v-if="!desktop"
-            class="mesh-studio__tabs"
-            role="tablist"
-            aria-label="Workflow type"
-          >
-            <button
-              type="button"
-              :aria-selected="mode === 'mesh_roundtrip'"
-              :class="{ active: mode === 'mesh_roundtrip' }"
-              :disabled="!selectedModes.includes('mesh_roundtrip')"
-              @click="mode = 'mesh_roundtrip'"
-            >
-              Rebuild a mesh
-            </button>
-            <button
-              type="button"
-              :aria-selected="mode === 'text_to_mesh'"
-              :class="{ active: mode === 'text_to_mesh' }"
-              :disabled="!selectedModes.includes('text_to_mesh')"
-              @click="mode = 'text_to_mesh'"
-            >
-              Text to 3-D
-            </button>
-            <button
-              type="button"
-              :aria-selected="mode === 'mesh_texture'"
-              :class="{ active: mode === 'mesh_texture' }"
-              :disabled="!selectedModes.includes('mesh_texture')"
-              @click="mode = 'mesh_texture'"
-            >
-              Texture a mesh
-            </button>
+          <div v-if="desktop" class="mesh-studio__inspector-heading">
+            Settings
           </div>
+          <SegmentedControl
+            v-if="!desktop"
+            v-model="mode"
+            :options="modeOptions"
+            :disabled="busy || loading"
+            label="3-D workflow"
+            variant="neutral"
+          />
 
-          <label>
-            3-D style
-            <select v-model="meshModelName" data-test="mesh-workflow-model">
-              <option
-                v-for="model in meshModels"
-                :key="model.name"
-                :value="model.name"
-              >
-                {{ modelLabel(model) }}
-              </option>
-            </select>
-          </label>
+          <slot
+            name="mesh-picker"
+            :models="
+              meshModels.filter((model) =>
+                meshWorkflowModes(model).includes(mode),
+              )
+            "
+            :selected="meshModelName"
+            :select="(name: string) => (meshModelName = name)"
+            :disabled="busy"
+          >
+            <label>
+              3-D style
+              <select v-model="meshModelName" data-test="mesh-workflow-model">
+                <option
+                  v-for="model in meshModels.filter((model) =>
+                    meshWorkflowModes(model).includes(mode),
+                  )"
+                  :key="model.name"
+                  :value="model.name"
+                >
+                  {{ modelLabel(model) }}
+                </option>
+              </select>
+            </label>
+          </slot>
 
           <template v-if="mode === 'text_to_mesh'">
             <label>
@@ -647,26 +665,38 @@ onBeforeUnmount(() => {
                 placeholder="A hand-carved wooden fox, centered on a plain background"
               />
             </label>
-            <label>
-              Picture style
-              <select v-model="imageModelName">
-                <option
-                  v-for="model in imageModels"
-                  :key="model.name"
-                  :value="model.name"
-                >
-                  {{ modelLabel(model) }}
-                </option>
-              </select>
-            </label>
-            <label
+            <slot
+              name="image-picker"
+              :models="imageModels"
+              :selected="imageModelName"
+              :select="(name: string) => (imageModelName = name)"
+              :disabled="busy"
+            >
+              <label>
+                Picture style
+                <select v-model="imageModelName">
+                  <option
+                    v-for="model in imageModels"
+                    :key="model.name"
+                    :value="model.name"
+                  >
+                    {{ modelLabel(model) }}
+                  </option>
+                </select>
+              </label>
+            </slot>
+            <div
               v-if="textureAvailable"
               class="mesh-studio__check"
               data-test="mesh-workflow-texture"
             >
-              <input v-model="texture" type="checkbox" />
+              <SwitchToggle
+                v-model="texture"
+                :disabled="busy"
+                label="Paint PBR materials after geometry"
+              />
               Paint PBR materials after geometry
-            </label>
+            </div>
             <p
               v-else
               class="mesh-studio__availability"
@@ -694,7 +724,7 @@ onBeforeUnmount(() => {
               Appearance image
               <input
                 type="file"
-                accept="image/png,image/jpeg,image/webp"
+                accept="image/png,image/jpeg"
                 @change="
                   appearanceFile =
                     ($event.target as HTMLInputElement).files?.[0] ?? null
@@ -735,13 +765,17 @@ onBeforeUnmount(() => {
               <option :value="4096">4096</option>
             </select>
           </label>
-          <label
+          <div
             v-if="delightAvailable && mode !== 'mesh_roundtrip'"
             class="mesh-studio__check"
           >
-            <input v-model="delight" type="checkbox" />
+            <SwitchToggle
+              v-model="delight"
+              :disabled="busy"
+              label="Remove baked lighting and highlights before building the mesh"
+            />
             Remove baked lighting and highlights before building the mesh
-          </label>
+          </div>
           <button
             class="mesh-studio__primary"
             type="submit"
@@ -887,12 +921,13 @@ onBeforeUnmount(() => {
   flex-direction: column;
   gap: 16px;
 }
-.mesh-studio label {
+.mesh-studio label,
+.mesh-studio__check {
   display: grid;
   gap: 7px;
   color: var(--mold-text-2);
   font-size: var(--mold-fs-xs);
-  font-weight: 650;
+  font-weight: 500;
 }
 .mesh-studio select,
 .mesh-studio textarea,
@@ -908,24 +943,9 @@ onBeforeUnmount(() => {
   resize: vertical;
   line-height: 1.45;
 }
-.mesh-studio__tabs {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  gap: 4px;
-  padding: 4px;
-  background: var(--mold-bg);
-}
-.mesh-studio__tabs button,
 .mesh-studio__actions button {
   padding: 9px;
   color: var(--mold-text-2);
-}
-.mesh-studio__tabs button.active {
-  background: var(--mold-surface-2);
-  color: var(--mold-text);
-}
-.mesh-studio__tabs button:disabled {
-  opacity: 0.35;
 }
 .mesh-studio__check {
   display: flex !important;
@@ -1096,7 +1116,11 @@ onBeforeUnmount(() => {
   min-height: 0;
   width: 100%;
   max-width: none;
-  grid-template-columns: minmax(0, 1fr) var(--mold-shell-inspector-w, 300px);
+  grid-template-columns: minmax(0, 1fr) var(
+      --mesh-inspector-width,
+      var(--mold-shell-inspector-w, 300px)
+    );
+  position: relative;
   gap: 0;
   margin: 0;
 }
@@ -1162,5 +1186,24 @@ onBeforeUnmount(() => {
   .mesh-studio--desktop .mesh-studio__header-actions select {
     max-width: 150px;
   }
+}
+
+.mesh-studio--desktop .mesh-studio__inspector-heading {
+  height: var(--mold-shell-viewbar-h);
+  min-height: var(--mold-shell-viewbar-h);
+  display: flex;
+  align-items: center;
+  margin: -16px -16px 0;
+  padding: 0 14px;
+  border-bottom: var(--mold-bw) solid var(--mold-border);
+  background: var(--mold-bg);
+  color: var(--mold-text);
+  font-size: var(--mold-fs-xs);
+  font-weight: 600;
+}
+.mesh-studio--desktop .mesh-studio__check {
+  flex-direction: row-reverse;
+  justify-content: space-between;
+  line-height: var(--mold-lh-body);
 }
 </style>

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -1,5 +1,10 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import SegmentedControl from "@ui/components/SegmentedControl.vue";
+import type {
+  MeshWorkflowRequirements,
+  MeshWorkflowRoute,
+} from "../lib/meshWorkflowRouting";
 
 import { apiFetchTo, apiJsonTo, type ApiTarget } from "../api/client";
 import {
@@ -29,9 +34,20 @@ import {
   type ReferenceUploadLease,
 } from "../api/referenceUploads";
 
-const props = defineProps<{ target: ApiTarget }>();
+const props = defineProps<{
+  target: ApiTarget;
+  hostLabel?: string;
+  desktop?: boolean;
+  availableModels?: WorkflowModel[];
+  resolveTarget?: (
+    requirements: MeshWorkflowRequirements,
+  ) => Promise<MeshWorkflowRoute>;
+}>();
 
-const models = ref<WorkflowModel[]>([]);
+const hostModels = ref<WorkflowModel[]>([]);
+const models = computed(() => props.availableModels ?? hostModels.value);
+const ownedTarget = ref<ApiTarget>({ ...props.target });
+const ownerLabel = ref(props.hostLabel ?? "");
 const jobs = ref<MeshWorkflowJobSummary[]>([]);
 const detail = ref<MeshWorkflowJobDetail<WorkflowGenerateRequest> | null>(null);
 const selectedId = ref("");
@@ -53,10 +69,11 @@ const loading = ref(true);
 const error = ref("");
 const resultSrc = ref("");
 const resultPoster = ref("");
-const instanceId = ref("");
-const referenceUploads = ref<ReferenceUploadCapabilities | null>(null);
 let pollTimer: ReturnType<typeof setTimeout> | null = null;
 let resultEpoch = 0;
+let contextEpoch = 0;
+let selectionEpoch = 0;
+let loadedResult = "";
 
 const meshModels = computed(() =>
   models.value.filter(
@@ -138,59 +155,85 @@ function clearPoll(): void {
 
 function schedulePoll(): void {
   clearPoll();
-  if (settled.value || !selectedId.value) return;
+  if (
+    !selectedId.value ||
+    !detail.value ||
+    !["queued", "running"].includes(detail.value.state)
+  )
+    return;
   pollTimer = setTimeout(() => void refreshSelected(), 750);
 }
 
 async function refreshJobs(): Promise<void> {
-  const listing = await listMeshWorkflows(props.target);
-  jobs.value = listing.jobs;
+  const target = ownedTarget.value;
+  const epoch = contextEpoch;
+  const listing = await listMeshWorkflows(target);
+  if (epoch === contextEpoch && target === ownedTarget.value)
+    jobs.value = listing.jobs;
 }
 
 async function refreshSelected(): Promise<void> {
-  if (!selectedId.value) return;
+  clearPoll();
+  const epoch = ++selectionEpoch;
+  const id = selectedId.value;
+  if (!id) {
+    detail.value = null;
+    revokeResult();
+    return;
+  }
+  const target = ownedTarget.value;
   try {
-    detail.value = await getMeshWorkflow<WorkflowGenerateRequest>(
-      props.target,
-      selectedId.value,
-    );
+    const result = await getMeshWorkflow<WorkflowGenerateRequest>(target, id);
+    if (epoch !== selectionEpoch) return;
+    detail.value = result;
     await loadResult();
   } catch (cause) {
-    error.value = cause instanceof Error ? cause.message : String(cause);
+    if (epoch === selectionEpoch)
+      error.value = cause instanceof Error ? cause.message : String(cause);
   } finally {
-    schedulePoll();
+    if (epoch === selectionEpoch) schedulePoll();
   }
 }
 
-async function bootstrap(): Promise<void> {
-  loading.value = true;
-  error.value = "";
-  try {
-    const [availableModels, status, capabilities] = await Promise.all([
-      apiJsonTo<WorkflowModel[]>(props.target, "/api/models"),
-      apiJsonTo<{ instance_id: string }>(props.target, "/api/status"),
-      apiJsonTo<{ reference_uploads?: ReferenceUploadCapabilities | null }>(
-        props.target,
-        "/api/capabilities",
-      ),
-      refreshJobs(),
-    ]);
-    models.value = availableModels;
-    instanceId.value = status.instance_id;
-    referenceUploads.value = capabilities.reference_uploads ?? null;
+function chooseModels(): void {
+  if (!meshModels.value.some((model) => model.name === meshModelName.value)) {
     meshModelName.value =
       meshModels.value.find((model) =>
         meshWorkflowModes(model).includes("mesh_texture"),
       )?.name ??
       meshModels.value[0]?.name ??
       "";
+  }
+  if (!imageModels.value.some((model) => model.name === imageModelName.value))
     imageModelName.value = imageModels.value[0]?.name ?? "";
-    selectedId.value = jobs.value[0]?.id ?? "";
-    await refreshSelected();
+}
+
+async function bootstrap(): Promise<void> {
+  const epoch = ++contextEpoch;
+  ++selectionEpoch;
+  clearPoll();
+  revokeResult();
+  selectedId.value = "";
+  detail.value = null;
+  ownedTarget.value = { ...props.target };
+  ownerLabel.value = props.hostLabel ?? "";
+  const target = ownedTarget.value;
+  loading.value = true;
+  error.value = "";
+  try {
+    const [availableModels, listing] = await Promise.all([
+      apiJsonTo<WorkflowModel[]>(target, "/api/models"),
+      listMeshWorkflows(target),
+    ]);
+    if (epoch !== contextEpoch) return;
+    hostModels.value = availableModels;
+    jobs.value = listing.jobs;
+    chooseModels();
   } catch (cause) {
-    error.value = cause instanceof Error ? cause.message : String(cause);
+    if (epoch === contextEpoch)
+      error.value = cause instanceof Error ? cause.message : String(cause);
   } finally {
-    loading.value = false;
+    if (epoch === contextEpoch) loading.value = false;
   }
 }
 
@@ -222,22 +265,66 @@ async function submit(): Promise<void> {
   busy.value = true;
   error.value = "";
   let uploadLease: ReferenceUploadLease<WorkflowGenerateRequest> | null = null;
+  const epoch = contextEpoch;
+  const draft = {
+    mode: mode.value,
+    prompt: prompt.value,
+    texture: texture.value,
+    textureResolution: textureResolution.value,
+    delight: delight.value,
+    delightAvailable: delightAvailable.value,
+    textureAvailable: textureAvailable.value,
+    selectedImageModel: selectedImageModel.value,
+    meshFile: meshFile.value,
+    appearanceFile: appearanceFile.value,
+    upAxis: upAxis.value,
+    metersPerUnit: metersPerUnit.value,
+  };
   try {
+    const route = props.resolveTarget
+      ? await props.resolveTarget({
+          mode: draft.mode,
+          meshModel: meshModel.name,
+          ...(draft.mode === "text_to_mesh"
+            ? { imageModel: draft.selectedImageModel!.name }
+            : {}),
+          texture:
+            draft.mode === "mesh_texture" ||
+            (draft.mode === "text_to_mesh" &&
+              draft.textureAvailable &&
+              draft.texture),
+          delight:
+            draft.mode !== "mesh_roundtrip" &&
+            draft.delightAvailable &&
+            draft.delight,
+        })
+      : { target: { ...props.target }, label: props.hostLabel ?? "" };
+    if (epoch !== contextEpoch) return;
+    const submissionTarget = route.target;
+    const [status, capabilities] = await Promise.all([
+      apiJsonTo<{ instance_id: string }>(submissionTarget, "/api/status"),
+      apiJsonTo<{ reference_uploads?: ReferenceUploadCapabilities | null }>(
+        submissionTarget,
+        "/api/capabilities",
+      ),
+    ]);
+    if (epoch !== contextEpoch) return;
+    const submissionUploads = capabilities.reference_uploads ?? null;
     let request =
-      mode.value === "text_to_mesh"
+      draft.mode === "text_to_mesh"
         ? buildTextToMeshWorkflow({
-            prompt: prompt.value,
-            imageModel: selectedImageModel.value!,
+            prompt: draft.prompt,
+            imageModel: draft.selectedImageModel!,
             meshModel,
-            texture: texture.value,
-            textureResolution: textureResolution.value,
-            delight: delightAvailable.value && delight.value,
+            texture: draft.texture,
+            textureResolution: draft.textureResolution,
+            delight: draft.delightAvailable && draft.delight,
           })
         : await (async () => {
-            const mesh = meshFile.value!;
+            const mesh = draft.meshFile!;
             const useUpload =
-              referenceUploads.value?.available === true &&
-              Boolean(props.target.apiKey?.trim());
+              submissionUploads?.available === true &&
+              Boolean(submissionTarget.apiKey?.trim());
             const meshPayload = useUpload ? null : await filePayload(mesh);
             const meshFormat: "glb" | "obj" = mesh.name
               .toLowerCase()
@@ -251,18 +338,18 @@ async function submit(): Promise<void> {
               meshByteLength: mesh.size,
               ...(meshPayload ? { meshSha256: meshPayload.sha256 } : {}),
               meshFormat,
-              upAxis: upAxis.value,
-              metersPerUnit: metersPerUnit.value,
+              upAxis: draft.upAxis,
+              metersPerUnit: draft.metersPerUnit,
             };
-            if (mode.value === "mesh_roundtrip") {
+            if (draft.mode === "mesh_roundtrip") {
               return buildMeshRoundtripWorkflow(shared);
             }
-            const appearancePayload = await filePayload(appearanceFile.value!);
+            const appearancePayload = await filePayload(draft.appearanceFile!);
             return buildMeshTextureWorkflow({
               ...shared,
               appearanceBase64: appearancePayload.base64,
-              textureResolution: textureResolution.value,
-              delight: delightAvailable.value && delight.value,
+              textureResolution: draft.textureResolution,
+              delight: draft.delightAvailable && draft.delight,
             });
           })();
     const meshRequest =
@@ -278,17 +365,17 @@ async function submit(): Promise<void> {
       (directMeshUpload ||
         requestShouldUseReferenceUploads(
           meshRequest,
-          props.target,
-          referenceUploads.value,
+          submissionTarget,
+          submissionUploads,
         ))
     ) {
       uploadLease = await prepareReferenceUploads({
-        target: props.target,
-        expectedInstanceId: instanceId.value,
-        capabilities: referenceUploads.value,
+        target: submissionTarget,
+        expectedInstanceId: status.instance_id,
+        capabilities: submissionUploads,
         request: meshRequest,
         ...(directMeshUpload
-          ? { uploadBodies: new Map([[1, meshFile.value!]]) }
+          ? { uploadBodies: new Map([[1, draft.meshFile!]]) }
           : {}),
       });
       if (request.mode === "mesh_texture") {
@@ -297,11 +384,21 @@ async function submit(): Promise<void> {
         request = { ...request, roundtrip_request: uploadLease.request };
       }
     }
-    const created = await createMeshWorkflow(props.target, request);
+    if (epoch !== contextEpoch) {
+      await uploadLease?.cancel().catch(() => undefined);
+      return;
+    }
+    const created = await createMeshWorkflow(submissionTarget, request);
     uploadLease = null;
-    await refreshJobs();
+    if (epoch !== contextEpoch) return;
+    clearPoll();
+    ++selectionEpoch;
+    revokeResult();
+    detail.value = null;
+    ownedTarget.value = submissionTarget;
+    ownerLabel.value = route.label;
     selectedId.value = created.job_id;
-    await refreshSelected();
+    await refreshJobs();
   } catch (cause) {
     await uploadLease?.cancel().catch(() => undefined);
     error.value = cause instanceof Error ? cause.message : String(cause);
@@ -314,7 +411,7 @@ async function cancel(): Promise<void> {
   if (!selectedId.value) return;
   busy.value = true;
   try {
-    await cancelMeshWorkflow(props.target, selectedId.value);
+    await cancelMeshWorkflow(ownedTarget.value, selectedId.value);
     await Promise.all([refreshJobs(), refreshSelected()]);
   } catch (cause) {
     error.value = cause instanceof Error ? cause.message : String(cause);
@@ -327,7 +424,7 @@ async function resume(): Promise<void> {
   if (!selectedId.value) return;
   busy.value = true;
   try {
-    await resumeMeshWorkflow(props.target, selectedId.value);
+    await resumeMeshWorkflow(ownedTarget.value, selectedId.value);
     await Promise.all([refreshJobs(), refreshSelected()]);
   } catch (cause) {
     error.value = cause instanceof Error ? cause.message : String(cause);
@@ -341,7 +438,7 @@ async function remove(): Promise<void> {
   busy.value = true;
   error.value = "";
   try {
-    await deleteMeshWorkflow(props.target, selectedId.value);
+    await deleteMeshWorkflow(ownedTarget.value, selectedId.value);
     selectedId.value = "";
     detail.value = null;
     revokeResult();
@@ -354,6 +451,8 @@ async function remove(): Promise<void> {
 }
 
 function revokeResult(): void {
+  ++resultEpoch;
+  loadedResult = "";
   if (resultSrc.value) URL.revokeObjectURL(resultSrc.value);
   if (resultPoster.value) URL.revokeObjectURL(resultPoster.value);
   resultSrc.value = "";
@@ -362,24 +461,50 @@ function revokeResult(): void {
 
 async function loadResult(): Promise<void> {
   const filename = detail.value?.output_filename;
-  const epoch = ++resultEpoch;
   if (!filename) {
     revokeResult();
     return;
   }
+  const target = ownedTarget.value;
+  const identity = JSON.stringify([target.baseUrl, target.apiKey, filename]);
+  if (loadedResult === identity && resultSrc.value) return;
+  const epoch = ++resultEpoch;
   const media = await apiFetchTo(
-    props.target,
+    target,
     `/api/gallery/image/${encodeURIComponent(filename)}`,
   );
   const poster = await apiFetchTo(
-    props.target,
+    target,
     `/api/gallery/thumbnail/${encodeURIComponent(filename)}`,
   ).catch(() => null);
+  if (!media.ok) throw new Error("Could not load the 3-D result.");
+  const blob = await media.blob();
+  const posterBlob = poster?.ok ? await poster.blob() : null;
   if (epoch !== resultEpoch) return;
   revokeResult();
-  resultSrc.value = URL.createObjectURL(await media.blob());
-  if (poster) resultPoster.value = URL.createObjectURL(await poster.blob());
+  loadedResult = identity;
+  resultSrc.value = URL.createObjectURL(blob);
+  if (posterBlob) resultPoster.value = URL.createObjectURL(posterBlob);
 }
+
+const modeOptions = computed(() =>
+  [
+    { value: "text_to_mesh" as const, label: "From words" },
+    { value: "mesh_roundtrip" as const, label: "Rebuild" },
+    { value: "mesh_texture" as const, label: "Add texture" },
+  ].filter((option) =>
+    meshModels.value.some((model) =>
+      meshWorkflowModes(model).includes(option.value),
+    ),
+  ),
+);
+watch(mode, (value) => {
+  if (!selectedModes.value.includes(value))
+    meshModelName.value =
+      meshModels.value.find((model) => meshWorkflowModes(model).includes(value))
+        ?.name ?? "";
+});
+watch(models, chooseModels);
 
 watch(meshModelName, () => {
   if (!selectedModes.value.includes(mode.value)) {
@@ -391,22 +516,40 @@ watch(meshModelName, () => {
   }
   if (!textureAvailable.value) texture.value = false;
 });
-watch(selectedId, () => void refreshSelected());
+watch(selectedId, () => {
+  revokeResult();
+  void refreshSelected();
+});
 watch(
   [() => props.target.baseUrl, () => props.target.apiKey],
   () => void bootstrap(),
 );
 onMounted(() => void bootstrap());
 onBeforeUnmount(() => {
+  ++contextEpoch;
+  ++selectionEpoch;
   clearPoll();
   revokeResult();
 });
 </script>
 
 <template>
-  <section class="mesh-studio" aria-label="3-D workflow studio">
+  <section
+    class="mesh-studio"
+    :class="{ 'mesh-studio--desktop': desktop }"
+    aria-label="3-D workflow studio"
+  >
     <header class="mesh-studio__header">
-      <div>
+      <SegmentedControl
+        v-if="desktop"
+        v-model="mode"
+        :options="modeOptions"
+        :disabled="busy || loading"
+        label="3-D workflow"
+        variant="neutral"
+        compact
+      />
+      <div v-else>
         <p class="mesh-studio__eyebrow">Hunyuan3D workflow</p>
         <h1>Build and texture a 3-D object</h1>
         <p>
@@ -415,8 +558,14 @@ onBeforeUnmount(() => {
         </p>
       </div>
       <div class="mesh-studio__header-actions">
-        <slot name="machine" />
-        <select v-model="selectedId" aria-label="Previous 3-D workflow">
+        <span v-if="ownerLabel && selectedId" class="mesh-studio__owner">{{
+          ownerLabel
+        }}</span>
+        <select
+          v-model="selectedId"
+          :disabled="busy"
+          aria-label="Previous 3-D workflow"
+        >
           <option value="">New workflow</option>
           <option v-for="job in jobs" :key="job.id" :value="job.id">
             {{
@@ -430,6 +579,7 @@ onBeforeUnmount(() => {
             {{ job.state }}
           </option>
         </select>
+        <slot name="machine" :busy="busy" />
       </div>
     </header>
 
@@ -438,67 +588,48 @@ onBeforeUnmount(() => {
 
     <div v-else class="mesh-studio__grid">
       <form class="mesh-studio__composer" @submit.prevent="submit">
-        <div
-          class="mesh-studio__tabs"
-          role="tablist"
-          aria-label="Workflow type"
-        >
-          <button
-            type="button"
-            :aria-selected="mode === 'mesh_roundtrip'"
-            :class="{ active: mode === 'mesh_roundtrip' }"
-            :disabled="!selectedModes.includes('mesh_roundtrip')"
-            @click="mode = 'mesh_roundtrip'"
+        <fieldset class="mesh-studio__fields" :disabled="busy">
+          <span v-if="desktop" class="ms-group-label">Settings</span>
+          <div
+            v-if="!desktop"
+            class="mesh-studio__tabs"
+            role="tablist"
+            aria-label="Workflow type"
           >
-            Rebuild a mesh
-          </button>
-          <button
-            type="button"
-            :aria-selected="mode === 'text_to_mesh'"
-            :class="{ active: mode === 'text_to_mesh' }"
-            :disabled="!selectedModes.includes('text_to_mesh')"
-            @click="mode = 'text_to_mesh'"
-          >
-            Text to 3-D
-          </button>
-          <button
-            type="button"
-            :aria-selected="mode === 'mesh_texture'"
-            :class="{ active: mode === 'mesh_texture' }"
-            :disabled="!selectedModes.includes('mesh_texture')"
-            @click="mode = 'mesh_texture'"
-          >
-            Texture a mesh
-          </button>
-        </div>
-
-        <label>
-          3-D model
-          <select v-model="meshModelName" data-test="mesh-workflow-model">
-            <option
-              v-for="model in meshModels"
-              :key="model.name"
-              :value="model.name"
+            <button
+              type="button"
+              :aria-selected="mode === 'mesh_roundtrip'"
+              :class="{ active: mode === 'mesh_roundtrip' }"
+              :disabled="!selectedModes.includes('mesh_roundtrip')"
+              @click="mode = 'mesh_roundtrip'"
             >
-              {{ modelLabel(model) }}
-            </option>
-          </select>
-        </label>
+              Rebuild a mesh
+            </button>
+            <button
+              type="button"
+              :aria-selected="mode === 'text_to_mesh'"
+              :class="{ active: mode === 'text_to_mesh' }"
+              :disabled="!selectedModes.includes('text_to_mesh')"
+              @click="mode = 'text_to_mesh'"
+            >
+              Text to 3-D
+            </button>
+            <button
+              type="button"
+              :aria-selected="mode === 'mesh_texture'"
+              :class="{ active: mode === 'mesh_texture' }"
+              :disabled="!selectedModes.includes('mesh_texture')"
+              @click="mode = 'mesh_texture'"
+            >
+              Texture a mesh
+            </button>
+          </div>
 
-        <template v-if="mode === 'text_to_mesh'">
           <label>
-            Describe the object
-            <textarea
-              v-model="prompt"
-              rows="5"
-              placeholder="A hand-carved wooden fox, centered on a plain background"
-            />
-          </label>
-          <label>
-            Image model
-            <select v-model="imageModelName">
+            3-D style
+            <select v-model="meshModelName" data-test="mesh-workflow-model">
               <option
-                v-for="model in imageModels"
+                v-for="model in meshModels"
                 :key="model.name"
                 :value="model.name"
               >
@@ -506,102 +637,129 @@ onBeforeUnmount(() => {
               </option>
             </select>
           </label>
-          <label
-            v-if="textureAvailable"
-            class="mesh-studio__check"
-            data-test="mesh-workflow-texture"
-          >
-            <input v-model="texture" type="checkbox" />
-            Paint PBR materials after geometry
-          </label>
-          <p
-            v-else
-            class="mesh-studio__availability"
-            data-test="mesh-workflow-texture-unavailable"
-          >
-            PBR painting is unavailable on this machine. Geometry generation
-            remains available.
-          </p>
-        </template>
 
-        <template v-else>
-          <label class="mesh-studio__file">
-            Source mesh (GLB or OBJ)
-            <input
-              type="file"
-              accept=".glb,.obj,model/gltf-binary,model/obj"
-              @change="
-                meshFile =
-                  ($event.target as HTMLInputElement).files?.[0] ?? null
-              "
-            />
-            <span>{{ meshFile?.name || "Choose a mesh" }}</span>
-          </label>
-          <label v-if="mode === 'mesh_texture'" class="mesh-studio__file">
-            Appearance image
-            <input
-              type="file"
-              accept="image/png,image/jpeg,image/webp"
-              @change="
-                appearanceFile =
-                  ($event.target as HTMLInputElement).files?.[0] ?? null
-              "
-            />
-            <span>{{ appearanceFile?.name || "Choose an image" }}</span>
-          </label>
-          <div class="mesh-studio__row">
+          <template v-if="mode === 'text_to_mesh'">
             <label>
-              Up axis
-              <select v-model="upAxis">
-                <option value="y">Y up</option>
-                <option value="z">Z up</option>
-              </select>
-            </label>
-            <label>
-              Metres per unit
-              <input
-                v-model.number="metersPerUnit"
-                type="number"
-                min="0.000001"
-                max="1000000"
-                step="any"
+              Describe the object
+              <textarea
+                v-model="prompt"
+                rows="5"
+                placeholder="A hand-carved wooden fox, centered on a plain background"
               />
             </label>
-          </div>
-        </template>
+            <label>
+              Picture style
+              <select v-model="imageModelName">
+                <option
+                  v-for="model in imageModels"
+                  :key="model.name"
+                  :value="model.name"
+                >
+                  {{ modelLabel(model) }}
+                </option>
+              </select>
+            </label>
+            <label
+              v-if="textureAvailable"
+              class="mesh-studio__check"
+              data-test="mesh-workflow-texture"
+            >
+              <input v-model="texture" type="checkbox" />
+              Paint PBR materials after geometry
+            </label>
+            <p
+              v-else
+              class="mesh-studio__availability"
+              data-test="mesh-workflow-texture-unavailable"
+            >
+              PBR painting is unavailable on this machine. Geometry generation
+              remains available.
+            </p>
+          </template>
 
-        <label
-          v-if="(mode === 'text_to_mesh' && texture) || mode === 'mesh_texture'"
-        >
-          Texture size
-          <select v-model.number="textureResolution">
-            <option :value="1024">1024</option>
-            <option :value="2048">2048</option>
-            <option :value="4096">4096</option>
-          </select>
-        </label>
-        <label
-          v-if="delightAvailable && mode !== 'mesh_roundtrip'"
-          class="mesh-studio__check"
-        >
-          <input v-model="delight" type="checkbox" />
-          Remove baked lighting and highlights before building the mesh
-        </label>
-        <button
-          class="mesh-studio__primary"
-          type="submit"
-          :disabled="!canSubmit"
-        >
-          {{
-            busy
-              ? "Preparing…"
-              : mode === "text_to_mesh"
-                ? "Build 3-D object"
-                : mode === "mesh_roundtrip"
-                  ? "Rebuild mesh"
-                  : "Paint mesh"
-          }}
-        </button>
+          <template v-else>
+            <label class="mesh-studio__file">
+              Source mesh (GLB or OBJ)
+              <input
+                type="file"
+                accept=".glb,.obj,model/gltf-binary,model/obj"
+                @change="
+                  meshFile =
+                    ($event.target as HTMLInputElement).files?.[0] ?? null
+                "
+              />
+              <span>{{ meshFile?.name || "Choose a mesh" }}</span>
+            </label>
+            <label v-if="mode === 'mesh_texture'" class="mesh-studio__file">
+              Appearance image
+              <input
+                type="file"
+                accept="image/png,image/jpeg,image/webp"
+                @change="
+                  appearanceFile =
+                    ($event.target as HTMLInputElement).files?.[0] ?? null
+                "
+              />
+              <span>{{ appearanceFile?.name || "Choose an image" }}</span>
+            </label>
+            <div class="mesh-studio__row">
+              <label>
+                Up axis
+                <select v-model="upAxis">
+                  <option value="y">Y up</option>
+                  <option value="z">Z up</option>
+                </select>
+              </label>
+              <label>
+                Metres per unit
+                <input
+                  v-model.number="metersPerUnit"
+                  type="number"
+                  min="0.000001"
+                  max="1000000"
+                  step="any"
+                />
+              </label>
+            </div>
+          </template>
+
+          <label
+            v-if="
+              (mode === 'text_to_mesh' && texture) || mode === 'mesh_texture'
+            "
+          >
+            Texture size
+            <select v-model.number="textureResolution">
+              <option :value="1024">1024</option>
+              <option :value="2048">2048</option>
+              <option :value="4096">4096</option>
+            </select>
+          </label>
+          <label
+            v-if="delightAvailable && mode !== 'mesh_roundtrip'"
+            class="mesh-studio__check"
+          >
+            <input v-model="delight" type="checkbox" />
+            Remove baked lighting and highlights before building the mesh
+          </label>
+          <button
+            class="mesh-studio__primary"
+            type="submit"
+            :disabled="!canSubmit"
+          >
+            {{
+              busy
+                ? "Preparing…"
+                : desktop
+                  ? "Generate"
+                  : mode === "text_to_mesh"
+                    ? "Build 3-D object"
+                    : mode === "mesh_roundtrip"
+                      ? "Rebuild mesh"
+                      : "Paint mesh"
+            }}
+          </button>
+        </fieldset>
       </form>
 
       <article class="mesh-studio__result">
@@ -720,6 +878,9 @@ onBeforeUnmount(() => {
   border: 1px solid var(--mold-border);
   background: var(--mold-surface);
   padding: 20px;
+}
+.mesh-studio__fields {
+  display: contents;
 }
 .mesh-studio__composer {
   display: flex;
@@ -895,6 +1056,111 @@ onBeforeUnmount(() => {
   }
   .mesh-studio__result {
     min-height: 440px;
+  }
+}
+/* Desktop shares the 40px view toolbar and the standard right inspector. */
+.mesh-studio--desktop {
+  display: flex;
+  flex-direction: column;
+  padding: 0;
+  overflow: hidden;
+  min-width: 0;
+  background: var(--mold-canvas);
+}
+.mesh-studio--desktop .mesh-studio__header {
+  height: 40px;
+  flex-shrink: 0;
+  align-items: center;
+  flex-direction: row;
+  gap: 12px;
+  max-width: none;
+  width: 100%;
+  margin: 0;
+  padding: 0 12px;
+  border-bottom: var(--mold-bw) solid var(--mold-border);
+  background: var(--mold-bg-crust);
+}
+.mesh-studio--desktop .mesh-studio__header-actions {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  min-width: 0;
+  margin-left: auto;
+}
+.mesh-studio--desktop .mesh-studio__header-actions select {
+  width: auto;
+  max-width: 200px;
+}
+.mesh-studio--desktop .mesh-studio__grid {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  max-width: none;
+  grid-template-columns: minmax(0, 1fr) var(--mold-shell-inspector-w, 300px);
+  gap: 0;
+  margin: 0;
+}
+.mesh-studio--desktop .mesh-studio__composer {
+  grid-column: 2;
+  grid-row: 1;
+  min-height: 0;
+  overflow-y: auto;
+  gap: 16px;
+  padding: 16px;
+  border: 0;
+  border-left: var(--mold-bw) solid var(--mold-border);
+  background: var(--mold-bg-deep);
+}
+.mesh-studio--desktop .mesh-studio__result {
+  grid-column: 1;
+  grid-row: 1;
+  min-width: 0;
+  min-height: 0;
+  padding: 24px;
+  border: 0;
+  background: var(--mold-canvas);
+  overflow: auto;
+}
+.mesh-studio--desktop .mesh-studio__result :deep(.mesh-viewer) {
+  min-height: 0;
+  height: 100%;
+}
+.mesh-studio--desktop select,
+.mesh-studio--desktop input[type="number"] {
+  height: var(--mold-ctl-md);
+  padding: 0 8px;
+  font-size: var(--mold-fs-xs);
+}
+.mesh-studio--desktop textarea {
+  padding: 8px;
+  font-size: var(--mold-fs-sm);
+}
+.mesh-studio--desktop .mesh-studio__primary {
+  padding: 8px 12px;
+  font-size: var(--mold-fs-sm);
+  font-weight: 600;
+}
+.mesh-studio__owner {
+  font: var(--mold-fs-micro) var(--mold-font-mono);
+  color: var(--mold-text-2);
+}
+.mesh-studio--desktop .mesh-studio__error {
+  margin: 8px 12px;
+  flex-shrink: 0;
+}
+@media (max-width: 760px) {
+  .mesh-studio--desktop .mesh-studio__header {
+    height: auto;
+    min-height: 40px;
+    flex-wrap: wrap;
+    padding: 8px;
+  }
+  .mesh-studio--desktop .mesh-studio__header-actions {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+  .mesh-studio--desktop .mesh-studio__header-actions select {
+    max-width: 150px;
   }
 }
 </style>

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -393,7 +393,7 @@ watch(meshModelName, () => {
 });
 watch(selectedId, () => void refreshSelected());
 watch(
-  () => [props.target.baseUrl, props.target.apiKey],
+  [() => props.target.baseUrl, () => props.target.apiKey],
   () => void bootstrap(),
 );
 onMounted(() => void bootstrap());

--- a/studio/lib/meshWorkflowRouting.test.ts
+++ b/studio/lib/meshWorkflowRouting.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from "vitest";
+import { supportsMeshWorkflow } from "./meshWorkflowRouting";
+import type { WorkflowModel } from "./meshWorkflowAuthoring";
+
+const mesh: WorkflowModel = {
+  name: "hunyuan3d",
+  family: "hunyuan3d",
+  downloaded: true,
+  default_steps: 5,
+  default_guidance: 5,
+  default_width: 0,
+  default_height: 0,
+  generation_profile: {
+    default_recipe_id: "shape",
+    recipes: [
+      {
+        id: "shape",
+        capabilities: {
+          mesh: {
+            workflow_modes: ["text_to_mesh", "mesh_roundtrip", "mesh_texture"],
+            delight: { mode: "adjustable" },
+          },
+        },
+      },
+    ],
+  },
+};
+const image: WorkflowModel = {
+  ...mesh,
+  name: "z-image",
+  family: "z-image",
+  modality: "image",
+  generation_profile: null,
+};
+const request = {
+  mode: "text_to_mesh" as const,
+  meshModel: mesh.name,
+  imageModel: image.name,
+  texture: true,
+  delight: true,
+};
+
+describe("complete mesh workflow placement", () => {
+  it("requires the image and mesh stages on the same machine", () => {
+    expect(supportsMeshWorkflow([mesh, image], request)).toBe(true);
+    expect(supportsMeshWorkflow([mesh], request)).toBe(false);
+    expect(supportsMeshWorkflow([image], request)).toBe(false);
+  });
+  it("refuses unavailable runtimes and missing optional stage capabilities", () => {
+    expect(
+      supportsMeshWorkflow(
+        [{ ...mesh, runtime_available: false }, image],
+        request,
+      ),
+    ).toBe(false);
+    const shapeOnly = {
+      ...mesh,
+      generation_profile: {
+        default_recipe_id: "shape",
+        recipes: [
+          {
+            id: "shape",
+            capabilities: { mesh: { workflow_modes: ["text_to_mesh"] } },
+          },
+        ],
+      },
+    };
+    expect(supportsMeshWorkflow([shapeOnly, image], request)).toBe(false);
+    expect(
+      supportsMeshWorkflow([shapeOnly, image], {
+        ...request,
+        texture: false,
+        delight: false,
+      }),
+    ).toBe(true);
+    expect(
+      supportsMeshWorkflow([shapeOnly, image], { ...request, texture: false }),
+    ).toBe(false);
+  });
+  it("does not require an image generator when rebuilding a supplied mesh", () => {
+    expect(
+      supportsMeshWorkflow([mesh], { ...request, mode: "mesh_roundtrip" }),
+    ).toBe(true);
+  });
+});

--- a/studio/lib/meshWorkflowRouting.ts
+++ b/studio/lib/meshWorkflowRouting.ts
@@ -1,0 +1,53 @@
+import type { ApiTarget } from "../api/client";
+import {
+  isTextImageWorkflowModel,
+  meshWorkflowModes,
+  type WorkflowModel,
+} from "./meshWorkflowAuthoring";
+
+export interface MeshWorkflowRequirements {
+  mode: "text_to_mesh" | "mesh_roundtrip" | "mesh_texture";
+  meshModel: string;
+  imageModel?: string;
+  texture: boolean;
+  delight: boolean;
+}
+
+export interface MeshWorkflowRoute {
+  target: ApiTarget;
+  label: string;
+}
+
+/** All stages stay on one machine; a fleet-wide union is not an execution plan. */
+export function supportsMeshWorkflow(
+  models: readonly WorkflowModel[],
+  request: MeshWorkflowRequirements,
+): boolean {
+  const mesh = models.find((model) => model.name === request.meshModel);
+  if (
+    !mesh?.downloaded ||
+    mesh.runtime_available === false ||
+    mesh.family !== "hunyuan3d"
+  )
+    return false;
+  const modes = meshWorkflowModes(mesh);
+  if (
+    !modes.includes(request.mode) ||
+    (request.texture && !modes.includes("mesh_texture"))
+  )
+    return false;
+  if (request.delight) {
+    const profile = mesh.generation_profile;
+    const recipe = profile?.recipes.find(
+      (value) => value.id === profile.default_recipe_id,
+    );
+    if (recipe?.capabilities.mesh?.delight?.mode !== "adjustable") return false;
+  }
+  return (
+    request.mode !== "text_to_mesh" ||
+    models.some(
+      (model) =>
+        model.name === request.imageModel && isTextImageWorkflowModel(model),
+    )
+  );
+}

--- a/web/src/components/create/ActivityStrip.vue
+++ b/web/src/components/create/ActivityStrip.vue
@@ -548,7 +548,7 @@ const active = computed(
 
 .activity__error {
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   gap: 9px;
   border: 1px solid color-mix(in srgb, var(--stop) 45%, var(--edge));
   background: color-mix(in srgb, var(--stop) 10%, var(--bench));
@@ -573,6 +573,9 @@ const active = computed(
 }
 
 .activity__dismiss {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
   flex: 0 0 auto;
   border-radius: 4px;
   padding: 2px;

--- a/web/src/composables/useHostRouting.ts
+++ b/web/src/composables/useHostRouting.ts
@@ -141,7 +141,11 @@ export interface HostRouting {
   /** Host-RAM pressure for one machine, or null when it does not report it. */
   hostMemoryPressure: (hostId: string) => HostMemoryLevel | null;
   /** Resolve the concrete dispatch route for a model, or null if unreachable. */
-  resolve: (model: string | null) => HostRoute | null;
+  resolve: (
+    model: string | null,
+    eligibleHostIds?: readonly string[],
+  ) => HostRoute | null;
+  modelsForHost: (hostId: string) => ModelInfoExtended[];
   /** Resolve through each host's read-only authoritative scheduler preview. */
   resolveFeasible: (
     request: GenerateRequestWire,
@@ -780,7 +784,10 @@ function withReferenceUploads(route: HostRoute | null): HostRoute | null {
   };
 }
 
-function resolve(model: string | null): HostRoute | null {
+function resolve(
+  model: string | null,
+  eligibleHostIds?: readonly string[],
+): HostRoute | null {
   const selection = targetId.value;
   if (
     model &&
@@ -790,9 +797,11 @@ function resolve(model: string | null): HostRoute | null {
   ) {
     return null;
   }
-  const eligible = model
-    ? hosts.value.filter((host) => !accessRestrictionForHost(host.id, model))
-    : hosts.value;
+  const eligible = hosts.value.filter(
+    (host) =>
+      (!eligibleHostIds || eligibleHostIds.includes(host.id)) &&
+      (!model || !accessRestrictionForHost(host.id, model)),
+  );
   if (
     model &&
     (selection === AUTO_TARGET_ID || selection === CAPABLE_TARGET_ID) &&
@@ -1533,6 +1542,8 @@ export function useHostRouting(): HostRouting {
     queueStatus,
     hostMemoryPressure,
     resolve,
+    modelsForHost: (hostId: string) =>
+      accessibleModelsByHost.value[hostId] ?? [],
     resolveFeasible,
     revalidateFeasible,
     resolveFeasibleChain,

--- a/web/src/pages/MeshWorkflowPage.test.ts
+++ b/web/src/pages/MeshWorkflowPage.test.ts
@@ -22,6 +22,7 @@ vi.mock("../composables/useHostRouting", async () => {
     useHostRouting: () => ({
       hosts,
       targetId,
+      targetModels: ref([]),
       setTarget: (id: string) => {
         targetId.value = id;
       },

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -68,7 +68,10 @@ async function resolveTarget(requirements: MeshWorkflowRequirements) {
       "No selected machine can run all these 3-D stages. Choose styles installed together on one ready machine.",
     );
   return {
-    target: { baseUrl: route.target.baseUrl, apiKey: route.target.apiKey ?? null },
+    target: {
+      baseUrl: route.target.baseUrl,
+      apiKey: route.target.apiKey ?? null,
+    },
     label: route.label,
   };
 }

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -1,6 +1,12 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
+import CreateModelPicker from "../components/create/CreateModelPicker.vue";
+import {
+  supportsMeshWorkflow,
+  type MeshWorkflowRequirements,
+} from "@studio/lib/meshWorkflowRouting";
+import type { WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import MeshWorkflowHostPicker from "@studio/components/MeshWorkflowHostPicker.vue";
 import { useHostRouting } from "../composables/useHostRouting";
 import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
@@ -15,7 +21,7 @@ const selectedHost = computed(
 );
 const target = computed(() => {
   const host = selectedHost.value;
-  if (!host || (host.status !== "ready" && !host.stale)) return null;
+  if (!host) return null;
   return { baseUrl: host.url, apiKey: host.apiKey ?? null };
 });
 
@@ -37,8 +43,34 @@ watch(
 );
 
 function selectHost(id: string): void {
-  selectedHostId.value = id;
+  if (id !== AUTO_TARGET_ID && id !== CAPABLE_TARGET_ID)
+    selectedHostId.value = id;
   routing.setTarget(id);
+}
+
+function pickerModels(filtered: WorkflowModel[]) {
+  const names = new Set(filtered.map((model) => model.name));
+  return routing.targetModels.value.filter((model) => names.has(model.name));
+}
+async function resolveTarget(requirements: MeshWorkflowRequirements) {
+  await routing.refresh();
+  const eligible = routing.hosts.value
+    .filter(
+      (host) =>
+        host.status === "ready" &&
+        !host.stale &&
+        supportsMeshWorkflow(routing.modelsForHost(host.id), requirements),
+    )
+    .map((host) => host.id);
+  const route = routing.resolve(requirements.meshModel, eligible);
+  if (!route)
+    throw new Error(
+      "No selected machine can run all these 3-D stages. Choose styles installed together on one ready machine.",
+    );
+  return {
+    target: { baseUrl: route.target.baseUrl, apiKey: route.target.apiKey ?? null },
+    label: route.label,
+  };
 }
 
 function hostStatus(): string {
@@ -53,20 +85,41 @@ function hostStatus(): string {
 <template>
   <MeshWorkflowStudio
     v-if="target"
-    :key="`${selectedHostId}:${target.baseUrl}:${target.apiKey ?? ''}`"
     :target="target"
+    :available-models="routing.targetModels.value"
+    :resolve-target="resolveTarget"
+    :host-label="selectedHost?.label ?? ''"
   >
-    <template #machine>
+    <template #mesh-picker="{ models, selected, select }">
+      <CreateModelPicker
+        :models="pickerModels(models)"
+        :model="selected"
+        browse-to="/models?kind=mesh"
+        @select="(model) => select(model.name)"
+      />
+    </template>
+    <template #image-picker="{ models, selected, select }">
+      <CreateModelPicker
+        :models="pickerModels(models)"
+        :model="selected"
+        browse-to="/models?kind=image"
+        @select="(model) => select(model.name)"
+      />
+    </template>
+    <template #machine="{ busy }">
       <MeshWorkflowHostPicker
-        :model-value="selectedHostId"
+        :model-value="routing.targetId.value"
+        automatic
         :hosts="routing.hosts.value"
+        :disabled="busy"
         @update:model-value="selectHost"
       />
     </template>
   </MeshWorkflowStudio>
   <div v-else class="mesh-workflow-unavailable">
     <MeshWorkflowHostPicker
-      :model-value="selectedHostId"
+      :model-value="routing.targetId.value"
+      automatic
       :hosts="routing.hosts.value"
       @update:model-value="selectHost"
     />


### PR DESCRIPTION
## Summary

Fix Library video reuse and source-media recovery, add a persistent visible sound toggle, and keep desktop inspector actions inside their panel. Reuse now checks known mirrored copies for the retained source before reporting it missing, and paused queue entries load their saved settings from the job-detail endpoint.

Bring 3-D Studio into the surrounding app's layout and components: a resizable desktop inspector, filtered Generate/Create model pickers, shared switches and mode controls, and Auto/Most capable routing that keeps every stage on one eligible host. Telemetry no longer resets drafts or refetches unchanged results; host readiness refreshes inventory without clearing cached authoring choices. Fix text-to-mesh admission rejecting its own invalid future-image placeholder.

## Validation

- Frontend architecture checks, full Studio/web/desktop test suites, desktop/web/mobile builds, Rust formatting, and the targeted Rust admission regression passed.
- Real isolated Plato GPU UAT completed From words, Rebuild, and two Add texture workflows, including matting, delight, paint, and GLB publication.
- Native macOS WKWebView UAT verified the reported NYC video's context-menu reuse restores its original source without a warning, mute synchronization, wrapped actions, persistent inspector resizing, filtered pickers, native uploads/submission, and textured GLB rendering. Web and mobile viewers also rendered the real outputs.
- Instrumented repeat UAT verified intermediate paint progress through all 15 steps; the earlier stale-label observation was not reproduced.
- Independent Claude Sonnet review completed; its valid redundant preference-write finding was fixed and reviewed again. Regression coverage includes queue-detail failures and owner-specific cancel/resume.

Evidence and qualification boundaries: `docs/qualification/desktop-library-cleanup-2026-09-08.md`. Production services and existing paused jobs were not changed by UAT. Physical phone hardware and release installer delivery were not tested.

CI follow-up: Android boot-ANR evidence now uses file capture and `adb pull`, avoiding the default 1 MB child-process stdout limit. The temporary device file is removed after transfer. Claude reviewed this harness fix; application assertions are unchanged.
