### PR TITLE
fix(build): pin candle to the revision the cuDNN corrections shipped in

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -554,7 +554,7 @@ dependencies = [
 [[package]]
 name = "candle-core-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -585,7 +585,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -596,7 +596,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "cudaforge",
 ]
@@ -604,7 +604,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels-mold"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "block2",
  "half",
@@ -619,7 +619,7 @@ dependencies = [
 [[package]]
 name = "candle-nn-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "candle-core-mold",
  "candle-metal-kernels-mold",
@@ -636,7 +636,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "candle-core-mold",
  "candle-nn-mold",
@@ -647,7 +647,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "byteorder",
  "candle-core-mold",
@@ -665,7 +665,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/crates/mold-candle/Cargo.toml
+++ b/crates/mold-candle/Cargo.toml
@@ -36,9 +36,9 @@ h3-private-uat = []
 flash-attn = ["dep:candle-flash-attn", "cuda"]
 
 [dependencies]
-candle = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
+candle = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
 half = "2"
 # Already vendored transitively through candle-core, so this adds no new crates
 # to the Nix vendor set. `float8` must resolve to the same version candle uses
@@ -51,7 +51,7 @@ float8 = "0.7"
 # call site stops typechecking (#1399). The fork's payload at this revision is
 # upstream 0.11.0 with only that package rename applied, so the H3 runtime
 # fingerprint still qualifies the exact kernel it always did.
-candle-flash-attn = { git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8", optional = true }
+candle-flash-attn = { git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 sha2 = "0.10"

--- a/crates/mold-candle/src/minimax_h3/attention.rs
+++ b/crates/mold-candle/src/minimax_h3/attention.rs
@@ -52,8 +52,8 @@ pub const H3_FLASH_ATTN_PACKAGE_VERSION: &str = "0.11.0";
 /// record naming a payload that was not compiled is worse than none.
 pub const H3_FLASH_ATTN_SOURCE: &str = concat!(
     "git+https://github.com/utensils/candle.git",
-    "?rev=c34de9b7c16aa92ed159982128954562b7c16ab8",
-    "#c34de9b7c16aa92ed159982128954562b7c16ab8"
+    "?rev=bf2cd29a791dbc053df826b4377d092c3809d17f",
+    "#bf2cd29a791dbc053df826b4377d092c3809d17f"
 );
 pub const H3_FLASH_ATTN_QUALIFIED_COMPUTE_CAPABILITY: (u16, u16) = (8, 9);
 /// v2 (#1399): the archive-checksum field became the source-identity field.

--- a/crates/mold-inference/Cargo.toml
+++ b/crates/mold-inference/Cargo.toml
@@ -174,22 +174,22 @@ mold-catalog = { path = "../mold-catalog", package = "mold-ai-catalog", version 
 mold-candle = { path = "../mold-candle", package = "mold-ai-candle", version = "0.28.0" }
 anyhow = "1"
 zip = { version = "8.6", default-features = false }
-candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
+candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
 cudarc = { version = "0.19.8", default-features = false, features = ["driver"], optional = true }
 # Optional flash-attention v2. Pulled in only by the `flash-attn` feature.
 #
 # Pinned to the same fork revision as every other candle crate above, so its
 # `Tensor` type is identical to ours. A crates.io `candle-flash-attn` depends
 # on the upstream-named `candle-core` and breaks the CUDA build (#1399).
-candle-flash-attn = { git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8", optional = true }
+candle-flash-attn = { git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f", optional = true }
 # ONNX protobuf support for the hand-ported U²-Net and InsightFace models.
 # Pinned to the same fork revision as every other candle crate above, so its
 # `Tensor` type is identical to ours. CPU-only by
 # construction: `candle-onnx`'s `get_tensor` materializes every initializer on
 # `Device::Cpu` (candle-onnx/src/eval.rs:191-232).
-candle-onnx = { git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8", optional = true }
+candle-onnx = { git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f", optional = true }
 # `candle-onnx` does not re-export `prost`, and mold decodes the `ModelProto`
 # from a retained descriptor rather than through that crate's path-based
 # `read_file`. Same 0.14 release candle-onnx builds against, so cargo unifies

--- a/crates/mold-server/Cargo.toml
+++ b/crates/mold-server/Cargo.toml
@@ -149,6 +149,6 @@ mp4-rs = { package = "mp4", version = "0.14" }
 # Chain route tests build a synthetic motion-tail Tensor via the same
 # candle APIs the inference crate uses — keep this in lockstep with
 # Keep server tests on the same patched official Candle identity as inference.
-candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
+candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
 # Live-search integration tests stub Civitai with a wiremock server.
 wiremock = "0.6"

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -725,7 +725,7 @@ dependencies = [
 [[package]]
 name = "candle-core-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "byteorder",
  "candle-kernels",
@@ -756,7 +756,7 @@ dependencies = [
 [[package]]
 name = "candle-flash-attn"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "anyhow",
  "candle-core-mold",
@@ -767,7 +767,7 @@ dependencies = [
 [[package]]
 name = "candle-kernels"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "cudaforge",
 ]
@@ -775,7 +775,7 @@ dependencies = [
 [[package]]
 name = "candle-metal-kernels-mold"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "block2",
  "half",
@@ -790,7 +790,7 @@ dependencies = [
 [[package]]
 name = "candle-nn-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "candle-core-mold",
  "candle-metal-kernels-mold",
@@ -807,7 +807,7 @@ dependencies = [
 [[package]]
 name = "candle-onnx"
 version = "0.11.0"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "candle-core-mold",
  "candle-nn-mold",
@@ -818,7 +818,7 @@ dependencies = [
 [[package]]
 name = "candle-transformers-mold"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "byteorder",
  "candle-core-mold",
@@ -836,7 +836,7 @@ dependencies = [
 [[package]]
 name = "candle-ug"
 version = "0.11.1"
-source = "git+https://github.com/utensils/candle.git?rev=c34de9b7c16aa92ed159982128954562b7c16ab8#c34de9b7c16aa92ed159982128954562b7c16ab8"
+source = "git+https://github.com/utensils/candle.git?rev=bf2cd29a791dbc053df826b4377d092c3809d17f#bf2cd29a791dbc053df826b4377d092c3809d17f"
 dependencies = [
  "ug",
  "ug-cuda",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -167,7 +167,7 @@ mold-inference = { path = "../../crates/mold-inference", package = "mold-ai-infe
 # TEMPORARY: mirror the root workspace's same-name compatibility patch because
 # this standalone Cargo root owns an independent dependency graph.
 [patch.crates-io]
-candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
-candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "c34de9b7c16aa92ed159982128954562b7c16ab8" }
+candle-core = { package = "candle-core-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-nn = { package = "candle-nn-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
+candle-transformers = { package = "candle-transformers-mold", git = "https://github.com/utensils/candle.git", rev = "bf2cd29a791dbc053df826b4377d092c3809d17f" }
 cudarc = { git = "https://github.com/utensils/cudarc", rev = "9b3b1bc276bc27c3e99343ee82db7f99705b9ed5" }

--- a/docs/architecture/candle-extension.md
+++ b/docs/architecture/candle-extension.md
@@ -105,7 +105,7 @@ jobs. release-plz retains version PRs and tags with registry publishing disabled
 ## Compatibility revision lifecycle
 
 The current compatibility source is revision
-`c34de9b7c16aa92ed159982128954562b7c16ab8` of `utensils/candle`, which contains
+`bf2cd29a791dbc053df826b4377d092c3809d17f` of `utensils/candle`, which contains
 the renamed `candle-core-mold` / `candle-nn-mold` / `candle-transformers-mold`
 packages every Mold cargo root pins. No manifest names a branch — the identity
 script rejects a `branch =` source outright — so moving the compatibility source

--- a/docs/qualification/hunyuan3d-campaign.md
+++ b/docs/qualification/hunyuan3d-campaign.md
@@ -638,7 +638,17 @@ it is not a completion checklist with assumed passes.
   including H3 payload provenance. The Nix source hash is
   `sha256-CREJfuti4jbOkCce8ywfGjtdquCGjW0QQqQr9WUpvJQ=`; the same archive-prefetch
   method reproduced the previous pinned hash before computing this one.
-  `candle-cudnn-pin-contract-v1.log` passes the single-identity contract. The
+  `candle-cudnn-pin-contract-v1.log` passes the single-identity contract.
+- **Correction (2026-09-08).** The pin above held on the campaign branch only.
+  The merge that shipped this work to `main` (#1620) carried the consumer code,
+  the rules entry and this record, but pinned Candle `c34de9b7`, which contains
+  neither correction — so both were inert on every CUDA build from that merge
+  until the pin was moved to the merge commit
+  `bf2cd29a791dbc053df826b4377d092c3809d17f`, Nix archive hash
+  `sha256-yCwX+XdtJKY6oXp++9d9kw6opSJlRHV69Khc9LwaSQo=`. Neither
+  `sha256-CREJfuti4jbOkCce8ywfGjtdquCGjW0QQqQr9WUpvJQ=` above nor
+  `sha256-9Q+34Aow5+d9xzz6uedU6zTbKYtyOugbUEOyXRCnLbU=` below was ever the
+  shipped hash. The
   independent real512 Torch VAE comparison remains required after this backend
   correction; the numerical regression alone does not close it.
 
@@ -1087,7 +1097,9 @@ it is not a completion checklist with assumed passes.
 - All dependency declarations, both Candle-containing lockfiles, and H3's
   backend provenance point to that commit. The Nix source archive hash is
   `sha256-9Q+34Aow5+d9xzz6uedU6zTbKYtyOugbUEOyXRCnLbU=`. Single-Candle identity,
-  desktop lock sync and desktop Nix source-hash contracts pass. Full upscaler
+  desktop lock sync and desktop Nix source-hash contracts pass. (Campaign branch only —
+  see the 2026-09-08 correction above; the revision that actually shipped is
+  the merge `bf2cd29a791dbc053df826b4377d092c3809d17f`.) Full upscaler
   comparison against the original unsubstituted oracle remains the exit gate.
 - That original-oracle comparison now passes on both full 512-to-2048 view-00
   streams. Albedo (`paint-upscaler-explicit-first-albedo00-v1`) has zero error

--- a/flake.nix
+++ b/flake.nix
@@ -618,7 +618,7 @@
               cargoLock = {
                 lockFile = ./desktop/src-tauri/Cargo.lock;
                 outputHashes = {
-                  "candle-core-mold-0.11.1" = "sha256-gInEf6Y3muHf+uzg974bfoSFJMhKoOqkz1aNjgXHduI=";
+                  "candle-core-mold-0.11.1" = "sha256-yCwX+XdtJKY6oXp++9d9kw6opSJlRHV69Khc9LwaSQo=";
                   "cudarc-0.19.8" = "sha256-ARnabIhBCzahrk/kVCt5084gftGDyCBme3jxg+mvkUA=";
                 };
               };


### PR DESCRIPTION
Moves the candle pin from `c34de9b7` to `bf2cd29a` (utensils/candle#14), which
carries two cuDNN convolution corrections mold's code and docs already assume.

## The problem

PR #1620 shipped the consumer side of the Hunyuan3D paint campaign's cuDNN work
— `rrdbnet.rs`'s explicit algorithm selection, the `.claude/rules/inference.md`
invariant, the changelog note, and the campaign qualification record — but
pinned candle at `c34de9b7`, which contains neither correction. The pin never
pointed at the revision the work was qualified against, so both behaviors were
inert on every CUDA build since.

`docs/qualification/hunyuan3d-campaign.md:1082` states "all dependency
declarations, both Candle-containing lockfiles, and H3's backend provenance
point to that commit". They did not.

### 1. The explicit cuDNN algorithm dispatched nothing

`rrdbnet.rs:145` asks for `ImplicitPrecompGemm` on Real-ESRGAN's first
convolution to avoid an im2col rounding difference that, in its own comment,
"amplif[ies] through all 23 RRDBs". At the pinned revision the CUDA dispatch arm
never read the field:

```rust
if crate::cudnn_policy::is_enabled() && cudnn_is_worth_it_2d(params, self.dtype()) {
```

That convolution is 3-channel with a 3x3 kernel, so its column buffer is
`27 x H x W` — 7.1M elements at the default 512-pixel tile, against a 35M
half-precision threshold. It cannot clear it at any supported tile size, so the
request was discarded on every run. The upscaler runs F16 on GPU
(`upscaler/engine.rs:636`), so the second defect compounded on the same path.

### 2. Half convolutions accumulated in half

Torch promotes HALF convolution compute to FLOAT while keeping HALF storage on
both of its cuDNN routes (`aten/src/ATen/cudnn/Descriptors.h:202-205`,
`native/cudnn/Conv_v8.cpp:124-129`). Candle passed `f16` as the compute type;
a tensor-op math mode does not promote the compute descriptor.

## Verification

Candle's CI is CPU-only `cargo check` and never reaches these paths, so the
suite was run on hardware — 4x NVIDIA L40S, driver 595.71.05.

Against the **old pinned** `c34de9b7`, with only the new tests applied and no
source changes:

```
assertion `left == right` failed: explicit algorithm was ignored below the threshold
  left: 0
 right: 1

F16 cuDNN accumulation relative deviation: 0.010695187

test result: FAILED. 9 passed; 3 failed
```

`left: 0` is the substantive result: an explicitly requested algorithm
dispatched cuDNN zero times. The `.010695187` deviation reproduces the figure
recorded at `docs/qualification/hunyuan3d-campaign.md:630` when this was first
qualified.

Against the **new pin**: `test result: ok. 12 passed; 0 failed`.

In this repo: `cargo check --workspace --all-targets` clean,
`scripts/tests/candle-single-identity.sh` passes on all three lockfiles.

## Blast radius

`ConvPolicy::Video` (Wan, LTX) and `ConvPolicy::Paint` select cuDNN;
`ConvPolicy::Image` stays on im2col. So convolution numerics move toward the
Torch reference for video VAE decode and Hunyuan3D paint on CUDA builds, and
still-image generation is byte-for-byte unchanged.

## Not closed by this

The paint qualification gates were recorded against these commits, so this
restores the configuration they were measured under — it does not re-run them.
The real512 VAE bound was still failing in those notes and remains open.

## Docs corrected here

- `docs/architecture/candle-extension.md:107` named the old revision as "the
  current compatibility source" — the only stale SHA left in the repo.
- `docs/qualification/hunyuan3d-campaign.md` asserted twice that "all
  dependency declarations, both Candle-containing lockfiles, and H3's backend
  provenance point to that commit", naming two Nix hashes that were never
  shipped. Those claims held on the campaign branch only. Rather than rewrite
  an evidence record, a dated correction is appended to each.

## No changelog fragment

`changelog.d/hunyuan3d-campaign.md` is still unassembled and already carries
both notes ("CUDA half-precision convolutions", "Real-ESRGAN cuDNN dispatch").
Neither has reached a released section, so no user ever saw the broken claim,
and a "Fixed" bullet here would contradict two "Added" bullets in the same
release. Labelled `skip-changelog`; this PR makes the existing notes true.

## Nix hash

`sha256-yCwX+XdtJKY6oXp++9d9kw6opSJlRHV69Khc9LwaSQo=`, computed with
`nix store prefetch-file --unpack` on the GitHub archive. The method was
validated first by reproducing the outgoing `sha256-gInEf6…` for `c34de9b7`.

https://claude.ai/code/session_01S1PVcju7evhKq3t9tEFXiW
