### PR TITLE
fix(hunyuan3d): preserve source bytes in delight requests

### DIFF
--- a/changelog.d/hunyuan3d-delight-source-image.md
+++ b/changelog.d/hunyuan3d-delight-source-image.md
@@ -1,0 +1,1 @@
+- **Fix Hunyuan3D lighting removal.** Requests with lighting removal enabled no longer fail with `invalid type: sequence, expected a string` while preparing the source image for the delight stage.

--- a/crates/mold-inference/src/hunyuan3d/delight.rs
+++ b/crates/mold-inference/src/hunyuan3d/delight.rs
@@ -266,22 +266,7 @@ pub(crate) fn delight_rgba(
     source: &RgbaImage,
     progress: &crate::progress::ProgressReporter,
 ) -> Result<RgbaImage> {
-    let mut bytes = std::io::Cursor::new(Vec::new());
-    image::DynamicImage::ImageRgba8(source.clone())
-        .write_to(&mut bytes, image::ImageFormat::Png)
-        .context("encode matted input for delight")?;
-    let request: GenerateRequest = serde_json::from_value(serde_json::json!({
-        "prompt": "",
-        "model": mold_core::manifest::HUNYUAN3D_DELIGHT_MANIFEST,
-        "width": SIZE,
-        "height": SIZE,
-        "steps": STEPS,
-        "guidance": 1.0,
-        "seed": SEED,
-        "scheduler": "euler-ancestral",
-        "output_format": "png",
-        "source_image": bytes.into_inner()
-    }))?;
+    let request = delight_request(source)?;
     let loaded = load_delight(paths, gpu_ordinal, progress)?;
     let response = generate_loaded(&loaded, &request, progress)?;
     let image = response
@@ -292,6 +277,28 @@ pub(crate) fn delight_rgba(
     Ok(image::load_from_memory(&image.data)
         .context("decode delighted intermediate")?
         .to_rgba8())
+}
+
+fn delight_request(source: &RgbaImage) -> Result<GenerateRequest> {
+    let mut bytes = std::io::Cursor::new(Vec::new());
+    image::DynamicImage::ImageRgba8(source.clone())
+        .write_to(&mut bytes, image::ImageFormat::Png)
+        .context("encode matted input for delight")?;
+    let mut request: GenerateRequest = serde_json::from_value(serde_json::json!({
+        "prompt": "",
+        "model": mold_core::manifest::HUNYUAN3D_DELIGHT_MANIFEST,
+        "width": SIZE,
+        "height": SIZE,
+        "steps": STEPS,
+        "guidance": 1.0,
+        "seed": SEED,
+        "scheduler": "euler-ancestral",
+        "output_format": "png"
+    }))?;
+    // The wire schema accepts base64 strings, not JSON arrays of byte values.
+    // This internal PNG already has the typed representation we need.
+    request.source_image = Some(bytes.into_inner());
+    Ok(request)
 }
 
 fn load_delight(
@@ -485,6 +492,31 @@ impl InferenceEngine for DelightEngine {
 #[cfg(test)]
 mod tests {
     use super::*;
+    #[test]
+    fn delight_request_preserves_rgba_source_and_pinned_recipe() {
+        let source = RgbaImage::from_fn(3, 2, |x, y| {
+            image::Rgba([x as u8 * 70, y as u8 * 90, 123, (x + y) as u8 * 50])
+        });
+        let request = delight_request(&source).expect("build internal delight request");
+        let bytes = request.source_image.as_ref().expect("source PNG");
+        assert_eq!(image::load_from_memory(bytes).unwrap().to_rgba8(), source);
+        assert_eq!(request.prompt, "");
+        assert_eq!(
+            request.model,
+            mold_core::manifest::HUNYUAN3D_DELIGHT_MANIFEST
+        );
+        assert_eq!((request.width, request.height), (SIZE, SIZE));
+        assert_eq!(request.steps, STEPS);
+        assert_eq!(request.guidance, 1.0);
+        assert_eq!(request.seed, Some(SEED));
+        assert_eq!(request.scheduler, Some(Scheduler::EulerAncestral));
+        assert_eq!(request.output_format, Some(OutputFormat::Png));
+        let wire = serde_json::to_value(&request).unwrap();
+        assert!(wire["source_image"].is_string());
+        let restored: GenerateRequest = serde_json::from_value(wire).unwrap();
+        assert_eq!(restored.source_image, request.source_image);
+    }
+
     #[test]
     fn alpha_erosion_matches_a_three_by_three_min_filter() {
         let mut image = RgbaImage::from_pixel(SIZE, SIZE, image::Rgba([0, 0, 0, 255]));


### PR DESCRIPTION
Hunyuan3D requests with lighting removal enabled fail before the delight model runs with `generation error: invalid type: sequence, expected a string`. The internal request builder inserted PNG bytes into `json!`, producing a numeric array, while `GenerateRequest.source_image` deserializes a base64 string. The affected held request on Plato had `mesh.delight: true`.

Attach the encoded PNG directly to the typed request after constructing the fixed recipe. Extract request preparation so a CPU-only regression test exercises the production path, preserves RGBA pixels and the pinned recipe, and checks the public base64 serialization round-trip. Add a release note.

Validation:
- All applicable CI checks passed on `9843b747efce8886ecd2c8ca145941b66a3860c7`: Rust, Windows, Metal, desktop, and changelog. The Rust job also passed the full Hunyuan3D mesh test suite and feature-enabled Clippy.
- Independent sub-agent peer review approved the final diff with no findings.
- New regression failed before the fix with the exact reported error.
- All four delight tests passed with `cargo +1.95.0 test -p mold-ai-inference --lib --features mesh-delight hunyuan3d::delight`.
- `cargo +1.95.0 clippy -p mold-ai-inference --features mesh-delight --lib -- -D warnings` passed.
- `cargo +1.95.0 fmt --all -- --check` and `git diff --check` passed.
- The unchanged recipe was checked against Tencent's [dehighlight implementation](https://github.com/Tencent-Hunyuan/Hunyuan3D-2/blob/f8db63096c8282cb27354314d896feba5ba6ff8a/hy3dgen/texgen/utils/dehighlight_utils.py#L93-L102).

No generation was launched and the held production job was left intact.
