### PR TITLE
fix(studio): keep the 3-D Studio's draft, filters and routing honest

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -142,6 +142,25 @@ the model controls, and the length slider. A sequence is now something you scrip
   feature remains CUDA-only), guarded by the PR-native feature graph and the
   desktop distribution contract test.
 
+- **A print knows which 3-D workflow made it.** Every stage of a durable mesh
+  workflow is admitted as an ORDINARY generation, so its queue row and its
+  published print are otherwise indistinguishable from a hand-authored render:
+  the row routed to New image, which cannot resume a workflow, and a
+  text-to-3-D run left its source picture, its matted and delighted copies and
+  its mesh in the gallery as four unrelated prints. `MeshWorkflowProvenance`
+  (`job_id`, `mode`, `role`, `stage_index`) is stamped in
+  `mesh_workflow_runner::admit_child`, the one place that knows both the
+  workflow and the stage. It rides `GenerateRequest`, so the live queue entry —
+  whose `metadata` IS the request — and the finished print carry the same
+  answer, and `queue_media`'s exhaustive sanitizer retains it so a replayed
+  stage still publishes into the run that owns it. It is server-minted and
+  REFUSED on `/api/generate`, `/api/generate/stream` and
+  `/api/generation-batches`: a client able to mint it could route another
+  person's queue row into the 3-D Studio and file a stranger's print inside
+  their run. `studio/lib/meshWorkflowProvenance.ts` is the one client reading —
+  `role: "final_glb"` is the run's LEAD, and ABSENCE is an ordinary print or an
+  older host, never a refusal.
+
 - **Background matting is profile-driven and its transformed inputs are durable private media.** `capabilities.mesh.matting` is the one Auto/On/Off contract every authoring surface reads. Auto preserves useful alpha and otherwise runs the pinned pure-Rust U²-Net stage before shape weights load; On always recomputes and Off preserves the historical pixels. Processed PNGs never enter the public response or GLB: a durable job seals them under its purpose-keyed `generation_queue_derived_media` obligation before gallery publication, hands every authored and derived set to the same archive identity, and exposes the processed roles for authenticated download while refusing them for request reuse so matting cannot be applied twice. Cancellation, held-row retention, startup reconciliation, gallery deletion, and queue settlement cover all attached sets.
 
 - **Delight is a fixed durable preprocessing stage.** `capabilities.mesh.delight` is the only client gate. When true, the scheduler runs the hidden `hunyuan3d-delight:fp16` worker after matting and before shape or paint, using Tencent's exact 512²/50-step Euler ancestral/seed-42/guidance-1 InstructPix2Pix recipe. Its eight-channel UNet concatenates the unscaled VAE posterior mode with the noisy latent; applying the VAE decode scale to that conditioning erases the source. The delighted PNG is retained as its own `delighted_image` artifact and becomes the sole image handed to the next stage. Direct Hunyuan3D requests run the same matting-then-delight order before loading shape or paint weights.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,8 +158,15 @@ the model controls, and the length slider. A sequence is now something you scrip
   `/api/generation-batches`: a client able to mint it could route another
   person's queue row into the 3-D Studio and file a stranger's print inside
   their run. `studio/lib/meshWorkflowProvenance.ts` is the one client reading —
-  `role: "final_glb"` is the run's LEAD, and ABSENCE is an ordinary print or an
-  older host, never a refusal.
+  `role: "final_glb"` names the run's LEAD, and ABSENCE is an ordinary print or
+  an older host, never a refusal.
+
+  What reads it TODAY is the routing: a workflow's queue row opens
+  `/create/3d?workflow=<id>&host=<hostId>` rather than New image, which cannot
+  resume a durable workflow at all. The host rides the link because a workflow
+  lives on ONE machine. Collapsing a run's several prints into one gallery item
+  led by the mesh is what the `final_glb` lead EXISTS for and is not yet
+  wired — the Library still draws every stage's print as its own tile.
 
 - **Background matting is profile-driven and its transformed inputs are durable private media.** `capabilities.mesh.matting` is the one Auto/On/Off contract every authoring surface reads. Auto preserves useful alpha and otherwise runs the pinned pure-Rust U²-Net stage before shape weights load; On always recomputes and Off preserves the historical pixels. Processed PNGs never enter the public response or GLB: a durable job seals them under its purpose-keyed `generation_queue_derived_media` obligation before gallery publication, hands every authored and derived set to the same archive identity, and exposes the processed roles for authenticated download while refusing them for request reuse so matting cannot be applied twice. Cancellation, held-row retention, startup reconciliation, gallery deletion, and queue settlement cover all attached sets.
 

--- a/changelog.d/3d-studio-correctness.md
+++ b/changelog.d/3d-studio-correctness.md
@@ -8,7 +8,9 @@
   land on New image under its 3-D section, which cannot resume a durable
   workflow at all — its stages, Cancel, Resume and history live only in the
   Studio. Prints and queue rows made by a workflow now carry which workflow
-  made them, and every door routes there.
+  made them and which machine ran them, and every door routes there — a
+  workflow on another machine opens against that machine, not whichever one
+  the studio was last browsing.
 - **⌘↩ generates in the 3-D Studio.** It used to leave the view and render a
   picture in New image while the status bar advertised the shortcut as though
   it worked.

--- a/changelog.d/3d-studio-correctness.md
+++ b/changelog.d/3d-studio-correctness.md
@@ -15,6 +15,8 @@
   picture in New image while the status bar advertised the shortcut as though
   it worked.
 - **Picture style offers only picture styles.** The text-to-3-D image stage
-  listed LTX-2, Wan and MiniMax H3 among its still-picture candidates; it now
-  reads the same style partition the New image section strip and the Styles
-  kind filter use.
+  listed LTX-2, Wan and MiniMax H3 among its still-picture candidates, and also
+  the prompt-expansion LLM and the upscalers — none of which can draw a
+  picture. It now reads the same style partition the New image section strip
+  and the Styles kind filter use, plus one shared answer to "is this a style at
+  all" that the desktop and web pickers had been answering separately.

--- a/changelog.d/3d-studio-correctness.md
+++ b/changelog.d/3d-studio-correctness.md
@@ -1,0 +1,18 @@
+- **The 3-D Studio keeps what you were making.** Leaving for the Queue, My
+  images or Settings and coming back no longer clears the description, the
+  chosen styles, the attached mesh, the stage settings or the machine the
+  workflow is pinned to. The draft also survives a restart; an attached file
+  does not, and the well says so rather than promising bytes the next launch
+  cannot read.
+- **A 3-D workflow's queue row opens the 3-D Studio.** Clicking one used to
+  land on New image under its 3-D section, which cannot resume a durable
+  workflow at all — its stages, Cancel, Resume and history live only in the
+  Studio. Prints and queue rows made by a workflow now carry which workflow
+  made them, and every door routes there.
+- **⌘↩ generates in the 3-D Studio.** It used to leave the view and render a
+  picture in New image while the status bar advertised the shortcut as though
+  it worked.
+- **Picture style offers only picture styles.** The text-to-3-D image stage
+  listed LTX-2, Wan and MiniMax H3 among its still-picture candidates; it now
+  reads the same style partition the New image section strip and the Styles
+  kind filter use.

--- a/crates/mold-cli/src/commands/generate.rs
+++ b/crates/mold-cli/src/commands/generate.rs
@@ -1313,6 +1313,8 @@ pub async fn run(
                     })?;
                     let control = ic_lora_control.clone().unwrap_or_else(|| "hdr".to_string());
                     let mut probe_req = GenerateRequest {
+                        // The CLI authors one-shots; 3-D workflows are a Studio surface.
+                        mesh_workflow: None,
                         offload: offload.then_some(true),
                         mesh: None,
                         video_only: None,
@@ -1500,6 +1502,8 @@ pub async fn run(
     }
 
     let mut req = GenerateRequest {
+        // The CLI authors one-shots; 3-D workflows are a Studio surface.
+        mesh_workflow: None,
         offload: offload.then_some(true),
         mesh: mesh_options,
         collection: resolved_filing.collection,

--- a/crates/mold-cli/src/commands/mcp.rs
+++ b/crates/mold-cli/src/commands/mcp.rs
@@ -2846,6 +2846,8 @@ fn build_generate_request(
     }
 
     Ok(GenerateRequest {
+        // The CLI authors one-shots; 3-D workflows are a Studio surface.
+        mesh_workflow: None,
         offload: None,
         mesh: None,
         video_only: None,
@@ -6292,6 +6294,7 @@ mod tests {
     async fn async_job_registry_tracks_completed_image() {
         let jobs = AsyncJobRegistry::default();
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -6424,6 +6427,7 @@ mod tests {
         GalleryImage {
             filename: filename.into(),
             metadata: mold_core::OutputMetadata {
+                mesh_workflow: None,
                 video_only: None,
                 attention_path: None,
                 int8_arm: None,

--- a/crates/mold-cli/src/commands/runpod.rs
+++ b/crates/mold-cli/src/commands/runpod.rs
@@ -1764,6 +1764,8 @@ pub async fn run_run(opts: RunOptions) -> Result<()> {
         .clone()
         .or_else(|| config.default_negative_prompt.clone());
     let req = mold_core::GenerateRequest {
+        // The CLI authors one-shots; 3-D workflows are a Studio surface.
+        mesh_workflow: None,
         offload: None,
         mesh: None,
         video_only: None,

--- a/crates/mold-core/src/chain.rs
+++ b/crates/mold-core/src/chain.rs
@@ -857,6 +857,8 @@ impl ChainRequest {
             offload: self.offload,
             mesh: None,
             video_only: None,
+            // A sequence is not a 3-D workflow stage.
+            mesh_workflow: None,
             // A sequence has exactly one gallery print — the stitched output.
             // Its title and filing come from the chain request and ride the
             // same `OutputMetadata` plumbing as a one-shot's, which is why

--- a/crates/mold-core/src/mesh_workflow.rs
+++ b/crates/mold-core/src/mesh_workflow.rs
@@ -156,6 +156,75 @@ impl std::str::FromStr for MeshWorkflowJobState {
     }
 }
 
+/// Which durable 3-D workflow produced a piece of work, and the part it plays
+/// in it.
+///
+/// Every stage of a workflow is admitted as an ORDINARY generation, so without
+/// this the queue row and the finished print are indistinguishable from a
+/// hand-authored render: a queue row could only route back to New image, and a
+/// text-to-3-D run left its source picture, its matted and delighted copies and
+/// its mesh in the gallery as four unrelated prints. It rides
+/// [`crate::GenerateRequest`] and is copied onto [`crate::OutputMetadata`], so
+/// the live queue entry (whose `metadata` IS the request) and the published
+/// print carry the same answer.
+///
+/// Server-minted in the workflow runner and REFUSED on a public request — a
+/// client that could stamp it would forge a print into someone's workflow.
+/// Additive: absent on every print made outside the 3-D Studio, on every print
+/// made before this field, and on every older host.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
+pub struct MeshWorkflowProvenance {
+    /// The durable job under `/api/mesh-workflows`.
+    pub job_id: String,
+    /// The authored workflow shape: `text_to_mesh`, `mesh_roundtrip`, or
+    /// `mesh_texture`. A value this build does not know is still displayable.
+    pub mode: String,
+    /// The artifact role this output fills, the same vocabulary
+    /// [`MeshWorkflowArtifact::role`] uses: `generated_image`, `matted_image`,
+    /// `delighted_image`, `final_glb`. `final_glb` is the run's LEAD — the one
+    /// a client shows when it collapses the run into a single print.
+    pub role: String,
+    /// Zero-based stage that produced it, so a client can order the members
+    /// without knowing the stage graph.
+    pub stage_index: u32,
+}
+
+/// The role whose print represents the whole run.
+pub const MESH_WORKFLOW_LEAD_ROLE: &str = "final_glb";
+
+impl CreateMeshWorkflowRequest {
+    /// The workflow's wire tag — the same word `mode` carries on the request.
+    pub fn mode_str(&self) -> &'static str {
+        match self {
+            Self::TextToMesh { .. } => "text_to_mesh",
+            Self::MeshTexture { .. } => "mesh_texture",
+            Self::MeshRoundtrip { .. } => "mesh_roundtrip",
+        }
+    }
+}
+
+/// Refuse a client-supplied [`MeshWorkflowProvenance`] on a public request.
+///
+/// The field is provenance the SERVER mints in the workflow runner. A request
+/// that arrived over the public generate doors carrying one would be claiming
+/// membership of a durable workflow it is not a stage of — which would route
+/// another person's queue row into the 3-D Studio, and file a stranger's print
+/// inside their run's stack in the Library. Refused by name rather than
+/// silently stripped, so a client that sends it learns why.
+pub fn client_minted_mesh_workflow_refusal(req: &GenerateRequest) -> Option<&'static str> {
+    req.mesh_workflow.is_some().then_some(
+        "mesh_workflow is server-minted provenance and cannot be supplied by a client; \
+         create a 3-D workflow with POST /api/mesh-workflows instead",
+    )
+}
+
+impl MeshWorkflowProvenance {
+    /// Whether this output is the one a collapsed view shows.
+    pub fn is_lead(&self) -> bool {
+        self.role == MESH_WORKFLOW_LEAD_ROLE
+    }
+}
+
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, utoipa::ToSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MeshWorkflowStageKind {
@@ -907,5 +976,75 @@ mod tests {
             manifest.to_toml(),
             Err(MoldError::Validation(message)) if message.contains("portable relative path")
         ));
+    }
+
+    /*
+     * The field is the one thread tying a queue row and a finished print back
+     * to the workflow that made them, so a client able to mint it could route
+     * another person's row into the 3-D Studio and file a stranger's print
+     * inside their run. It is refused by name rather than silently stripped.
+     */
+    #[test]
+    fn a_client_cannot_mint_workflow_provenance() {
+        let mut request = crate::test_support::minimal_generate_request("flux-dev:q8");
+        assert!(client_minted_mesh_workflow_refusal(&request).is_none());
+        request.mesh_workflow = Some(MeshWorkflowProvenance {
+            job_id: "someone-elses-workflow".into(),
+            mode: "text_to_mesh".into(),
+            role: MESH_WORKFLOW_LEAD_ROLE.into(),
+            stage_index: 4,
+        });
+        let refusal = client_minted_mesh_workflow_refusal(&request)
+            .expect("a supplied mesh_workflow is refused");
+        assert!(refusal.contains("server-minted"));
+        assert!(refusal.contains("/api/mesh-workflows"));
+    }
+
+    #[test]
+    fn only_the_mesh_is_the_lead_of_its_run() {
+        let member = |role: &str| MeshWorkflowProvenance {
+            job_id: "workflow-1".into(),
+            mode: "text_to_mesh".into(),
+            role: role.into(),
+            stage_index: 0,
+        };
+        assert!(member(MESH_WORKFLOW_LEAD_ROLE).is_lead());
+        for role in ["generated_image", "matted_image", "delighted_image"] {
+            assert!(!member(role).is_lead(), "{role} is not the run's lead");
+        }
+    }
+
+    /* The wire tag is the same word the create request carries. */
+    #[test]
+    fn the_mode_tag_matches_the_request_it_came_from() {
+        let request = |json: serde_json::Value| {
+            serde_json::from_value::<CreateMeshWorkflowRequest>(json).expect("mode parses")
+        };
+        for (json, expected) in [
+            (
+                serde_json::json!({
+                    "mode": "text_to_mesh",
+                    "image_request": crate::test_support::minimal_generate_request("flux-dev:q8"),
+                    "mesh_request": crate::test_support::minimal_generate_request("flux-dev:q8"),
+                }),
+                "text_to_mesh",
+            ),
+            (
+                serde_json::json!({
+                    "mode": "mesh_texture",
+                    "texture_request": crate::test_support::minimal_generate_request("flux-dev:q8"),
+                }),
+                "mesh_texture",
+            ),
+            (
+                serde_json::json!({
+                    "mode": "mesh_roundtrip",
+                    "roundtrip_request": crate::test_support::minimal_generate_request("flux-dev:q8"),
+                }),
+                "mesh_roundtrip",
+            ),
+        ] {
+            assert_eq!(request(json).mode_str(), expected);
+        }
     }
 }

--- a/crates/mold-core/src/minimax_h3.rs
+++ b/crates/mold-core/src/minimax_h3.rs
@@ -3743,6 +3743,7 @@ mod tests {
 
     fn request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-core/src/placement_test.rs
+++ b/crates/mold-core/src/placement_test.rs
@@ -117,6 +117,7 @@ fn advanced_placement_defaults_to_auto_pair() {
 fn generate_request_placement_round_trips() {
     use super::GenerateRequest;
     let req = GenerateRequest {
+        mesh_workflow: None,
         offload: None,
         mesh: None,
         video_only: None,

--- a/crates/mold-core/src/test_support.rs
+++ b/crates/mold-core/src/test_support.rs
@@ -7,6 +7,7 @@ pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 #[cfg(test)]
 pub(crate) fn minimal_generate_request(model: &str) -> crate::types::GenerateRequest {
     crate::types::GenerateRequest {
+        mesh_workflow: None,
         offload: None,
         mesh: None,
         video_only: None,

--- a/crates/mold-core/src/types.rs
+++ b/crates/mold-core/src/types.rs
@@ -2014,6 +2014,11 @@ pub struct GenerateRequest {
     /// Total number of siblings in the prepared batch.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub batch_count: Option<u32>,
+    /// Which durable 3-D workflow this request is a stage of. Server-minted by
+    /// the workflow runner; a public request carrying it is refused, since a
+    /// client that could stamp it would forge a print into someone's workflow.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mesh_workflow: Option<crate::mesh_workflow::MeshWorkflowProvenance>,
     /// LoRA adapter to apply during generation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub lora: Option<LoraWeight>,
@@ -3312,6 +3317,14 @@ pub struct OutputMetadata {
     /// settings authoring surface.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chain: Option<crate::chain::ChainOutputMetadata>,
+    /// The durable 3-D workflow that produced this print, and the role it
+    /// plays in it (additive). Every stage of a workflow publishes an ordinary
+    /// print, so this is what lets a client route a queue row back to the 3-D
+    /// Studio, reopen a finished print as its workflow, and collapse a run's
+    /// several outputs into one gallery item led by the mesh. Absent means the
+    /// print was not made by a workflow — or the host predates the field.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mesh_workflow: Option<crate::mesh_workflow::MeshWorkflowProvenance>,
     pub version: String,
 }
 
@@ -3397,6 +3410,7 @@ impl OutputMetadata {
             batch_id: req.batch_id.clone(),
             batch_index: req.batch_index,
             batch_count: req.batch_count,
+            mesh_workflow: req.mesh_workflow.clone(),
             output_mode: Some(GenerationOutputMode::OneShot),
             // Stamped by the worker immediately before the save; the request
             // does not know which queue job is carrying it.
@@ -7004,6 +7018,7 @@ mod tests {
     #[test]
     fn generate_request_serde_roundtrip() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -7258,6 +7273,7 @@ mod tests {
     #[test]
     fn generate_request_negative_prompt_roundtrip() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -7340,6 +7356,7 @@ mod tests {
     #[test]
     fn generate_request_negative_prompt_omitted_when_none() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -7625,6 +7642,7 @@ mod tests {
     /// A plain text-to-image request every metadata test can start from.
     fn text_to_image_request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -7958,6 +7976,7 @@ mod tests {
     #[test]
     fn output_metadata_records_source_image_provenance() {
         let mut req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -8207,6 +8226,7 @@ mod tests {
     #[test]
     fn output_metadata_includes_negative_prompt_when_provided() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -8286,6 +8306,7 @@ mod tests {
     #[test]
     fn output_metadata_includes_strength_and_scheduler_when_applicable() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -8368,6 +8389,7 @@ mod tests {
     #[test]
     fn output_metadata_preserves_recreate_knobs() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -9168,6 +9190,7 @@ mod tests {
         // Minimal PNG-like bytes for testing
         let image_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -9253,6 +9276,7 @@ mod tests {
         let image_a = vec![0x89, 0x50, 0x4E, 0x47];
         let image_b = vec![0xFF, 0xD8, 0xFF, 0xE0];
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -9351,6 +9375,7 @@ mod tests {
     #[test]
     fn generate_request_source_image_omitted_in_json_when_none() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -9434,6 +9459,7 @@ mod tests {
     fn generate_request_control_image_base64_roundtrip() {
         let control_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -9538,6 +9564,7 @@ mod tests {
         let mask_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         let source_bytes = vec![0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-core/src/validation.rs
+++ b/crates/mold-core/src/validation.rs
@@ -4468,6 +4468,7 @@ mod tests {
 
     fn valid_req() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-db/src/db.rs
+++ b/crates/mold-db/src/db.rs
@@ -960,6 +960,9 @@ pub(crate) fn row_to_record(row: &rusqlite::Row<'_>) -> rusqlite::Result<Generat
         fps: row.get::<_, Option<i64>>(21)?.map(|n| n as u32),
         chain_job_id: None,
         chain: None,
+        // A row reconstructed from the legacy columns knows nothing about a
+        // 3-D workflow; the field only ever arrives with the saved JSON.
+        mesh_workflow: None,
         version: row.get(22)?,
         id_image_name: None,
         id_image_sha256: None,
@@ -1088,6 +1091,7 @@ mod tests {
 
     fn meta() -> OutputMetadata {
         OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-db/src/metadata_io.rs
+++ b/crates/mold-db/src/metadata_io.rs
@@ -183,6 +183,9 @@ pub fn synthesize_from_filename(filename: &str, timestamp_secs: u64) -> OutputMe
         fps: None,
         chain_job_id: None,
         chain: None,
+        // A row reconstructed from the legacy columns knows nothing about a
+        // 3-D workflow; the field only ever arrives with the saved JSON.
+        mesh_workflow: None,
         version: format!("synthesized@{timestamp_secs}"),
         id_image_name: None,
         id_image_sha256: None,

--- a/crates/mold-db/src/record.rs
+++ b/crates/mold-db/src/record.rs
@@ -185,6 +185,7 @@ mod tests {
 
     fn meta() -> OutputMetadata {
         OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-discord/src/commands/generate.rs
+++ b/crates/mold-discord/src/commands/generate.rs
@@ -593,6 +593,8 @@ pub fn build_generate_request(params: BuildParams<'_>) -> GenerateRequest {
         offload: None,
         mesh: None,
         video_only: None,
+        // The bot authors one-shots; 3-D workflows are a Studio surface.
+        mesh_workflow: None,
         collection: None,
         tags: None,
         title: None,

--- a/crates/mold-inference/src/chain/orchestrator.rs
+++ b/crates/mold-inference/src/chain/orchestrator.rs
@@ -470,6 +470,8 @@ fn build_stage_generate_request(
         offload: chain.offload,
         mesh: None,
         video_only: None,
+        // A chain stage is not a 3-D workflow stage.
+        mesh_workflow: None,
         collection: None,
         tags: None,
         title: None,

--- a/crates/mold-inference/src/flux/pipeline.rs
+++ b/crates/mold-inference/src/flux/pipeline.rs
@@ -3716,6 +3716,7 @@ mod tests {
         plural: Option<Vec<LoraWeight>>,
     ) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/flux2/pipeline.rs
+++ b/crates/mold-inference/src/flux2/pipeline.rs
@@ -2654,6 +2654,7 @@ mod tests {
             CachedTensor::from_tensor(&txt_emb).unwrap(),
         );
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/image.rs
+++ b/crates/mold-inference/src/image.rs
@@ -365,6 +365,7 @@ mod tests {
     fn test_encode_png_with_metadata_chunks() {
         let tensor = solid_red_tensor(4, 4);
         let metadata = OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,
@@ -481,6 +482,7 @@ mod tests {
     #[test]
     fn test_build_output_metadata_respects_opt_out() {
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -560,6 +562,7 @@ mod tests {
     #[test]
     fn test_update_output_metadata_size_overrides_dimensions() {
         let mut metadata = Some(OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,
@@ -648,6 +651,7 @@ mod tests {
 
     fn test_metadata() -> OutputMetadata {
         OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,
@@ -829,6 +833,7 @@ mod tests {
     fn test_encode_jpeg_metadata_roundtrip() {
         let tensor = solid_red_tensor(8, 8);
         let metadata = OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-inference/src/ltx2/conditioning.rs
+++ b/crates/mold-inference/src/ltx2/conditioning.rs
@@ -312,6 +312,7 @@ mod tests {
 
     fn req() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/ltx2/execution.rs
+++ b/crates/mold-inference/src/ltx2/execution.rs
@@ -238,6 +238,7 @@ mod tests {
 
     fn req(model: &str) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/ltx2/lora.rs
+++ b/crates/mold-inference/src/ltx2/lora.rs
@@ -257,6 +257,7 @@ mod tests {
 
     fn dummy_request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/ltx2/pipeline.rs
+++ b/crates/mold-inference/src/ltx2/pipeline.rs
@@ -2198,6 +2198,7 @@ mod tests {
 
     fn request(output_format: OutputFormat, enable_audio: Option<bool>) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -2531,6 +2532,7 @@ mod tests {
 
     fn bare_t2v_req(model: &str) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -2614,6 +2616,7 @@ mod tests {
             0,
         );
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,
@@ -2847,6 +2850,7 @@ mod tests {
             0,
         );
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/ltx2/runtime.rs
+++ b/crates/mold-inference/src/ltx2/runtime.rs
@@ -8784,6 +8784,7 @@ mod tests {
 
     fn req(model: &str, format: OutputFormat, enable_audio: Option<bool>) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/ltx_video/video_enc.rs
+++ b/crates/mold-inference/src/ltx_video/video_enc.rs
@@ -94,6 +94,7 @@ impl VideoMetadata {
         mold_core::OutputMetadata {
             video_only: None,
             attention_path: None,
+            mesh_workflow: None,
             int8_arm: None,
             collection: None,
             tags: None,

--- a/crates/mold-inference/src/minimax_h3/pipeline.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline.rs
@@ -1664,6 +1664,7 @@ mod tests {
 
     fn request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
+++ b/crates/mold-inference/src/minimax_h3/pipeline/ref2va.rs
@@ -1575,6 +1575,7 @@ mod tests {
 
     fn request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/sd15/lora.rs
+++ b/crates/mold-inference/src/sd15/lora.rs
@@ -1207,6 +1207,7 @@ mod tests {
         loras: Option<Vec<mold_core::LoraWeight>>,
     ) -> mold_core::GenerateRequest {
         mold_core::GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/sd3/pipeline.rs
+++ b/crates/mold-inference/src/sd3/pipeline.rs
@@ -1832,6 +1832,7 @@ mod tests {
         let key = cfg_prompt_cache_key("a cat", "", 1.0);
         store_cached_tensor_pair(&engine.prompt_cache, key, &context, &y).unwrap();
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/sdxl/lora.rs
+++ b/crates/mold-inference/src/sdxl/lora.rs
@@ -1234,6 +1234,7 @@ mod tests {
         loras: Option<Vec<mold_core::LoraWeight>>,
     ) -> mold_core::GenerateRequest {
         mold_core::GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/wan/pipeline.rs
+++ b/crates/mold-inference/src/wan/pipeline.rs
@@ -3265,6 +3265,7 @@ mod tests {
 
     fn request() -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-inference/src/zimage/pipeline.rs
+++ b/crates/mold-inference/src/zimage/pipeline.rs
@@ -2938,6 +2938,7 @@ mod tests {
             CachedTensor::from_tensor(&cap_feats).unwrap(),
         );
         let req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -3573,6 +3573,8 @@ pub(crate) fn build_stage_generate_request(
         offload: chain.offload,
         mesh: None,
         video_only: None,
+        // A chain stage is not a 3-D workflow stage.
+        mesh_workflow: None,
         collection: None,
         tags: None,
         title: None,

--- a/crates/mold-server/src/mesh_workflow_runner.rs
+++ b/crates/mold-server/src/mesh_workflow_runner.rs
@@ -6,7 +6,7 @@ use std::time::{Duration, SystemTime, UNIX_EPOCH};
 use anyhow::{anyhow, bail, Context};
 use mold_core::mesh_workflow::{
     CreateMeshWorkflowRequest, MeshWorkflowArtifact, MeshWorkflowJobState, MeshWorkflowManifest,
-    MeshWorkflowStageKind, MeshWorkflowStageState,
+    MeshWorkflowProvenance, MeshWorkflowStageKind, MeshWorkflowStageState,
 };
 use mold_core::{
     GenerationBatchAdmissionRequest, GenerationBatchChildState, MeshMattingMode, OutputFormat,
@@ -158,15 +158,27 @@ async fn drive_job(
         }
         let stages = mesh_workflow_jobs::stages_for_job(db, &job.id)?;
         let request: CreateMeshWorkflowRequest = serde_json::from_str(&current.request_json)?;
+        let request_mode = request.mode_str();
         match next_action(&request, &stages)? {
             NextAction::SubmitImage { attempt_epoch } => {
-                let request = crate::mesh_workflow_media::hydrate_for_admission(
+                let image = crate::mesh_workflow_media::hydrate_for_admission(
                     workflows_root,
                     &current.work_dir,
                     "image",
                 )?;
-                let batch_id =
-                    admit_child(state, &current.id, "image", attempt_epoch, request).await?;
+                let batch_id = admit_child(
+                    state,
+                    "image",
+                    MeshWorkflowProvenance {
+                        job_id: current.id.clone(),
+                        mode: request_mode.to_string(),
+                        role: "generated_image".into(),
+                        stage_index: stage_index_for(&stages, MeshWorkflowStageKind::Image)?,
+                    },
+                    attempt_epoch,
+                    image,
+                )
+                .await?;
                 if !attach_batch(
                     db,
                     &current.id,
@@ -238,8 +250,19 @@ async fn drive_job(
                         "output_format": "png"
                     }))?;
                 child.source_image = Some(source);
-                let batch_id =
-                    admit_child(state, &current.id, "matting", attempt_epoch, child).await?;
+                let batch_id = admit_child(
+                    state,
+                    "matting",
+                    MeshWorkflowProvenance {
+                        job_id: current.id.clone(),
+                        mode: request_mode.to_string(),
+                        role: "matted_image".into(),
+                        stage_index: stage_index_for(&stages, MeshWorkflowStageKind::Matting)?,
+                    },
+                    attempt_epoch,
+                    child,
+                )
+                .await?;
                 if !attach_batch(
                     db,
                     &current.id,
@@ -313,8 +336,19 @@ async fn drive_job(
                         "output_format": "png"
                     }))?;
                 child.source_image = Some(source);
-                let batch_id =
-                    admit_child(state, &current.id, "delight", attempt_epoch, child).await?;
+                let batch_id = admit_child(
+                    state,
+                    "delight",
+                    MeshWorkflowProvenance {
+                        job_id: current.id.clone(),
+                        mode: request_mode.to_string(),
+                        role: "delighted_image".into(),
+                        stage_index: stage_index_for(&stages, MeshWorkflowStageKind::Delight)?,
+                    },
+                    attempt_epoch,
+                    child,
+                )
+                .await?;
                 if !attach_batch(
                     db,
                     &current.id,
@@ -408,8 +442,23 @@ async fn drive_job(
                     child.source_image =
                         Some(std::fs::read(current.work_dir.join(&image.relative_path))?);
                 }
-                let batch_id =
-                    admit_child(state, &current.id, "mesh", attempt_epoch, child).await?;
+                // The same stage the wait arm retains `final_glb` under: Shape
+                // when the run builds geometry, Paint when it only textures.
+                let mesh_stage_index = stage_index_for(&stages, MeshWorkflowStageKind::Shape)
+                    .or_else(|_| stage_index_for(&stages, MeshWorkflowStageKind::Paint))?;
+                let batch_id = admit_child(
+                    state,
+                    "mesh",
+                    MeshWorkflowProvenance {
+                        job_id: current.id.clone(),
+                        mode: request_mode.to_string(),
+                        role: "final_glb".into(),
+                        stage_index: mesh_stage_index,
+                    },
+                    attempt_epoch,
+                    child,
+                )
+                .await?;
                 let kinds = mesh_execution_kinds(&stages);
                 if !attach_batch(db, &current.id, &stages, &kinds, &batch_id)? {
                     crate::routes::cancel_generation_batch_children(state, &batch_id)
@@ -621,13 +670,37 @@ fn mesh_artifact(stages: &[MeshWorkflowStageRow]) -> anyhow::Result<&MeshWorkflo
         .context("completed mesh workflow has no retained GLB artifact")
 }
 
+/// Admit one stage of a workflow as an ordinary durable generation.
+///
+/// The stage is stamped with its workflow's provenance HERE, at the one place
+/// that knows both. Every stage publishes a real gallery print, so without the
+/// stamp the print and the queue row are indistinguishable from a hand-authored
+/// render: a queue row could only route back to New image, and a text-to-3-D run
+/// scattered its source picture, its matted and delighted copies and its mesh
+/// across My images as four unrelated tiles. It rides the request, so the live
+/// queue entry (whose `metadata` IS the request) and the published print carry
+/// the same answer, and the durable sanitizer retains it across a restart.
+/// The advertised index of `kind` in this job's stage graph.
+fn stage_index_for(
+    stages: &[MeshWorkflowStageRow],
+    kind: MeshWorkflowStageKind,
+) -> anyhow::Result<u32> {
+    stages
+        .iter()
+        .find(|stage| stage.kind == kind)
+        .map(|stage| stage.stage_index)
+        .with_context(|| format!("mesh workflow has no {kind:?} stage"))
+}
+
 async fn admit_child(
     state: &AppState,
-    workflow_id: &str,
     stage: &str,
+    provenance: MeshWorkflowProvenance,
     attempt_epoch: i64,
-    request: mold_core::GenerateRequest,
+    mut request: mold_core::GenerateRequest,
 ) -> anyhow::Result<String> {
+    let workflow_id = provenance.job_id.clone();
+    request.mesh_workflow = Some(provenance);
     let admission = state
         .queue_journal
         .queue_media_admission()
@@ -640,7 +713,7 @@ async fn admit_child(
                 instance_id: state.instance_id.to_string(),
             }),
             GenerationBatchAdmissionRequest {
-                client_batch_id: deterministic_batch_id(workflow_id, stage, attempt_epoch),
+                client_batch_id: deterministic_batch_id(&workflow_id, stage, attempt_epoch),
                 requests: vec![request],
             },
             None,

--- a/crates/mold-server/src/mesh_workflow_runner.rs
+++ b/crates/mold-server/src/mesh_workflow_runner.rs
@@ -202,7 +202,7 @@ async fn drive_job(
                 let artifact = retain_gallery_artifact(
                     &output_dir,
                     &current,
-                    0,
+                    stage_index_for(&stages, MeshWorkflowStageKind::Image)?,
                     "generated_image",
                     &filename,
                 )?;
@@ -442,10 +442,8 @@ async fn drive_job(
                     child.source_image =
                         Some(std::fs::read(current.work_dir.join(&image.relative_path))?);
                 }
-                // The same stage the wait arm retains `final_glb` under: Shape
-                // when the run builds geometry, Paint when it only textures.
-                let mesh_stage_index = stage_index_for(&stages, MeshWorkflowStageKind::Shape)
-                    .or_else(|_| stage_index_for(&stages, MeshWorkflowStageKind::Paint))?;
+                // The same stage the wait arm retains `final_glb` under.
+                let mesh_stage_index = mesh_stage_index(&stages)?;
                 let batch_id = admit_child(
                     state,
                     "mesh",
@@ -473,16 +471,10 @@ async fn drive_job(
                     tokio::time::sleep(Duration::from_millis(500)).await;
                     continue;
                 };
-                let stage_index = stages
-                    .iter()
-                    .find(|stage| stage.kind == MeshWorkflowStageKind::Shape)
-                    .or_else(|| {
-                        stages
-                            .iter()
-                            .find(|stage| stage.kind == MeshWorkflowStageKind::Paint)
-                    })
-                    .map(|stage| stage.stage_index)
-                    .context("mesh workflow has no mesh-producing stage")?;
+                // The same authority the submit arm stamped `final_glb` with:
+                // the retained artifact's index and the provenance's must be
+                // one number, or the field stops meaning anything.
+                let stage_index = mesh_stage_index(&stages)?;
                 let output_dir = state.config.read().await.effective_output_dir();
                 let artifact = retain_gallery_artifact(
                     &output_dir,
@@ -670,17 +662,11 @@ fn mesh_artifact(stages: &[MeshWorkflowStageRow]) -> anyhow::Result<&MeshWorkflo
         .context("completed mesh workflow has no retained GLB artifact")
 }
 
-/// Admit one stage of a workflow as an ordinary durable generation.
-///
-/// The stage is stamped with its workflow's provenance HERE, at the one place
-/// that knows both. Every stage publishes a real gallery print, so without the
-/// stamp the print and the queue row are indistinguishable from a hand-authored
-/// render: a queue row could only route back to New image, and a text-to-3-D run
-/// scattered its source picture, its matted and delighted copies and its mesh
-/// across My images as four unrelated tiles. It rides the request, so the live
-/// queue entry (whose `metadata` IS the request) and the published print carry
-/// the same answer, and the durable sanitizer retains it across a restart.
 /// The advertised index of `kind` in this job's stage graph.
+///
+/// The ONE spelling of that lookup. It is what a stamped `stage_index` means,
+/// and the value has to match the index its artifact is retained under — so a
+/// second hand-inlined copy is a way for the two to drift apart silently.
 fn stage_index_for(
     stages: &[MeshWorkflowStageRow],
     kind: MeshWorkflowStageKind,
@@ -692,6 +678,23 @@ fn stage_index_for(
         .with_context(|| format!("mesh workflow has no {kind:?} stage"))
 }
 
+/// The stage that carries the finished mesh: Shape where the run builds
+/// geometry, Paint where it only textures a supplied mesh.
+fn mesh_stage_index(stages: &[MeshWorkflowStageRow]) -> anyhow::Result<u32> {
+    stage_index_for(stages, MeshWorkflowStageKind::Shape)
+        .or_else(|_| stage_index_for(stages, MeshWorkflowStageKind::Paint))
+}
+
+/// Admit one stage of a workflow as an ordinary durable generation.
+///
+/// The stage is stamped with its workflow's provenance HERE, at the one place
+/// that knows both. Every stage publishes a real gallery print, so without the
+/// stamp the print and the queue row are indistinguishable from a hand-authored
+/// render: a queue row could only route back to New image, and a text-to-3-D run
+/// scattered its source picture, its matted and delighted copies and its mesh
+/// across My images as four unrelated tiles. It rides the request, so the live
+/// queue entry (whose `metadata` IS the request) and the published print carry
+/// the same answer, and the durable sanitizer retains it across a restart.
 async fn admit_child(
     state: &AppState,
     stage: &str,

--- a/crates/mold-server/src/model_manager.rs
+++ b/crates/mold-server/src/model_manager.rs
@@ -5279,6 +5279,7 @@ mod tests {
     #[test]
     fn activation_hint_from_request_classifies_correctly() {
         let mut req = GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-server/src/queue.rs
+++ b/crates/mold-server/src/queue.rs
@@ -4901,6 +4901,7 @@ mod tests {
     /// hand to `OutputMetadata::from_generate_request` in tests.
     fn fake_request(model: &str) -> GenerateRequest {
         GenerateRequest {
+            mesh_workflow: None,
             offload: None,
             mesh: None,
             video_only: None,

--- a/crates/mold-server/src/queue_media.rs
+++ b/crates/mold-server/src/queue_media.rs
@@ -581,6 +581,10 @@ fn extract_request_fields(
         // survives a restart on the request rather than through the encrypted
         // media set, and a replayed job re-renders the same geometry.
         mesh,
+        // Server-minted provenance, retained like the batch ids beside it: a
+        // replayed stage must still publish into the workflow that owns it,
+        // or a restart would orphan the run's members from its mesh.
+        mesh_workflow,
         video_only,
         prompt,
         negative_prompt,
@@ -763,6 +767,7 @@ fn extract_request_fields(
 
     let sanitized = mold_core::GenerateRequest {
         offload,
+        mesh_workflow,
         prompt,
         negative_prompt,
         model,

--- a/crates/mold-server/src/queue_media.rs
+++ b/crates/mold-server/src/queue_media.rs
@@ -1519,6 +1519,12 @@ mod tests {
                 { "frame": 0, "image": "a2V5ZnJhbWU=", "name": "keyframe-secret.png" }
             ],
             "hdr_exr_dir": "/private/exr-output",
+            "mesh_workflow": {
+                "job_id": "run-1",
+                "mode": "text_to_mesh",
+                "role": "final_glb",
+                "stage_index": 3
+            },
             "lora": { "path": "/private/singular-lora.safetensors", "scale": 0.5 },
             "loras": [
                 { "path": "/private/stack-a.safetensors", "scale": 0.7 },

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -553,6 +553,7 @@ use crate::queue::clean_error_message;
         mold_core::RetainedSourceMediaInventory,
         mold_core::mesh_workflow::CreateMeshWorkflowRequest,
         mold_core::mesh_workflow::CreateMeshWorkflowResponse,
+        mold_core::mesh_workflow::MeshWorkflowProvenance,
         mold_core::mesh_workflow::MeshWorkflowJobState,
         mold_core::mesh_workflow::MeshWorkflowStageKind,
         mold_core::mesh_workflow::MeshWorkflowStageState,

--- a/crates/mold-server/src/routes.rs
+++ b/crates/mold-server/src/routes.rs
@@ -2933,6 +2933,12 @@ async fn admit_generation_batch(
         return Err(unready.api_error());
     }
     body.client_batch_id = canonical_client_batch_id(&body.client_batch_id)?;
+    for request in &body.requests {
+        if let Some(reason) = mold_core::mesh_workflow::client_minted_mesh_workflow_refusal(request)
+        {
+            return Err(ApiError::validation(reason));
+        }
+    }
     if body.requests.is_empty() || body.requests.len() > MAX_HETEROGENEOUS_BATCH_OUTPUTS {
         return Err(ApiError::validation(format!(
             "requests must contain 1..={MAX_HETEROGENEOUS_BATCH_OUTPUTS} children"
@@ -3366,6 +3372,9 @@ async fn generate(
     headers: HeaderMap,
     Json(mut req): Json<mold_core::GenerateRequest>,
 ) -> Result<Response, ApiError> {
+    if let Some(reason) = mold_core::mesh_workflow::client_minted_mesh_workflow_refusal(&req) {
+        return Err(ApiError::validation(reason));
+    }
     mold_core::minimax_h3::canonicalize_request_model(&mut req);
     crate::gallery_source_media::hydrate_reuse_session(
         &state,
@@ -4550,6 +4559,9 @@ async fn generate_stream(
     headers: HeaderMap,
     Json(mut req): Json<mold_core::GenerateRequest>,
 ) -> Result<Response, ApiError> {
+    if let Some(reason) = mold_core::mesh_workflow::client_minted_mesh_workflow_refusal(&req) {
+        return Err(ApiError::validation(reason));
+    }
     mold_core::minimax_h3::canonicalize_request_model(&mut req);
     crate::gallery_source_media::hydrate_reuse_session(
         &state,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -784,6 +784,111 @@ mod tests {
         );
     }
 
+    /*
+     * `mesh_workflow` is provenance the SERVER mints in the workflow runner.
+     * A client able to supply it could route another person's queue row into
+     * the 3-D Studio and file a stranger's print inside their run's stack in
+     * the Library, so every public door that takes a `GenerateRequest` and
+     * publishes has to refuse it BY NAME rather than silently stripping it.
+     *
+     * The unit test on `client_minted_mesh_workflow_refusal` proves the
+     * predicate; this proves each door actually asks it.
+     */
+    #[tokio::test]
+    async fn every_public_generate_door_refuses_client_minted_workflow_provenance() {
+        let forged = serde_json::json!({
+            "prompt": "forged",
+            "model": "flux-dev:q8",
+            "width": 512,
+            "height": 512,
+            "steps": 1,
+            "guidance": 1.0,
+            "seed": 1,
+            "batch_size": 1,
+            "output_format": "png",
+            "mesh_workflow": {
+                "job_id": "someone-elses-run",
+                "mode": "text_to_mesh",
+                "role": "final_glb",
+                "stage_index": 0
+            }
+        });
+
+        for (path, body) in [
+            ("/api/generate", forged.clone()),
+            ("/api/generate/stream", forged.clone()),
+        ] {
+            let app = app_empty();
+            let response = app
+                .oneshot(
+                    Request::post(path)
+                        .header("content-type", "application/json")
+                        .body(Body::from(serde_json::to_vec(&body).unwrap()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::UNPROCESSABLE_ENTITY,
+                "{path} accepted client-minted mesh_workflow"
+            );
+            let refused = json_body(response).await;
+            assert_eq!(refused["code"], "VALIDATION_ERROR", "{path}");
+            assert!(
+                refused["error"]
+                    .as_str()
+                    .unwrap()
+                    .contains("server-minted provenance"),
+                "{path} refused without saying why: {refused}"
+            );
+        }
+
+        /*
+         * The batch door needs a host that can actually admit: its
+         * `DurableAdmissionReadiness` gate answers 503 first, and rightly so —
+         * a host that can replay nothing refuses everything before it looks at
+         * the request. So this half runs against a durable state.
+         */
+        let root = tempfile::tempdir().unwrap();
+        let db = Arc::new(Some(mold_db::MetadataDb::open_in_memory().unwrap()));
+        let (mut state, _rx) = durable_state(db, root.path());
+        install_authoritative_v2(&mut state);
+        let journal = state.queue_journal.clone();
+        let app = app_with_state(state.clone());
+        let response = app
+            .oneshot(json_request(
+                "POST",
+                "/api/generation-batches",
+                serde_json::json!({
+                    "client_batch_id": uuid::Uuid::new_v4().to_string(),
+                    "requests": [forged],
+                }),
+            ))
+            .await
+            .unwrap();
+        let status = response.status();
+        let refused = json_body(response).await;
+        assert_eq!(
+            status,
+            StatusCode::UNPROCESSABLE_ENTITY,
+            "/api/generation-batches accepted client-minted mesh_workflow: {refused}"
+        );
+        assert_eq!(refused["code"], "VALIDATION_ERROR");
+        assert!(
+            refused["error"]
+                .as_str()
+                .unwrap()
+                .contains("server-minted provenance"),
+            "{refused}"
+        );
+        // Refused BEFORE anything was queued — not stripped and admitted.
+        assert!(
+            journal.list_all().is_empty(),
+            "a forged request left a durable row behind"
+        );
+    }
+
     fn seed_chain_job(
         db: &mold_db::MetadataDb,
         mold_home: &std::path::Path,

--- a/crates/mold-server/src/routes_test.rs
+++ b/crates/mold-server/src/routes_test.rs
@@ -1080,6 +1080,7 @@ mod tests {
 
     fn output_metadata(prompt: &str) -> mold_core::OutputMetadata {
         mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,
@@ -17446,6 +17447,7 @@ mod tests {
         let db_path = dir.path().join("mold.db");
         let db = MetadataDb::open(&db_path).unwrap();
         let metadata = mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,
@@ -18382,6 +18384,7 @@ mod tests {
 
         let db = MetadataDb::open(&dir.path().join("mold.db")).unwrap();
         let metadata = mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-tui/src/app.rs
+++ b/crates/mold-tui/src/app.rs
@@ -9761,6 +9761,7 @@ impl App {
                         let meta = mold_core::OutputMetadata {
                             video_only: None,
                             attention_path: None,
+                            mesh_workflow: None,
                             int8_arm: None,
                             collection: submitted_params.collection.clone(),
                             tags: (!submitted_filing.is_empty()).then_some(submitted_filing),
@@ -10356,6 +10357,7 @@ impl App {
                     let meta = mold_core::OutputMetadata {
                         video_only: None,
                         attention_path: None,
+                        mesh_workflow: None,
                         int8_arm: None,
                         // An upscale of a filed print stays filed: the copy
                         // is the same picture, and losing its title and tags
@@ -11760,6 +11762,7 @@ mod tests {
         let entry = GalleryEntry {
             path: std::path::PathBuf::from("/home/user/.mold/output/mold-flux-1234.png"),
             metadata: mold_core::OutputMetadata {
+                mesh_workflow: None,
                 video_only: None,
                 attention_path: None,
                 int8_arm: None,
@@ -11850,6 +11853,7 @@ mod tests {
         let entry = GalleryEntry {
             path: std::path::PathBuf::new(),
             metadata: mold_core::OutputMetadata {
+                mesh_workflow: None,
                 video_only: None,
                 attention_path: None,
                 int8_arm: None,
@@ -12001,6 +12005,7 @@ mod tests {
 
     fn make_test_metadata() -> mold_core::OutputMetadata {
         mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-tui/src/backend.rs
+++ b/crates/mold-tui/src/backend.rs
@@ -1606,6 +1606,8 @@ pub(crate) fn build_request(
 
     Ok(GenerateRequest {
         offload: None,
+        // The TUI authors one-shots; 3-D workflows are a Studio surface.
+        mesh_workflow: None,
         // Absent-until-touched, like every optional block: an untouched form
         // ships no `mesh` at all (the recipe's defaults apply), and the
         // capability sync already cleared the block on any recipe whose

--- a/crates/mold-tui/src/gallery_scan.rs
+++ b/crates/mold-tui/src/gallery_scan.rs
@@ -603,6 +603,7 @@ mod tests {
 
     fn meta(prompt: &str, model: &str) -> mold_core::OutputMetadata {
         mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-tui/src/ui/gallery.rs
+++ b/crates/mold-tui/src/ui/gallery.rs
@@ -371,6 +371,7 @@ pub(crate) mod tests {
 
     pub(crate) fn test_metadata(width: u32, height: u32) -> mold_core::OutputMetadata {
         mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/crates/mold-tui/src/ui/library_details.rs
+++ b/crates/mold-tui/src/ui/library_details.rs
@@ -224,6 +224,7 @@ mod tests {
 
     fn test_metadata() -> mold_core::OutputMetadata {
         mold_core::OutputMetadata {
+            mesh_workflow: None,
             video_only: None,
             attention_path: None,
             int8_arm: None,

--- a/desktop/src/App.vue
+++ b/desktop/src/App.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { onMounted, onUnmounted, watch } from "vue";
+import { MESH_WORKFLOW_ROUTE } from "@studio/lib/meshWorkflowProvenance";
 import { useRouter } from "vue-router";
 import TitleBar from "./components/shell/TitleBar.vue";
 import Sidebar from "./components/shell/Sidebar.vue";
@@ -281,8 +282,14 @@ async function listenForMenu() {
         return void router.push("/create");
       // New image consumes these intents, so every raiser has to route there:
       // an intent left pending would fire on the next visit instead.
+      //
+      // Generate is the exception: the 3-D Studio consumes it too, so on that
+      // route ⌘↩ stays put. It used to raise the intent and push `/create`,
+      // which left the view and rendered a picture — while the status bar
+      // advertised the hint as if it worked.
       case "generate":
         ui.generate();
+        if (router.currentRoute.value.path === MESH_WORKFLOW_ROUTE) return;
         return void router.push("/create");
       case "expand-prompt":
         ui.expandPrompt();

--- a/desktop/src/components/shell/CommandPalette.test.ts
+++ b/desktop/src/components/shell/CommandPalette.test.ts
@@ -7,7 +7,13 @@ const searchCatalogMock = vi.hoisted(() =>
   vi.fn().mockResolvedValue({ entries: [], page: 1, page_size: 12, total: 0 }),
 );
 const startCatalogDownloadMock = vi.hoisted(() => vi.fn().mockResolvedValue("job-1"));
-vi.mock("vue-router", () => ({ useRouter: () => ({ push: routerPush }) }));
+// The palette keeps Generate on the 3-D Studio's route instead of pushing
+// /create, so it reads the current route as well as the router.
+const routePath = vi.hoisted(() => ({ value: "/create" }));
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: routerPush }),
+  useRoute: () => ({ path: routePath.value }),
+}));
 vi.mock("../../lib/api/history", () => ({ fetchHistory: vi.fn().mockResolvedValue([]) }));
 vi.mock("../../lib/api/models", () => ({ loadModel: vi.fn(), unloadModel: vi.fn() }));
 vi.mock("../../lib/api/catalog", () => ({
@@ -812,6 +818,45 @@ describe("CommandPalette a11y semantics", () => {
     expect(wrapper.get("[role='combobox']").attributes("aria-activedescendant")).toBe(
       "cmd-palette-option-0",
     );
+    wrapper.unmount();
+  });
+});
+
+describe("CommandPalette — Generate respects the route it is on", () => {
+  beforeEach(() => {
+    routePath.value = "/create";
+    routerPush.mockClear();
+  });
+
+  async function runGenerate() {
+    const wrapper = await openPalette();
+    const option = wrapper
+      .findAll("[role='option']")
+      .find((o) => o.text().includes("Generate from these words"));
+    expect(option).toBeTruthy();
+    const before = useUiStore().generateTick;
+    await option!.trigger("click");
+    expect(useUiStore().generateTick).toBe(before + 1);
+    return wrapper;
+  }
+
+  /*
+   * The native menu's Generate was fixed to stay on /create/3d, but the
+   * palette raises the SAME intent and still pushed /create — so ⌘K then
+   * "Generate from these words" left the 3-D Studio and rendered a picture
+   * in New image. One of the two raisers had been fixed.
+   */
+  it("stays on the 3-D Studio rather than rendering a picture in New image", async () => {
+    routePath.value = "/create/3d";
+    const wrapper = await runGenerate();
+    expect(routerPush).not.toHaveBeenCalledWith("/create");
+    wrapper.unmount();
+  });
+
+  it("still routes to New image from anywhere else", async () => {
+    routePath.value = "/library";
+    const wrapper = await runGenerate();
+    expect(routerPush).toHaveBeenCalledWith("/create");
     wrapper.unmount();
   });
 });

--- a/desktop/src/components/shell/CommandPalette.vue
+++ b/desktop/src/components/shell/CommandPalette.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, toRef, watch } from "vue";
-import { useRouter } from "vue-router";
+import { useRoute, useRouter } from "vue-router";
+import { MESH_WORKFLOW_ROUTE } from "@studio/lib/meshWorkflowProvenance";
 import Icon from "@ui/components/Icon.vue";
 import { useOverlayStack } from "@ui/lib/overlayStack";
 import { useUiStore } from "../../stores/ui";
@@ -55,6 +56,7 @@ const ui = useUiStore();
 // Escape first and stopped it before the palette's own input ever saw it.
 useOverlayStack(toRef(ui, "paletteOpen"), "command-palette");
 const router = useRouter();
+const route = useRoute();
 const gallery = useGalleryStore();
 const models = useModelStore();
 const hostModels = useHostModelsStore();
@@ -341,8 +343,11 @@ const staticCommands = computed<Command[]>(() => {
       keywords: ["make", "render", "submit", "run"],
       key: shortcutLabel("↩"),
       run: () => {
+        // The 3-D Studio consumes this intent too, so on that route Generate
+        // stays put. Routing to New image there rendered a picture and left
+        // the view — the same fault the native menu had.
         ui.generate();
-        go("/create");
+        if (route.path !== MESH_WORKFLOW_ROUTE) go("/create");
       },
     },
     {

--- a/desktop/src/composables/useOpenLiveWork.ts
+++ b/desktop/src/composables/useOpenLiveWork.ts
@@ -2,6 +2,7 @@ import { useRouter } from "vue-router";
 import type { FleetActiveWork } from "@studio/api/activity";
 import { findQueueEntryById } from "@studio/api/queuePlan";
 import { selectedQueueGeneration } from "@studio/api/generationSelection";
+import { meshWorkflowRouteFor } from "@studio/lib/meshWorkflowProvenance";
 import type { OutputMetadata } from "../lib/api/types";
 import { useComposerStore } from "../stores/composer";
 import { useHostsStore } from "../stores/hosts";
@@ -36,6 +37,15 @@ export function useOpenLiveWork() {
         const selection = selectedQueueGeneration<OutputMetadata>(entry ? [entry] : [], row.id);
         if (!selection) {
           toasts.push("This host cannot restore settings for that generation", "error");
+          return;
+        }
+        // A 3-D Studio stage is admitted as an ordinary generation, so it
+        // arrives here looking like any other print. New image cannot resume
+        // it: the stages, Cancel, Resume and history live only under
+        // /api/mesh-workflows. Route to the surface that owns the work.
+        const workflow = meshWorkflowRouteFor(selection.metadata);
+        if (workflow) {
+          await router.push(workflow);
           return;
         }
         composer.set({

--- a/desktop/src/composables/useOpenLiveWork.ts
+++ b/desktop/src/composables/useOpenLiveWork.ts
@@ -43,7 +43,7 @@ export function useOpenLiveWork() {
         // arrives here looking like any other print. New image cannot resume
         // it: the stages, Cancel, Resume and history live only under
         // /api/mesh-workflows. Route to the surface that owns the work.
-        const workflow = meshWorkflowRouteFor(selection.metadata);
+        const workflow = meshWorkflowRouteFor(selection.metadata, row.hostId);
         if (workflow) {
           await router.push(workflow);
           return;

--- a/desktop/src/composables/useQueueCommands.test.ts
+++ b/desktop/src/composables/useQueueCommands.test.ts
@@ -11,7 +11,8 @@ import { defineComponent } from "vue";
 import { mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 
-vi.mock("vue-router", () => ({ useRouter: () => ({ push: vi.fn() }) }));
+const push = vi.hoisted(() => vi.fn());
+vi.mock("vue-router", () => ({ useRouter: () => ({ push }) }));
 vi.mock("../lib/api/client", () => ({
   apiJson: vi.fn(() => Promise.resolve([])),
   apiJsonTo: vi.fn(() => Promise.resolve({})),
@@ -553,5 +554,54 @@ describe("useQueueCommands — the pause scopes stay apart", () => {
 
     api.contextMenu(event, queuedRow());
     expect(labels(menu.entries)).not.toContain("Pause");
+  });
+});
+
+describe("useQueueCommands — a 3-D workflow's row opens its own studio", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    __resetQueueCommandState();
+    vi.clearAllMocks();
+    readyLocalHost();
+  });
+
+  const print = (metadata: Record<string, unknown>) =>
+    ({
+      kind: "print",
+      print: {
+        clientId: "job-1",
+        status: "complete",
+        request: metadata,
+        result: { filename: "print.glb" },
+      },
+    }) as never;
+
+  /*
+   * A 3-D Studio stage is admitted as an ordinary generation, so its row was
+   * indistinguishable from a hand-authored print and landed on New image —
+   * which cannot resume a durable workflow at all. Its stages, Cancel, Resume
+   * and history live only under /api/mesh-workflows.
+   */
+  it("routes a workflow's own row to the 3-D Studio, on that workflow", () => {
+    commands().open(
+      print({
+        mesh_workflow: {
+          job_id: "workflow-1",
+          mode: "text_to_mesh",
+          role: "final_glb",
+          stage_index: 4,
+        },
+      }),
+    );
+    expect(push).toHaveBeenCalledWith({
+      path: "/create/3d",
+      query: { workflow: "workflow-1" },
+    });
+  });
+
+  /* Absence is an ordinary print or an older host, never a refusal. */
+  it("leaves every other print on New image", () => {
+    commands().open(print({ prompt: "a brass teapot" }));
+    expect(push).toHaveBeenCalledWith("/create");
   });
 });

--- a/desktop/src/composables/useQueueCommands.test.ts
+++ b/desktop/src/composables/useQueueCommands.test.ts
@@ -571,6 +571,8 @@ describe("useQueueCommands — a 3-D workflow's row opens its own studio", () =>
       print: {
         clientId: "job-1",
         status: "complete",
+        // A workflow lives on ONE machine, so the row has to carry which.
+        hostId: "hal9000-7680",
         request: metadata,
         result: { filename: "print.glb" },
       },
@@ -595,7 +597,7 @@ describe("useQueueCommands — a 3-D workflow's row opens its own studio", () =>
     );
     expect(push).toHaveBeenCalledWith({
       path: "/create/3d",
-      query: { workflow: "workflow-1" },
+      query: { workflow: "workflow-1", host: "hal9000-7680" },
     });
   });
 

--- a/desktop/src/composables/useQueueCommands.ts
+++ b/desktop/src/composables/useQueueCommands.ts
@@ -2,6 +2,7 @@ import { computed, ref, type ComputedRef, type Ref } from "vue";
 import { useRouter } from "vue-router";
 import { apiFetchTo } from "@studio/api/client";
 import type { FleetActiveWork } from "@studio/api/activity";
+import { meshWorkflowRouteFor } from "@studio/lib/meshWorkflowProvenance";
 import { useOpenLiveWork } from "./useOpenLiveWork";
 import { useQueueActivity, type QueueRow } from "./useQueueActivity";
 import { jobCanBeRemoved, useGenerationStore, type Job } from "../stores/generation";
@@ -442,6 +443,13 @@ export function useQueueCommands(): QueueCommands {
   }
 
   function openPrint(job: Job) {
+    // Work a 3-D workflow made belongs to the 3-D Studio; New image cannot
+    // resume a durable workflow, only re-render one of its stages.
+    const workflow = meshWorkflowRouteFor(job.request ?? job.result?.metadata);
+    if (workflow) {
+      void router.push(workflow);
+      return;
+    }
     generation.select(job.clientId);
     if (job.request) composer.set({ request: job.request });
     if (job.status === "complete") {

--- a/desktop/src/composables/useQueueCommands.ts
+++ b/desktop/src/composables/useQueueCommands.ts
@@ -445,7 +445,7 @@ export function useQueueCommands(): QueueCommands {
   function openPrint(job: Job) {
     // Work a 3-D workflow made belongs to the 3-D Studio; New image cannot
     // resume a durable workflow, only re-render one of its stages.
-    const workflow = meshWorkflowRouteFor(job.request ?? job.result?.metadata);
+    const workflow = meshWorkflowRouteFor(job.request ?? job.result?.metadata, job.hostId);
     if (workflow) {
       void router.push(workflow);
       return;

--- a/desktop/src/composables/useQueueCommands.ts
+++ b/desktop/src/composables/useQueueCommands.ts
@@ -445,7 +445,12 @@ export function useQueueCommands(): QueueCommands {
   function openPrint(job: Job) {
     // Work a 3-D workflow made belongs to the 3-D Studio; New image cannot
     // resume a durable workflow, only re-render one of its stages.
-    const workflow = meshWorkflowRouteFor(job.request ?? job.result?.metadata, job.hostId);
+    // Ask each carrier in turn rather than `??`-ing them: a present request
+    // that carries no provenance would short-circuit the completed print's
+    // metadata, which is the one that always has it.
+    const workflow =
+      meshWorkflowRouteFor(job.request, job.hostId) ??
+      meshWorkflowRouteFor(job.result?.metadata, job.hostId);
     if (workflow) {
       void router.push(workflow);
       return;

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -555,6 +555,9 @@ export interface GenerationMemoryEstimate {
   fits_device_capacity?: boolean | null;
 }
 
+/** Re-exported so a wire type and the policy that reads it cannot drift. */
+export type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
+
 /**
  * Subset of mold-core GenerateRequest the desktop sends.
  *
@@ -562,9 +565,6 @@ export interface GenerationMemoryEstimate {
  * JSON (no `data:` prefix), so `source_image` / `mask_image` / `control_image`
  * are typed as `string` here, not bytes.
  */
-/** Re-exported so a wire type and the policy that reads it cannot drift. */
-export type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
-
 export interface GenerateRequest {
   /** Server-minted: which durable 3-D workflow this request is a stage of. A
    * client never sends it — the generate doors refuse one that does. */

--- a/desktop/src/lib/api/types.ts
+++ b/desktop/src/lib/api/types.ts
@@ -3,6 +3,7 @@
  * Source of truth: /api/openapi.json — a drift snapshot test guards these
  * once the OpenAPI harness lands (see desktop/docs/architecture.md §5).
  */
+import type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
 
 import type { ChainOutputMetadata, ChainRequestWire } from "@studio/lib/api/chainTypes";
 import type { HostMemorySnapshot } from "@studio/lib/hostMemory";
@@ -561,7 +562,13 @@ export interface GenerationMemoryEstimate {
  * JSON (no `data:` prefix), so `source_image` / `mask_image` / `control_image`
  * are typed as `string` here, not bytes.
  */
+/** Re-exported so a wire type and the policy that reads it cannot drift. */
+export type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
+
 export interface GenerateRequest {
+  /** Server-minted: which durable 3-D workflow this request is a stage of. A
+   * client never sends it — the generate doors refuse one that does. */
+  mesh_workflow?: MeshWorkflowProvenance | null;
   prompt: string;
   prompt_transform?: PromptTransformProvenance | null;
   negative_prompt?: string | null;
@@ -820,6 +827,11 @@ export interface OutputMetadata {
    * chain jobs with a server-side record — ephemeral chain outputs and
    * pre-#564 rows carry nothing (additive; newer servers only). */
   chain_job_id?: string | null;
+  /** The durable 3-D workflow that produced this print, and the role it plays
+   * in it. Additive: absent on every print made outside the 3-D Studio and on
+   * every host that predates the field — which reads as an ordinary print,
+   * never as a refusal. */
+  mesh_workflow?: MeshWorkflowProvenance | null;
   /** The queue id of the generation that produced this print. The server's own
    * replay idempotence key, and the exact answer to "is this print mine?" —
    * absent on hosts that predate it. */

--- a/desktop/src/stores/models.ts
+++ b/desktop/src/stores/models.ts
@@ -1,12 +1,18 @@
 import { defineStore } from "pinia";
 import { apiJson } from "../lib/api/client";
+import { isGenerationModel as isGenerationModelShared } from "@studio/lib/generationModels";
 import type { ModelEntry } from "../lib/api/types";
 
-/** Families that never appear in the generation model picker. */
-const NON_GENERATION_FAMILIES = new Set(["real-esrgan", "upscaler", "qwen3-expand", "controlnet"]);
-
+/**
+ * Whether a row is a style a person can pick.
+ *
+ * The list lives in `@studio/lib/generationModels` — this surface and web each
+ * had their own and they had already drifted (this one knew `real-esrgan`,
+ * web knew `companion` and `control-net`), which is how the 3-D Studio came to
+ * offer the prompt expander as a picture style.
+ */
 export function isGenerationModel(m: ModelEntry): boolean {
-  return !NON_GENERATION_FAMILIES.has(m.family);
+  return isGenerationModelShared(m);
 }
 
 export const useModelStore = defineStore("models", {

--- a/desktop/src/views/MeshWorkflowView.test.ts
+++ b/desktop/src/views/MeshWorkflowView.test.ts
@@ -2,13 +2,25 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// The view reads `?workflow=` — the queue row's route back here — so these
+// cases mount it against a stub route they can rewrite.
+const routeQuery = vi.hoisted(() => ({ value: {} as Record<string, string> }));
+vi.mock("vue-router", () => ({ useRoute: () => ({ query: routeQuery.value }) }));
+
+const generate = vi.hoisted(() => vi.fn());
 vi.mock("@studio/components/MeshWorkflowStudio.vue", () => ({
   default: {
-    props: ["target", "resolveTarget", "availableModels", "desktop", "hostLabel"],
+    props: ["target", "resolveTarget", "availableModels", "desktop", "hostLabel", "openWorkflow"],
+    // Returning an object (not a render function) keeps the template below.
+    setup: (_props: unknown, { expose }: { expose: (value: unknown) => void }) => {
+      expose({ generate });
+      return {};
+    },
     template: `
       <div data-test="mesh-studio">
         <span data-test="target-url">{{ target.baseUrl }}</span>
         <span data-test="target-key">{{ target.apiKey }}</span>
+        <span data-test="open-workflow">{{ openWorkflow }}</span>
         <slot name="machine" />
       </div>
     `,
@@ -25,6 +37,7 @@ import { useHostModelsStore } from "../stores/hostModels";
 import MeshWorkflowView from "./MeshWorkflowView.vue";
 import { useConnectionStore } from "../stores/connection";
 import { useHostsStore } from "../stores/hosts";
+import { useUiStore } from "../stores/ui";
 
 function mountView() {
   const pinia = createPinia();
@@ -51,7 +64,10 @@ function mountView() {
 }
 
 describe("MeshWorkflowView host routing", () => {
-  beforeEach(() => vi.clearAllMocks());
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeQuery.value = {};
+  });
 
   it("routes the complete studio to the selected authenticated machine", async () => {
     const wrapper = mountView();
@@ -174,6 +190,59 @@ describe("MeshWorkflowView host routing", () => {
     wrapper.findComponent(HostChip).vm.$emit("update:modelValue", "renderbox-7680");
     await flushPromises();
     await expect(resolve(request)).rejects.toThrow("Render box cannot run all");
+    wrapper.unmount();
+  });
+});
+
+describe("MeshWorkflowView shell integration", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    routeQuery.value = {};
+  });
+
+  /*
+   * The queue row's route back here. A 3-D Studio stage is admitted as an
+   * ordinary generation, so clicking it used to land on New image — which
+   * cannot resume a durable workflow at all.
+   */
+  it("opens on the workflow a deep link names", async () => {
+    routeQuery.value = { workflow: "workflow-7" };
+    const wrapper = mountView();
+    await flushPromises();
+    expect(wrapper.get("[data-test='open-workflow']").text()).toBe("workflow-7");
+    wrapper.unmount();
+  });
+
+  /*
+   * Before this, ⌘↩ raised the Generate intent AND pushed `/create`: pressing
+   * it here left the view and rendered a picture, while the status bar
+   * advertised the hint as though it worked.
+   */
+  it("generates here when the shell raises ⌘↩, and consumes the intent once", async () => {
+    const wrapper = mountView();
+    await flushPromises();
+    const ui = useUiStore();
+
+    ui.generate();
+    await flushPromises();
+    expect(generate).toHaveBeenCalledTimes(1);
+
+    ui.generate();
+    await flushPromises();
+    expect(generate).toHaveBeenCalledTimes(2);
+    wrapper.unmount();
+  });
+
+  it("does not generate for an intent another view already consumed", async () => {
+    const pinia = createPinia();
+    setActivePinia(pinia);
+    const ui = useUiStore();
+    ui.generate();
+    expect(ui.consumeIntent("generate")).toBe(true);
+
+    const wrapper = mountView();
+    await flushPromises();
+    expect(generate).not.toHaveBeenCalled();
     wrapper.unmount();
   });
 });

--- a/desktop/src/views/MeshWorkflowView.test.ts
+++ b/desktop/src/views/MeshWorkflowView.test.ts
@@ -214,6 +214,31 @@ describe("MeshWorkflowView shell integration", () => {
   });
 
   /*
+   * A durable workflow lives on ONE machine. A link carrying only the id sent
+   * a queue row from another machine to whichever one this view happened to be
+   * browsing, which then reported the workflow gone instead of showing its
+   * progress and its Resume / Cancel controls.
+   */
+  it("binds to the machine the link names before loading the workflow", async () => {
+    routeQuery.value = { workflow: "workflow-7", host: "renderbox-7680" };
+    const wrapper = mountView();
+    await flushPromises();
+    expect(wrapper.get("[data-test='target-url']").text()).toBe("http://renderbox:7680");
+    expect(wrapper.get("[data-test='target-key']").text()).toBe("remote-secret");
+    expect(wrapper.get("[data-test='open-workflow']").text()).toBe("workflow-7");
+    wrapper.unmount();
+  });
+
+  /* A machine this app does not know is not a reason to move the pin. */
+  it("leaves the machine alone when the link names one it does not have", async () => {
+    routeQuery.value = { workflow: "workflow-7", host: "a-machine-we-forgot" };
+    const wrapper = mountView();
+    await flushPromises();
+    expect(wrapper.get("[data-test='target-url']").text()).toBe("http://127.0.0.1:49152");
+    wrapper.unmount();
+  });
+
+  /*
    * Before this, ⌘↩ raised the Generate intent AND pushed `/create`: pressing
    * it here left the view and rendered a picture, while the status bar
    * advertised the hint as though it worked.

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -96,9 +96,15 @@ watch(
  * not exist. A link that does not say (an older one) leaves the pin alone.
  */
 watch(
-  () => meshWorkflowHostFromQuery(route.query),
-  (hostId) => {
-    if (!hostId || !hosts.all.some((host) => host.id === hostId)) return;
+  [() => meshWorkflowHostFromQuery(route.query), () => hosts.all.map((h) => h.id).join("|")],
+  ([hostId]) => {
+    if (!hostId || browseHostId.value === hostId) return;
+    // The machine may not be known yet: `extras` fills in asynchronously and
+    // the file's own comment below says connections become ready AFTER this
+    // view mounts on a cold launch. The query never changes, so a query-only
+    // watcher would drop the pin here and never look again — which is why the
+    // host list is a source too.
+    if (!hosts.all.some((host) => host.id === hostId)) return;
     browseHostId.value = hostId;
     routing.value = hostId;
     draft.persist();

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
+import { storeToRefs } from "pinia";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
+import { useMeshWorkflowDraftStore } from "@studio/stores/meshWorkflowDraft";
 import { meshWorkflowModes, type WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import {
   supportsMeshWorkflow,
@@ -39,8 +41,14 @@ function pickerModels(filtered: WorkflowModel[]): ModelEntry[] {
   return [...rows.values()];
 }
 const inventory = useHostModelsStore();
-const routing = ref<string | null>(null);
-const browseHostId = ref("");
+/*
+ * The machine pin and the machine being browsed belong to the draft, not to
+ * this mount: leaving for the Queue and coming back used to drop the workflow
+ * back onto whichever host answered first. `HostChip` writes `routing`, and
+ * the watcher below still follows it to the browsing host.
+ */
+const draft = useMeshWorkflowDraftStore();
+const { routing, browseHostId } = storeToRefs(draft);
 const selectedHost = computed(
   () => hosts.all.find((host) => host.id === browseHostId.value) ?? null,
 );
@@ -58,6 +66,7 @@ watch(
 );
 watch(routing, (value) => {
   if (value && value !== "capable") browseHostId.value = value;
+  draft.persist();
 });
 // Connections become ready after the view mounts on a cold launch. Refresh
 // only when that authority set changes, never on queue/GPU telemetry ticks.

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -4,7 +4,10 @@ import { storeToRefs } from "pinia";
 import { useRoute } from "vue-router";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
 import { useMeshWorkflowDraftStore } from "@studio/stores/meshWorkflowDraft";
-import { meshWorkflowIdFromQuery } from "@studio/lib/meshWorkflowProvenance";
+import {
+  meshWorkflowHostFromQuery,
+  meshWorkflowIdFromQuery,
+} from "@studio/lib/meshWorkflowProvenance";
 import { meshWorkflowModes, type WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import {
   supportsMeshWorkflow,
@@ -86,6 +89,23 @@ watch(
   },
   { immediate: true },
 );
+/*
+ * A durable workflow lives on ONE machine, so the link that opens it names
+ * that machine too. Without this a queue row from another host asked whichever
+ * machine the studio happened to be browsing and was told the workflow does
+ * not exist. A link that does not say (an older one) leaves the pin alone.
+ */
+watch(
+  () => meshWorkflowHostFromQuery(route.query),
+  (hostId) => {
+    if (!hostId || !hosts.all.some((host) => host.id === hostId)) return;
+    browseHostId.value = hostId;
+    routing.value = hostId;
+    draft.persist();
+  },
+  { immediate: true },
+);
+
 watch(routing, (value) => {
   if (value && value !== "capable") browseHostId.value = value;
   draft.persist();

--- a/desktop/src/views/MeshWorkflowView.vue
+++ b/desktop/src/views/MeshWorkflowView.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import { computed, ref, watch } from "vue";
 import { storeToRefs } from "pinia";
+import { useRoute } from "vue-router";
 import MeshWorkflowStudio from "@studio/components/MeshWorkflowStudio.vue";
 import { useMeshWorkflowDraftStore } from "@studio/stores/meshWorkflowDraft";
+import { meshWorkflowIdFromQuery } from "@studio/lib/meshWorkflowProvenance";
 import { meshWorkflowModes, type WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import {
   supportsMeshWorkflow,
@@ -17,9 +19,29 @@ import type { ModelEntry } from "../lib/api/types";
 import HostChip from "../components/create/HostChip.vue";
 import { useHostsStore } from "../stores/hosts";
 import { useHostModelsStore } from "../stores/hostModels";
+import { useUiStore } from "../stores/ui";
 
 const hosts = useHostsStore();
 const prefs = useAppPrefsStore();
+const route = useRoute();
+const ui = useUiStore();
+const studio = ref<{ generate: () => void } | null>(null);
+// The queue row's route back here (`?workflow=`), read by the shell because
+// routing is the shell's job — the shared studio is handed the id.
+const openWorkflow = computed(() => meshWorkflowIdFromQuery(route.query));
+
+/*
+ * ⌘↩ used to raise the Generate intent AND push `/create`, so pressing it
+ * here left the view and rendered a picture — while the status bar advertised
+ * the hint. The shell now stays put on this route and this view consumes the
+ * intent, exactly as New image does.
+ */
+watch(
+  () => ui.generateTick,
+  () => {
+    if (ui.consumeIntent("generate")) studio.value?.generate();
+  },
+);
 const draftWidth = ref<number | null>(null);
 const inspectorWidth = computed(() => draftWidth.value ?? prefs.generateParamsWidth);
 function resizeInspector(dx: number) {
@@ -125,7 +147,9 @@ async function resolveTarget(requirements: MeshWorkflowRequirements): Promise<Me
 <template>
   <MeshWorkflowStudio
     v-if="target"
+    ref="studio"
     :target="target"
+    :open-workflow="openWorkflow"
     :style="{ '--mesh-inspector-width': inspectorWidth + 'px' }"
     :available-models="availableModels"
     :resolve-target="resolveTarget"

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -300,8 +300,11 @@ shared segmented control on the toolbar; only workflows supported by the
 connected machines appear.
 
 **The description and Generate live on the composer**, with the ⌘↩ keycap, as
-they do on New image — and ⌘↩ generates here rather than leaving for New image.
-**3-D style** and **Picture style** are composer chips beside them. Reuse
+they do on New image. **3-D style** and **Picture style** are composer chips
+beside them. On the desktop shell ⌘↩ generates HERE rather than leaving for New
+image — every raiser of that intent (the native menu and the ⌘K palette alike)
+stays on this route and lets the view consume it. The web SPA has no keyboard
+Generate on any surface, so the keycap is the desktop composer's. Reuse
 Generate's model picker with filtered candidates, including its search, family
 groups, availability, and friendly labels; do not build a second selector, and
 narrow the candidates through `outputKindForModel` rather than a second

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -199,7 +199,7 @@ a literal.
 | ----------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
 | Tokens: six complete theme maps + the theme-invariant set; a fenced legacy bridge keeps the `--desk/--bath/…` names alive for web and the phone | `ui/tokens.css` (single source, consumed by `web/` and `desktop/`)                                                          |
 | Shell metrics, control heights, semantic surfaces, `--mold-state-*`                                                                             | `ui/mold-desktop.css`                                                                                                       |
-| Theme contract (`ThemeId`, `THEME_FAMILY_META`, `toneChoice`, `migrateLegacyTheme`, `applyTheme`)                                                      | `ui/theme.ts`, re-exported by `desktop/src/lib/theme.ts` and consumed by `web/src/lib/theme.ts`                             |
+| Theme contract (`ThemeId`, `THEME_FAMILY_META`, `toneChoice`, `migrateLegacyTheme`, `applyTheme`)                                               | `ui/theme.ts`, re-exported by `desktop/src/lib/theme.ts` and consumed by `web/src/lib/theme.ts`                             |
 | Desktop Tailwind layer (`bg-panel`, `text-fg-dim`, `rounded-control`, `text-micro`…)                                                            | `desktop/src/styles/tokens.css` + `base.css`; `tokens.legacy.test.ts` refuses the retired vocabulary                        |
 | Shared kit: shimmer, pulse, `.ms-toolbar-button`, `.ms-group-label`, `.ms-card-edge`, `.ms-lib-upscaled`                                        | `ui/kit.css`                                                                                                                |
 | Shared primitives (`SegmentedControl` `inline`, `SliderRow` `low`/`high`, `ModalPanel` header + `#description`, `DrawerPanel`)                  | `ui/components/` (Vue, token-var styled)                                                                                    |
@@ -291,19 +291,38 @@ image and says so.
 
 ## 3-D Studio workflows
 
-The 3-D Studio uses the desktop shell's 40px view toolbar, a full-height result
-canvas, and the standard inspector on the right (300px by default, resizable
+The 3-D Studio is New image's anatomy, not a variation on it: the desktop
+shell's 40px view toolbar, a full-height result canvas, a composer on the bottom
+edge, and the standard inspector on the right (300px by default, resizable
 280–480px with Generate's shared handle, width setting, keyboard controls, and
-double-click reset). **From words**, **Rebuild**,
-and **Add texture** are the shared segmented control; only workflows supported
-by the connected machines appear. Workflow inputs belong together in the
-inspector, including the description or source files, with **Generate** at its
-foot. Use **3-D style** and **Picture style** for the two style pickers. Reuse
+double-click reset). **From words**, **Rebuild**, and **Add texture** are the
+shared segmented control on the toolbar; only workflows supported by the
+connected machines appear.
+
+**The description and Generate live on the composer**, with the ⌘↩ keycap, as
+they do on New image — and ⌘↩ generates here rather than leaving for New image.
+**3-D style** and **Picture style** are composer chips beside them. Reuse
 Generate's model picker with filtered candidates, including its search, family
-groups, availability, and friendly labels; do not build a second selector.
-Use the shared switches and inspector typography for stage settings. The
-result and its stage progress occupy the canvas, without a separate landing-page
-heading or oversized cards.
+groups, availability, and friendly labels; do not build a second selector, and
+narrow the candidates through `outputKindForModel` rather than a second
+predicate. The inspector holds the stage settings — texture and its size,
+lighting removal, and for a supplied mesh its file wells and orientation — using
+the shared switches, group labels and inspector typography. The result and its
+stage progress occupy the canvas, without a separate landing-page heading or
+oversized cards.
+
+(This supersedes the original "workflow inputs belong together in the inspector,
+with Generate at its foot". Putting the prompt where every other making-view
+puts it is what makes the surface read as part of the app, and it gives ⌘↩ an
+obvious home.)
+
+**The draft belongs to a store, never to the view.** The router lazy-loads this
+surface and nothing keeps it alive, so a component-local ref loses the
+description, both styles, the attachments, the stage settings and the machine
+pin on any trip to the Queue. `studio/stores/meshWorkflowDraft.ts` holds them,
+exactly as `generateForm` does for New image. An attached file is deliberately
+session-scoped: a browser cannot re-open a file handle from a previous session,
+so the well comes back empty rather than promising bytes it cannot read.
 
 The existing **Where it runs** chip is the last toolbar control. **Auto** chooses
 the least-busy eligible machine; **Most capable** chooses its strongest eligible

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -1,5 +1,25 @@
 import { flushPromises, mount } from "@vue/test-utils";
+import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import { setMeshWorkflowDraftStorage } from "../stores/meshWorkflowDraft";
+
+/*
+ * The 3-D Studio draft is a module-scoped store, so a case that leaves a
+ * selected workflow behind would have the NEXT mount restore it and fetch its
+ * result — which is exactly how the polling budget below saw four fetches
+ * instead of two. Every case starts on a fresh Pinia and a storage stub;
+ * happy-dom keeps one localStorage per file, so the stub is what stops the
+ * cases hydrating each other's prompts.
+ */
+beforeEach(() => {
+  setActivePinia(createPinia());
+  setMeshWorkflowDraftStorage({
+    getItem: () => null,
+    setItem: () => {},
+    removeItem: () => {},
+  });
+});
 
 const createMeshWorkflow = vi.hoisted(() =>
   vi.fn(async () => ({ job_id: "workflow-1" })),
@@ -195,6 +215,37 @@ it("retains unchanged result media across progress polls and stops polling on un
     revokeUrl.mockRestore();
     vi.useRealTimers();
   }
+});
+
+/*
+ * The reported bug, at the level a person hits it: type a description, go to
+ * the Queue, come back. The router lazy-loads this view and nothing keeps it
+ * alive, so every draft ref used to unmount with it.
+ */
+it("keeps the description and the chosen styles across leaving the view and returning", async () => {
+  const first = mount(MeshWorkflowStudio, {
+    props: { target: { baseUrl: "http://local:7680", apiKey: null } },
+  });
+  await flushPromises();
+  await first.get("textarea").setValue("a hand-carved wooden fox");
+  const style = first.get<HTMLSelectElement>(
+    "[data-test='mesh-workflow-model']",
+  ).element.value;
+  expect(style).not.toBe("");
+  first.unmount();
+
+  const second = mount(MeshWorkflowStudio, {
+    props: { target: { baseUrl: "http://local:7680", apiKey: null } },
+  });
+  await flushPromises();
+  expect(second.get<HTMLTextAreaElement>("textarea").element.value).toBe(
+    "a hand-carved wooden fox",
+  );
+  expect(
+    second.get<HTMLSelectElement>("[data-test='mesh-workflow-model']").element
+      .value,
+  ).toBe(style);
+  second.unmount();
 });
 
 it("restores a selected workflow's settings without overwriting edits on progress polls", async () => {

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -325,3 +325,121 @@ it.each([
     }
   },
 );
+
+describe("a returning view does not overwrite what you were writing", () => {
+  const job = (id: string) => ({
+    contract_version: 1,
+    id,
+    state: "completed",
+    mode: "text_to_mesh",
+    stage_count: 3,
+    current_stage: 2,
+    created_at_ms: Date.now(),
+    updated_at_ms: Date.now(),
+  });
+
+  async function withOneFinishedRun() {
+    const { listMeshWorkflows, getMeshWorkflow } =
+      await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [job("run-1")],
+    } as never);
+    vi.mocked(getMeshWorkflow).mockResolvedValue({
+      id: "run-1",
+      state: "completed",
+      mode: "text_to_mesh",
+      stages: [],
+      request: {
+        mode: "text_to_mesh",
+        image_request: {
+          model: "z-image-turbo:q8",
+          prompt: "the finished run",
+        },
+        mesh_request: {
+          model: "hunyuan3d-mini-turbo:fp16",
+          mesh: { texture: false },
+        },
+      },
+    } as never);
+  }
+
+  /*
+   * `bootstrap` retains the selection, and it used to restore the DRAFT from
+   * it on every entry. So after your first run — the normal state — leaving
+   * for the Queue and coming back reverted your unsent description to the
+   * finished workflow's and dropped both attachments, then persisted the
+   * clobbered values. That is the reported bug, reintroduced for the common
+   * case. The draft is only restored for a DEEP LINK, which is a request to
+   * open someone's specific workflow.
+   */
+  it("keeps a new description over a finished run's, across a remount", async () => {
+    await withOneFinishedRun();
+    const target = { baseUrl: "http://local:7680", apiKey: null };
+
+    // Arrive on the workflow the way a queue row does, then type over it.
+    const first = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true, openWorkflow: "run-1" },
+    });
+    await flushPromises();
+    await first.get("textarea").setValue("a completely different object");
+    first.unmount();
+
+    const second = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true },
+    });
+    await flushPromises();
+    expect(second.get<HTMLTextAreaElement>("textarea").element.value).toBe(
+      "a completely different object",
+    );
+    second.unmount();
+  });
+
+  /* A deep link IS a request to open that workflow, so it does restore. */
+  it("restores the workflow's own settings when a link names it", async () => {
+    await withOneFinishedRun();
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+        openWorkflow: "run-1",
+      },
+    });
+    await flushPromises();
+    expect(wrapper.get<HTMLTextAreaElement>("textarea").element.value).toBe(
+      "the finished run",
+    );
+    wrapper.unmount();
+  });
+
+  /*
+   * The machine is RECORDED, not inferred: `ownedTarget` is re-seeded from
+   * the props on every fresh mount, so comparing against it always said "same
+   * machine" and a hal9000 job id was retained against plato — clearing the
+   * canvas with "no longer on this machine", which is wrong and unexplained.
+   */
+  it("drops a selection belonging to a machine it no longer talks to", async () => {
+    await withOneFinishedRun();
+    const first = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://hal9000:7680", apiKey: "hk" },
+        desktop: true,
+        openWorkflow: "run-1",
+      },
+    });
+    await flushPromises();
+    first.unmount();
+
+    // A FRESH mount against a different machine — the case the old test missed.
+    const { listMeshWorkflows } = await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({ jobs: [] } as never);
+    const second = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://plato:7680", apiKey: "pk" },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    expect(second.text()).not.toContain("no longer on this machine");
+    second.unmount();
+  });
+});

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -1,5 +1,6 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { storeToRefs } from "pinia";
 import SwitchToggle from "@ui/components/SwitchToggle.vue";
 import SegmentedControl from "@ui/components/SegmentedControl.vue";
 import type {
@@ -28,6 +29,8 @@ import {
   type WorkflowGenerateRequest,
   type WorkflowModel,
 } from "../lib/meshWorkflowAuthoring";
+import { isMeshFamily } from "../lib/legacyRecipeRules";
+import { useMeshWorkflowDraftStore } from "../stores/meshWorkflowDraft";
 import MeshViewer from "./MeshViewer.vue";
 import {
   prepareReferenceUploads,
@@ -52,20 +55,29 @@ const ownedTarget = ref<ApiTarget>({ ...props.target });
 const ownerLabel = ref(props.hostLabel ?? "");
 const jobs = ref<MeshWorkflowJobSummary[]>([]);
 const detail = ref<MeshWorkflowJobDetail<WorkflowGenerateRequest> | null>(null);
-const selectedId = ref("");
-const mode = ref<"text_to_mesh" | "mesh_roundtrip" | "mesh_texture">(
-  "text_to_mesh",
-);
-const imageModelName = ref("");
-const meshModelName = ref("");
-const prompt = ref("");
-const texture = ref(true);
-const textureResolution = ref(2048);
-const delight = ref(false);
-const meshFile = ref<File | null>(null);
-const appearanceFile = ref<File | null>(null);
-const upAxis = ref<"y" | "z">("y");
-const metersPerUnit = ref(1);
+
+/*
+ * The draft lives in a store, not in this component: the router lazy-loads
+ * this view and nothing keeps it alive, so every one of these used to be a
+ * local `ref` that unmounted with the view — a trip to the Queue and back
+ * landed on an empty form. `jobs`, `detail`, the epochs and the result URLs
+ * stay local because they belong to this mount and are re-fetched on the next.
+ */
+const draft = useMeshWorkflowDraftStore();
+const {
+  mode,
+  imageModelName,
+  meshModelName,
+  prompt,
+  texture,
+  textureResolution,
+  delight,
+  meshFile,
+  appearanceFile,
+  upAxis,
+  metersPerUnit,
+  selectedId,
+} = storeToRefs(draft);
 const busy = ref(false);
 const loading = ref(true);
 const error = ref("");
@@ -82,7 +94,7 @@ const meshModels = computed(() =>
     (model) =>
       model.downloaded &&
       model.runtime_available !== false &&
-      model.family === "hunyuan3d" &&
+      isMeshFamily(model.family) &&
       meshWorkflowModes(model).some((value) =>
         ["text_to_mesh", "mesh_roundtrip", "mesh_texture"].includes(value),
       ),
@@ -551,6 +563,27 @@ watch(
   [() => props.target.baseUrl, () => props.target.apiKey],
   () => void bootstrap(),
 );
+
+/*
+ * Persist the scalars the moment they settle rather than on unmount: the
+ * webview can be closed or reloaded without an unmount hook ever running, and
+ * a draft that only survives a graceful exit is not a draft.
+ */
+watch(
+  [
+    mode,
+    meshModelName,
+    imageModelName,
+    prompt,
+    texture,
+    textureResolution,
+    delight,
+    upAxis,
+    metersPerUnit,
+  ],
+  () => draft.persist(),
+);
+
 onMounted(() => void bootstrap());
 onBeforeUnmount(() => {
   ++contextEpoch;

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -253,6 +253,11 @@ function chooseModels(): void {
     imageModelName.value = imageModels.value[0]?.name ?? "";
 }
 
+/** A machine's identity for the purpose of owning a workflow. */
+function targetIdentity(target: ApiTarget): string {
+  return `${target.baseUrl}\u0000${target.apiKey ?? ""}`;
+}
+
 async function bootstrap(): Promise<void> {
   const epoch = ++contextEpoch;
   ++selectionEpoch;
@@ -266,10 +271,9 @@ async function bootstrap(): Promise<void> {
    * change does clear it: the workflow belongs to the machine that ran it.
    */
   const deepLink = props.openWorkflow?.trim() ?? "";
-  const sameMachine =
-    ownedTarget.value.baseUrl === props.target.baseUrl &&
-    (ownedTarget.value.apiKey ?? null) === (props.target.apiKey ?? null);
-  selectedId.value = deepLink || (sameMachine ? selectedId.value : "");
+  const machine = targetIdentity(props.target);
+  if (deepLink) draft.selectWorkflow(deepLink, machine);
+  else if (!draft.selectionBelongsTo(machine)) draft.selectWorkflow("", "");
   detail.value = null;
   ownedTarget.value = { ...props.target };
   ownerLabel.value = props.hostLabel ?? "";
@@ -289,10 +293,19 @@ async function bootstrap(): Promise<void> {
     // against an empty job list. Restore the deep-linked workflow's draft now
     // that the listing can name it, and say so plainly when it is gone.
     if (selectedId.value) {
-      if (listing.jobs.some((job) => job.id === selectedId.value))
-        await refreshSelected(true);
-      else {
-        selectedId.value = "";
+      if (listing.jobs.some((job) => job.id === selectedId.value)) {
+        /*
+         * Restore the DRAFT only for a deep link. A returning view is showing
+         * a workflow the person already has, and their unsent description and
+         * attachments are the newer thing: `restoreWorkflowDraft` overwrites
+         * the prompt, both styles, every stage setting and BOTH file wells, so
+         * doing it on every entry reverted the draft to the finished
+         * workflow's — the exact loss this PR exists to end, for the normal
+         * case of having run something once.
+         */
+        await refreshSelected(Boolean(deepLink));
+      } else {
+        draft.selectWorkflow("", "");
         error.value = "That 3-D workflow is no longer on this machine.";
       }
     }
@@ -333,7 +346,7 @@ async function submit(): Promise<void> {
   error.value = "";
   let uploadLease: ReferenceUploadLease<WorkflowGenerateRequest> | null = null;
   const epoch = contextEpoch;
-  const draft = {
+  const submitted = {
     mode: mode.value,
     prompt: prompt.value,
     texture: texture.value,
@@ -350,20 +363,20 @@ async function submit(): Promise<void> {
   try {
     const route = props.resolveTarget
       ? await props.resolveTarget({
-          mode: draft.mode,
+          mode: submitted.mode,
           meshModel: meshModel.name,
-          ...(draft.mode === "text_to_mesh"
-            ? { imageModel: draft.selectedImageModel!.name }
+          ...(submitted.mode === "text_to_mesh"
+            ? { imageModel: submitted.selectedImageModel!.name }
             : {}),
           texture:
-            draft.mode === "mesh_texture" ||
-            (draft.mode === "text_to_mesh" &&
-              draft.textureAvailable &&
-              draft.texture),
+            submitted.mode === "mesh_texture" ||
+            (submitted.mode === "text_to_mesh" &&
+              submitted.textureAvailable &&
+              submitted.texture),
           delight:
-            draft.mode !== "mesh_roundtrip" &&
-            draft.delightAvailable &&
-            draft.delight,
+            submitted.mode !== "mesh_roundtrip" &&
+            submitted.delightAvailable &&
+            submitted.delight,
         })
       : { target: { ...props.target }, label: props.hostLabel ?? "" };
     if (epoch !== contextEpoch) return;
@@ -378,17 +391,17 @@ async function submit(): Promise<void> {
     if (epoch !== contextEpoch) return;
     const submissionUploads = capabilities.reference_uploads ?? null;
     let request =
-      draft.mode === "text_to_mesh"
+      submitted.mode === "text_to_mesh"
         ? buildTextToMeshWorkflow({
-            prompt: draft.prompt,
-            imageModel: draft.selectedImageModel!,
+            prompt: submitted.prompt,
+            imageModel: submitted.selectedImageModel!,
             meshModel,
-            texture: draft.texture,
-            textureResolution: draft.textureResolution,
-            delight: draft.delightAvailable && draft.delight,
+            texture: submitted.texture,
+            textureResolution: submitted.textureResolution,
+            delight: submitted.delightAvailable && submitted.delight,
           })
         : await (async () => {
-            const mesh = draft.meshFile!;
+            const mesh = submitted.meshFile!;
             const useUpload =
               submissionUploads?.available === true &&
               Boolean(submissionTarget.apiKey?.trim());
@@ -405,18 +418,20 @@ async function submit(): Promise<void> {
               meshByteLength: mesh.size,
               ...(meshPayload ? { meshSha256: meshPayload.sha256 } : {}),
               meshFormat,
-              upAxis: draft.upAxis,
-              metersPerUnit: draft.metersPerUnit,
+              upAxis: submitted.upAxis,
+              metersPerUnit: submitted.metersPerUnit,
             };
-            if (draft.mode === "mesh_roundtrip") {
+            if (submitted.mode === "mesh_roundtrip") {
               return buildMeshRoundtripWorkflow(shared);
             }
-            const appearancePayload = await filePayload(draft.appearanceFile!);
+            const appearancePayload = await filePayload(
+              submitted.appearanceFile!,
+            );
             return buildMeshTextureWorkflow({
               ...shared,
               appearanceBase64: appearancePayload.base64,
-              textureResolution: draft.textureResolution,
-              delight: draft.delightAvailable && draft.delight,
+              textureResolution: submitted.textureResolution,
+              delight: submitted.delightAvailable && submitted.delight,
             });
           })();
     const meshRequest =
@@ -442,7 +457,7 @@ async function submit(): Promise<void> {
         capabilities: submissionUploads,
         request: meshRequest,
         ...(directMeshUpload
-          ? { uploadBodies: new Map([[1, draft.meshFile!]]) }
+          ? { uploadBodies: new Map([[1, submitted.meshFile!]]) }
           : {}),
       });
       if (request.mode === "mesh_texture") {
@@ -464,7 +479,9 @@ async function submit(): Promise<void> {
     detail.value = null;
     ownedTarget.value = submissionTarget;
     ownerLabel.value = route.label;
-    selectedId.value = created.job_id;
+    // The run belongs to the machine that accepted it — which under Auto or
+    // Most capable is not necessarily the one being browsed.
+    draft.selectWorkflow(created.job_id, targetIdentity(submissionTarget));
     await refreshJobs();
   } catch (cause) {
     await uploadLease?.cancel().catch(() => undefined);
@@ -506,7 +523,7 @@ async function remove(): Promise<void> {
   error.value = "";
   try {
     await deleteMeshWorkflow(ownedTarget.value, selectedId.value);
-    selectedId.value = "";
+    draft.selectWorkflow("", "");
     detail.value = null;
     revokeResult();
     await refreshJobs();
@@ -595,7 +612,8 @@ watch(
   () => props.openWorkflow,
   (value) => {
     const id = value?.trim() ?? "";
-    if (id && id !== selectedId.value) selectedId.value = id;
+    if (id && id !== selectedId.value)
+      draft.selectWorkflow(id, targetIdentity(ownedTarget.value));
   },
 );
 

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -44,6 +44,12 @@ const props = defineProps<{
   hostLabel?: string;
   desktop?: boolean;
   availableModels?: WorkflowModel[];
+  /**
+   * A workflow to open on, from the shell's own `?workflow=` deep link — the
+   * queue row's route back here. Routing belongs to the shells, so this
+   * component is handed the id rather than reading the router itself.
+   */
+  openWorkflow?: string | null;
   resolveTarget?: (
     requirements: MeshWorkflowRequirements,
   ) => Promise<MeshWorkflowRoute>;
@@ -252,7 +258,9 @@ async function bootstrap(): Promise<void> {
   ++selectionEpoch;
   clearPoll();
   revokeResult();
-  selectedId.value = "";
+  // A deep link names the workflow to open on; without one this is a fresh
+  // visit, and the draft's own selection does not survive a host change.
+  selectedId.value = props.openWorkflow?.trim() ?? "";
   detail.value = null;
   ownedTarget.value = { ...props.target };
   ownerLabel.value = props.hostLabel ?? "";
@@ -268,6 +276,17 @@ async function bootstrap(): Promise<void> {
     hostModels.value = availableModels;
     jobs.value = listing.jobs;
     chooseModels();
+    // `selectedId` was set before the fetch, so its watcher has already run
+    // against an empty job list. Restore the deep-linked workflow's draft now
+    // that the listing can name it, and say so plainly when it is gone.
+    if (selectedId.value) {
+      if (listing.jobs.some((job) => job.id === selectedId.value))
+        await refreshSelected(true);
+      else {
+        selectedId.value = "";
+        error.value = "That 3-D workflow is no longer on this machine.";
+      }
+    }
   } catch (cause) {
     if (epoch === contextEpoch)
       error.value = cause instanceof Error ? cause.message : String(cause);
@@ -563,6 +582,16 @@ watch(
   [() => props.target.baseUrl, () => props.target.apiKey],
   () => void bootstrap(),
 );
+watch(
+  () => props.openWorkflow,
+  (value) => {
+    const id = value?.trim() ?? "";
+    if (id && id !== selectedId.value) selectedId.value = id;
+  },
+);
+
+/** The shell's ⌘↩ — the same Generate the composer's button runs. */
+defineExpose({ generate: () => void submit() });
 
 /*
  * Persist the scalars the moment they settle rather than on unmount: the

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -258,9 +258,18 @@ async function bootstrap(): Promise<void> {
   ++selectionEpoch;
   clearPoll();
   revokeResult();
-  // A deep link names the workflow to open on; without one this is a fresh
-  // visit, and the draft's own selection does not survive a host change.
-  selectedId.value = props.openWorkflow?.trim() ?? "";
+  /*
+   * A deep link names the workflow to open on. Without one, the selection is
+   * kept whenever this is the SAME machine — `bootstrap` also runs on every
+   * mount, so clearing unconditionally meant a trip to the Queue and back
+   * emptied the canvas even though the draft beneath it survived. A host
+   * change does clear it: the workflow belongs to the machine that ran it.
+   */
+  const deepLink = props.openWorkflow?.trim() ?? "";
+  const sameMachine =
+    ownedTarget.value.baseUrl === props.target.baseUrl &&
+    (ownedTarget.value.apiKey ?? null) === (props.target.apiKey ?? null);
+  selectedId.value = deepLink || (sameMachine ? selectedId.value : "");
   detail.value = null;
   ownedTarget.value = { ...props.target };
   ownerLabel.value = props.hostLabel ?? "";

--- a/studio/lib/generationModels.ts
+++ b/studio/lib/generationModels.ts
@@ -1,0 +1,76 @@
+/**
+ * Which installed styles can make something from a prompt.
+ *
+ * A machine's `/api/models` lists everything it holds, including things that
+ * are not styles at all: the prompt-expansion LLM, upscalers, ControlNets,
+ * companion encoders. Every picker that offers "pick a style" has to exclude
+ * them, and this is the ONE place that decides — the desktop store and the web
+ * filter each had their own list, and the two had already drifted apart
+ * (desktop knew `real-esrgan`, web knew `companion` and `control-net`).
+ *
+ * The 3-D Studio's Picture style picker is what surfaced it: it partitioned by
+ * output kind, correctly excluding clip and mesh styles, and then offered
+ * "Qwen3-1.7B — prompt expansion LLM" and "Real-ESRGAN x4+ — upscaler" as
+ * things to draw a picture with.
+ */
+
+/** Families that are never a style. The union of what each surface knew. */
+export const NON_GENERATION_FAMILIES: ReadonlySet<string> = new Set([
+  "real-esrgan",
+  "upscaler",
+  "qwen3-expand",
+  "companion",
+  "controlnet",
+  "control-net",
+]);
+
+/**
+ * Names that give a support artifact away when its family does not.
+ *
+ * A catalog install can land an encoder or an upscaler under a family this
+ * build has never heard of, so the family test alone is not enough.
+ */
+export const SUPPORT_NAME_PATTERNS: readonly RegExp[] = [
+  /\bupscal(e|er|ing)\b/i,
+  /\breal[-_ ]?esrgan\b/i,
+  /\bcontrol[-_ ]?net\b/i,
+  /\b(qwen3|prompt)[-_ ]?expand/i,
+  /\bclip[-_ ]?[lg]?\b/i,
+  /\btext[-_ ]?encoder\b/i,
+  /\btokenizer\b/i,
+  /\bvae\b/i,
+];
+
+/** Whether a family can make something from a prompt. */
+export function isGenerationFamily(family: string | null | undefined): boolean {
+  return !NON_GENERATION_FAMILIES.has((family ?? "").trim().toLowerCase());
+}
+
+/** The least a row needs for this module to answer. */
+export interface GenerationModelLike {
+  family: string;
+  name?: string | null;
+  display_name?: string | null;
+  description?: string | null;
+  hf_repo?: string | null;
+}
+
+/**
+ * Whether a row is a style a person can pick, rather than a support artifact.
+ *
+ * The family answers first; the name is the fallback for a catalog install
+ * whose family this build does not know.
+ */
+export function isGenerationModel(model: GenerationModelLike): boolean {
+  if (!isGenerationFamily(model.family)) return false;
+  const searchable = [
+    model.name,
+    model.display_name,
+    model.description,
+    model.hf_repo,
+  ]
+    .filter((value): value is string => typeof value === "string")
+    .join(" ")
+    .toLowerCase();
+  return !SUPPORT_NAME_PATTERNS.some((pattern) => pattern.test(searchable));
+}

--- a/studio/lib/meshWorkflowAuthoring.test.ts
+++ b/studio/lib/meshWorkflowAuthoring.test.ts
@@ -52,14 +52,24 @@ describe("the picture-style candidates", () => {
 
   it("still offers ordinary still-picture styles", () => {
     for (const family of ["flux", "z-image", "sdxl", "qwen-image"])
-      expect(isTextImageWorkflowModel(model(`${family}-checkpoint`, family)), family).toBe(true);
+      expect(
+        isTextImageWorkflowModel(model(`${family}-checkpoint`, family)),
+        family,
+      ).toBe(true);
   });
 
   it("refuses the mesh family, an undownloaded style and an unrunnable one", () => {
-    expect(isTextImageWorkflowModel(model("h3", "hunyuan3d", ["text_to_mesh"]))).toBe(false);
-    expect(isTextImageWorkflowModel({ ...model("flux", "flux"), downloaded: false })).toBe(false);
     expect(
-      isTextImageWorkflowModel({ ...model("flux", "flux"), runtime_available: false }),
+      isTextImageWorkflowModel(model("h3", "hunyuan3d", ["text_to_mesh"])),
+    ).toBe(false);
+    expect(
+      isTextImageWorkflowModel({ ...model("flux", "flux"), downloaded: false }),
+    ).toBe(false);
+    expect(
+      isTextImageWorkflowModel({
+        ...model("flux", "flux"),
+        runtime_available: false,
+      }),
     ).toBe(false);
   });
 
@@ -68,7 +78,9 @@ describe("the picture-style candidates", () => {
     canvasless.generation_profile!.recipes[0]!.capabilities.canvasless = true;
     expect(isTextImageWorkflowModel(canvasless)).toBe(false);
     const ignored = model("mute", "flux");
-    ignored.generation_profile!.recipes[0]!.capabilities.prompt = { mode: "ignored" };
+    ignored.generation_profile!.recipes[0]!.capabilities.prompt = {
+      mode: "ignored",
+    };
     expect(isTextImageWorkflowModel(ignored)).toBe(false);
   });
 });

--- a/studio/lib/meshWorkflowAuthoring.test.ts
+++ b/studio/lib/meshWorkflowAuthoring.test.ts
@@ -50,6 +50,37 @@ describe("the picture-style candidates", () => {
     }
   });
 
+  /*
+   * UAT found this: the partition sorts by OUTPUT KIND, so the prompt
+   * expander and the upscalers — neither a clip nor a mesh — landed in
+   * "still" and were offered as things to draw a picture with. Every other
+   * picker already excluded them, through two blocklists that had drifted.
+   */
+  it("refuses the support artifacts that are not styles at all", () => {
+    for (const [name, family] of [
+      ["qwen3-expand:q8", "qwen3-expand"],
+      ["real-esrgan-x4plus:fp16", "real-esrgan"],
+      ["upscaler:fp16", "upscaler"],
+      ["controlnet-depth:fp16", "controlnet"],
+      ["some-companion:fp16", "companion"],
+    ] as const)
+      expect(isTextImageWorkflowModel(model(name, family)), name).toBe(false);
+  });
+
+  /* A catalog install can land one under a family this build never heard of. */
+  it("refuses a support artifact whose family it does not recognise", () => {
+    for (const name of [
+      "my-vae-fix",
+      "some-text-encoder",
+      "RealESRGAN x4",
+      "prompt-expand-helper",
+    ])
+      expect(
+        isTextImageWorkflowModel(model(name, "brand-new-family")),
+        name,
+      ).toBe(false);
+  });
+
   it("still offers ordinary still-picture styles", () => {
     for (const family of ["flux", "z-image", "sdxl", "qwen-image"])
       expect(

--- a/studio/lib/meshWorkflowAuthoring.test.ts
+++ b/studio/lib/meshWorkflowAuthoring.test.ts
@@ -4,6 +4,7 @@ import {
   buildMeshRoundtripWorkflow,
   buildMeshTextureWorkflow,
   buildTextToMeshWorkflow,
+  isTextImageWorkflowModel,
   meshWorkflowModes,
   type WorkflowModel,
 } from "./meshWorkflowAuthoring";
@@ -32,6 +33,45 @@ function model(
     },
   };
 }
+
+describe("the picture-style candidates", () => {
+  /*
+   * `modality` is a CATALOG field: `model_manager` fills it only from a
+   * `cv:`/`hf:` sidecar, so every manifest checkpoint answers `undefined` and
+   * `modality !== "video"` waved LTX-2, Wan and MiniMax H3 straight into the
+   * Picture style list. The one partition authority is `outputKindForModel`,
+   * which the New image section strip and the Styles kind filter already read.
+   */
+  it("refuses a manifest video style that never reported a modality", () => {
+    for (const family of ["ltx-2", "ltx-video", "wan", "minimax-h3"]) {
+      const clip = model(`${family}-checkpoint`, family);
+      expect(clip.modality).toBeUndefined();
+      expect(isTextImageWorkflowModel(clip), family).toBe(false);
+    }
+  });
+
+  it("still offers ordinary still-picture styles", () => {
+    for (const family of ["flux", "z-image", "sdxl", "qwen-image"])
+      expect(isTextImageWorkflowModel(model(`${family}-checkpoint`, family)), family).toBe(true);
+  });
+
+  it("refuses the mesh family, an undownloaded style and an unrunnable one", () => {
+    expect(isTextImageWorkflowModel(model("h3", "hunyuan3d", ["text_to_mesh"]))).toBe(false);
+    expect(isTextImageWorkflowModel({ ...model("flux", "flux"), downloaded: false })).toBe(false);
+    expect(
+      isTextImageWorkflowModel({ ...model("flux", "flux"), runtime_available: false }),
+    ).toBe(false);
+  });
+
+  it("refuses a canvasless recipe and one that ignores the prompt", () => {
+    const canvasless = model("odd", "flux");
+    canvasless.generation_profile!.recipes[0]!.capabilities.canvasless = true;
+    expect(isTextImageWorkflowModel(canvasless)).toBe(false);
+    const ignored = model("mute", "flux");
+    ignored.generation_profile!.recipes[0]!.capabilities.prompt = { mode: "ignored" };
+    expect(isTextImageWorkflowModel(ignored)).toBe(false);
+  });
+});
 
 describe("mesh workflow authoring", () => {
   it("reads workflow availability from the selected recipe contract", () => {

--- a/studio/lib/meshWorkflowAuthoring.ts
+++ b/studio/lib/meshWorkflowAuthoring.ts
@@ -1,5 +1,6 @@
 import type { CreateMeshWorkflowRequest } from "../api/meshWorkflows";
 import type { GenerationReference } from "./generationReferences";
+import { outputKindForModel } from "./outputKind";
 
 export type MeshWorkflowMode =
   | "image_to_mesh"
@@ -77,13 +78,27 @@ export function meshWorkflowModes(model: WorkflowModel): MeshWorkflowMode[] {
   );
 }
 
+/**
+ * Which styles may drive the text-to-3-D image stage.
+ *
+ * The kind test is `outputKindForModel` — the ONE partition the New image
+ * section strip and the Styles kind filter already read — so this list can
+ * never disagree with the rest of the app about what a picture style is. It
+ * used to ask `family !== "hunyuan3d" && modality !== "video"`, and `modality`
+ * is a CATALOG field that `model_manager` fills only from a `cv:`/`hf:`
+ * sidecar: every manifest checkpoint answers `undefined`, so `undefined !==
+ * "video"` waved LTX-2, Wan and MiniMax H3 into the Picture style menu.
+ *
+ * The recipe tests stay on top of the partition and are this stage's own: it
+ * hands the stage a prompt and takes a picture back, so a canvasless recipe
+ * and one whose prompt is `ignored` are refused even though both are stills.
+ */
 export function isTextImageWorkflowModel(model: WorkflowModel): boolean {
   const recipe = defaultRecipe(model);
   return (
     model.downloaded &&
     model.runtime_available !== false &&
-    model.family !== "hunyuan3d" &&
-    model.modality !== "video" &&
+    outputKindForModel(model) === "still" &&
     recipe?.capabilities.canvasless !== true &&
     recipe?.capabilities.prompt?.mode !== "ignored"
   );

--- a/studio/lib/meshWorkflowAuthoring.ts
+++ b/studio/lib/meshWorkflowAuthoring.ts
@@ -1,5 +1,6 @@
 import type { CreateMeshWorkflowRequest } from "../api/meshWorkflows";
 import type { GenerationReference } from "./generationReferences";
+import { isGenerationModel } from "./generationModels";
 import { outputKindForModel } from "./outputKind";
 
 export type MeshWorkflowMode =
@@ -89,6 +90,11 @@ export function meshWorkflowModes(model: WorkflowModel): MeshWorkflowMode[] {
  * sidecar: every manifest checkpoint answers `undefined`, so `undefined !==
  * "video"` waved LTX-2, Wan and MiniMax H3 into the Picture style menu.
  *
+ * The partition alone is not enough: it sorts by OUTPUT KIND, so the prompt
+ * expander and the upscalers — neither of which is a clip or a mesh — landed
+ * in "still" and were offered as things to draw a picture with. UAT caught
+ * that; `isGenerationModel` is the shared answer to "is this a style at all".
+ *
  * The recipe tests stay on top of the partition and are this stage's own: it
  * hands the stage a prompt and takes a picture back, so a canvasless recipe
  * and one whose prompt is `ignored` are refused even though both are stills.
@@ -98,6 +104,7 @@ export function isTextImageWorkflowModel(model: WorkflowModel): boolean {
   return (
     model.downloaded &&
     model.runtime_available !== false &&
+    isGenerationModel(model) &&
     outputKindForModel(model) === "still" &&
     recipe?.capabilities.canvasless !== true &&
     recipe?.capabilities.prompt?.mode !== "ignored"

--- a/studio/lib/meshWorkflowProvenance.test.ts
+++ b/studio/lib/meshWorkflowProvenance.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from "vitest";
 import {
   isMeshWorkflowLead,
   MESH_WORKFLOW_LEAD_ROLE,
+  meshWorkflowHostFromQuery,
   meshWorkflowIdFromQuery,
   meshWorkflowProvenanceOf,
   meshWorkflowRouteFor,
@@ -29,6 +30,34 @@ describe("3-D workflow provenance", () => {
       path: "/create/3d",
       query: { workflow: "workflow-1" },
     });
+  });
+
+  /*
+   * A durable workflow lives on ONE machine: every read, poll, resume, cancel
+   * and result fetch is bound to that host's authenticated target. A link
+   * carrying only the id sent a queue row from another machine to whichever
+   * one the studio happened to be browsing, which answered that the workflow
+   * does not exist.
+   */
+  it("names the machine that ran it, so the link cannot ask the wrong server", () => {
+    expect(meshWorkflowRouteFor(run, "hal9000-7680")?.query).toEqual({
+      workflow: "workflow-1",
+      host: "hal9000-7680",
+    });
+  });
+
+  /* A caller that cannot know the machine leaves the studio's pin alone. */
+  it("omits the machine rather than guessing one", () => {
+    for (const hostId of [undefined, null, "", "   "])
+      expect(meshWorkflowRouteFor(run, hostId)?.query.host).toBeUndefined();
+  });
+
+  it("reads the machine a deep link names, and nothing else", () => {
+    expect(meshWorkflowHostFromQuery({ host: "hal9000-7680" })).toBe(
+      "hal9000-7680",
+    );
+    for (const query of [null, undefined, {}, { host: 7 }])
+      expect(meshWorkflowHostFromQuery(query as never)).toBe("");
   });
 
   /*

--- a/studio/lib/meshWorkflowProvenance.test.ts
+++ b/studio/lib/meshWorkflowProvenance.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  isMeshWorkflowLead,
+  MESH_WORKFLOW_LEAD_ROLE,
+  meshWorkflowIdFromQuery,
+  meshWorkflowProvenanceOf,
+  meshWorkflowRouteFor,
+} from "./meshWorkflowProvenance";
+
+const run = {
+  mesh_workflow: {
+    job_id: "workflow-1",
+    mode: "text_to_mesh",
+    role: MESH_WORKFLOW_LEAD_ROLE,
+    stage_index: 4,
+  },
+};
+
+describe("3-D workflow provenance", () => {
+  /*
+   * The reported bug: clicking a 3-D Studio job in the queue landed on
+   * Generate under its 3-D section. That view cannot resume a durable
+   * workflow at all — the stages, Cancel, Resume and history live only under
+   * /api/mesh-workflows.
+   */
+  it("routes work a workflow made to the 3-D Studio, on that workflow", () => {
+    expect(meshWorkflowRouteFor(run)).toEqual({
+      path: "/create/3d",
+      query: { workflow: "workflow-1" },
+    });
+  });
+
+  /*
+   * Absence is an ordinary print or an older host, NEVER a refusal — the
+   * `supports_strength` lesson. The caller keeps the routing it already had.
+   */
+  it("answers nothing for a print no workflow made", () => {
+    for (const carrier of [null, undefined, {}, { mesh_workflow: null }])
+      expect(meshWorkflowRouteFor(carrier)).toBeNull();
+  });
+
+  /* The id is what every door needs; without it the block cannot be acted on. */
+  it("refuses a block with no usable job id", () => {
+    for (const job_id of ["", "   ", undefined as unknown as string])
+      expect(
+        meshWorkflowProvenanceOf({
+          mesh_workflow: { ...run.mesh_workflow, job_id },
+        }),
+      ).toBeNull();
+  });
+
+  /*
+   * A newer host may name a mode or role this build has never heard of. That
+   * is still a workflow worth opening — only the id is load-bearing.
+   */
+  it("keeps routing a workflow whose mode and role this build does not know", () => {
+    const future = {
+      mesh_workflow: {
+        job_id: "workflow-9",
+        mode: "multiview_to_mesh",
+        role: "retopologised_glb",
+        stage_index: 7,
+      },
+    };
+    expect(meshWorkflowRouteFor(future)?.query.workflow).toBe("workflow-9");
+    expect(isMeshWorkflowLead(future)).toBe(false);
+  });
+
+  it("names only the mesh as its run's lead", () => {
+    expect(isMeshWorkflowLead(run)).toBe(true);
+    for (const role of ["generated_image", "matted_image", "delighted_image"])
+      expect(
+        isMeshWorkflowLead({ mesh_workflow: { ...run.mesh_workflow, role } }),
+        role,
+      ).toBe(false);
+  });
+
+  it("reads the workflow a deep link names, and nothing else", () => {
+    expect(meshWorkflowIdFromQuery({ workflow: "workflow-1" })).toBe(
+      "workflow-1",
+    );
+    expect(meshWorkflowIdFromQuery({ workflow: ["workflow-2", "x"] })).toBe(
+      "workflow-2",
+    );
+    for (const query of [null, undefined, {}, { workflow: 7 }])
+      expect(meshWorkflowIdFromQuery(query as never)).toBe("");
+  });
+});

--- a/studio/lib/meshWorkflowProvenance.ts
+++ b/studio/lib/meshWorkflowProvenance.ts
@@ -15,9 +15,20 @@
 /** The role whose print represents the whole run. */
 export const MESH_WORKFLOW_LEAD_ROLE = "final_glb";
 
-/** The 3-D Studio's route, and the query it reads a workflow id from. */
+/** The 3-D Studio's route, and the queries it reads a workflow from. */
 export const MESH_WORKFLOW_ROUTE = "/create/3d";
 export const MESH_WORKFLOW_QUERY = "workflow";
+/**
+ * The machine that owns the workflow.
+ *
+ * A durable workflow lives on ONE machine — every read, poll, resume, cancel
+ * and result fetch is bound to that host's authenticated target, and a host
+ * change remounts the studio so identities never cross machines. So a route
+ * carrying only the id is not enough on a fleet: a queue row from `hal9000`
+ * opened while the studio is browsing this Mac would ask the wrong server and
+ * be told the workflow does not exist.
+ */
+export const MESH_WORKFLOW_HOST_QUERY = "host";
 
 export interface MeshWorkflowProvenance {
   job_id: string;
@@ -77,20 +88,46 @@ export function isMeshWorkflowLead(
  */
 export function meshWorkflowRouteFor(
   carrier: MeshWorkflowProvenanceCarrier | null | undefined,
+  /** The machine that ran it. Omitted only when the caller cannot know. */
+  hostId?: string | null,
 ): { path: string; query: Record<string, string> } | null {
   const provenance = meshWorkflowProvenanceOf(carrier);
   if (!provenance) return null;
+  const host = hostId?.trim() ?? "";
   return {
     path: MESH_WORKFLOW_ROUTE,
-    query: { [MESH_WORKFLOW_QUERY]: provenance.job_id },
+    query: {
+      [MESH_WORKFLOW_QUERY]: provenance.job_id,
+      ...(host ? { [MESH_WORKFLOW_HOST_QUERY]: host } : {}),
+    },
   };
+}
+
+function queryString(
+  query: Record<string, unknown> | null | undefined,
+  key: string,
+): string {
+  const raw = query?.[key];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" ? value.trim() : "";
 }
 
 /** The workflow a `?workflow=` query names, if it names one. */
 export function meshWorkflowIdFromQuery(
   query: Record<string, unknown> | null | undefined,
 ): string {
-  const raw = query?.[MESH_WORKFLOW_QUERY];
-  const value = Array.isArray(raw) ? raw[0] : raw;
-  return typeof value === "string" ? value.trim() : "";
+  return queryString(query, MESH_WORKFLOW_QUERY);
+}
+
+/**
+ * The machine a `?host=` query names.
+ *
+ * Empty means the link did not say — an older link, or a caller that could not
+ * know — and the studio keeps whichever machine it is already browsing rather
+ * than guessing.
+ */
+export function meshWorkflowHostFromQuery(
+  query: Record<string, unknown> | null | undefined,
+): string {
+  return queryString(query, MESH_WORKFLOW_HOST_QUERY);
 }

--- a/studio/lib/meshWorkflowProvenance.ts
+++ b/studio/lib/meshWorkflowProvenance.ts
@@ -1,0 +1,96 @@
+/**
+ * Which durable 3-D workflow made a piece of work — the one client-side
+ * reading of the server's `mesh_workflow` provenance.
+ *
+ * Every stage of a workflow is admitted as an ordinary generation, so without
+ * this a queue row and a finished print look exactly like a hand-authored
+ * render: the row routed to New image, and a run's source picture, its matted
+ * and delighted copies and its mesh sat in My images as unrelated tiles.
+ *
+ * ABSENCE IS NOT A REFUSAL. A print with no block was made outside the 3-D
+ * Studio — or on a host that predates the field — and must keep behaving
+ * exactly as it does today: one tile, routed to New image, no reopen door.
+ */
+
+/** The role whose print represents the whole run. */
+export const MESH_WORKFLOW_LEAD_ROLE = "final_glb";
+
+/** The 3-D Studio's route, and the query it reads a workflow id from. */
+export const MESH_WORKFLOW_ROUTE = "/create/3d";
+export const MESH_WORKFLOW_QUERY = "workflow";
+
+export interface MeshWorkflowProvenance {
+  job_id: string;
+  /** `text_to_mesh` | `mesh_roundtrip` | `mesh_texture`, or a newer host's. */
+  mode: string;
+  /** `generated_image` | `matted_image` | `delighted_image` | `final_glb`. */
+  role: string;
+  stage_index: number;
+}
+
+/** The least a caller needs to carry for this module to answer. */
+export interface MeshWorkflowProvenanceCarrier {
+  mesh_workflow?: MeshWorkflowProvenance | null;
+}
+
+/**
+ * The block, when the value is one this build can act on.
+ *
+ * A newer host may name a `mode` or `role` this build has never heard of, and
+ * that is still a workflow worth routing to — only a missing or malformed
+ * `job_id` makes the block unusable, because the id is what every door needs.
+ */
+export function meshWorkflowProvenanceOf(
+  carrier: MeshWorkflowProvenanceCarrier | null | undefined,
+): MeshWorkflowProvenance | null {
+  const block = carrier?.mesh_workflow;
+  if (!block || typeof block !== "object") return null;
+  const jobId = typeof block.job_id === "string" ? block.job_id.trim() : "";
+  if (!jobId) return null;
+  return {
+    job_id: jobId,
+    mode: typeof block.mode === "string" ? block.mode : "",
+    role: typeof block.role === "string" ? block.role : "",
+    stage_index:
+      typeof block.stage_index === "number" &&
+      Number.isFinite(block.stage_index)
+        ? block.stage_index
+        : 0,
+  };
+}
+
+/** Whether this output is the one a collapsed view shows for its run. */
+export function isMeshWorkflowLead(
+  carrier: MeshWorkflowProvenanceCarrier | null | undefined,
+): boolean {
+  return meshWorkflowProvenanceOf(carrier)?.role === MESH_WORKFLOW_LEAD_ROLE;
+}
+
+/**
+ * Where work made by a workflow belongs — the 3-D Studio, opened on that
+ * workflow. `null` means "not from a workflow", and the caller keeps whatever
+ * routing it already had.
+ *
+ * A 3-D Studio job routed to New image is not merely the wrong view: New image
+ * cannot resume a durable workflow at all. Its stages, its Cancel and Resume,
+ * and its history live only under `/api/mesh-workflows`.
+ */
+export function meshWorkflowRouteFor(
+  carrier: MeshWorkflowProvenanceCarrier | null | undefined,
+): { path: string; query: Record<string, string> } | null {
+  const provenance = meshWorkflowProvenanceOf(carrier);
+  if (!provenance) return null;
+  return {
+    path: MESH_WORKFLOW_ROUTE,
+    query: { [MESH_WORKFLOW_QUERY]: provenance.job_id },
+  };
+}
+
+/** The workflow a `?workflow=` query names, if it names one. */
+export function meshWorkflowIdFromQuery(
+  query: Record<string, unknown> | null | undefined,
+): string {
+  const raw = query?.[MESH_WORKFLOW_QUERY];
+  const value = Array.isArray(raw) ? raw[0] : raw;
+  return typeof value === "string" ? value.trim() : "";
+}

--- a/studio/lib/meshWorkflowRouting.ts
+++ b/studio/lib/meshWorkflowRouting.ts
@@ -1,4 +1,5 @@
 import type { ApiTarget } from "../api/client";
+import { isMeshFamily } from "./legacyRecipeRules";
 import {
   isTextImageWorkflowModel,
   meshWorkflowModes,
@@ -27,7 +28,7 @@ export function supportsMeshWorkflow(
   if (
     !mesh?.downloaded ||
     mesh.runtime_available === false ||
-    mesh.family !== "hunyuan3d"
+    !isMeshFamily(mesh.family)
   )
     return false;
   const modes = meshWorkflowModes(mesh);

--- a/studio/stores/meshWorkflowDraft.test.ts
+++ b/studio/stores/meshWorkflowDraft.test.ts
@@ -1,0 +1,144 @@
+import { createPinia, setActivePinia } from "pinia";
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  MESH_WORKFLOW_DRAFT_KEY,
+  setMeshWorkflowDraftStorage,
+  useMeshWorkflowDraftStore,
+  type MeshWorkflowDraftStorage,
+} from "./meshWorkflowDraft";
+
+function memoryStorage(seed: Record<string, string> = {}) {
+  const map = new Map(Object.entries(seed));
+  const storage: MeshWorkflowDraftStorage = {
+    getItem: (key) => map.get(key) ?? null,
+    setItem: (key, value) => void map.set(key, value),
+    removeItem: (key) => void map.delete(key),
+  };
+  return { storage, map };
+}
+
+describe("the 3-D Studio draft", () => {
+  beforeEach(() => {
+    setActivePinia(createPinia());
+    setMeshWorkflowDraftStorage(null);
+  });
+
+  /*
+   * The reported bug: the view unmounts on every route change, so a
+   * component-local ref lost the whole form on a trip to the Queue. The store
+   * IS the fix, so the thing to pin is that a second instantiation — what a
+   * remount does — sees what the first one wrote.
+   */
+  it("keeps the draft across a remount of the view", () => {
+    const first = useMeshWorkflowDraftStore();
+    first.prompt = "a hand-carved wooden fox";
+    first.mode = "mesh_texture";
+    first.meshModelName = "hunyuan3d-2.1:fp16";
+    first.meshFile = new File(["glb"], "fox.glb");
+
+    // Same Pinia, second `useStore()` — exactly what a remounted view does.
+    const second = useMeshWorkflowDraftStore();
+    expect(second.prompt).toBe("a hand-carved wooden fox");
+    expect(second.mode).toBe("mesh_texture");
+    expect(second.meshModelName).toBe("hunyuan3d-2.1:fp16");
+    expect(second.meshFile?.name).toBe("fox.glb");
+  });
+
+  it("restores the scalars from storage on a fresh launch", () => {
+    const { storage, map } = memoryStorage();
+    setMeshWorkflowDraftStorage(storage);
+    const first = useMeshWorkflowDraftStore();
+    first.prompt = "a brass teapot";
+    first.textureResolution = 4096;
+    first.upAxis = "z";
+    first.metersPerUnit = 0.001;
+    first.routing = "plato";
+    first.persist();
+    expect(map.get(MESH_WORKFLOW_DRAFT_KEY)).toBeTruthy();
+
+    setActivePinia(createPinia());
+    const relaunched = useMeshWorkflowDraftStore();
+    expect(relaunched.prompt).toBe("a brass teapot");
+    expect(relaunched.textureResolution).toBe(4096);
+    expect(relaunched.upAxis).toBe("z");
+    expect(relaunched.metersPerUnit).toBe(0.001);
+    expect(relaunched.routing).toBe("plato");
+  });
+
+  /*
+   * A browser cannot re-open a file handle from a previous session, so a
+   * persisted name would promise bytes the next launch cannot read. The well
+   * comes back empty instead.
+   */
+  it("never promises an attached file survived a restart", () => {
+    const { storage, map } = memoryStorage();
+    setMeshWorkflowDraftStorage(storage);
+    const first = useMeshWorkflowDraftStore();
+    first.meshFile = new File(["glb"], "fox.glb");
+    first.appearanceFile = new File(["png"], "fox.png");
+    first.persist();
+    expect(map.get(MESH_WORKFLOW_DRAFT_KEY)).not.toContain("fox.glb");
+
+    setActivePinia(createPinia());
+    const relaunched = useMeshWorkflowDraftStore();
+    expect(relaunched.meshFile).toBeNull();
+    expect(relaunched.appearanceFile).toBeNull();
+  });
+
+  /*
+   * A stored record is data this build did not write. One unreadable value
+   * must never discard the rest of the draft — the per-key recovery rule
+   * `settings::load` learned when a stale dev build moved a Nightly install
+   * back to Stable and forgot every machine.
+   */
+  it("recovers per key from a record it cannot fully read", () => {
+    const { storage } = memoryStorage({
+      [MESH_WORKFLOW_DRAFT_KEY]: JSON.stringify({
+        version: 1,
+        prompt: "a brass teapot",
+        mode: "sculpt_from_vibes",
+        textureResolution: 7777,
+        metersPerUnit: -3,
+        upAxis: "q",
+      }),
+    });
+    setMeshWorkflowDraftStorage(storage);
+    const draft = useMeshWorkflowDraftStore();
+    expect(draft.prompt).toBe("a brass teapot");
+    expect(draft.mode).toBe("text_to_mesh");
+    expect(draft.textureResolution).toBe(2048);
+    expect(draft.metersPerUnit).toBe(1);
+    expect(draft.upAxis).toBe("y");
+  });
+
+  it("opens on the defaults when storage is unreadable or empty", () => {
+    setMeshWorkflowDraftStorage({
+      getItem: () => {
+        throw new Error("private mode");
+      },
+      setItem: () => {
+        throw new Error("private mode");
+      },
+      removeItem: () => {},
+    });
+    const draft = useMeshWorkflowDraftStore();
+    expect(draft.mode).toBe("text_to_mesh");
+    expect(draft.texture).toBe(true);
+    // A refused write must not throw out of the store.
+    expect(() => draft.persist()).not.toThrow();
+  });
+
+  it("reports what would be lost, and clears only the authored work", () => {
+    const draft = useMeshWorkflowDraftStore();
+    expect(draft.dirty).toBe(false);
+    draft.prompt = "a brass teapot";
+    draft.meshModelName = "hunyuan3d-2.1:fp16";
+    draft.selectedId = "workflow-1";
+    expect(draft.dirty).toBe(true);
+    draft.clear();
+    expect(draft.dirty).toBe(false);
+    expect(draft.selectedId).toBe("");
+    expect(draft.meshModelName).toBe("hunyuan3d-2.1:fp16");
+  });
+});

--- a/studio/stores/meshWorkflowDraft.ts
+++ b/studio/stores/meshWorkflowDraft.ts
@@ -1,0 +1,229 @@
+import { defineStore } from "pinia";
+import { computed, ref, shallowRef } from "vue";
+
+/**
+ * The 3-D Studio's draft, held outside the view.
+ *
+ * `MeshWorkflowStudio` unmounts on every route change — the router lazy-loads
+ * it and nothing wraps it in `<KeepAlive>` — so a component-local `ref` took
+ * the prompt, both styles, the attached files, the stage settings and the
+ * selected workflow with it. Leaving for the Queue and coming back landed on
+ * an empty form. This is the same reason `desktop/src/stores/generateForm.ts`
+ * exists for New image, and the same reason `parkedStillModel` had to move out
+ * of the Create toolbar and into the ui store.
+ *
+ * Two lifetimes on purpose:
+ *
+ * - The SCALARS persist to localStorage, like `lastUsedStyles`, so a restart
+ *   opens on the workflow you were writing.
+ * - The attached `File`s live in memory only. A browser cannot re-open a file
+ *   handle from a previous session, so persisting a name would promise a file
+ *   the next launch cannot read; the wells simply come back empty and say so.
+ *   Within a session they survive navigation, which is the reported bug.
+ */
+export type MeshWorkflowMode =
+  | "text_to_mesh"
+  | "mesh_roundtrip"
+  | "mesh_texture";
+
+export type MeshUpAxis = "y" | "z";
+
+export const MESH_WORKFLOW_DRAFT_KEY = "mold.create.meshWorkflowDraft.v1";
+
+/** Minimal storage surface — `localStorage`, or an injected stub in tests. */
+export interface MeshWorkflowDraftStorage {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+  removeItem(key: string): void;
+}
+
+let storageOverride: MeshWorkflowDraftStorage | null = null;
+
+/** Test hook: inject a storage stub (pass null to restore the browser default). */
+export function setMeshWorkflowDraftStorage(
+  storage: MeshWorkflowDraftStorage | null,
+): void {
+  storageOverride = storage;
+}
+
+function storage(): MeshWorkflowDraftStorage | null {
+  if (storageOverride) return storageOverride;
+  try {
+    return globalThis.localStorage ?? null;
+  } catch {
+    return null;
+  }
+}
+
+const MODES: readonly MeshWorkflowMode[] = [
+  "text_to_mesh",
+  "mesh_roundtrip",
+  "mesh_texture",
+];
+
+const TEXTURE_RESOLUTIONS: readonly number[] = [1024, 2048, 4096];
+
+interface PersistedV1 {
+  version: 1;
+  mode: MeshWorkflowMode;
+  meshModelName: string;
+  imageModelName: string;
+  prompt: string;
+  texture: boolean;
+  textureResolution: number;
+  delight: boolean;
+  upAxis: MeshUpAxis;
+  metersPerUnit: number;
+  /** The machine the workflow is pinned to, or `auto` / `capable`. */
+  routing: string | null;
+  browseHostId: string;
+}
+
+function defaults(): PersistedV1 {
+  return {
+    version: 1,
+    mode: "text_to_mesh",
+    meshModelName: "",
+    imageModelName: "",
+    prompt: "",
+    texture: true,
+    textureResolution: 2048,
+    delight: false,
+    upAxis: "y",
+    metersPerUnit: 1,
+    routing: null,
+    browseHostId: "",
+  };
+}
+
+/**
+ * A stored record is data this build did not write — an older or newer
+ * version, a hand-edited value, a truncated write. Every field falls back on
+ * its own so one unreadable value never discards the rest of the draft.
+ */
+function load(): PersistedV1 {
+  const record = defaults();
+  try {
+    const raw = storage()?.getItem(MESH_WORKFLOW_DRAFT_KEY);
+    if (!raw) return record;
+    const parsed = JSON.parse(raw) as Partial<PersistedV1> | null;
+    if (!parsed || typeof parsed !== "object" || parsed.version !== 1)
+      return record;
+    if (MODES.includes(parsed.mode as MeshWorkflowMode))
+      record.mode = parsed.mode as MeshWorkflowMode;
+    if (typeof parsed.meshModelName === "string")
+      record.meshModelName = parsed.meshModelName;
+    if (typeof parsed.imageModelName === "string")
+      record.imageModelName = parsed.imageModelName;
+    if (typeof parsed.prompt === "string") record.prompt = parsed.prompt;
+    if (typeof parsed.texture === "boolean") record.texture = parsed.texture;
+    if (TEXTURE_RESOLUTIONS.includes(parsed.textureResolution as number))
+      record.textureResolution = parsed.textureResolution as number;
+    if (typeof parsed.delight === "boolean") record.delight = parsed.delight;
+    if (parsed.upAxis === "y" || parsed.upAxis === "z")
+      record.upAxis = parsed.upAxis;
+    if (
+      typeof parsed.metersPerUnit === "number" &&
+      Number.isFinite(parsed.metersPerUnit) &&
+      parsed.metersPerUnit > 0
+    )
+      record.metersPerUnit = parsed.metersPerUnit;
+    if (typeof parsed.routing === "string" || parsed.routing === null)
+      record.routing = parsed.routing;
+    if (typeof parsed.browseHostId === "string")
+      record.browseHostId = parsed.browseHostId;
+  } catch {
+    // Unreadable storage or a corrupt record opens on the defaults.
+  }
+  return record;
+}
+
+export const useMeshWorkflowDraftStore = defineStore("meshWorkflowDraft", () => {
+  const initial = load();
+
+  const mode = ref<MeshWorkflowMode>(initial.mode);
+  const meshModelName = ref(initial.meshModelName);
+  const imageModelName = ref(initial.imageModelName);
+  const prompt = ref(initial.prompt);
+  const texture = ref(initial.texture);
+  const textureResolution = ref(initial.textureResolution);
+  const delight = ref(initial.delight);
+  const upAxis = ref<MeshUpAxis>(initial.upAxis);
+  const metersPerUnit = ref(initial.metersPerUnit);
+  const routing = ref<string | null>(initial.routing);
+  const browseHostId = ref(initial.browseHostId);
+
+  /*
+   * `shallowRef`, not `ref`: a `File` is host-object state with no useful
+   * reactive interior, and Vue's proxy over one breaks the identity the
+   * upload path compares against.
+   */
+  const meshFile = shallowRef<File | null>(null);
+  const appearanceFile = shallowRef<File | null>(null);
+
+  /**
+   * The workflow whose result is on the canvas. Session-scoped: a restart
+   * opens on a new workflow rather than re-fetching a job that may have been
+   * deleted, and the Recent workflows list is the way back to it.
+   */
+  const selectedId = ref("");
+
+  function persist(): void {
+    const record: PersistedV1 = {
+      version: 1,
+      mode: mode.value,
+      meshModelName: meshModelName.value,
+      imageModelName: imageModelName.value,
+      prompt: prompt.value,
+      texture: texture.value,
+      textureResolution: textureResolution.value,
+      delight: delight.value,
+      upAxis: upAxis.value,
+      metersPerUnit: metersPerUnit.value,
+      routing: routing.value,
+      browseHostId: browseHostId.value,
+    };
+    try {
+      storage()?.setItem(MESH_WORKFLOW_DRAFT_KEY, JSON.stringify(record));
+    } catch {
+      // Storage refused (quota, private mode): the session still remembers.
+    }
+  }
+
+  /** Whether anything the person typed or attached would be lost. */
+  const dirty = computed(
+    () =>
+      prompt.value.trim().length > 0 ||
+      meshFile.value !== null ||
+      appearanceFile.value !== null,
+  );
+
+  /** Start over, keeping the machine and the styles this session is using. */
+  function clear(): void {
+    prompt.value = "";
+    meshFile.value = null;
+    appearanceFile.value = null;
+    selectedId.value = "";
+    persist();
+  }
+
+  return {
+    mode,
+    meshModelName,
+    imageModelName,
+    prompt,
+    texture,
+    textureResolution,
+    delight,
+    upAxis,
+    metersPerUnit,
+    routing,
+    browseHostId,
+    meshFile,
+    appearanceFile,
+    selectedId,
+    dirty,
+    clear,
+    persist,
+  };
+});

--- a/studio/stores/meshWorkflowDraft.ts
+++ b/studio/stores/meshWorkflowDraft.ts
@@ -22,9 +22,7 @@ import { computed, ref, shallowRef } from "vue";
  *   Within a session they survive navigation, which is the reported bug.
  */
 export type MeshWorkflowMode =
-  | "text_to_mesh"
-  | "mesh_roundtrip"
-  | "mesh_texture";
+  "text_to_mesh" | "mesh_roundtrip" | "mesh_texture";
 
 export type MeshUpAxis = "y" | "z";
 
@@ -138,92 +136,95 @@ function load(): PersistedV1 {
   return record;
 }
 
-export const useMeshWorkflowDraftStore = defineStore("meshWorkflowDraft", () => {
-  const initial = load();
+export const useMeshWorkflowDraftStore = defineStore(
+  "meshWorkflowDraft",
+  () => {
+    const initial = load();
 
-  const mode = ref<MeshWorkflowMode>(initial.mode);
-  const meshModelName = ref(initial.meshModelName);
-  const imageModelName = ref(initial.imageModelName);
-  const prompt = ref(initial.prompt);
-  const texture = ref(initial.texture);
-  const textureResolution = ref(initial.textureResolution);
-  const delight = ref(initial.delight);
-  const upAxis = ref<MeshUpAxis>(initial.upAxis);
-  const metersPerUnit = ref(initial.metersPerUnit);
-  const routing = ref<string | null>(initial.routing);
-  const browseHostId = ref(initial.browseHostId);
+    const mode = ref<MeshWorkflowMode>(initial.mode);
+    const meshModelName = ref(initial.meshModelName);
+    const imageModelName = ref(initial.imageModelName);
+    const prompt = ref(initial.prompt);
+    const texture = ref(initial.texture);
+    const textureResolution = ref(initial.textureResolution);
+    const delight = ref(initial.delight);
+    const upAxis = ref<MeshUpAxis>(initial.upAxis);
+    const metersPerUnit = ref(initial.metersPerUnit);
+    const routing = ref<string | null>(initial.routing);
+    const browseHostId = ref(initial.browseHostId);
 
-  /*
-   * `shallowRef`, not `ref`: a `File` is host-object state with no useful
-   * reactive interior, and Vue's proxy over one breaks the identity the
-   * upload path compares against.
-   */
-  const meshFile = shallowRef<File | null>(null);
-  const appearanceFile = shallowRef<File | null>(null);
+    /*
+     * `shallowRef`, not `ref`: a `File` is host-object state with no useful
+     * reactive interior, and Vue's proxy over one breaks the identity the
+     * upload path compares against.
+     */
+    const meshFile = shallowRef<File | null>(null);
+    const appearanceFile = shallowRef<File | null>(null);
 
-  /**
-   * The workflow whose result is on the canvas. Session-scoped: a restart
-   * opens on a new workflow rather than re-fetching a job that may have been
-   * deleted, and the Recent workflows list is the way back to it.
-   */
-  const selectedId = ref("");
+    /**
+     * The workflow whose result is on the canvas. Session-scoped: a restart
+     * opens on a new workflow rather than re-fetching a job that may have been
+     * deleted, and the Recent workflows list is the way back to it.
+     */
+    const selectedId = ref("");
 
-  function persist(): void {
-    const record: PersistedV1 = {
-      version: 1,
-      mode: mode.value,
-      meshModelName: meshModelName.value,
-      imageModelName: imageModelName.value,
-      prompt: prompt.value,
-      texture: texture.value,
-      textureResolution: textureResolution.value,
-      delight: delight.value,
-      upAxis: upAxis.value,
-      metersPerUnit: metersPerUnit.value,
-      routing: routing.value,
-      browseHostId: browseHostId.value,
-    };
-    try {
-      storage()?.setItem(MESH_WORKFLOW_DRAFT_KEY, JSON.stringify(record));
-    } catch {
-      // Storage refused (quota, private mode): the session still remembers.
+    function persist(): void {
+      const record: PersistedV1 = {
+        version: 1,
+        mode: mode.value,
+        meshModelName: meshModelName.value,
+        imageModelName: imageModelName.value,
+        prompt: prompt.value,
+        texture: texture.value,
+        textureResolution: textureResolution.value,
+        delight: delight.value,
+        upAxis: upAxis.value,
+        metersPerUnit: metersPerUnit.value,
+        routing: routing.value,
+        browseHostId: browseHostId.value,
+      };
+      try {
+        storage()?.setItem(MESH_WORKFLOW_DRAFT_KEY, JSON.stringify(record));
+      } catch {
+        // Storage refused (quota, private mode): the session still remembers.
+      }
     }
-  }
 
-  /** Whether anything the person typed or attached would be lost. */
-  const dirty = computed(
-    () =>
-      prompt.value.trim().length > 0 ||
-      meshFile.value !== null ||
-      appearanceFile.value !== null,
-  );
+    /** Whether anything the person typed or attached would be lost. */
+    const dirty = computed(
+      () =>
+        prompt.value.trim().length > 0 ||
+        meshFile.value !== null ||
+        appearanceFile.value !== null,
+    );
 
-  /** Start over, keeping the machine and the styles this session is using. */
-  function clear(): void {
-    prompt.value = "";
-    meshFile.value = null;
-    appearanceFile.value = null;
-    selectedId.value = "";
-    persist();
-  }
+    /** Start over, keeping the machine and the styles this session is using. */
+    function clear(): void {
+      prompt.value = "";
+      meshFile.value = null;
+      appearanceFile.value = null;
+      selectedId.value = "";
+      persist();
+    }
 
-  return {
-    mode,
-    meshModelName,
-    imageModelName,
-    prompt,
-    texture,
-    textureResolution,
-    delight,
-    upAxis,
-    metersPerUnit,
-    routing,
-    browseHostId,
-    meshFile,
-    appearanceFile,
-    selectedId,
-    dirty,
-    clear,
-    persist,
-  };
-});
+    return {
+      mode,
+      meshModelName,
+      imageModelName,
+      prompt,
+      texture,
+      textureResolution,
+      delight,
+      upAxis,
+      metersPerUnit,
+      routing,
+      browseHostId,
+      meshFile,
+      appearanceFile,
+      selectedId,
+      dirty,
+      clear,
+      persist,
+    };
+  },
+);

--- a/studio/stores/meshWorkflowDraft.ts
+++ b/studio/stores/meshWorkflowDraft.ts
@@ -21,7 +21,15 @@ import { computed, ref, shallowRef } from "vue";
  *   the next launch cannot read; the wells simply come back empty and say so.
  *   Within a session they survive navigation, which is the reported bug.
  */
-export type MeshWorkflowMode =
+/**
+ * The three workflows a person can AUTHOR here.
+ *
+ * Deliberately narrower than `meshWorkflowAuthoring`'s `MeshWorkflowMode`,
+ * which is the recipe's advertised set and includes `image_to_mesh` and
+ * `multiview_to_mesh`. Two exported types under `@studio` sharing one name
+ * was an import waiting to go to the wrong one, so this has its own.
+ */
+export type AuthoredMeshWorkflowMode =
   "text_to_mesh" | "mesh_roundtrip" | "mesh_texture";
 
 export type MeshUpAxis = "y" | "z";
@@ -53,7 +61,7 @@ function storage(): MeshWorkflowDraftStorage | null {
   }
 }
 
-const MODES: readonly MeshWorkflowMode[] = [
+const MODES: readonly AuthoredMeshWorkflowMode[] = [
   "text_to_mesh",
   "mesh_roundtrip",
   "mesh_texture",
@@ -63,7 +71,7 @@ const TEXTURE_RESOLUTIONS: readonly number[] = [1024, 2048, 4096];
 
 interface PersistedV1 {
   version: 1;
-  mode: MeshWorkflowMode;
+  mode: AuthoredMeshWorkflowMode;
   meshModelName: string;
   imageModelName: string;
   prompt: string;
@@ -107,8 +115,8 @@ function load(): PersistedV1 {
     const parsed = JSON.parse(raw) as Partial<PersistedV1> | null;
     if (!parsed || typeof parsed !== "object" || parsed.version !== 1)
       return record;
-    if (MODES.includes(parsed.mode as MeshWorkflowMode))
-      record.mode = parsed.mode as MeshWorkflowMode;
+    if (MODES.includes(parsed.mode as AuthoredMeshWorkflowMode))
+      record.mode = parsed.mode as AuthoredMeshWorkflowMode;
     if (typeof parsed.meshModelName === "string")
       record.meshModelName = parsed.meshModelName;
     if (typeof parsed.imageModelName === "string")
@@ -141,7 +149,7 @@ export const useMeshWorkflowDraftStore = defineStore(
   () => {
     const initial = load();
 
-    const mode = ref<MeshWorkflowMode>(initial.mode);
+    const mode = ref<AuthoredMeshWorkflowMode>(initial.mode);
     const meshModelName = ref(initial.meshModelName);
     const imageModelName = ref(initial.imageModelName);
     const prompt = ref(initial.prompt);
@@ -154,19 +162,46 @@ export const useMeshWorkflowDraftStore = defineStore(
     const browseHostId = ref(initial.browseHostId);
 
     /*
-     * `shallowRef`, not `ref`: a `File` is host-object state with no useful
-     * reactive interior, and Vue's proxy over one breaks the identity the
-     * upload path compares against.
+     * `shallowRef`, not `ref`: a `File` has no useful reactive interior, so
+     * deep reactivity would only cost traversal on every write. (Vue would in
+     * fact leave it unproxied — `reactive()` classifies a `File` as
+     * `TargetType.INVALID` — so this is about intent, not a proxy bug.)
      */
     const meshFile = shallowRef<File | null>(null);
     const appearanceFile = shallowRef<File | null>(null);
 
     /**
-     * The workflow whose result is on the canvas. Session-scoped: a restart
-     * opens on a new workflow rather than re-fetching a job that may have been
-     * deleted, and the Recent workflows list is the way back to it.
+     * The workflow whose result is on the canvas, and the machine it belongs
+     * to.
+     *
+     * The machine is RECORDED, not inferred. A durable workflow lives on one
+     * host, and this view remounts on every route change — so comparing the
+     * incoming target against the component's own `ownedTarget` cannot answer
+     * "did the machine change while I was away": that ref is re-seeded from
+     * the props on each fresh mount and so always looks like the same machine.
+     * Keeping the owner beside the id is what lets a returning view tell a
+     * workflow of its own from one belonging to a machine it no longer talks
+     * to — otherwise a `hal9000` job id is retained against `plato` and the
+     * canvas clears with "no longer on this machine", which is both wrong and
+     * unexplained.
+     *
+     * Both are session-scoped: a restart opens on a new workflow rather than
+     * re-fetching a job that may since have been deleted, and Recent is the
+     * way back to it.
      */
     const selectedId = ref("");
+    const selectedHost = ref("");
+
+    /** Open `id`, remembering which machine it came from. */
+    function selectWorkflow(id: string, host: string): void {
+      selectedId.value = id;
+      selectedHost.value = id ? host : "";
+    }
+
+    /** Whether the open workflow belongs to `host`. False when none is open. */
+    function selectionBelongsTo(host: string): boolean {
+      return Boolean(selectedId.value) && selectedHost.value === host;
+    }
 
     function persist(): void {
       const record: PersistedV1 = {
@@ -203,7 +238,7 @@ export const useMeshWorkflowDraftStore = defineStore(
       prompt.value = "";
       meshFile.value = null;
       appearanceFile.value = null;
-      selectedId.value = "";
+      selectWorkflow("", "");
       persist();
     }
 
@@ -222,6 +257,9 @@ export const useMeshWorkflowDraftStore = defineStore(
       meshFile,
       appearanceFile,
       selectedId,
+      selectedHost,
+      selectWorkflow,
+      selectionBelongsTo,
       dirty,
       clear,
       persist,

--- a/web/src/composables/useOpenLiveWork.ts
+++ b/web/src/composables/useOpenLiveWork.ts
@@ -55,7 +55,7 @@ export function useOpenLiveWork(routing: HostRouting) {
         // arrives here looking like any other print. Create cannot resume a
         // durable workflow — its stages, Cancel, Resume and history live only
         // under /api/mesh-workflows.
-        const workflow = meshWorkflowRouteFor(selection.metadata);
+        const workflow = meshWorkflowRouteFor(selection.metadata, row.hostId);
         if (workflow) {
           await router.push(workflow);
           return;

--- a/web/src/composables/useOpenLiveWork.ts
+++ b/web/src/composables/useOpenLiveWork.ts
@@ -2,6 +2,7 @@ import { useRouter } from "vue-router";
 import type { FleetActiveWork } from "@studio/api/activity";
 import { findQueueEntryById } from "@studio/api/queuePlan";
 import { selectedQueueGeneration } from "@studio/api/generationSelection";
+import { meshWorkflowRouteFor } from "@studio/lib/meshWorkflowProvenance";
 import type { OutputMetadata } from "../types";
 import type { HostRouting } from "./useHostRouting";
 import { setGenerationHandoff } from "./useGenerationHandoff";
@@ -48,6 +49,15 @@ export function useOpenLiveWork(routing: HostRouting) {
             "error",
             "This host cannot restore settings for that generation.",
           );
+          return;
+        }
+        // A 3-D Studio stage is admitted as an ordinary generation, so it
+        // arrives here looking like any other print. Create cannot resume a
+        // durable workflow — its stages, Cancel, Resume and history live only
+        // under /api/mesh-workflows.
+        const workflow = meshWorkflowRouteFor(selection.metadata);
+        if (workflow) {
+          await router.push(workflow);
           return;
         }
         setGenerationHandoff({

--- a/web/src/lib/modelFilters.ts
+++ b/web/src/lib/modelFilters.ts
@@ -1,4 +1,5 @@
 import { familyLabel } from "@studio/lib/modelFamily";
+import { isGenerationModel } from "@studio/lib/generationModels";
 
 import type { ModelInfoExtended } from "../types";
 
@@ -22,25 +23,6 @@ export interface ModelFamilyGroup {
   label: string;
   models: ModelInfoExtended[];
 }
-
-const NON_GENERATION_FAMILIES = new Set([
-  "upscaler",
-  "qwen3-expand",
-  "companion",
-  "controlnet",
-  "control-net",
-]);
-
-const SUPPORT_NAME_PATTERNS = [
-  /\bupscal(e|er|ing)\b/i,
-  /\breal[-_ ]?esrgan\b/i,
-  /\bcontrol[-_ ]?net\b/i,
-  /\b(qwen3|prompt)[-_ ]?expand/i,
-  /\bclip[-_ ]?[lg]?\b/i,
-  /\btext[-_ ]?encoder\b/i,
-  /\btokenizer\b/i,
-  /\bvae\b/i,
-];
 
 const FAMILY_ORDER = [
   "flux",
@@ -74,14 +56,16 @@ const VARIANT_RANKS: Record<string, number> = {
   q4: 6,
 };
 
+/**
+ * Whether a row is a style a person can pick.
+ *
+ * The list lives in `@studio/lib/generationModels` — this surface and desktop
+ * each had their own and they had already drifted (this one knew `companion`
+ * and `control-net`, desktop knew `real-esrgan`), which is how the 3-D Studio
+ * came to offer the prompt expander as a picture style.
+ */
 export function isStandaloneGenerationModel(model: ModelInfoExtended): boolean {
-  const family = model.family.toLowerCase();
-  if (NON_GENERATION_FAMILIES.has(family)) return false;
-
-  const searchable = [model.name, model.description, model.hf_repo]
-    .join(" ")
-    .toLowerCase();
-  return !SUPPORT_NAME_PATTERNS.some((pattern) => pattern.test(searchable));
+  return isGenerationModel(model);
 }
 
 export function modelQuantization(model: ModelInfoExtended): string {

--- a/web/src/pages/MeshWorkflowPage.test.ts
+++ b/web/src/pages/MeshWorkflowPage.test.ts
@@ -1,17 +1,21 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-// The page reads `?workflow=` so a queue row can route back to a workflow;
-// these cases mount it outside a router.
-vi.mock("vue-router", () => ({ useRoute: () => ({ query: {} }) }));
+// The page reads `?workflow=` and `?host=` so a queue row can route back to a
+// workflow on the machine that ran it; these cases mount it outside a router.
+const routeQuery = vi.hoisted(() => ({ value: {} as Record<string, string> }));
+vi.mock("vue-router", () => ({
+  useRoute: () => ({ query: routeQuery.value }),
+}));
 
 vi.mock("@studio/components/MeshWorkflowStudio.vue", () => ({
   default: {
-    props: ["target"],
+    props: ["target", "openWorkflow"],
     template: `
       <div data-test="mesh-studio">
         <span data-test="target-url">{{ target.baseUrl }}</span>
         <span data-test="target-key">{{ target.apiKey }}</span>
+        <span data-test="open-workflow">{{ openWorkflow }}</span>
         <slot name="machine" />
       </div>
     `,
@@ -60,6 +64,7 @@ describe("MeshWorkflowPage host routing", () => {
     const routing = useHostRouting();
     routing.hosts.value = [origin, remote];
     (routing.targetId as unknown as { value: string }).value = "auto";
+    routeQuery.value = {};
   });
 
   it("routes models, workflows, and results to the selected authenticated host", async () => {
@@ -97,5 +102,64 @@ describe("MeshWorkflowPage host routing", () => {
           .element as HTMLSelectElement
       ).value,
     ).toBe("renderbox-7680");
+  });
+});
+
+describe("MeshWorkflowPage — a link names the machine that ran the workflow", () => {
+  beforeEach(() => {
+    const routing = useHostRouting();
+    routing.hosts.value = [origin, remote];
+    (routing.targetId as unknown as { value: string }).value = "auto";
+    routeQuery.value = {};
+  });
+
+  /*
+   * A durable workflow lives on ONE machine. A link carrying only the id sent
+   * a queue row from another machine to whichever one this page happened to
+   * be browsing, which reported the workflow gone.
+   *
+   * This path had no coverage at all, and the binding was written as an
+   * `immediate` watcher ABOVE the ref it writes — so it threw "Cannot access
+   * 'selectedHostId' before initialization" out of setup in dev, and was
+   * swallowed in production, silently restoring the very bug it fixed.
+   */
+  it("binds to the machine the link names before loading the workflow", async () => {
+    routeQuery.value = { workflow: "workflow-7", host: "renderbox-7680" };
+    const wrapper = mount(MeshWorkflowPage);
+    await flushPromises();
+    expect(wrapper.get("[data-test='target-url']").text()).toBe(
+      "https://renderbox.example",
+    );
+    expect(wrapper.get("[data-test='target-key']").text()).toBe(
+      "remote-secret",
+    );
+    expect(wrapper.get("[data-test='open-workflow']").text()).toBe(
+      "workflow-7",
+    );
+    wrapper.unmount();
+  });
+
+  /* A machine this browser does not know is not a reason to move the pin. */
+  it("leaves the machine alone when the link names one it does not have", async () => {
+    routeQuery.value = { workflow: "workflow-7", host: "a-machine-we-forgot" };
+    const wrapper = mount(MeshWorkflowPage);
+    await flushPromises();
+    expect(wrapper.get("[data-test='target-url']").text()).toBe(
+      "http://studio:7680",
+    );
+    wrapper.unmount();
+  });
+
+  /*
+   * Opening a 3-D queue row must not silently re-point New image's generate
+   * target — that is an app-wide setting, and only the machine picker should
+   * move it.
+   */
+  it("does not repoint the app's generate target", async () => {
+    routeQuery.value = { workflow: "workflow-7", host: "renderbox-7680" };
+    const wrapper = mount(MeshWorkflowPage);
+    await flushPromises();
+    expect(useHostRouting().targetId.value).toBe("auto");
+    wrapper.unmount();
   });
 });

--- a/web/src/pages/MeshWorkflowPage.test.ts
+++ b/web/src/pages/MeshWorkflowPage.test.ts
@@ -1,6 +1,10 @@
 import { flushPromises, mount } from "@vue/test-utils";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+// The page reads `?workflow=` so a queue row can route back to a workflow;
+// these cases mount it outside a router.
+vi.mock("vue-router", () => ({ useRoute: () => ({ query: {} }) }));
+
 vi.mock("@studio/components/MeshWorkflowStudio.vue", () => ({
   default: {
     props: ["target"],

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -23,21 +23,6 @@ const route = useRoute();
 // studio is handed the id rather than reading the router itself.
 const openWorkflow = computed(() => meshWorkflowIdFromQuery(route.query));
 
-/*
- * A durable workflow lives on ONE machine, so the link that opens it names
- * that machine too — otherwise a queue row from another host asks whichever
- * machine this page happens to be browsing and is told it does not exist.
- * A link that does not say (an older one) leaves the selection alone.
- */
-watch(
-  () => meshWorkflowHostFromQuery(route.query),
-  (hostId) => {
-    if (!hostId || !routing.hosts.value.some((host) => host.id === hostId))
-      return;
-    selectHost(hostId);
-  },
-  { immediate: true },
-);
 const selectedHostId = ref("");
 const selectedHost = computed(
   () =>
@@ -72,6 +57,32 @@ function selectHost(id: string): void {
     selectedHostId.value = id;
   routing.setTarget(id);
 }
+
+/*
+ * A durable workflow lives on ONE machine, so the link that opens it names
+ * that machine too — otherwise a queue row from another host asks whichever
+ * machine this page happens to be browsing and is told it does not exist.
+ * A link that does not say (an older one) leaves the selection alone.
+ *
+ * This has to sit BELOW `selectHost` and the refs it writes: an `immediate`
+ * watcher runs its callback synchronously inside `watch()`, so declared above
+ * them it threw `Cannot access 'selectedHostId' before initialization` — out
+ * of setup in dev, and swallowed in production, which silently restored the
+ * very bug it was added to fix.
+ *
+ * It also watches the host LIST: on a cold load the registry may not name the
+ * machine yet, and the query never changes, so a query-only watcher would drop
+ * the pin and never look again.
+ */
+watch(
+  [() => meshWorkflowHostFromQuery(route.query), () => routing.hosts.value],
+  ([hostId]) => {
+    if (!hostId || selectedHostId.value === hostId) return;
+    if (!routing.hosts.value.some((host) => host.id === hostId)) return;
+    selectedHostId.value = hostId;
+  },
+  { immediate: true },
+);
 
 function pickerModels(filtered: WorkflowModel[]) {
   const names = new Set(filtered.map((model) => model.name));

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -8,11 +8,17 @@ import {
 } from "@studio/lib/meshWorkflowRouting";
 import type { WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import MeshWorkflowHostPicker from "@studio/components/MeshWorkflowHostPicker.vue";
+import { useRoute } from "vue-router";
+import { meshWorkflowIdFromQuery } from "@studio/lib/meshWorkflowProvenance";
 import { useHostRouting } from "../composables/useHostRouting";
 import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
 import { ORIGIN_HOST_ID } from "../lib/hostRegistry";
 
 const routing = useHostRouting();
+const route = useRoute();
+// The queue row's route back here; routing is the shell's job, so the shared
+// studio is handed the id rather than reading the router itself.
+const openWorkflow = computed(() => meshWorkflowIdFromQuery(route.query));
 const selectedHostId = ref("");
 const selectedHost = computed(
   () =>
@@ -89,6 +95,7 @@ function hostStatus(): string {
   <MeshWorkflowStudio
     v-if="target"
     :target="target"
+    :open-workflow="openWorkflow"
     :available-models="routing.targetModels.value"
     :resolve-target="resolveTarget"
     :host-label="selectedHost?.label ?? ''"

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -97,7 +97,7 @@ function hostStatus(): string {
       <CreateModelPicker
         :models="pickerModels(models)"
         :model="selected"
-        browse-to="/models?kind=mesh"
+        browse-to="/models?type=mesh"
         @select="(model) => select(model.name)"
       />
     </template>
@@ -105,7 +105,7 @@ function hostStatus(): string {
       <CreateModelPicker
         :models="pickerModels(models)"
         :model="selected"
-        browse-to="/models?kind=image"
+        browse-to="/models?type=image"
         @select="(model) => select(model.name)"
       />
     </template>

--- a/web/src/pages/MeshWorkflowPage.vue
+++ b/web/src/pages/MeshWorkflowPage.vue
@@ -9,7 +9,10 @@ import {
 import type { WorkflowModel } from "@studio/lib/meshWorkflowAuthoring";
 import MeshWorkflowHostPicker from "@studio/components/MeshWorkflowHostPicker.vue";
 import { useRoute } from "vue-router";
-import { meshWorkflowIdFromQuery } from "@studio/lib/meshWorkflowProvenance";
+import {
+  meshWorkflowHostFromQuery,
+  meshWorkflowIdFromQuery,
+} from "@studio/lib/meshWorkflowProvenance";
 import { useHostRouting } from "../composables/useHostRouting";
 import { AUTO_TARGET_ID, CAPABLE_TARGET_ID } from "../lib/hostRouting";
 import { ORIGIN_HOST_ID } from "../lib/hostRegistry";
@@ -19,6 +22,22 @@ const route = useRoute();
 // The queue row's route back here; routing is the shell's job, so the shared
 // studio is handed the id rather than reading the router itself.
 const openWorkflow = computed(() => meshWorkflowIdFromQuery(route.query));
+
+/*
+ * A durable workflow lives on ONE machine, so the link that opens it names
+ * that machine too — otherwise a queue row from another host asks whichever
+ * machine this page happens to be browsing and is told it does not exist.
+ * A link that does not say (an older one) leaves the selection alone.
+ */
+watch(
+  () => meshWorkflowHostFromQuery(route.query),
+  (hostId) => {
+    if (!hostId || !routing.hosts.value.some((host) => host.id === hostId))
+      return;
+    selectHost(hostId);
+  },
+  { immediate: true },
+);
 const selectedHostId = ref("");
 const selectedHost = computed(
   () =>

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -1,3 +1,4 @@
+import type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
 import type { ChainOutputMetadata } from "@studio/lib/api/chainTypes";
 import type { OutputFormat as WireOutputFormat } from "@studio/lib/generated/generationProfileV1";
 import type {
@@ -81,7 +82,14 @@ export type Scheduler =
   | { "uni-pc": unknown }
   | { "edm-dpm-pp-2m": unknown };
 
+/** Re-exported so a wire type and the policy that reads it cannot drift. */
+export type { MeshWorkflowProvenance } from "@studio/lib/meshWorkflowProvenance";
+
 export interface OutputMetadata {
+  /** The durable 3-D workflow that produced this print, and the role it plays
+   * in it. Additive: absent on every print made outside the 3-D Studio and on
+   * every host that predates the field, which reads as an ordinary print. */
+  mesh_workflow?: MeshWorkflowProvenance | null;
   /** User-authored print title as it was at creation (D5). Embedded so
    * mirrors carry it; the gallery row's editable title wins for display. */
   title?: string | null;


### PR DESCRIPTION
First of four serialized PRs bringing the 3-D Studio into the app. This one is
correctness only — no visual rework yet.

## What was wrong

| Symptom | Cause |
| --- | --- |
| Navigating away lost the whole form | Every draft ref was component-local in a view the router lazy-loads and nothing keeps alive (`MeshWorkflowStudio.vue:49-78`) |
| A workflow's queue row landed on Generate ▸ 3-D object | `useQueueCommands.openPrint` and `useOpenLiveWork` pushed `/create` unconditionally; a stage is an ordinary `generation` work item with no workflow marker |
| ⌘↩ left the view and rendered a picture | `App.vue` raised the Generate intent **and** pushed `/create`, while the status bar advertised the hint |
| Picture style listed LTX-2, Wan and MiniMax H3 | `isTextImageWorkflowModel` tested `modality !== "video"`; `modality` is a catalog field that is `None` on every manifest checkpoint |

## The one wire addition

`admit_child` already held the workflow id and the stage when it built each
stage's `GenerateRequest`, so `MeshWorkflowProvenance` is stamped there.
`QueueJobEntryWire.metadata` **is** the request's metadata and
`OutputMetadata::from_request` copies it, so one additive field answers for the
live queue row *and* the finished print — and `queue_media`'s exhaustive
sanitizer retains it so a replayed stage still publishes into the run that owns
it. Same shape as `batch_id` and `chain_job_id` beside it.

It is server-minted and refused on `/api/generate`, `/api/generate/stream` and
`/api/generation-batches`: a client able to mint it could route another person's
queue row into the 3-D Studio and file a stranger's print inside their run.

PRs 2–4 build on it: the Mold Studio chrome, a real Recent-workflows panel
replacing the bare `<select>`, and collapsing a run's scattered prints into one
stacked Library tile.

## Notes

- `outputKindForModel` is now the single partition both pickers read — the same
  one the New image section strip and the Styles kind filter use. The existing
  fixture pinned `modality: "image"` explicitly, which is why this never failed.
- The draft store persists scalars across a restart. An attached `File` cannot
  be re-opened from a previous session, so it is deliberately session-scoped
  rather than promising bytes the next launch cannot read.
- Absence of `mesh_workflow` reads as an ordinary print or an older host, never
  as a refusal.

## Testing

- `cargo test -p mold-ai-core -p mold-ai-db --lib` green; `mold-ai-server --lib`
  green apart from three pre-existing failures that read the real `MOLD_HOME`
  (they pass against an empty one) and load-sensitive `durable_queue_feeder`
  timeouts.
- `cargo clippy --workspace --all-targets -- -D warnings` clean.
- studio 1748, desktop 6533, web 1928 tests green; `check:architecture` and
  `check:dead-code` clean.
- New regression tests: the remount keeps the draft, a workflow's row routes to
  `/create/3d?workflow=<id>`, ⌘↩ generates in place and consumes the intent
  once, a manifest video style with no `modality` is refused as a picture style,
  and a client-minted `mesh_workflow` is refused by name.