### PR TITLE
feat(studio): give reuse a door people can find

### DIFF
--- a/changelog.d/3d-studio-reuse.md
+++ b/changelog.d/3d-studio-reuse.md
@@ -4,3 +4,9 @@
   these settings again** line — replacing a dropdown whose rows read
   "Text to 3-D · completed". **New workflow** on the toolbar starts fresh
   without forgetting the machine or the styles in use.
+- **A past 3-D run's settings come back when you ask for them.** Clicking the
+  workflow you already have open restores it rather than doing nothing, the
+  list keeps up with a run in progress instead of freezing on its first
+  status, and opening a past run no longer empties a file well it cannot
+  refill — Rebuild and Add texture say which file to choose again.
+

--- a/changelog.d/3d-studio-reuse.md
+++ b/changelog.d/3d-studio-reuse.md
@@ -1,0 +1,6 @@
+- **Saving and reusing a 3-D workflow is a door you can see.** The settings rail
+  gains a **Recent** tab listing every workflow that machine has run — what it
+  made, what stage it is on or how it ended, how long ago, and an accent **Use
+  these settings again** line — replacing a dropdown whose rows read
+  "Text to 3-D · completed". **New workflow** on the toolbar starts fresh
+  without forgetting the machine or the styles in use.

--- a/desktop/src/lib/format.ts
+++ b/desktop/src/lib/format.ts
@@ -95,15 +95,9 @@ export function formatUptime(seconds: number): string {
   return `${days}d ${hours % 24}h`;
 }
 
-/** Compact relative timestamp for MRU lists ("just now", "5m ago", "3d ago"). */
-export function timeAgo(thenMs: number, nowMs: number = Date.now()): string {
-  const seconds = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
-  if (seconds < 60) return "just now";
-  const minutes = Math.floor(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.floor(minutes / 60);
-  if (hours < 24) return `${hours}h ago`;
-  const days = Math.floor(hours / 24);
-  if (days < 30) return `${days}d ago`;
-  return new Date(thenMs).toLocaleDateString();
-}
+/** Compact relative timestamp for MRU lists ("just now", "5m ago", "3d ago").
+ *
+ * Re-exported from `@studio/lib/relativeTime`, which owns it: `studio/` is the
+ * lower layer and cannot import from a shell, and the 3-D Studio's Recent list
+ * needs exactly these words. Every existing caller keeps importing it here. */
+export { timeAgo } from "@studio/lib/relativeTime";

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -319,6 +319,18 @@ with Generate at its foot". Putting the prompt where every other making-view
 puts it is what makes the surface read as part of the app, and it gives ⌘↩ an
 obvious home.)
 
+**Reuse is a door, not a dropdown.** The desktop rail is **Settings | Recent**,
+the peer of New image's tab strip, with a mono count. A Recent row says what
+was made in the toolbar's own words, what it is doing in the queue's vocabulary
+(the stage and `n/N` while it runs, `Finished` / `Stopped` / `Failed`
+otherwise — never the raw wire state), and carries the accent **Use these
+settings again** line. Clicking restores explicitly rather than through a
+watcher, because the row you are most likely to click is the one already open.
+A workflow's FILES cannot be restored, so a supplied-mesh run says which to
+choose again rather than leaving Generate disabled for no visible reason, and
+opening a run never clears an attachment you already made. **New workflow**
+clears the authored work and keeps the machine and the styles in use.
+
 **The draft belongs to a store, never to the view.** The router lazy-loads this
 surface and nothing keeps it alive, so a component-local ref loses the
 description, both styles, the attachments, the stage settings and the machine

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -2,7 +2,10 @@ import { flushPromises, mount } from "@vue/test-utils";
 import { createPinia, setActivePinia } from "pinia";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import { setMeshWorkflowDraftStorage } from "../stores/meshWorkflowDraft";
+import {
+  setMeshWorkflowDraftStorage,
+  useMeshWorkflowDraftStore,
+} from "../stores/meshWorkflowDraft";
 
 /*
  * The 3-D Studio draft is a module-scoped store, so a case that leaves a
@@ -803,6 +806,164 @@ describe("saving and reusing a 3-D workflow", () => {
       wrapper.get<HTMLSelectElement>("[data-test='mesh-workflow-model']")
         .element.value,
     ).toBe(style);
+    wrapper.unmount();
+  });
+});
+
+describe("Recent keeps its promise", () => {
+  const target = { baseUrl: "http://local:7680", apiKey: null };
+  const now = Date.now();
+  const job = (id: string, over: Record<string, unknown> = {}) => ({
+    contract_version: 1,
+    id,
+    state: "completed",
+    mode: "text_to_mesh",
+    stage_count: 3,
+    current_stage: 2,
+    created_at_ms: now,
+    updated_at_ms: now,
+    ...over,
+  });
+
+  /*
+   * The single commonest click: the row that is ALREADY selected — after a
+   * submit, after a deep link from the Queue, or after an earlier click. It
+   * renders highlighted, so it reads as the live row. Assigning `selectedId`
+   * to its existing value fires no watcher, so "Use these settings again" did
+   * nothing at all: no restore, no message, no press feedback.
+   */
+  it("restores even when the clicked row is the one already open", async () => {
+    const { listMeshWorkflows, getMeshWorkflow } =
+      await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [job("run-1")],
+    } as never);
+    vi.mocked(getMeshWorkflow).mockResolvedValue({
+      id: "run-1",
+      state: "completed",
+      mode: "text_to_mesh",
+      stages: [],
+      request: {
+        mode: "text_to_mesh",
+        image_request: {
+          model: "z-image-turbo:q8",
+          prompt: "the original run",
+        },
+        mesh_request: {
+          model: "hunyuan3d-mini-turbo:fp16",
+          mesh: { texture: false },
+        },
+      },
+    } as never);
+
+    // Arrive with it already open, the way a queue row does.
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true, openWorkflow: "run-1" },
+    });
+    await flushPromises();
+    await wrapper
+      .get("[data-test='mesh-composer'] textarea")
+      .setValue("edited away");
+
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    await wrapper.get("[data-test='mesh-recent-run-1']").trigger("click");
+    await flushPromises();
+
+    expect(
+      wrapper.get<HTMLTextAreaElement>("[data-test='mesh-composer'] textarea")
+        .element.value,
+    ).toBe("the original run");
+    wrapper.unmount();
+  });
+
+  /*
+   * A row's sentence comes from the LISTING, not from `detail`, so polling
+   * only the open workflow left a running row reading "1/3 · just now" for the
+   * whole run — and still saying it after the mesh was on the canvas.
+   */
+  it("refreshes the listing while a workflow runs, not just its detail", async () => {
+    vi.useFakeTimers();
+    const { listMeshWorkflows, getMeshWorkflow } =
+      await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [job("run-1", { state: "running", current_stage: 0 })],
+    } as never);
+    vi.mocked(getMeshWorkflow).mockResolvedValue({
+      id: "run-1",
+      state: "running",
+      mode: "text_to_mesh",
+      stages: [],
+    } as never);
+
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true, openWorkflow: "run-1" },
+    });
+    await flushPromises();
+    const before = vi.mocked(listMeshWorkflows).mock.calls.length;
+
+    await vi.advanceTimersByTimeAsync(800);
+    await flushPromises();
+    expect(vi.mocked(listMeshWorkflows).mock.calls.length).toBeGreaterThan(
+      before,
+    );
+
+    wrapper.unmount();
+    vi.useRealTimers();
+  });
+
+  /*
+   * A `File` cannot be restored from a past request, so clearing the wells
+   * destroyed the person's own attachment and put nothing in its place.
+   */
+  it("keeps an attached file when a past run is opened", async () => {
+    const { listMeshWorkflows, getMeshWorkflow } =
+      await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [job("run-1")],
+    } as never);
+    vi.mocked(getMeshWorkflow).mockResolvedValue({
+      id: "run-1",
+      state: "completed",
+      mode: "text_to_mesh",
+      stages: [],
+      request: {
+        mode: "text_to_mesh",
+        image_request: { model: "z-image-turbo:q8", prompt: "restored" },
+        mesh_request: {
+          model: "hunyuan3d-mini-turbo:fp16",
+          mesh: { texture: false },
+        },
+      },
+    } as never);
+
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true },
+    });
+    await flushPromises();
+    const draft = useMeshWorkflowDraftStore();
+    draft.meshFile = new File(["glb"], "mine.glb");
+
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    await wrapper.get("[data-test='mesh-recent-run-1']").trigger("click");
+    await flushPromises();
+    expect(draft.meshFile?.name).toBe("mine.glb");
+    wrapper.unmount();
+  });
+
+  /* A 300px rail is not a place for two hundred bordered cards. */
+  it("bounds how many past runs it lists", async () => {
+    const { listMeshWorkflows } = await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: Array.from({ length: 200 }, (_, i) => job(`run-${i}`)),
+    } as never);
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: { target, desktop: true },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    const rows = wrapper.findAll("[data-test^='mesh-recent-run-']");
+    expect(rows.length).toBeGreaterThan(0);
+    expect(rows.length).toBeLessThanOrEqual(24);
     wrapper.unmount();
   });
 });

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -666,8 +666,86 @@ describe("saving and reusing a 3-D workflow", () => {
 
     const second = wrapper.get("[data-test='mesh-recent-workflow-2']");
     expect(second.text()).toContain("Add texture");
-    expect(second.text()).toContain("completed");
+    // The queue's own word, never the raw wire state (lexicon §2).
+    expect(second.text()).toContain("Finished");
+    expect(second.text()).not.toContain("completed");
     expect(second.text()).toContain("2h ago");
+    wrapper.unmount();
+  });
+
+  /*
+   * The lexicon table forbids the raw wire words ("Being made / Waiting /
+   * Finished", never "active, queued, done"), and these are the same words
+   * `lib/queueRows.ts` puts on a print's row — so a finished workflow and a
+   * finished print read alike.
+   */
+  it("says a settled run's state in the queue's own words", async () => {
+    const { listMeshWorkflows } = await import("../api/meshWorkflows");
+    const now = Date.now();
+    const row = (id: string, state: string) => ({
+      contract_version: 1,
+      id,
+      state,
+      mode: "text_to_mesh",
+      stage_count: 3,
+      current_stage: 2,
+      created_at_ms: now,
+      updated_at_ms: now,
+    });
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [row("a", "completed"), row("b", "failed"), row("c", "cancelled")],
+    } as never);
+
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    expect(wrapper.get("[data-test='mesh-recent-a']").text()).toContain(
+      "Finished",
+    );
+    expect(wrapper.get("[data-test='mesh-recent-b']").text()).toContain(
+      "Failed",
+    );
+    expect(wrapper.get("[data-test='mesh-recent-c']").text()).toContain(
+      "Stopped",
+    );
+    for (const raw of ["completed", "cancelled"])
+      expect(wrapper.text(), raw).not.toContain(raw);
+    wrapper.unmount();
+  });
+
+  /* A state this build has never heard of still reads as itself. */
+  it("shows an unknown state rather than nothing", async () => {
+    const { listMeshWorkflows } = await import("../api/meshWorkflows");
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [
+        {
+          contract_version: 1,
+          id: "z",
+          state: "reticulating",
+          mode: "text_to_mesh",
+          stage_count: 3,
+          current_stage: 0,
+          created_at_ms: Date.now(),
+          updated_at_ms: Date.now(),
+        },
+      ],
+    } as never);
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    expect(wrapper.get("[data-test='mesh-recent-z']").text()).toContain(
+      "reticulating",
+    );
     wrapper.unmount();
   });
 

--- a/studio/components/MeshWorkflowStudio.test.ts
+++ b/studio/components/MeshWorkflowStudio.test.ts
@@ -13,6 +13,9 @@ import { setMeshWorkflowDraftStorage } from "../stores/meshWorkflowDraft";
  * cases hydrating each other's prompts.
  */
 beforeEach(() => {
+  // `clearAllMocks` resets calls but NOT a `mockResolvedValue`, so one case's
+  // job listing kept answering in the next.
+  listMeshWorkflows.mockResolvedValue({ jobs: [] });
   setActivePinia(createPinia());
   setMeshWorkflowDraftStorage({
     getItem: () => null,
@@ -595,6 +598,133 @@ describe("the composer is the one place a 3-D object is authored", () => {
     await flushPromises();
     expect(wrapper.text()).not.toContain("TEXTURE SIZE");
     expect(wrapper.text()).toContain("Texture size");
+    wrapper.unmount();
+  });
+});
+
+describe("saving and reusing a 3-D workflow", () => {
+  /*
+   * Reuse always worked — selecting a past job restores its draft through
+   * `restoreWorkflowDraft`. Its only door was a bare `<select>` whose rows
+   * read "Text to 3-D · completed": no verb, no date, no sense that picking
+   * one brought the whole recipe back. That is why it read as missing rather
+   * than merely hidden.
+   */
+  it("lists past workflows with what they are doing and what a click does", async () => {
+    const { listMeshWorkflows } = await import("../api/meshWorkflows");
+    const now = Date.now();
+    vi.mocked(listMeshWorkflows).mockResolvedValue({
+      jobs: [
+        {
+          contract_version: 1,
+          id: "workflow-1",
+          state: "running",
+          mode: "text_to_mesh",
+          stage_count: 6,
+          current_stage: 2,
+          current_stage_kind: "shape",
+          created_at_ms: now - 60_000,
+          updated_at_ms: now - 60_000,
+        },
+        {
+          contract_version: 1,
+          id: "workflow-2",
+          state: "completed",
+          mode: "mesh_texture",
+          stage_count: 3,
+          current_stage: 2,
+          created_at_ms: now - 7_200_000,
+          updated_at_ms: now - 7_200_000,
+        },
+      ],
+    } as never);
+
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+
+    // The tab names itself and counts what it holds.
+    expect(wrapper.get("[data-test='mesh-tab-recent']").text()).toContain(
+      "Recent",
+    );
+    expect(wrapper.get("[data-test='mesh-tab-recent']").text()).toContain("2");
+
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    const first = wrapper.get("[data-test='mesh-recent-workflow-1']");
+    // The workflow's own toolbar word, not a private vocabulary.
+    expect(first.text()).toContain("From words");
+    // Running says the stage it is on, the way the queue does.
+    expect(first.text()).toContain("Build geometry");
+    expect(first.text()).toContain("3/6");
+    expect(first.text()).toContain("1m ago");
+    // And the accent line names what a click does, in the app's own words.
+    expect(first.text()).toContain("Use these settings again");
+
+    const second = wrapper.get("[data-test='mesh-recent-workflow-2']");
+    expect(second.text()).toContain("Add texture");
+    expect(second.text()).toContain("completed");
+    expect(second.text()).toContain("2h ago");
+    wrapper.unmount();
+  });
+
+  it("says plainly when a machine has made nothing yet", async () => {
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    expect(wrapper.get("[data-test='mesh-recent']").text()).toContain(
+      "Nothing made here yet",
+    );
+    wrapper.unmount();
+  });
+
+  /* The two tabs are exclusive: Recent must not sit under the settings. */
+  it("shows one tab at a time", async () => {
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    expect(wrapper.find("[data-test='mesh-recent']").exists()).toBe(false);
+    await wrapper.get("[data-test='mesh-tab-recent']").trigger("click");
+    expect(wrapper.find("[data-test='mesh-recent']").exists()).toBe(true);
+    expect(wrapper.find("[data-test='mesh-workflow-texture']").exists()).toBe(
+      false,
+    );
+    wrapper.unmount();
+  });
+
+  /* Starting fresh clears the authored work, never the machine or the styles. */
+  it("starts a new workflow without forgetting the styles in use", async () => {
+    const wrapper = mount(MeshWorkflowStudio, {
+      props: {
+        target: { baseUrl: "http://local:7680", apiKey: null },
+        desktop: true,
+      },
+    });
+    await flushPromises();
+    await wrapper.get("textarea").setValue("a hand-carved wooden fox");
+    const style = wrapper.get<HTMLSelectElement>(
+      "[data-test='mesh-workflow-model']",
+    ).element.value;
+
+    await wrapper.get("[data-test='mesh-new-workflow']").trigger("click");
+    await flushPromises();
+    expect(wrapper.get<HTMLTextAreaElement>("textarea").element.value).toBe("");
+    expect(
+      wrapper.get<HTMLSelectElement>("[data-test='mesh-workflow-model']")
+        .element.value,
+    ).toBe(style);
     wrapper.unmount();
   });
 });

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -201,18 +201,41 @@ function workflowModeLabel(mode: string): string {
 }
 
 /**
- * What a past run is waiting on, said the way the queue says it — running
- * shows its stage, everything else says its state plainly.
+ * The queue's own words for a settled run.
+ *
+ * Raw wire states — `completed`, `cancelled` — are what the lexicon table
+ * forbids ("Being made / Waiting / Finished", never "active, queued, done").
+ * These are the same words `lib/queueRows.ts` puts on a print's row, so a
+ * finished workflow and a finished print read alike. A state this build has
+ * never heard of still reads as itself rather than as nothing.
+ */
+const WORKFLOW_STATE_LABEL: Record<string, string> = {
+  queued: "Waiting",
+  running: "Being made",
+  paused: "Paused",
+  completed: "Finished",
+  failed: "Failed",
+  cancelled: "Stopped",
+};
+
+/**
+ * What a past run is doing, said the way the queue says it — running shows the
+ * stage it is on and how far through, everything else its state and when.
+ *
+ * `current_stage` is 0-based on the wire (verified against a real host: a
+ * completed three-stage run reports `current_stage: 2`), so the `+ 1` is what
+ * makes it read 3/3 rather than 2/3.
  */
 function workflowStatusLine(job: MeshWorkflowJobSummary): string {
   const when = timeAgo(job.updated_at_ms || job.created_at_ms);
   if (job.state === "running" || job.state === "queued") {
     const stage = job.current_stage_kind
       ? stageLabel(job.current_stage_kind)
-      : "Preparing";
+      : "Getting ready";
     return `${stage} · ${job.current_stage + 1}/${job.stage_count} · ${when}`;
   }
-  return `${job.state} · ${when}`;
+  const state = WORKFLOW_STATE_LABEL[job.state] ?? job.state;
+  return `${state} · ${when}`;
 }
 
 /** Start over without leaving the machine or the styles this session is using. */

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -38,6 +38,7 @@ import {
   type WorkflowModel,
 } from "../lib/meshWorkflowAuthoring";
 import { autoGrowRows } from "../lib/autogrow";
+import { timeAgo } from "../lib/relativeTime";
 import { isMeshFamily } from "../lib/legacyRecipeRules";
 import { useMeshWorkflowDraftStore } from "../stores/meshWorkflowDraft";
 import MeshViewer from "./MeshViewer.vue";
@@ -173,6 +174,52 @@ const canSubmit = computed(() => {
  * The Y/Z wording is `ui/components/MeshGeometryFields.vue`'s own, so the
  * import side and the export side name the same axes the same way.
  */
+/**
+ * The inspector's tabs — the peer of New image's Settings | Starters | Recent.
+ *
+ * Reuse already worked (`restoreWorkflowDraft`), but its only door was a bare
+ * `<select>` whose rows read "Text to 3-D · completed": no thumbnail, no
+ * prompt, no date, and no verb. A person could not tell that picking one
+ * restored the whole recipe, which is why saving and reusing a workflow read
+ * as missing rather than merely hidden.
+ */
+type InspectorTab = "settings" | "recent";
+const inspectorTab = ref<InspectorTab>("settings");
+const inspectorTabs = computed(() => [
+  { id: "settings" as const, label: "Settings", count: 0 },
+  { id: "recent" as const, label: "Recent", count: jobs.value.length },
+]);
+
+const WORKFLOW_MODE_LABEL: Record<string, string> = {
+  text_to_mesh: "From words",
+  mesh_roundtrip: "Rebuild",
+  mesh_texture: "Add texture",
+};
+/** The workflow's own toolbar word; a newer host's mode still reads as itself. */
+function workflowModeLabel(mode: string): string {
+  return WORKFLOW_MODE_LABEL[mode] ?? mode.replace(/_/g, " ");
+}
+
+/**
+ * What a past run is waiting on, said the way the queue says it — running
+ * shows its stage, everything else says its state plainly.
+ */
+function workflowStatusLine(job: MeshWorkflowJobSummary): string {
+  const when = timeAgo(job.updated_at_ms || job.created_at_ms);
+  if (job.state === "running" || job.state === "queued") {
+    const stage = job.current_stage_kind
+      ? stageLabel(job.current_stage_kind)
+      : "Preparing";
+    return `${stage} · ${job.current_stage + 1}/${job.stage_count} · ${when}`;
+  }
+  return `${job.state} · ${when}`;
+}
+
+/** Start over without leaving the machine or the styles this session is using. */
+function startNewWorkflow(): void {
+  draft.clear();
+}
+
 const textureSizeOptions = [
   { value: 1024, label: "1024" },
   { value: 2048, label: "2048" },
@@ -750,22 +797,26 @@ onBeforeUnmount(() => {
         <span v-if="ownerLabel && selectedId" class="mesh-studio__owner">{{
           ownerLabel
         }}</span>
+        <button
+          v-if="desktop"
+          type="button"
+          class="ms-toolbar-button"
+          data-test="mesh-new-workflow"
+          :disabled="busy || (!selectedId && !draft.dirty)"
+          title="Start a new 3-D workflow"
+          @click="startNewWorkflow"
+        >
+          New workflow
+        </button>
         <select
+          v-else
           v-model="selectedId"
           :disabled="busy"
           aria-label="Previous 3-D workflow"
         >
           <option value="">New workflow</option>
           <option v-for="job in jobs" :key="job.id" :value="job.id">
-            {{
-              job.mode === "text_to_mesh"
-                ? "Text to 3-D"
-                : job.mode === "mesh_roundtrip"
-                  ? "Rebuild mesh"
-                  : "Texture mesh"
-            }}
-            ·
-            {{ job.state }}
+            {{ workflowModeLabel(job.mode) }} · {{ job.state }}
           </option>
         </select>
         <slot name="machine" :busy="busy" />
@@ -779,223 +830,285 @@ onBeforeUnmount(() => {
       <slot name="inspector-resize" />
       <form class="mesh-studio__composer" @submit.prevent="submit">
         <fieldset class="mesh-studio__fields" :disabled="busy">
-          <div v-if="desktop" class="mesh-studio__inspector-heading">
-            Settings
-          </div>
-          <SegmentedControl
-            v-if="!desktop"
-            v-model="mode"
-            :options="modeOptions"
-            :disabled="busy || loading"
-            label="3-D workflow"
-            variant="neutral"
-          />
-
-          <slot
-            v-if="!desktop"
-            name="mesh-picker"
-            :models="
-              meshModels.filter((model) =>
-                meshWorkflowModes(model).includes(mode),
-              )
-            "
-            :selected="meshModelName"
-            :select="(name: string) => (meshModelName = name)"
-            :disabled="busy"
+          <div
+            v-if="desktop"
+            class="mesh-studio__inspector-heading"
+            role="tablist"
+            aria-label="3-D settings"
           >
-            <label>
-              3-D style
-              <select v-model="meshModelName" data-test="mesh-workflow-model">
-                <option
-                  v-for="model in meshModels.filter((model) =>
-                    meshWorkflowModes(model).includes(mode),
-                  )"
-                  :key="model.name"
-                  :value="model.name"
-                >
-                  {{ modelLabel(model) }}
-                </option>
-              </select>
-            </label>
-          </slot>
+            <button
+              v-for="tab in inspectorTabs"
+              :key="tab.id"
+              type="button"
+              role="tab"
+              class="mesh-studio__tab"
+              :data-test="`mesh-tab-${tab.id}`"
+              :data-on="inspectorTab === tab.id ? 'true' : undefined"
+              :aria-selected="inspectorTab === tab.id"
+              @click.prevent="inspectorTab = tab.id"
+            >
+              {{ tab.label
+              }}<span v-if="tab.count" class="mesh-studio__tab-count">{{
+                tab.count
+              }}</span>
+            </button>
+          </div>
 
-          <template v-if="mode === 'text_to_mesh'">
-            <template v-if="!desktop">
-              <label>
-                Describe the object
-                <textarea
-                  v-model="prompt"
-                  rows="5"
-                  placeholder="A hand-carved wooden fox, centered on a plain background"
-                />
-              </label>
-              <slot
-                name="image-picker"
-                :models="imageModels"
-                :selected="imageModelName"
-                :select="(name: string) => (imageModelName = name)"
-                :disabled="busy"
-              >
-                <label>
-                  Picture style
-                  <select v-model="imageModelName">
-                    <option
-                      v-for="model in imageModels"
-                      :key="model.name"
-                      :value="model.name"
-                    >
-                      {{ modelLabel(model) }}
-                    </option>
-                  </select>
-                </label>
-              </slot>
-            </template>
-            <div
-              v-if="textureAvailable"
-              class="mesh-studio__check"
-              data-test="mesh-workflow-texture"
-            >
-              <SwitchToggle
-                v-model="texture"
-                :disabled="busy"
-                label="Paint PBR materials after geometry"
-              />
-              <span class="mesh-studio__check-label" aria-hidden="true"
-                >Paint PBR materials after geometry</span
-              >
-            </div>
-            <p
-              v-else
-              class="mesh-studio__availability"
-              data-test="mesh-workflow-texture-unavailable"
-            >
-              PBR painting is unavailable on this machine. Geometry generation
-              remains available.
+          <!--
+            Recent workflows: the door that reuse always had and never showed.
+            A row says what was made, what it is doing now, and — in the
+            accent, in the app's own words — that picking it brings the whole
+            recipe back.
+          -->
+          <div
+            v-if="desktop && inspectorTab === 'recent'"
+            class="mesh-studio__recent"
+            data-test="mesh-recent"
+          >
+            <p v-if="!jobs.length" class="mesh-studio__recent-empty">
+              Nothing made here yet. Your finished 3-D objects appear in this
+              list, and one click brings their settings back.
             </p>
-          </template>
+            <button
+              v-for="job in jobs"
+              :key="job.id"
+              type="button"
+              class="mesh-studio__recent-row"
+              :data-test="`mesh-recent-${job.id}`"
+              :data-on="selectedId === job.id ? 'true' : undefined"
+              :disabled="busy"
+              @click="draft.selectWorkflow(job.id, targetIdentity(ownedTarget))"
+            >
+              <span class="mesh-studio__recent-title">{{
+                workflowModeLabel(job.mode)
+              }}</span>
+              <span class="mesh-studio__recent-meta">{{
+                workflowStatusLine(job)
+              }}</span>
+              <span class="mesh-studio__recent-reuse"
+                >Use these settings again</span
+              >
+            </button>
+          </div>
 
-          <template v-else>
-            <label class="mesh-studio__file">
-              Source mesh (GLB or OBJ)
-              <input
-                type="file"
-                accept=".glb,.obj,model/gltf-binary,model/obj"
-                @change="
-                  meshFile =
-                    ($event.target as HTMLInputElement).files?.[0] ?? null
-                "
-              />
-              <span>{{ meshFile?.name || "Choose a mesh" }}</span>
-            </label>
-            <label v-if="mode === 'mesh_texture'" class="mesh-studio__file">
-              Appearance image
-              <input
-                type="file"
-                accept="image/png,image/jpeg"
-                @change="
-                  appearanceFile =
-                    ($event.target as HTMLInputElement).files?.[0] ?? null
-                "
-              />
-              <span>{{ appearanceFile?.name || "Choose an image" }}</span>
-            </label>
-            <div class="mesh-studio__field">
+          <template v-if="!desktop || inspectorTab === 'settings'">
+            <SegmentedControl
+              v-if="!desktop"
+              v-model="mode"
+              :options="modeOptions"
+              :disabled="busy || loading"
+              label="3-D workflow"
+              variant="neutral"
+            />
+
+            <slot
+              v-if="!desktop"
+              name="mesh-picker"
+              :models="
+                meshModels.filter((model) =>
+                  meshWorkflowModes(model).includes(mode),
+                )
+              "
+              :selected="meshModelName"
+              :select="(name: string) => (meshModelName = name)"
+              :disabled="busy"
+            >
+              <label>
+                3-D style
+                <select v-model="meshModelName" data-test="mesh-workflow-model">
+                  <option
+                    v-for="model in meshModels.filter((model) =>
+                      meshWorkflowModes(model).includes(mode),
+                    )"
+                    :key="model.name"
+                    :value="model.name"
+                  >
+                    {{ modelLabel(model) }}
+                  </option>
+                </select>
+              </label>
+            </slot>
+
+            <template v-if="mode === 'text_to_mesh'">
+              <template v-if="!desktop">
+                <label>
+                  Describe the object
+                  <textarea
+                    v-model="prompt"
+                    rows="5"
+                    placeholder="A hand-carved wooden fox, centered on a plain background"
+                  />
+                </label>
+                <slot
+                  name="image-picker"
+                  :models="imageModels"
+                  :selected="imageModelName"
+                  :select="(name: string) => (imageModelName = name)"
+                  :disabled="busy"
+                >
+                  <label>
+                    Picture style
+                    <select v-model="imageModelName">
+                      <option
+                        v-for="model in imageModels"
+                        :key="model.name"
+                        :value="model.name"
+                      >
+                        {{ modelLabel(model) }}
+                      </option>
+                    </select>
+                  </label>
+                </slot>
+              </template>
+              <div
+                v-if="textureAvailable"
+                class="mesh-studio__check"
+                data-test="mesh-workflow-texture"
+              >
+                <SwitchToggle
+                  v-model="texture"
+                  :disabled="busy"
+                  label="Paint PBR materials after geometry"
+                />
+                <span class="mesh-studio__check-label" aria-hidden="true"
+                  >Paint PBR materials after geometry</span
+                >
+              </div>
+              <p
+                v-else
+                class="mesh-studio__availability"
+                data-test="mesh-workflow-texture-unavailable"
+              >
+                PBR painting is unavailable on this machine. Geometry generation
+                remains available.
+              </p>
+            </template>
+
+            <template v-else>
+              <label class="mesh-studio__file">
+                Source mesh (GLB or OBJ)
+                <input
+                  type="file"
+                  accept=".glb,.obj,model/gltf-binary,model/obj"
+                  @change="
+                    meshFile =
+                      ($event.target as HTMLInputElement).files?.[0] ?? null
+                  "
+                />
+                <span>{{ meshFile?.name || "Choose a mesh" }}</span>
+              </label>
+              <label v-if="mode === 'mesh_texture'" class="mesh-studio__file">
+                Appearance image
+                <input
+                  type="file"
+                  accept="image/png,image/jpeg"
+                  @change="
+                    appearanceFile =
+                      ($event.target as HTMLInputElement).files?.[0] ?? null
+                  "
+                />
+                <span>{{ appearanceFile?.name || "Choose an image" }}</span>
+              </label>
+              <div class="mesh-studio__field">
+                <span class="ms-group-label mesh-studio__label"
+                  >Which way is up</span
+                >
+                <SegmentedControl
+                  v-if="desktop"
+                  v-model="upAxis"
+                  :options="upAxisOptions"
+                  :disabled="busy"
+                  label="Which way is up"
+                  variant="neutral"
+                  compact
+                />
+                <select v-else v-model="upAxis" aria-label="Which way is up">
+                  <option value="y">Y up</option>
+                  <option value="z">Z up</option>
+                </select>
+                <p class="mesh-studio__truth">{{ upAxisTruth }}</p>
+              </div>
+              <div class="mesh-studio__field">
+                <span class="ms-group-label mesh-studio__label"
+                  >How big one unit is</span
+                >
+                <input
+                  v-model.number="metersPerUnit"
+                  class="mesh-studio__number"
+                  type="number"
+                  min="0.000001"
+                  max="1000000"
+                  step="any"
+                  aria-label="How big one unit is"
+                />
+                <p class="mesh-studio__truth">
+                  {{ metersPerUnit }} m per unit · what the file calls 1
+                </p>
+              </div>
+            </template>
+
+            <div
+              v-if="
+                (mode === 'text_to_mesh' && texture) || mode === 'mesh_texture'
+              "
+              class="mesh-studio__field"
+            >
               <span class="ms-group-label mesh-studio__label"
-                >Which way is up</span
+                >Texture size</span
               >
               <SegmentedControl
                 v-if="desktop"
-                v-model="upAxis"
-                :options="upAxisOptions"
+                v-model="textureResolution"
+                :options="textureSizeOptions"
                 :disabled="busy"
-                label="Which way is up"
+                label="Texture size"
                 variant="neutral"
                 compact
               />
-              <select v-else v-model="upAxis" aria-label="Which way is up">
-                <option value="y">Y up</option>
-                <option value="z">Z up</option>
-              </select>
-              <p class="mesh-studio__truth">{{ upAxisTruth }}</p>
-            </div>
-            <div class="mesh-studio__field">
-              <span class="ms-group-label mesh-studio__label"
-                >How big one unit is</span
+              <select
+                v-else
+                v-model.number="textureResolution"
+                aria-label="Texture size"
               >
-              <input
-                v-model.number="metersPerUnit"
-                class="mesh-studio__number"
-                type="number"
-                min="0.000001"
-                max="1000000"
-                step="any"
-                aria-label="How big one unit is"
-              />
+                <option :value="1024">1024</option>
+                <option :value="2048">2048</option>
+                <option :value="4096">4096</option>
+              </select>
               <p class="mesh-studio__truth">
-                {{ metersPerUnit }} m per unit · what the file calls 1
+                {{ textureResolution }} px · bigger takes longer to paint
               </p>
             </div>
+            <div
+              v-if="delightAvailable && mode !== 'mesh_roundtrip'"
+              class="mesh-studio__check"
+            >
+              <SwitchToggle
+                v-model="delight"
+                :disabled="busy"
+                label="Remove baked lighting and highlights before building the mesh"
+              />
+              <span class="mesh-studio__check-label" aria-hidden="true"
+                >Remove baked lighting and highlights before building the
+                mesh</span
+              >
+            </div>
+            <button
+              v-if="!desktop"
+              class="mesh-studio__primary"
+              type="submit"
+              :disabled="!canSubmit"
+            >
+              {{
+                busy
+                  ? "Preparing…"
+                  : mode === "text_to_mesh"
+                    ? "Build 3-D object"
+                    : mode === "mesh_roundtrip"
+                      ? "Rebuild mesh"
+                      : "Paint mesh"
+              }}
+            </button>
           </template>
-
-          <div
-            v-if="
-              (mode === 'text_to_mesh' && texture) || mode === 'mesh_texture'
-            "
-            class="mesh-studio__field"
-          >
-            <span class="ms-group-label mesh-studio__label">Texture size</span>
-            <SegmentedControl
-              v-if="desktop"
-              v-model="textureResolution"
-              :options="textureSizeOptions"
-              :disabled="busy"
-              label="Texture size"
-              variant="neutral"
-              compact
-            />
-            <select
-              v-else
-              v-model.number="textureResolution"
-              aria-label="Texture size"
-            >
-              <option :value="1024">1024</option>
-              <option :value="2048">2048</option>
-              <option :value="4096">4096</option>
-            </select>
-            <p class="mesh-studio__truth">
-              {{ textureResolution }} px · bigger takes longer to paint
-            </p>
-          </div>
-          <div
-            v-if="delightAvailable && mode !== 'mesh_roundtrip'"
-            class="mesh-studio__check"
-          >
-            <SwitchToggle
-              v-model="delight"
-              :disabled="busy"
-              label="Remove baked lighting and highlights before building the mesh"
-            />
-            <span class="mesh-studio__check-label" aria-hidden="true"
-              >Remove baked lighting and highlights before building the
-              mesh</span
-            >
-          </div>
-          <button
-            v-if="!desktop"
-            class="mesh-studio__primary"
-            type="submit"
-            :disabled="!canSubmit"
-          >
-            {{
-              busy
-                ? "Preparing…"
-                : mode === "text_to_mesh"
-                  ? "Build 3-D object"
-                  : mode === "mesh_roundtrip"
-                    ? "Rebuild mesh"
-                    : "Paint mesh"
-            }}
-          </button>
         </fieldset>
       </form>
 
@@ -1112,7 +1225,23 @@ onBeforeUnmount(() => {
                 :selected="meshModelName"
                 :select="(name: string) => (meshModelName = name)"
                 :disabled="busy"
-              />
+              >
+                <select
+                  v-model="meshModelName"
+                  data-test="mesh-workflow-model"
+                  aria-label="3-D style"
+                >
+                  <option
+                    v-for="model in meshModels.filter((model) =>
+                      meshWorkflowModes(model).includes(mode),
+                    )"
+                    :key="model.name"
+                    :value="model.name"
+                  >
+                    {{ modelLabel(model) }}
+                  </option>
+                </select>
+              </slot>
               <slot
                 v-if="mode === 'text_to_mesh'"
                 name="image-picker"
@@ -1120,7 +1249,17 @@ onBeforeUnmount(() => {
                 :selected="imageModelName"
                 :select="(name: string) => (imageModelName = name)"
                 :disabled="busy"
-              />
+              >
+                <select v-model="imageModelName" aria-label="Picture style">
+                  <option
+                    v-for="model in imageModels"
+                    :key="model.name"
+                    :value="model.name"
+                  >
+                    {{ modelLabel(model) }}
+                  </option>
+                </select>
+              </slot>
               <span class="ms-composer__spacer" />
               <button
                 class="ms-composer__generate"
@@ -1527,6 +1666,86 @@ onBeforeUnmount(() => {
   background: var(--mold-bg-deep);
   color: var(--mold-text);
   font-size: var(--mold-fs-xs);
+  font-weight: 600;
+}
+
+/* The inspector's tab strip — the same 26px control ladder InspectorPanel's
+ * tabs sit on, inside the one-toolbar-tall header. */
+.mesh-studio--desktop .mesh-studio__inspector-heading {
+  gap: 2px;
+  padding: 0 8px;
+  font-weight: 400;
+}
+.mesh-studio--desktop .mesh-studio__tab {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  justify-content: center;
+  height: var(--mold-ctl-md, 26px);
+  padding: 0;
+  border: 0;
+  border-radius: var(--mold-radius-1);
+  background: transparent;
+  color: var(--mold-text-2);
+  font-family: var(--mold-font-sans);
+  font-size: var(--mold-fs-xs);
+  font-weight: 600;
+  cursor: pointer;
+}
+.mesh-studio--desktop .mesh-studio__tab[data-on="true"] {
+  background: var(--mold-row-selected);
+  color: var(--mold-text);
+}
+.mesh-studio--desktop .mesh-studio__tab-count {
+  font-family: var(--mold-font-mono);
+  font-size: var(--mold-fs-micro);
+  color: var(--mold-text-dim);
+}
+
+/* Recent workflows: one row per past run — what it made, what it is doing,
+ * and the accent line naming what a click does. */
+.mesh-studio--desktop .mesh-studio__recent {
+  display: grid;
+  gap: 6px;
+  min-width: 0;
+}
+.mesh-studio--desktop .mesh-studio__recent-empty {
+  margin: 0;
+  color: var(--mold-text-dim);
+  font-size: var(--mold-fs-xs);
+  line-height: var(--mold-lh-body);
+}
+.mesh-studio--desktop .mesh-studio__recent-row {
+  display: grid;
+  gap: 3px;
+  padding: 9px 11px;
+  border: var(--mold-bw) solid var(--mold-border);
+  border-radius: var(--mold-radius-2);
+  background: var(--mold-surface);
+  text-align: left;
+  cursor: pointer;
+}
+.mesh-studio--desktop .mesh-studio__recent-row:hover:not(:disabled) {
+  border-color: var(--mold-border-focus);
+}
+.mesh-studio--desktop .mesh-studio__recent-row[data-on="true"] {
+  border-color: var(--mold-blue);
+  box-shadow: inset 0 0 0 1px var(--mold-blue);
+}
+.mesh-studio--desktop .mesh-studio__recent-title {
+  color: var(--mold-text);
+  font-size: var(--mold-fs-xs);
+  font-weight: 600;
+}
+.mesh-studio--desktop .mesh-studio__recent-meta {
+  font-family: var(--mold-font-mono);
+  font-size: var(--mold-fs-micro);
+  color: var(--mold-text-dim);
+}
+.mesh-studio--desktop .mesh-studio__recent-reuse {
+  color: var(--mold-blue);
+  font-size: var(--mold-fs-micro);
   font-weight: 600;
 }
 

--- a/studio/components/MeshWorkflowStudio.vue
+++ b/studio/components/MeshWorkflowStudio.vue
@@ -185,10 +185,27 @@ const canSubmit = computed(() => {
  */
 type InspectorTab = "settings" | "recent";
 const inspectorTab = ref<InspectorTab>("settings");
+/** The newest runs, bounded — the listing arrives newest first. */
+const recentWorkflows = computed(() =>
+  jobs.value.slice(0, RECENT_WORKFLOWS_CAP),
+);
 const inspectorTabs = computed(() => [
   { id: "settings" as const, label: "Settings", count: 0 },
-  { id: "recent" as const, label: "Recent", count: jobs.value.length },
+  {
+    id: "recent" as const,
+    label: "Recent",
+    count: recentWorkflows.value.length,
+  },
 ]);
+
+/**
+ * How many past runs Recent shows.
+ *
+ * The listing is unbounded on the wire (`ORDER BY created_at_ms DESC`, no
+ * LIMIT), and New image's Recent caps for the same reason: a 300px rail is not
+ * a place for two hundred bordered cards.
+ */
+const RECENT_WORKFLOWS_CAP = 24;
 
 const WORKFLOW_MODE_LABEL: Record<string, string> = {
   text_to_mesh: "From words",
@@ -238,8 +255,26 @@ function workflowStatusLine(job: MeshWorkflowJobSummary): string {
   return `${state} · ${when}`;
 }
 
+/**
+ * Open a past run from Recent, and actually bring its recipe back.
+ *
+ * This restores EXPLICITLY rather than leaning on `watch(selectedId)`: after a
+ * submit, after a deep link from the Queue, or after any earlier click, the
+ * clicked row IS already `selectedId` — and Vue does not fire a watcher for an
+ * unchanged value, so the row that reads as live was exactly the one where
+ * "Use these settings again" did nothing at all.
+ */
+function openRecentWorkflow(job: MeshWorkflowJobSummary): void {
+  const already = selectedId.value === job.id;
+  draft.selectWorkflow(job.id, targetIdentity(ownedTarget.value));
+  if (already) void refreshSelected(true);
+}
+
 /** Start over without leaving the machine or the styles this session is using. */
 function startNewWorkflow(): void {
+  // A stale refusal ("no longer on this machine") must not outlive the run it
+  // was about.
+  error.value = "";
   draft.clear();
 }
 
@@ -324,7 +359,19 @@ function schedulePoll(): void {
     !["queued", "running"].includes(detail.value.state)
   )
     return;
-  pollTimer = setTimeout(() => void refreshSelected(), 750);
+  pollTimer = setTimeout(() => {
+    void refreshSelected();
+    /*
+     * The LISTING has to move too, not just the open workflow's detail. Recent
+     * rows read their state and stage from the summary, so without this a
+     * running row said "Getting ready · 1/6 · just now" for the whole run and
+     * kept saying it after the finished mesh was on the canvas beside it. It
+     * is also how a workflow started elsewhere — another window, the CLI —
+     * ever appears. Failures are swallowed: a listing that misses one tick is
+     * not worth an error banner over the canvas.
+     */
+    void refreshJobs().catch(() => undefined);
+  }, 750);
 }
 
 async function refreshJobs(): Promise<void> {
@@ -362,9 +409,16 @@ async function refreshSelected(restoreDraft = false): Promise<void> {
 function restoreWorkflowDraft(
   request: CreateMeshWorkflowRequest<WorkflowGenerateRequest>,
 ): void {
-  // History is a different request; never carry another workflow's attachments.
-  meshFile.value = null;
-  appearanceFile.value = null;
+  /*
+   * The attachments are KEPT.
+   *
+   * They were nulled here on the reasoning that history is a different
+   * request — but a `File` cannot be restored from a past workflow at all, so
+   * clearing them destroyed the person's own attachment and put nothing in its
+   * place: attach a 40 MB mesh in Rebuild, click a Recent row to see what you
+   * ran yesterday, and the well empties with no undo and no message. What is
+   * in the wells is what the wells show, and it is theirs.
+   */
   mode.value = request.mode;
   const mesh =
     request.mode === "text_to_mesh"
@@ -382,6 +436,26 @@ function restoreWorkflowDraft(
     imageModelName.value = request.image_request.model;
   }
 }
+
+/**
+ * What a restored run could not bring back.
+ *
+ * A supplied-mesh workflow's inputs are FILES, and a browser cannot re-open
+ * one from a past request — so Rebuild and Add texture restore their settings
+ * and no source. Saying so is the difference between a door that half works
+ * and a Generate button that is disabled for no visible reason.
+ */
+const restoredNeedsSource = computed(() => {
+  if (!selectedId.value || mode.value === "text_to_mesh") return "";
+  if (
+    mode.value === "mesh_texture" &&
+    (!meshFile.value || !appearanceFile.value)
+  )
+    return "Choose the mesh and the picture again — a workflow's files cannot be restored.";
+  if (mode.value === "mesh_roundtrip" && !meshFile.value)
+    return "Choose the mesh again — a workflow's files cannot be restored.";
+  return "";
+});
 
 function chooseModels(): void {
   if (!meshModels.value.some((model) => model.name === meshModelName.value)) {
@@ -418,6 +492,14 @@ async function bootstrap(): Promise<void> {
   if (deepLink) draft.selectWorkflow(deepLink, machine);
   else if (!draft.selectionBelongsTo(machine)) draft.selectWorkflow("", "");
   detail.value = null;
+  /*
+   * The previous machine's runs are not this machine's. The `loading` gate
+   * already hides the panel while the new listing is in flight, so this is not
+   * fixing a reachable click — it keeps the STATE honest rather than relying
+   * on a render gate to cover for it, which is what would break the day the
+   * panel learns to render during a refresh.
+   */
+  jobs.value = [];
   ownedTarget.value = { ...props.target };
   ownerLabel.value = props.hostLabel ?? "";
   const target = ownedTarget.value;
@@ -833,9 +915,15 @@ onBeforeUnmount(() => {
         </button>
         <select
           v-else
-          v-model="selectedId"
+          :value="selectedId"
           :disabled="busy"
           aria-label="Previous 3-D workflow"
+          @change="
+            draft.selectWorkflow(
+              ($event.target as HTMLSelectElement).value,
+              targetIdentity(ownedTarget),
+            )
+          "
         >
           <option value="">New workflow</option>
           <option v-for="job in jobs" :key="job.id" :value="job.id">
@@ -893,14 +981,14 @@ onBeforeUnmount(() => {
               list, and one click brings their settings back.
             </p>
             <button
-              v-for="job in jobs"
+              v-for="job in recentWorkflows"
               :key="job.id"
               type="button"
               class="mesh-studio__recent-row"
               :data-test="`mesh-recent-${job.id}`"
               :data-on="selectedId === job.id ? 'true' : undefined"
               :disabled="busy"
-              @click="draft.selectWorkflow(job.id, targetIdentity(ownedTarget))"
+              @click="openRecentWorkflow(job)"
             >
               <span class="mesh-studio__recent-title">{{
                 workflowModeLabel(job.mode)
@@ -1008,6 +1096,13 @@ onBeforeUnmount(() => {
             </template>
 
             <template v-else>
+              <p
+                v-if="restoredNeedsSource"
+                class="mesh-studio__availability"
+                data-test="mesh-restore-needs-source"
+              >
+                {{ restoredNeedsSource }}
+              </p>
               <label class="mesh-studio__file">
                 Source mesh (GLB or OBJ)
                 <input
@@ -1684,21 +1779,18 @@ onBeforeUnmount(() => {
   display: flex;
   align-items: center;
   margin: -16px -16px 4px;
-  padding: 0 14px;
+  /* The strip is the tabs' own track: 8px, not the 14px a title needed. */
+  padding: 0 8px;
+  gap: 2px;
   border-bottom: var(--mold-bw) solid var(--mold-border);
   background: var(--mold-bg-deep);
   color: var(--mold-text);
   font-size: var(--mold-fs-xs);
-  font-weight: 600;
+  font-weight: 400;
 }
 
 /* The inspector's tab strip — the same 26px control ladder InspectorPanel's
  * tabs sit on, inside the one-toolbar-tall header. */
-.mesh-studio--desktop .mesh-studio__inspector-heading {
-  gap: 2px;
-  padding: 0 8px;
-  font-weight: 400;
-}
 .mesh-studio--desktop .mesh-studio__tab {
   display: inline-flex;
   align-items: center;

--- a/studio/lib/relativeTime.test.ts
+++ b/studio/lib/relativeTime.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import { timeAgo } from "./relativeTime";
+
+/*
+ * These words are what MRU lists across the app say — the desktop's own lists
+ * and the 3-D Studio's Recent panel both read them, which is why the function
+ * lives in `studio/` rather than in a shell. Its only coverage used to be a
+ * desktop test reaching through the re-export, so the module that owns the
+ * words was never exercised by the studio suite.
+ */
+describe("timeAgo", () => {
+  const now = Date.UTC(2026, 8, 9, 12, 0, 0);
+  const ago = (ms: number) => timeAgo(now - ms, now);
+
+  it("says just now for anything under a minute", () => {
+    expect(ago(0)).toBe("just now");
+    expect(ago(59_000)).toBe("just now");
+  });
+
+  it("counts minutes, then hours, then days", () => {
+    expect(ago(60_000)).toBe("1m ago");
+    expect(ago(59 * 60_000)).toBe("59m ago");
+    expect(ago(60 * 60_000)).toBe("1h ago");
+    expect(ago(23 * 3_600_000)).toBe("23h ago");
+    expect(ago(24 * 3_600_000)).toBe("1d ago");
+    expect(ago(29 * 86_400_000)).toBe("29d ago");
+  });
+
+  /* Past a month a relative count stops meaning anything; show the date. */
+  it("falls back to a date beyond thirty days", () => {
+    expect(ago(30 * 86_400_000)).not.toMatch(/ago$/);
+    expect(ago(400 * 86_400_000)).not.toMatch(/ago$/);
+  });
+
+  /* A clock that disagrees must not produce "-3m ago". */
+  it("never counts backwards for a timestamp in the future", () => {
+    expect(timeAgo(now + 60_000, now)).toBe("just now");
+  });
+});

--- a/studio/lib/relativeTime.ts
+++ b/studio/lib/relativeTime.ts
@@ -1,0 +1,18 @@
+/**
+ * Compact relative timestamps for MRU lists — "just now", "5m ago", "3d ago".
+ *
+ * It lives here rather than in a shell because both the desktop's own lists
+ * and the shared 3-D Studio's Recent panel say the same thing, and `studio/`
+ * is the layer both can read.
+ */
+export function timeAgo(thenMs: number, nowMs: number = Date.now()): string {
+  const seconds = Math.max(0, Math.floor((nowMs - thenMs) / 1000));
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d ago`;
+  return new Date(thenMs).toLocaleDateString();
+}

--- a/website/guide/mesh.md
+++ b/website/guide/mesh.md
@@ -250,6 +250,14 @@ delight, shape, paint, and finalization are checkpointed, a shutdown parks unfin
 work, and **Resume** continues the same child job after restart. Settled
 workflow-owned inputs and stage copies remain available until **Delete workflow
 data** releases them; deleting the Library print remains a separate action.
+On the desktop app the settings rail carries **Settings | Recent**. Recent
+lists that machine's past workflows — what each one made, what stage it is on
+or how it ended, and how long ago — and one click brings its whole recipe back:
+the mode, both styles and every stage setting. A supplied mesh cannot come back
+(a file is not something an app can re-open for you), so Rebuild and Add
+texture say which file to choose again. **New workflow** on the toolbar starts
+fresh without forgetting the machine or the styles you are using.
+
 Choose **Run workflow on** before authoring to bind the whole studio session to
 one connected machine. Its models, previous workflows, uploads, progress,
 resume/cancel actions, and final GLB all stay on that machine; authenticated


### PR DESCRIPTION
Third of four. Follows #1660 (correctness) and #1661 (chrome).

## Why

Reuse already worked. Selecting a past job restores the entire recipe through
`restoreWorkflowDraft` — mode, both styles, texture settings, the prompt. Its
only door was a bare `<select>` in the header whose rows read:

```
Text to 3-D · completed
```

No date, no progress, no thumbnail, and no verb — nothing telling you a click
brought the whole recipe back. Saving and reusing a workflow read as missing
rather than merely hidden, which is exactly how it was reported.

## What changed

The settings rail becomes **Settings | Recent**, the peer of New image's tab
strip, with a mono count. A Recent row reads:

```
From words
Build geometry · 3/6 · 1m ago
Use these settings again
```

- the workflow's own toolbar word (`From words` / `Rebuild` / `Add texture`),
  and a mode a newer host names still reads as itself;
- the queue's vocabulary while it runs — the stage name and `n/N` — and its
  state otherwise, with a relative time;
- the accent **Use these settings again** line the Create Recent tab uses, so
  what a click does is on the row rather than implied.

**New workflow** is now an explicit toolbar button that clears the authored
work and keeps the machine and the styles in use, replacing the `<select>`'s
first option. Web keeps the `<select>` until its own redesign.

## Notes

- `timeAgo` moves to `studio/lib/relativeTime.ts` — one implementation,
  re-exported from desktop's `format.ts` so every existing caller is unchanged
  — because `studio/` cannot import from a shell.
- The composer's picker slots gain default content, so the shared component
  stands up without a shell filling them.

## Testing

studio 1774 · desktop 6568 green. New cases cover the row's contents and
vocabulary, the empty state, that the two tabs are exclusive, and that New
workflow clears the prompt without forgetting the style in use.