### PR TITLE
fix(ci): re-send the Android smoke tap instead of waiting longer for it

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,6 +27,7 @@ on:
         "scripts/tests/android-app-smoke.mjs",
         "scripts/tests/android-legacy-downloads.sh",
         "scripts/tests/android-legacy-media-smoke.mjs",
+        "scripts/lib/android-smoke-wait.mjs",
         "flake.nix",
         ".github/workflows/android.yml",
       ]
@@ -55,6 +56,7 @@ on:
         "scripts/tests/android-app-smoke.mjs",
         "scripts/tests/android-legacy-downloads.sh",
         "scripts/tests/android-legacy-media-smoke.mjs",
+        "scripts/lib/android-smoke-wait.mjs",
         "flake.nix",
         ".github/workflows/android.yml",
       ]
@@ -114,6 +116,7 @@ jobs:
               - 'scripts/tests/android-app-smoke.mjs'
               - 'scripts/tests/android-legacy-downloads.sh'
               - 'scripts/tests/android-legacy-media-smoke.mjs'
+              - 'scripts/lib/android-smoke-wait.mjs'
               - 'flake.nix'
               - '.github/workflows/android.yml'
 
@@ -165,6 +168,8 @@ jobs:
         run: cargo tauri --version | grep -F '2.11.4'
       - name: Install frontend dependencies
         run: bun install --frozen-lockfile
+      - name: Verify Android smoke wait policy
+        run: bun test scripts/lib/android-smoke-wait.test.mjs
       - name: Verify Android launcher assets
         run: bash scripts/tests/android-release-assets.sh
       - name: Build Android validation APK

--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -27,7 +27,7 @@ on:
         "scripts/tests/android-app-smoke.mjs",
         "scripts/tests/android-legacy-downloads.sh",
         "scripts/tests/android-legacy-media-smoke.mjs",
-        "scripts/lib/android-smoke-wait.mjs",
+        "scripts/lib/android-smoke-*.mjs",
         "flake.nix",
         ".github/workflows/android.yml",
       ]
@@ -56,7 +56,7 @@ on:
         "scripts/tests/android-app-smoke.mjs",
         "scripts/tests/android-legacy-downloads.sh",
         "scripts/tests/android-legacy-media-smoke.mjs",
-        "scripts/lib/android-smoke-wait.mjs",
+        "scripts/lib/android-smoke-*.mjs",
         "flake.nix",
         ".github/workflows/android.yml",
       ]
@@ -116,7 +116,7 @@ jobs:
               - 'scripts/tests/android-app-smoke.mjs'
               - 'scripts/tests/android-legacy-downloads.sh'
               - 'scripts/tests/android-legacy-media-smoke.mjs'
-              - 'scripts/lib/android-smoke-wait.mjs'
+              - 'scripts/lib/android-smoke-*.mjs'
               - 'flake.nix'
               - '.github/workflows/android.yml'
 

--- a/scripts/android-identity-picker-smoke.mjs
+++ b/scripts/android-identity-picker-smoke.mjs
@@ -3,47 +3,31 @@
 // generation is needed. CDP controls the real Tauri WebView, not a browser copy.
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
+import {
+  resolveDeadlineMs,
+  until as untilWith,
+} from "./lib/android-smoke-wait.mjs";
 
 const adb = process.env.ADB ?? "adb";
 const serial = process.env.ANDROID_SERIAL ?? "emulator-5554";
 const output =
   process.env.MOLD_ANDROID_EVIDENCE ?? "/tmp/mold-android-identity-picker";
+// A `uiautomator dump` of a full screen and an `exec-out screencap` both
+// outgrow execFileSync's 1 MB default; ENOBUFS there kills the run outright.
+const ADB_MAX_BUFFER = 32 * 1024 * 1024;
 const run = (...args) =>
-  execFileSync(adb, ["-s", serial, ...args], { encoding: "utf8" }).trim();
+  execFileSync(adb, ["-s", serial, ...args], {
+    encoding: "utf8",
+    maxBuffer: ADB_MAX_BUFFER,
+  }).trim();
 const shell = (...args) => run("shell", ...args);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
-/** Same deadline policy as `tests/android-app-smoke.mjs` — see the note there:
- *  this loop returns the instant its condition holds, so a generous window
- *  costs a healthy run nothing and only gives a software-rendered emulator and
- *  a flaky `adb` room to recover. */
-const UNTIL_TIMEOUT_MS = Number(
-  process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS ?? 90_000,
-);
-
-async function until(read, label) {
-  const started = Date.now();
-  const deadline = started + UNTIL_TIMEOUT_MS;
-  let lastError;
-  let attempts = 0;
-  while (Date.now() < deadline) {
-    attempts += 1;
-    try {
-      const value = await read();
-      if (value) return value;
-    } catch (error) {
-      lastError = error;
-    }
-    await sleep(200);
-  }
-  throw new Error(
-    `Timed out: ${label} (${Math.round((Date.now() - started) / 1000)}s, ` +
-      `${attempts} attempts)`,
-    { cause: lastError },
-  );
-}
+/** The deadline every wait in this script shares; see the shared module. */
+const timeoutMs = resolveDeadlineMs(process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS);
+const until = (read, label) => untilWith(read, label, { timeoutMs });
 
 assert(
   shell("getprop", "ro.kernel.qemu") === "1",
@@ -234,7 +218,9 @@ try {
     assert(!early, source + " did not open: " + JSON.stringify(early));
     writeFileSync(
       output + "/" + source + ".png",
-      execFileSync(adb, ["-s", serial, "exec-out", "screencap", "-p"]),
+      execFileSync(adb, ["-s", serial, "exec-out", "screencap", "-p"], {
+        maxBuffer: ADB_MAX_BUFFER,
+      }),
     );
     shell("input", "keyevent", "KEYCODE_BACK");
     const result = await until(

--- a/scripts/android-identity-picker-smoke.mjs
+++ b/scripts/android-identity-picker-smoke.mjs
@@ -222,6 +222,12 @@ try {
         maxBuffer: ADB_MAX_BUFFER,
       }),
     );
+    // Deliberately NOT wrapped in `actUntil` like the CI smoke test's Back is.
+    // The hazard is the same — a dropped press waits out the whole deadline —
+    // but this script is manual-only (no workflow runs it; it needs a device
+    // and the isolated redesign UAT package), so the change could not be
+    // verified before shipping. It gains the shared deadline and the richer
+    // timeout message either way.
     shell("input", "keyevent", "KEYCODE_BACK");
     const result = await until(
       () => evaluate("window.__pickerUat"),

--- a/scripts/android-identity-picker-smoke.mjs
+++ b/scripts/android-identity-picker-smoke.mjs
@@ -15,10 +15,21 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
+/** Same deadline policy as `tests/android-app-smoke.mjs` — see the note there:
+ *  this loop returns the instant its condition holds, so a generous window
+ *  costs a healthy run nothing and only gives a software-rendered emulator and
+ *  a flaky `adb` room to recover. */
+const UNTIL_TIMEOUT_MS = Number(
+  process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS ?? 90_000,
+);
+
 async function until(read, label) {
-  const deadline = Date.now() + 30_000;
+  const started = Date.now();
+  const deadline = started + UNTIL_TIMEOUT_MS;
   let lastError;
+  let attempts = 0;
   while (Date.now() < deadline) {
+    attempts += 1;
     try {
       const value = await read();
       if (value) return value;
@@ -27,7 +38,11 @@ async function until(read, label) {
     }
     await sleep(200);
   }
-  throw new Error("Timed out: " + label, { cause: lastError });
+  throw new Error(
+    `Timed out: ${label} (${Math.round((Date.now() - started) / 1000)}s, ` +
+      `${attempts} attempts)`,
+    { cause: lastError },
+  );
 }
 
 assert(

--- a/scripts/lib/android-smoke-wait.mjs
+++ b/scripts/lib/android-smoke-wait.mjs
@@ -1,0 +1,101 @@
+// The waiting policy both Android smoke scripts share.
+//
+// It lives in one module because each rule below was got wrong by a copy that
+// only existed in one of the two scripts.
+
+/** How long a single wait may take before it is called a failure. */
+export const DEFAULT_SMOKE_TIMEOUT_MS = 30_000;
+/** How often a wait re-reads its condition. */
+export const POLL_INTERVAL_MS = 200;
+/** How many polls pass before a retried action is dispatched again (~1s). */
+export const REDISPATCH_EVERY_ATTEMPTS = 5;
+
+const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+/**
+ * Read the deadline out of the environment.
+ *
+ * `Number(process.env.X ?? fallback)` looks right and is not: `??` only catches
+ * `null`/`undefined`, so an EMPTY variable parses as `0` — and a zero deadline
+ * makes `while (Date.now() < deadline)` false on its first evaluation, so every
+ * wait fails after zero attempts with no clue why. `MOLD_ANDROID_SMOKE_TIMEOUT_MS=`
+ * in a shell, or an unset `env:` value in a workflow, is exactly that string.
+ *
+ * Absent or blank falls back. A value that is PRESENT but unusable throws
+ * instead, because silently ignoring a typo would run the suite on a deadline
+ * nobody chose.
+ */
+export function resolveDeadlineMs(raw, fallback = DEFAULT_SMOKE_TIMEOUT_MS) {
+  if (raw === undefined || raw === null || String(raw).trim() === "")
+    return fallback;
+  const parsed = Number(raw);
+  if (!Number.isFinite(parsed) || parsed <= 0)
+    throw new Error(
+      `MOLD_ANDROID_SMOKE_TIMEOUT_MS must be a positive number of ` +
+        `milliseconds, got ${JSON.stringify(String(raw))}`,
+    );
+  return parsed;
+}
+
+/**
+ * Poll `read` until it answers truthy, then return that value.
+ *
+ * The failure says what was waited on, for how long, and how many times it
+ * looked: "Timed out: select hosts" alone could not tell a slow emulator from
+ * a condition that was never going to hold.
+ */
+export async function until(read, label, options = {}) {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_SMOKE_TIMEOUT_MS;
+  const now = options.now ?? (() => Date.now());
+  const pause = options.sleep ?? sleep;
+  const started = now();
+  const deadline = started + timeoutMs;
+  let lastError;
+  let attempts = 0;
+  while (now() < deadline) {
+    attempts += 1;
+    try {
+      const value = await read();
+      if (value) return value;
+    } catch (error) {
+      lastError = error;
+    }
+    if (options.onRetry) {
+      try {
+        await options.onRetry(attempts);
+      } catch (error) {
+        lastError = error;
+      }
+    }
+    await pause(options.pollIntervalMs ?? POLL_INTERVAL_MS);
+  }
+  throw new Error(
+    `Timed out: ${label} (${Math.round((now() - started) / 1000)}s, ` +
+      `${attempts} attempts)`,
+    { cause: lastError },
+  );
+}
+
+/**
+ * Do something, then wait for it to have taken effect — re-doing it if it did
+ * not.
+ *
+ * A synthetic `Input.dispatchTouchEvent` is occasionally dropped on a CI
+ * emulator: the evidence from every timed-out run shows the app still on the
+ * PREVIOUS tab with focus still on the previous tab's button, rendered,
+ * responsive, and with no ANR, while the wait round-tripped ~150 CDP calls
+ * against a screen no tap had reached. Retrying only the ASSERTION cannot
+ * recover from that — the tap is never sent again — which is why a longer
+ * deadline bought nothing but a slower red build. The action itself is what
+ * has to be retried.
+ */
+export async function actUntil(act, read, label, options = {}) {
+  const every = options.redispatchEvery ?? REDISPATCH_EVERY_ATTEMPTS;
+  await act();
+  return until(read, label, {
+    ...options,
+    onRetry: async (attempts) => {
+      if (attempts % every === 0) await act();
+    },
+  });
+}

--- a/scripts/lib/android-smoke-wait.mjs
+++ b/scripts/lib/android-smoke-wait.mjs
@@ -50,7 +50,12 @@ export async function until(read, label, options = {}) {
   const pause = options.sleep ?? sleep;
   const started = now();
   const deadline = started + timeoutMs;
-  let lastError;
+  // Kept apart on purpose: a re-dispatch that throws must not clobber the
+  // reason the wait was actually failing. Re-tapping a button that has since
+  // been `v-if`'d away throws every single time, and folding both into one
+  // slot left every genuine timeout blaming the retry.
+  let lastReadError;
+  let lastActError;
   let attempts = 0;
   while (now() < deadline) {
     attempts += 1;
@@ -58,22 +63,24 @@ export async function until(read, label, options = {}) {
       const value = await read();
       if (value) return value;
     } catch (error) {
-      lastError = error;
+      lastReadError = error;
     }
     if (options.onRetry) {
       try {
         await options.onRetry(attempts);
       } catch (error) {
-        lastError = error;
+        lastActError = error;
       }
     }
     await pause(options.pollIntervalMs ?? POLL_INTERVAL_MS);
   }
-  throw new Error(
+  const failure = new Error(
     `Timed out: ${label} (${Math.round((now() - started) / 1000)}s, ` +
       `${attempts} attempts)`,
-    { cause: lastError },
+    { cause: lastReadError },
   );
+  if (lastActError) failure.actError = lastActError;
+  throw failure;
 }
 
 /**
@@ -95,7 +102,17 @@ export async function actUntil(act, read, label, options = {}) {
   return until(read, label, {
     ...options,
     onRetry: async (attempts) => {
-      if (attempts % every === 0) await act();
+      if (attempts % every !== 0) return;
+      // Re-READ, immediately before re-dispatching. The poll that scheduled
+      // this retry is already one interval old, and for an action that is not
+      // idempotent that gap is the whole risk: a second Android Back arriving
+      // after the panel closed finds nothing to consume, so `useMobileBack`
+      // returns without `preventDefault`, the native plugin sees
+      // `consumed != "true"` and calls `delegate()` — which finishes the
+      // activity. The smoke test would then PASS its Back assertion (the tab
+      // bar is back) and fail three steps later for no visible reason.
+      if (await read()) return;
+      await act();
     },
   });
 }

--- a/scripts/lib/android-smoke-wait.mjs
+++ b/scripts/lib/android-smoke-wait.mjs
@@ -65,6 +65,11 @@ export async function until(read, label, options = {}) {
     } catch (error) {
       lastReadError = error;
     }
+    // After the read, which reads naturally but is NOT what makes a retry
+    // safe: `actUntil` re-reads immediately before it dispatches, and that
+    // guard is what prevents an over-dispatch. Moving this ahead of the read
+    // is therefore harmless, and no test pins the order — deliberately, so
+    // nobody strengthens a property the code does not rely on.
     if (options.onRetry) {
       try {
         await options.onRetry(attempts);
@@ -74,9 +79,15 @@ export async function until(read, label, options = {}) {
     }
     await pause(options.pollIntervalMs ?? POLL_INTERVAL_MS);
   }
+  // Name the action's failure in the MESSAGE, not just on the object: a run
+  // whose every dispatch threw looks identical in the log to one whose reads
+  // simply never came true, and those want different fixes.
+  const acted = lastActError
+    ? `; last dispatch failed: ${lastActError.message}`
+    : "";
   const failure = new Error(
     `Timed out: ${label} (${Math.round((now() - started) / 1000)}s, ` +
-      `${attempts} attempts)`,
+      `${attempts} attempts)${acted}`,
     { cause: lastReadError },
   );
   if (lastActError) failure.actError = lastActError;
@@ -98,11 +109,17 @@ export async function until(read, label, options = {}) {
  */
 export async function actUntil(act, read, label, options = {}) {
   const every = options.redispatchEvery ?? REDISPATCH_EVERY_ATTEMPTS;
-  await act();
+  // The OPENING dispatch happens inside the loop, not ahead of it, so it is
+  // exactly as retryable as every later one. Dispatched outside, a transient
+  // failure in the very first attempt killed the whole run: a CI emulator
+  // answered `Input.dispatchTouchEvent` past the 10s CDP timeout and the
+  // suite died with a bare `CDP timeout`, naming no step. The action is the
+  // thing that goes wrong here — there is no reason its first try is special.
+  let dispatched = false;
   return until(read, label, {
     ...options,
     onRetry: async (attempts) => {
-      if (attempts % every !== 0) return;
+      if (dispatched && attempts % every !== 0) return;
       // Re-READ, immediately before re-dispatching. The poll that scheduled
       // this retry is already one interval old, and for an action that is not
       // idempotent that gap is the whole risk: a second Android Back arriving
@@ -111,8 +128,9 @@ export async function actUntil(act, read, label, options = {}) {
       // `consumed != "true"` and calls `delegate()` — which finishes the
       // activity. The smoke test would then PASS its Back assertion (the tab
       // bar is back) and fail three steps later for no visible reason.
-      if (await read()) return;
+      if (dispatched && (await read())) return;
       await act();
+      dispatched = true;
     },
   });
 }

--- a/scripts/lib/android-smoke-wait.test.mjs
+++ b/scripts/lib/android-smoke-wait.test.mjs
@@ -134,9 +134,11 @@ describe("actUntil", () => {
    * The property that makes it safe to retry an action that is NOT idempotent
    * (the hardware Back key): nothing is dispatched once the condition holds.
    *
-   * Counting the ACTS is what pins it. An earlier version of this test only
-   * recorded the ORDER of reads and acts, which survived moving the retry
-   * ahead of the read — the precise mutation it existed to catch.
+   * Counting the ACTS is what pins it. An earlier version recorded only the
+   * ORDER of reads and acts and survived moving the retry ahead of the read —
+   * the precise mutation it existed to catch. That order is no longer the
+   * protection anyway: the re-read guard below is, and it is what the next
+   * test pins.
    */
   test("never dispatches again once the condition holds", async () => {
     const clock = fakeClock();
@@ -197,6 +199,47 @@ describe("actUntil", () => {
       counts.push(taps);
     }
     expect(counts[1]).toBeLessThan(counts[0]);
+  });
+
+  /*
+   * The opening dispatch is as retryable as the rest. A CI emulator answered
+   * `Input.dispatchTouchEvent` past the 10s CDP timeout and the run died with
+   * a bare "CDP timeout" naming no step, because that first dispatch happened
+   * outside the loop.
+   */
+  test("recovers when the very first dispatch throws", async () => {
+    const clock = fakeClock();
+    let attemptsToAct = 0;
+    let landed = false;
+    await actUntil(
+      () => {
+        attemptsToAct += 1;
+        if (attemptsToAct === 1)
+          throw new Error("CDP timeout: Input.dispatchTouchEvent");
+        landed = true;
+      },
+      () => landed,
+      "select hosts",
+      { ...clock, timeoutMs: 30_000, redispatchEvery: 5 },
+    );
+    expect(attemptsToAct).toBe(2);
+    expect(landed).toBe(true);
+  });
+
+  test("names the failed dispatch in the timeout message", async () => {
+    const clock = fakeClock();
+    await expect(
+      actUntil(
+        () => {
+          throw new Error("CDP timeout: Input.dispatchTouchEvent");
+        },
+        () => false,
+        "select hosts",
+        { ...clock, timeoutMs: 1_000, redispatchEvery: 5 },
+      ),
+    ).rejects.toThrow(
+      /last dispatch failed: CDP timeout: Input\.dispatchTouchEvent/,
+    );
   });
 
   test("still fails when the action never takes effect", async () => {

--- a/scripts/lib/android-smoke-wait.test.mjs
+++ b/scripts/lib/android-smoke-wait.test.mjs
@@ -132,35 +132,53 @@ describe("actUntil", () => {
 
   /*
    * The property that makes it safe to retry an action that is NOT idempotent
-   * (the hardware Back key): a re-dispatch only ever follows a poll that has
-   * just read the condition as false, and nothing is dispatched once it holds.
-   * A blind timer would press Back again after the panel had already closed,
-   * popping the navigation underneath it.
+   * (the hardware Back key): nothing is dispatched once the condition holds.
+   *
+   * Counting the ACTS is what pins it. An earlier version of this test only
+   * recorded the ORDER of reads and acts, which survived moving the retry
+   * ahead of the read — the precise mutation it existed to catch.
    */
   test("never dispatches again once the condition holds", async () => {
     const clock = fakeClock();
-    const order = [];
-    let landed = false;
+    let acts = 0;
+    let reads = 0;
     await actUntil(
       () => {
-        order.push("act");
-        // The action lands on the second dispatch.
-        if (order.filter((o) => o === "act").length >= 2) landed = true;
+        acts += 1;
       },
-      () => {
-        order.push("read");
-        return landed;
-      },
+      () => ++reads >= 5,
       "native Back dismisses settings",
       { ...clock, timeoutMs: 30_000, redispatchEvery: 5 },
     );
-    // Every dispatch after the first is immediately preceded by a false read,
-    // and none follows the read that returned true.
-    expect(order[0]).toBe("act");
-    expect(order.at(-1)).toBe("read");
-    for (let i = 1; i < order.length; i++)
-      if (order[i] === "act") expect(order[i - 1]).toBe("read");
-    expect(order.filter((o) => o === "act")).toHaveLength(2);
+    // The opening dispatch and nothing else: the fifth read succeeds, and no
+    // retry may be scheduled off a read that came back true.
+    expect(acts).toBe(1);
+  });
+
+  /*
+   * ...and it re-READS immediately before re-dispatching. The poll that
+   * scheduled a retry is already one interval old, and an Android Back that
+   * arrives after the panel has closed finds nothing to consume and exits the
+   * app — passing the assertion, failing three steps later for no reason.
+   */
+  test("does not dispatch when the condition settled since the last poll", async () => {
+    const clock = fakeClock();
+    let acts = 0;
+    let settled = false;
+    await actUntil(
+      () => {
+        acts += 1;
+      },
+      () => {
+        const answer = settled;
+        // Settles in the gap AFTER the poll that will schedule the retry.
+        if (acts === 1 && !settled) settled = true;
+        return answer;
+      },
+      "native Back dismisses settings",
+      { ...clock, timeoutMs: 30_000, redispatchEvery: 1 },
+    );
+    expect(acts).toBe(1);
   });
 
   test("a slower cadence dispatches less often over the same wait", async () => {

--- a/scripts/lib/android-smoke-wait.test.mjs
+++ b/scripts/lib/android-smoke-wait.test.mjs
@@ -130,6 +130,57 @@ describe("actUntil", () => {
     expect(landed).toBe(true);
   });
 
+  /*
+   * The property that makes it safe to retry an action that is NOT idempotent
+   * (the hardware Back key): a re-dispatch only ever follows a poll that has
+   * just read the condition as false, and nothing is dispatched once it holds.
+   * A blind timer would press Back again after the panel had already closed,
+   * popping the navigation underneath it.
+   */
+  test("never dispatches again once the condition holds", async () => {
+    const clock = fakeClock();
+    const order = [];
+    let landed = false;
+    await actUntil(
+      () => {
+        order.push("act");
+        // The action lands on the second dispatch.
+        if (order.filter((o) => o === "act").length >= 2) landed = true;
+      },
+      () => {
+        order.push("read");
+        return landed;
+      },
+      "native Back dismisses settings",
+      { ...clock, timeoutMs: 30_000, redispatchEvery: 5 },
+    );
+    // Every dispatch after the first is immediately preceded by a false read,
+    // and none follows the read that returned true.
+    expect(order[0]).toBe("act");
+    expect(order.at(-1)).toBe("read");
+    for (let i = 1; i < order.length; i++)
+      if (order[i] === "act") expect(order[i - 1]).toBe("read");
+    expect(order.filter((o) => o === "act")).toHaveLength(2);
+  });
+
+  test("a slower cadence dispatches less often over the same wait", async () => {
+    const counts = [];
+    for (const redispatchEvery of [5, 15]) {
+      const clock = fakeClock();
+      let taps = 0;
+      await actUntil(
+        () => {
+          taps += 1;
+        },
+        () => false,
+        "back",
+        { ...clock, timeoutMs: 30_000, redispatchEvery },
+      ).catch(() => {});
+      counts.push(taps);
+    }
+    expect(counts[1]).toBeLessThan(counts[0]);
+  });
+
   test("still fails when the action never takes effect", async () => {
     const clock = fakeClock();
     let taps = 0;

--- a/scripts/lib/android-smoke-wait.test.mjs
+++ b/scripts/lib/android-smoke-wait.test.mjs
@@ -1,0 +1,149 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_SMOKE_TIMEOUT_MS,
+  actUntil,
+  resolveDeadlineMs,
+  until,
+} from "./android-smoke-wait.mjs";
+
+describe("resolveDeadlineMs", () => {
+  test("an absent or blank value falls back", () => {
+    for (const raw of [undefined, null, "", "   "])
+      expect(resolveDeadlineMs(raw)).toBe(DEFAULT_SMOKE_TIMEOUT_MS);
+  });
+
+  test("an empty variable never becomes a zero deadline", () => {
+    // `Number(process.env.X ?? 30_000)` answers 0 here, which runs every wait
+    // zero times and fails the whole suite in milliseconds.
+    expect(resolveDeadlineMs("")).toBeGreaterThan(0);
+  });
+
+  test("a usable override is taken", () => {
+    expect(resolveDeadlineMs("45000")).toBe(45_000);
+    expect(resolveDeadlineMs(45_000)).toBe(45_000);
+  });
+
+  test("a present but unusable value is refused by name", () => {
+    for (const raw of ["abc", "0", "-5", "NaN"])
+      expect(() => resolveDeadlineMs(raw)).toThrow(
+        /MOLD_ANDROID_SMOKE_TIMEOUT_MS/,
+      );
+  });
+});
+
+/** A clock the test moves by hand, so no test waits on real time. */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    sleep: async (ms) => {
+      t += ms;
+    },
+  };
+}
+
+describe("until", () => {
+  test("returns the first truthy value without waiting out the deadline", async () => {
+    const clock = fakeClock();
+    let reads = 0;
+    const value = await until(
+      () => (++reads >= 3 ? "ready" : false),
+      "something",
+      { ...clock, timeoutMs: 30_000 },
+    );
+    expect(value).toBe("ready");
+    expect(reads).toBe(3);
+  });
+
+  test("names the label, the elapsed time and the attempt count", async () => {
+    const clock = fakeClock();
+    await expect(
+      until(() => false, "select hosts", { ...clock, timeoutMs: 1_000 }),
+    ).rejects.toThrow(/Timed out: select hosts \(1s, 5 attempts\)/);
+  });
+
+  test("keeps the last read error as the cause", async () => {
+    const clock = fakeClock();
+    const failure = new Error("CDP timeout: Runtime.evaluate");
+    const error = await until(
+      () => {
+        throw failure;
+      },
+      "reading",
+      { ...clock, timeoutMs: 400 },
+    ).catch((e) => e);
+    expect(error.cause).toBe(failure);
+  });
+});
+
+describe("actUntil", () => {
+  test("dispatches once when the action lands", async () => {
+    const clock = fakeClock();
+    let taps = 0;
+    let landed = false;
+    await actUntil(
+      () => {
+        taps += 1;
+        landed = true;
+      },
+      () => landed,
+      "select hosts",
+      { ...clock, timeoutMs: 30_000 },
+    );
+    expect(taps).toBe(1);
+  });
+
+  test("re-dispatches a dropped action until it takes effect", async () => {
+    const clock = fakeClock();
+    // The emulator swallows the first two taps, exactly as the CI evidence
+    // shows: the app stays on the previous tab while the wait polls a screen
+    // no tap ever reached.
+    let taps = 0;
+    let landed = false;
+    await actUntil(
+      () => {
+        taps += 1;
+        if (taps > 2) landed = true;
+      },
+      () => landed,
+      "select hosts",
+      { ...clock, timeoutMs: 30_000, redispatchEvery: 5 },
+    );
+    expect(taps).toBe(3);
+    expect(landed).toBe(true);
+  });
+
+  test("a retry that throws does not abandon the wait", async () => {
+    const clock = fakeClock();
+    let taps = 0;
+    let landed = false;
+    await actUntil(
+      () => {
+        taps += 1;
+        if (taps === 2) throw new Error("dispatch refused");
+        if (taps > 2) landed = true;
+      },
+      () => landed,
+      "select hosts",
+      { ...clock, timeoutMs: 30_000, redispatchEvery: 5 },
+    );
+    expect(landed).toBe(true);
+  });
+
+  test("still fails when the action never takes effect", async () => {
+    const clock = fakeClock();
+    let taps = 0;
+    await expect(
+      actUntil(
+        () => {
+          taps += 1;
+        },
+        () => false,
+        "select hosts",
+        { ...clock, timeoutMs: 1_000, redispatchEvery: 5 },
+      ),
+    ).rejects.toThrow(/Timed out: select hosts/);
+    // One opening dispatch, and one more each time the poll count comes round.
+    expect(taps).toBe(2);
+  });
+});

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -2,57 +2,34 @@
 // generation is needed. CDP controls the real Tauri WebView, not a browser copy.
 import { execFileSync } from "node:child_process";
 import { mkdirSync, writeFileSync } from "node:fs";
+import {
+  actUntil,
+  resolveDeadlineMs,
+  until as untilWith,
+} from "../lib/android-smoke-wait.mjs";
 import { runLegacyMediaSmoke } from "./android-legacy-media-smoke.mjs";
 
 const adb = process.env.ADB ?? "adb";
 const serial = process.env.ANDROID_SERIAL ?? "emulator-5554";
 const output =
   process.env.MOLD_ANDROID_EVIDENCE ?? "/tmp/mold-android-app-smoke";
+// `exec-out screencap` and `dumpsys` both outgrow execFileSync's 1 MB default,
+// which aborts the whole script with ENOBUFS while it is capturing the evidence
+// for some OTHER failure — losing the answer and reporting the wrong question.
+const ADB_MAX_BUFFER = 32 * 1024 * 1024;
 const run = (...args) =>
-  execFileSync(adb, ["-s", serial, ...args], { encoding: "utf8" }).trim();
+  execFileSync(adb, ["-s", serial, ...args], {
+    encoding: "utf8",
+    maxBuffer: ADB_MAX_BUFFER,
+  }).trim();
 const shell = (...args) => run("shell", ...args);
 const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
-/**
- * How long a single wait may take.
- *
- * This polls every 200ms and returns the instant its condition holds, so a
- * generous deadline costs a healthy run NOTHING — it only lengthens the time
- * to fail. On a CI runner the emulator renders in software (`lavapipe`) and
- * `adb` intermittently exits 1, which this loop swallows into `lastError` and
- * retries; 30s was not enough window for adb to recover, and the late steps of
- * a long interaction sequence — the last tab of five, the Back that follows
- * it — were the ones that ran out. Override for a slower machine still.
- */
-const UNTIL_TIMEOUT_MS = Number(
-  process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS ?? 90_000,
-);
-
-async function until(read, label) {
-  const started = Date.now();
-  const deadline = started + UNTIL_TIMEOUT_MS;
-  let lastError;
-  let attempts = 0;
-  while (Date.now() < deadline) {
-    attempts += 1;
-    try {
-      const value = await read();
-      if (value) return value;
-    } catch (error) {
-      lastError = error;
-    }
-    await sleep(200);
-  }
-  // Say what was waited on and for how long: "Timed out: select hosts" alone
-  // could not distinguish a slow emulator from a condition that never holds.
-  throw new Error(
-    `Timed out: ${label} (${Math.round((Date.now() - started) / 1000)}s, ` +
-      `${attempts} attempts)`,
-    { cause: lastError },
-  );
-}
+/** The deadline every wait in this script shares; see the shared module. */
+const timeoutMs = resolveDeadlineMs(process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS);
+const until = (read, label) => untilWith(read, label, { timeoutMs });
 
 assert(
   shell("getprop", "ro.kernel.qemu") === "1",
@@ -126,11 +103,7 @@ try {
     // Pull the PNG as a file: full-resolution screenshots can exceed the
     // child-process stdout buffer before the app smoke test even starts.
     shell("screencap", "-p", "/sdcard/mold-boot-launcher-anr.png");
-    run(
-      "pull",
-      "/sdcard/mold-boot-launcher-anr.png",
-      output + "/boot-launcher-anr.png",
-    );
+    run("pull", "/sdcard/mold-boot-launcher-anr.png", output + "/boot-launcher-anr.png");
     shell("rm", "-f", "/sdcard/mold-boot-launcher-anr.png");
     shell("am", "force-stop", "com.android.launcher3");
   }
@@ -252,9 +225,16 @@ try {
     originalTab = await evaluate(
       'document.querySelector(".mobile-tab[aria-current=page]").dataset.test',
     );
+    // Tap, then wait for the tap to have landed — re-tapping if it did not.
+    // A synthetic touch is occasionally swallowed by the CI emulator, and the
+    // evidence from every timed-out run shows the app still on the PREVIOUS
+    // tab, rendered and responsive, with no ANR: waiting longer on a screen no
+    // tap reached only makes the same failure slower.
+    const tap = (name, read, label) =>
+      actUntil(() => click(name), read, label, { timeoutMs });
     for (const tab of ["generate", "queue", "gallery", "catalog", "hosts"]) {
-      await click("mobile-tab-" + tab);
-      await until(
+      await tap(
+        "mobile-tab-" + tab,
         () =>
           evaluate(
             "document.querySelector(" +
@@ -264,8 +244,8 @@ try {
         "select " + tab,
       );
     }
-    await click("mobile-open-settings");
-    await until(
+    await tap(
+      "mobile-open-settings",
       () => evaluate('!!document.querySelector(".is-settings-open")'),
       "settings opens",
     );

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -15,10 +15,28 @@ const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
 const assert = (condition, message) => {
   if (!condition) throw new Error(message);
 };
+/**
+ * How long a single wait may take.
+ *
+ * This polls every 200ms and returns the instant its condition holds, so a
+ * generous deadline costs a healthy run NOTHING — it only lengthens the time
+ * to fail. On a CI runner the emulator renders in software (`lavapipe`) and
+ * `adb` intermittently exits 1, which this loop swallows into `lastError` and
+ * retries; 30s was not enough window for adb to recover, and the late steps of
+ * a long interaction sequence — the last tab of five, the Back that follows
+ * it — were the ones that ran out. Override for a slower machine still.
+ */
+const UNTIL_TIMEOUT_MS = Number(
+  process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS ?? 90_000,
+);
+
 async function until(read, label) {
-  const deadline = Date.now() + 30_000;
+  const started = Date.now();
+  const deadline = started + UNTIL_TIMEOUT_MS;
   let lastError;
+  let attempts = 0;
   while (Date.now() < deadline) {
+    attempts += 1;
     try {
       const value = await read();
       if (value) return value;
@@ -27,7 +45,13 @@ async function until(read, label) {
     }
     await sleep(200);
   }
-  throw new Error("Timed out: " + label, { cause: lastError });
+  // Say what was waited on and for how long: "Timed out: select hosts" alone
+  // could not distinguish a slow emulator from a condition that never holds.
+  throw new Error(
+    `Timed out: ${label} (${Math.round((Date.now() - started) / 1000)}s, ` +
+      `${attempts} attempts)`,
+    { cause: lastError },
+  );
 }
 
 assert(
@@ -102,7 +126,11 @@ try {
     // Pull the PNG as a file: full-resolution screenshots can exceed the
     // child-process stdout buffer before the app smoke test even starts.
     shell("screencap", "-p", "/sdcard/mold-boot-launcher-anr.png");
-    run("pull", "/sdcard/mold-boot-launcher-anr.png", output + "/boot-launcher-anr.png");
+    run(
+      "pull",
+      "/sdcard/mold-boot-launcher-anr.png",
+      output + "/boot-launcher-anr.png",
+    );
     shell("rm", "-f", "/sdcard/mold-boot-launcher-anr.png");
     shell("am", "force-stop", "com.android.launcher3");
   }

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -29,6 +29,9 @@ const assert = (condition, message) => {
 };
 /** The deadline every wait in this script shares; see the shared module. */
 const timeoutMs = resolveDeadlineMs(process.env.MOLD_ANDROID_SMOKE_TIMEOUT_MS);
+/** ~3s between Back presses: slow enough that a panel still animating shut is
+ *  never raced into a second press, quick enough to recover a dropped key. */
+const BACK_REDISPATCH_EVERY_ATTEMPTS = 15;
 const until = (read, label) => untilWith(read, label, { timeoutMs });
 
 assert(
@@ -250,11 +253,24 @@ try {
       "settings opens",
     );
     await recordNavigation("before native Back");
-    shell("input", "keyevent", "4");
-    await until(
+    /*
+     * The hardware Back key gets dropped exactly as a synthetic touch does:
+     * `navigation.json` from the API 36 failure shows `settingsOpen: true` and
+     * `historyLength: 2` unchanged across all 148 polls — the identical state
+     * the API 35 run recorded a moment before it PASSED, so the app was fine
+     * and the key never arrived.
+     *
+     * Back is the one action here that is not idempotent — a second press with
+     * the panel already dismissed would pop the tab navigation instead — so it
+     * re-presses on a much slower cadence than a tab tap, and only ever right
+     * after a poll has just read the panel as still open.
+     */
+    await actUntil(
+      () => shell("input", "keyevent", "4"),
       () =>
         evaluate('!!document.querySelector(".mobile-tab[aria-current=page]")'),
       "native Back dismisses settings",
+      { timeoutMs, redispatchEvery: BACK_REDISPATCH_EVERY_ATTEMPTS },
     );
     assert(
       await evaluate(
@@ -269,11 +285,17 @@ try {
     shell("settings", "put", "system", "font_scale", "1");
     await sleep(500);
     const normal = await metrics();
-    shell("settings", "put", "system", "font_scale", "2");
-    const large = await until(async () => {
-      const m = await metrics();
-      return m.font >= normal.font * 1.9 && m;
-    }, "live system font scale");
+    // Idempotent: writing the same scale again is a no-op, so this one simply
+    // re-applies until the WebView reflows.
+    const large = await actUntil(
+      () => shell("settings", "put", "system", "font_scale", "2"),
+      async () => {
+        const m = await metrics();
+        return m.font >= normal.font * 1.9 && m;
+      },
+      "live system font scale",
+      { timeoutMs },
+    );
     assert(
       large.scrollWidth <= large.width + 1,
       "Large text causes horizontal overflow",

--- a/scripts/tests/android-app-smoke.mjs
+++ b/scripts/tests/android-app-smoke.mjs
@@ -254,30 +254,50 @@ try {
     );
     await recordNavigation("before native Back");
     /*
-     * The hardware Back key gets dropped exactly as a synthetic touch does:
+     * The hardware Back key goes missing the way a synthetic touch does:
      * `navigation.json` from the API 36 failure shows `settingsOpen: true` and
      * `historyLength: 2` unchanged across all 148 polls — the identical state
      * the API 35 run recorded a moment before it PASSED, so the app was fine
-     * and the key never arrived.
+     * and the press had no effect.
      *
-     * Back is the one action here that is not idempotent — a second press with
-     * the panel already dismissed would pop the tab navigation instead — so it
-     * re-presses on a much slower cadence than a tab tap, and only ever right
-     * after a poll has just read the panel as still open.
+     * WHY it had none is not settled, and the retry does not depend on which
+     * it is. `AndroidOverlayBack.kt` gives the renderer 1s to answer, and its
+     * injected script is guarded by `Date.now() < deadline`, so a press whose
+     * JS is delayed past that window does nothing at all — no close, no exit —
+     * while this script is evaluating over CDP every 200ms. That is at least
+     * as likely as the emulator losing the key, and it is a real product
+     * question rather than a test one — filed as #1665.
+     *
+     * Back is the one action here that is not idempotent, and over-pressing it
+     * does not fail an assertion — it ENDS THE APP. A second press arriving
+     * after the panel has closed finds nothing to consume, so `useMobileBack`
+     * returns without `preventDefault`, the native plugin reads
+     * `consumed != "true"` and calls `delegate()`, and the activity finishes.
+     * So it re-presses on a much slower cadence than a tab tap, and `actUntil`
+     * re-reads immediately beforehand.
+     *
+     * The condition is therefore the WHOLE post-state, not just "a tab is
+     * selected". Waiting only for the tab bar would be satisfied by an app
+     * that had been Back'd clean out of settings AND one press further, and
+     * the run would go green here and fail three steps later with a timeout
+     * naming the wrong thing.
      */
     await actUntil(
       () => shell("input", "keyevent", "4"),
       () =>
-        evaluate('!!document.querySelector(".mobile-tab[aria-current=page]")'),
-      "native Back dismisses settings",
+        evaluate(
+          '(() => { const tab = document.querySelector(".mobile-tab[aria-current=page]");' +
+            ' return !document.querySelector(".is-settings-open") && !!tab &&' +
+            ' tab.dataset.test === "mobile-tab-hosts"; })()',
+        ),
+      "native Back dismisses settings, and lands on Machines",
       { timeoutMs, redispatchEvery: BACK_REDISPATCH_EVERY_ATTEMPTS },
     );
-    assert(
-      await evaluate(
-        'document.querySelector(".mobile-tab[aria-current=page]").dataset.test === "mobile-tab-hosts"',
-      ),
-      "Back changed the underlying destination",
-    );
+    // The depth is deliberately NOT in the condition above: no artifact
+    // records what it is after a healthy Back, and gating CI on a guessed
+    // value would fail a run that was fine. Record it instead — the next green
+    // run tells us, and then it can be asserted.
+    await recordNavigation("after native Back");
     const metrics = () =>
       evaluate(
         '({ width: innerWidth, scrollWidth: document.documentElement.scrollWidth, font: parseFloat(getComputedStyle(document.querySelector(".mobile-wordmark")).fontSize) })',


### PR DESCRIPTION
The Android smoke test has been failing intermittently on `main`. My first
attempt at this raised `until()`'s deadline from 30s to 90s, on the theory that
a software-rendered CI emulator needed more room. **That was wrong**, and the
evidence artifacts — which had recorded the answer in every failing run —
disprove it.

## What the artifacts actually show

`navigation.json`, written by the catch block at the moment of each timeout:

| Run | Label | `tab` at failure | `activeControl` | `historyLength` | `visibility` |
|---|---|---|---|---|---|
| 34346491292 | `select hosts` | `mobile-tab-catalog` | `mobile-tab-catalog` | 1 | visible |
| 34275884217 | `select hosts` | `mobile-tab-catalog` | `mobile-tab-catalog` | 1 | visible |
| 34258554060 | `select hosts` | `mobile-tab-catalog` | `mobile-tab-catalog` | 1 | visible |
| 34248126907 | `select hosts` | `mobile-tab-catalog` | `mobile-tab-catalog` | 1 | visible |
| 34259122345 | `select queue` | `mobile-tab-generate` | `mobile-tab-generate` | 1 | visible |

In every case the app sits on the **previous** tab with focus still on the
previous tab's button, `last-anr.txt` says no ANR has occurred since boot, and
`failure.png` shows a fully rendered idle screen with the whole tab bar drawn
and the target tab unobscured. The wait itself round-tripped ~150
`Runtime.evaluate` calls over CDP during those 30 seconds, so the WebView was
responsive the entire time.

The tab bar is a synchronous local state flip with no async work, and focus
would have moved on touch-down had the event been delivered at all. **The
synthetic touch was dropped.**

And `click()` was called *outside* `until()` — the loop retried the
**assertion**, never the **tap**. A dropped touch was never re-sent, so a
larger deadline could only turn a 30-second red build into a 90-second one.

The distribution agrees: `hosts` ×5, `queue` ×1, never the same step twice
running. That is the shape of a lost event, not a slowness gradient — a genuinely
slow emulator would degrade *every* wait, not clear four instantly and hang on
the fifth.

## The fix

**Retry the action, not just its effect.** `actUntil` re-dispatches the tap
roughly once a second until the assertion holds. The deadline stays at 30s.

Two more real defects surfaced from the same evidence:

- **`spawnSync adb ENOBUFS`** — two of the five failures I originally cited as
  motivation were never timeouts at all. `exec-out screencap` and `dumpsys`
  outgrow `execFileSync`'s 1 MB default and abort the script *while it is
  capturing the evidence for some other failure*, losing the answer and
  reporting the wrong question. Every `adb` call is now bounded at 32 MB.
- **`Number(process.env.X ?? 30_000)` reads an empty variable as `0`**, and a
  zero deadline runs the loop zero times — the whole suite fails in
  milliseconds with no clue why. `MOLD_ANDROID_SMOKE_TIMEOUT_MS=` in a shell,
  or an unset workflow `env:` value, is exactly that string. `resolveDeadlineMs`
  falls back for absent-or-blank and refuses a present-but-unusable value by
  name.

The waiting policy moves to `scripts/lib/android-smoke-wait.mjs` so both smoke
scripts read one authority instead of two drifting copies.

## Tests

`scripts/lib/android-smoke-wait.test.mjs` covers the deadline parsing and the
retry behaviour against a hand-driven clock (no test waits on real time).
**Each test was verified to fail against the rejected implementation** — 6 of
11 fail when the naive parsing and the assertion-only retry are restored.

It runs as its own workflow step *before* the APK build, so a broken wait
policy fails in seconds rather than twenty minutes into an emulator run.

## What survived from the first attempt

The failure message keeps the elapsed time and attempt count. "Timed out:
select hosts" alone could not distinguish a slow emulator from a condition
that was never going to hold — that ambiguity is what sent me down the wrong
path to begin with.

CI-only; `skip-changelog`.