### PR TITLE
fix(test): stop the desktop suite deciding its results on DNS

### DIFF
--- a/desktop/src/components/machines/HostQueuePanel.test.ts
+++ b/desktop/src/components/machines/HostQueuePanel.test.ts
@@ -113,7 +113,11 @@ async function mountPanel(
 
 beforeEach(() => {
   vi.clearAllMocks();
-  vi.unstubAllGlobals();
+  // No `unstubAllGlobals()` here. Setup-file hooks run FIRST, so unstubbing in
+  // this file's own `beforeEach` restored the real global `fetch` and undid the
+  // suite-wide network guard for every test below. `mountPanel` installs this
+  // file's own `fetch` anyway, and the guard reinstalls itself each test, so
+  // there is nothing left for it to clean up.
 });
 
 describe("HostQueuePanel", () => {

--- a/desktop/src/mobile/MobileApp.test.ts
+++ b/desktop/src/mobile/MobileApp.test.ts
@@ -594,8 +594,13 @@ class FakeIntersectionObserver {
 function mountMobileApp(pinia: Pinia = createPinia()): VueWrapper {
   return mount(MobileApp, {
     attachTo: document.body,
-    // DevelopCanvas paints on a real 2D context happy-dom doesn't provide.
-    global: { plugins: [pinia], stubs: { DevelopCanvas: true } },
+    // DevelopCanvas paints on a real 2D context happy-dom doesn't provide,
+    // and MeshViewer uploads to a WebGL one it does not provide either — it
+    // fetches the glTF itself, fails, and the figure's own @fail recovery then
+    // clears the result, so whether the mesh arm was still on screen came down
+    // to how long a DNS miss took. Its rendering has its own tests; here the
+    // question is only which arm a finished 3-D print takes.
+    global: { plugins: [pinia], stubs: { DevelopCanvas: true, MeshViewer: true } },
   });
 }
 

--- a/desktop/src/test-setup.ts
+++ b/desktop/src/test-setup.ts
@@ -1,4 +1,7 @@
-import { beforeEach, vi } from "vitest";
+// The network guard is shared with `studio/vitest.config.ts` so the two
+// runners that collect `studio/**` cannot disagree about it.
+import "@studio/test-setup";
+import { beforeEach } from "vitest";
 
 /*
  * happy-dom keeps one `localStorage` per test FILE, so anything a store
@@ -13,26 +16,4 @@ beforeEach(() => {
   } catch {
     // No storage in this environment.
   }
-});
-
-/*
- * No test reaches the network. Several suites drive host URLs that do not
- * exist as fixtures ("studio", "render.tailnet.ts.net") while the code under
- * test sometimes calls `fetch` directly rather than through a mocked API
- * module — `MeshViewer` is the one component that loads its media that way.
- * Those tests were therefore deciding their result on DNS: a slow lookup left
- * a load pending long enough to assert against, and on a network that answers
- * NXDOMAIN with a landing server the reply is not HTTP at all, which surfaces
- * as `HPE_INVALID_CONSTANT` from Node's client. Both also feed the 5s timeouts
- * that make a full run flake under load. A test that wants a response stubs
- * `fetch` itself; this only makes a MISSING stub instant and local instead of
- * slow and dependent on which network the machine is on.
- */
-beforeEach(() => {
-  vi.stubGlobal(
-    "fetch",
-    vi.fn(() =>
-      Promise.reject(new TypeError("fetch is not stubbed: tests must not use the network")),
-    ),
-  );
 });

--- a/desktop/src/test-setup.ts
+++ b/desktop/src/test-setup.ts
@@ -1,4 +1,4 @@
-import { beforeEach } from "vitest";
+import { beforeEach, vi } from "vitest";
 
 /*
  * happy-dom keeps one `localStorage` per test FILE, so anything a store
@@ -13,4 +13,26 @@ beforeEach(() => {
   } catch {
     // No storage in this environment.
   }
+});
+
+/*
+ * No test reaches the network. Several suites drive host URLs that do not
+ * exist as fixtures ("studio", "render.tailnet.ts.net") while the code under
+ * test sometimes calls `fetch` directly rather than through a mocked API
+ * module — `MeshViewer` is the one component that loads its media that way.
+ * Those tests were therefore deciding their result on DNS: a slow lookup left
+ * a load pending long enough to assert against, and on a network that answers
+ * NXDOMAIN with a landing server the reply is not HTTP at all, which surfaces
+ * as `HPE_INVALID_CONSTANT` from Node's client. Both also feed the 5s timeouts
+ * that make a full run flake under load. A test that wants a response stubs
+ * `fetch` itself; this only makes a MISSING stub instant and local instead of
+ * slow and dependent on which network the machine is on.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.reject(new TypeError("fetch is not stubbed: tests must not use the network")),
+    ),
+  );
 });

--- a/studio/test-setup.ts
+++ b/studio/test-setup.ts
@@ -1,0 +1,35 @@
+import { beforeEach, vi } from "vitest";
+
+/*
+ * No test reaches the network.
+ *
+ * Several suites drive host URLs that do not exist, as fixtures ("studio",
+ * "render.tailnet.ts.net"), while the code under test calls `fetch` directly
+ * rather than through a mocked API module — `api/client.ts` on every request,
+ * and `components/MeshViewer.vue` for the one component that loads its own
+ * media. Those tests were deciding their results on DNS: a slow lookup left a
+ * load pending long enough to assert against, and on a network that answers
+ * NXDOMAIN with a landing server the reply is not HTTP at all, which surfaces
+ * as `HPE_INVALID_CONSTANT` from Node's client. Every lookup is also a real
+ * wait feeding the 5s timeouts that make a full run flake under load.
+ *
+ * A test that wants a response stubs `fetch` itself; this only makes a MISSING
+ * stub instant and local instead of slow and dependent on which network the
+ * machine is on. Do not call `vi.unstubAllGlobals()` in a file-level
+ * `beforeEach` — setup-file hooks run FIRST, so that restores the real global
+ * and undoes this for the whole file; `afterEach` is fine.
+ *
+ * This lives in `studio/` so its two runners agree: `studio/vitest.config.ts`
+ * loads it directly, and `desktop/src/test-setup.ts` imports it for the desktop
+ * runner, which also collects `../studio/**` and `../ui/**`.
+ */
+beforeEach(() => {
+  vi.stubGlobal(
+    "fetch",
+    vi.fn(() =>
+      Promise.reject(
+        new TypeError("fetch is not stubbed: tests must not use the network"),
+      ),
+    ),
+  );
+});

--- a/studio/vitest.config.ts
+++ b/studio/vitest.config.ts
@@ -13,6 +13,7 @@ export default defineConfig({
   },
   test: {
     environment: "happy-dom",
+    setupFiles: ["./test-setup.ts"],
     include: ["**/*.test.ts"],
   },
 });


### PR DESCRIPTION
## The problem

Several desktop suites drive host URLs that do not exist, as fixtures — `studio`, `render.tailnet.ts.net` — while the code under test calls `fetch` directly rather than through a mocked API module. Two places do: `studio/api/client.ts:54,89` on every request (the source of the `ENOTFOUND studio` errors), and `studio/components/MeshViewer.vue:766` for the one component that loads its own media. So `MobileApp.test.ts` really did try to fetch `https://studio/media/armchair.glb` over the network.

**That decided a result.** On a failed load the mesh figure's `@fail` handler (`recoverGeneratedMedia`) retries once, gives up, and clears the result — so whether the mesh arm was still on screen to assert against came down to *how long a DNS miss took*. The test named below passed because the network is slow.

It also produced two symptoms that looked like unrelated flakiness:

- On a network that answers NXDOMAIN with a landing server, the reply is not HTTP at all and Node's client raises `HPE_INVALID_CONSTANT` on a four-byte packet:
  ```
  Error: Parse Error: Expected HTTP/, RTSP/ or ICE/
    code: 'HPE_INVALID_CONSTANT', bytesParsed: 0, rawPacket: <Buffer 01 00 00 00>
  ```
- Every lookup is a real wait, feeding the `Test timed out in 5000ms` failures that make a full local run flake under load (a run competing with other work showed 28 failures across 5 files, with a *moving* failure set).

## The change

`desktop/src/test-setup.ts` installs a rejecting `fetch` before each test, so a MISSING stub fails instantly and locally instead of slowly and dependent on which network the machine is on. A test that wants a response still stubs `fetch` itself, exactly as `ConnectMachineModal.test.ts` already does.

The guard lives in `studio/test-setup.ts` and is loaded by **both** runners that collect `studio/**` — `studio/vitest.config.ts` directly, and `desktop/src/test-setup.ts` by import — so `bun run test:studio` and the desktop runner cannot disagree about it. (Found in review: studio's own config declared no `setupFiles` at all.)

`HostQueuePanel.test.ts` called `vi.unstubAllGlobals()` in a file-level `beforeEach`. Setup-file hooks run FIRST, so that restored the real global `fetch` for every test in the file and silently undid the guard there. It is the only such site — 24 others are in `afterEach`, 8 inline — and it was not leaking today, but it made the guard's promise one file away from false.

The one test that depended on the slow load now stubs `MeshViewer`, following the `DevelopCanvas` precedent already in that mount: happy-dom provides neither the 2D context one needs nor the WebGL context the other does. `MeshViewer`'s rendering has its own tests; the question in `MobileApp.test.ts` is only which arm a finished 3-D print takes.

## Measurements

Full desktop suite, 6628 tests, **498 files passing either way** — the change alters no test's outcome.

The durable, reproducible result is **network errors: 46 → 0** (`ENOTFOUND` / `EHOSTUNREACH` / `ECONNREFUSED` / `HPE_INVALID_CONSTANT`). That has held on every run, on two machines, and it is a property of the change.

**Wall-clock is not a claim this PR makes.** An earlier uncontrolled run suggested ~7x; a controlled pair suggested ~1.9x (90s → 47s); an independent reviewer measured ~20% (63s → 52s) and never reproduced the 90s baseline at all. The spread is real: how much a removed DNS miss is worth depends entirely on how fast that machine's resolver fails, so the number is network-conditional rather than a property of the diff. It gets faster; by how much is not something this PR should assert.

Two further things this does **not** claim. The controlled baseline passed every test — the 28 failures seen earlier appear only under load, so removing 46 network waits is a contributing fix there, not a proven cure. And **web is untouched on purpose**: its suite leaks nothing (1931 passed, 0 network errors) because its tests mock the API layer.

## Verification

- `cd desktop && bunx vitest run` — 6628 passed, 0 network errors
- `bunx vitest run --config studio/vitest.config.ts` — 1794 passed under the guard's other runner
- `cd desktop && bunx vue-tsc -b` — clean
- `cd web && bunx vitest run` — 1931 passed, unaffected
- `bun run fmt:check` — clean

No user-visible change, so `skip-changelog`.
