### PR TITLE
fix(upscale): route completed clips through Framewise workflows

### DIFF
--- a/changelog.d/canvas-framewise-upscale.md
+++ b/changelog.d/canvas-framewise-upscale.md
@@ -1,0 +1,5 @@
+- **Make bigger works on completed clips.** Desktop Create now opens the durable
+  Framewise video upscaler for MP4 results, with progress and pause/resume/cancel
+  controls on the original machine. Web Create's recent-video action opens the
+  same workflow in Library. Still-image upscaling is unchanged
+  ([#1677](https://github.com/utensils/mold/pull/1677)).

--- a/desktop/src/views/GenerateView.upscale.test.ts
+++ b/desktop/src/views/GenerateView.upscale.test.ts
@@ -1,0 +1,444 @@
+/**
+ * "Make bigger" follows the media file on the Create canvas. Durable video
+ * completions carry an encoded MP4 filename but may omit the old
+ * `video_frames` marker, so the filename/format must select the durable
+ * Framewise workflow and retain the machine that made the print.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { createPinia, setActivePinia } from "pinia";
+import { flushPromises, mount } from "@vue/test-utils";
+import { installMemoryLocalStorage } from "../lib/testSupport/memoryLocalStorage";
+
+installMemoryLocalStorage();
+
+const {
+  createFramewiseUpscale,
+  findRecoverableFramewiseUpscale,
+  getFramewiseUpscale,
+  transitionFramewiseUpscale,
+  upscaleLibraryImage,
+} = vi.hoisted(() => ({
+  createFramewiseUpscale: vi.fn(),
+  findRecoverableFramewiseUpscale: vi.fn(),
+  getFramewiseUpscale: vi.fn(),
+  transitionFramewiseUpscale: vi.fn(),
+  upscaleLibraryImage: vi.fn(),
+}));
+
+vi.mock("@studio/api/videoUpscale", () => ({
+  createFramewiseUpscale,
+  findRecoverableFramewiseUpscale,
+  getFramewiseUpscale,
+  transitionFramewiseUpscale,
+  upscaleLibraryImage,
+}));
+
+const upscaleImage = vi.hoisted(() => vi.fn());
+vi.mock("../lib/api/upscale", () => ({ upscaleImage }));
+vi.mock("vue-router", () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn() }),
+  useRoute: () => ({ query: {} }),
+}));
+vi.mock("../lib/api/client", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../lib/api/client")>()),
+  apiJson: vi.fn(() => Promise.resolve([])),
+  apiJsonTo: vi.fn(() => Promise.resolve([])),
+  apiFetch: vi.fn(),
+}));
+vi.mock("../lib/ipc", () => ({
+  inTauri: () => false,
+  ipc: { saveOutputBytes: vi.fn(() => Promise.resolve("saved.png")) },
+}));
+
+import GenerateView from "./GenerateView.vue";
+import { newJob } from "../lib/generationJob";
+import { useConnectionStore } from "../stores/connection";
+import { useGenerationStore } from "../stores/generation";
+import { useHostModelsStore } from "../stores/hostModels";
+import { useHostsStore } from "../stores/hosts";
+import { useModelStore } from "../stores/models";
+import type { GenerateRequest, ModelEntry } from "../lib/api/types";
+
+const target = { baseUrl: "http://127.0.0.1:7680", apiKey: "local-key" };
+const imageModel = {
+  name: "sdxl-base:fp16",
+  family: "sdxl",
+  downloaded: true,
+  default_width: 1024,
+  default_height: 1024,
+  default_steps: 30,
+  default_guidance: 7,
+} as ModelEntry;
+const upscaler = {
+  name: "real-esrgan-x4plus:fp16",
+  family: "real-esrgan",
+  downloaded: true,
+} as ModelEntry;
+
+const queuedJob = {
+  contract_version: 1,
+  id: "vup-canvas-1",
+  state: "queued",
+  source: { kind: "library", filename: "teapot-motion.mp4" },
+  model: upscaler.name,
+  completed_frames: 0,
+  total_frames: 24,
+  disclosure: "Framewise upscale",
+};
+const completedJob = {
+  ...queuedJob,
+  state: "completed",
+  completed_frames: 24,
+  output_filename: "teapot-motion-framewise-upscaled.mp4",
+};
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  const promise = new Promise<T>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+let wrapper: ReturnType<typeof mount> | null = null;
+
+beforeEach(() => {
+  setActivePinia(createPinia());
+  vi.clearAllMocks();
+  localStorage.clear();
+  findRecoverableFramewiseUpscale.mockResolvedValue(null);
+  createFramewiseUpscale.mockResolvedValue(queuedJob);
+  getFramewiseUpscale.mockResolvedValue(completedJob);
+  transitionFramewiseUpscale.mockResolvedValue(queuedJob);
+  upscaleLibraryImage.mockResolvedValue({
+    filename: "teapot-upscaled.png",
+    model: upscaler.name,
+    scale_factor: 4,
+  });
+
+  const connection = useConnectionStore();
+  connection.info = { mode: "local", ...target };
+  connection.status = "ready";
+  const hosts = useHostsStore();
+  hosts.initialized = true;
+  hosts.capabilities.local = {
+    video_upscale: { available: true, gallery_image: true },
+  } as never;
+  useModelStore().all = [imageModel, upscaler];
+  useHostModelsStore().byHost.local = {
+    entries: [imageModel, upscaler],
+    fetchedAt: Date.now(),
+    error: null,
+  };
+});
+
+afterEach(() => {
+  wrapper?.unmount();
+  wrapper = null;
+  document.body.innerHTML = "";
+});
+
+function finishPrint(
+  filename: string,
+  format: "png" | "mp4",
+  origin: { hostId: string | null; hostLabel: string | null } = {
+    hostId: null,
+    hostLabel: null,
+  },
+) {
+  const generation = useGenerationStore();
+  const job = newJob({
+    prompt: "a brass teapot in motion",
+    model: imageModel.name,
+    width: 1024,
+    height: 1024,
+    steps: 30,
+  } as GenerateRequest);
+  Object.assign(job, {
+    clientId: 1,
+    batchId: 1,
+    id: "finished-print",
+    status: "complete",
+    ...origin,
+    resultUrl: format === "mp4" ? "blob:encoded-video" : "blob:encoded-image",
+    result: {
+      image: "ZW5jb2RlZC1tZWRpYQ==",
+      filename,
+      model: imageModel.name,
+      format,
+      width: 1024,
+      height: 1024,
+      seed_used: 4821,
+      generation_time_ms: 1000,
+      // Deliberately no video_frames: durable encoded clips do not need the
+      // raw-frame fallback marker.
+    },
+  });
+  generation.jobs.push(job);
+  generation.selectedClientId = job.clientId;
+  return job;
+}
+
+async function mountView() {
+  wrapper = mount(GenerateView, { shallow: false, attachTo: document.body });
+  await flushPromises();
+  return wrapper;
+}
+
+describe("GenerateView — Make bigger", () => {
+  it("routes an encoded MP4 without video_frames through Framewise upscale on its source host", async () => {
+    const view = await mountView();
+    finishPrint("teapot-motion.mp4", "mp4");
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+
+    expect(document.querySelector("[aria-label='Framewise upscale video']")).not.toBeNull();
+    expect(findRecoverableFramewiseUpscale).toHaveBeenCalledWith(target, "teapot-motion.mp4");
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscale).toHaveBeenCalledWith(target, "teapot-motion.mp4", upscaler.name);
+    expect(getFramewiseUpscale).toHaveBeenCalledWith(target, "vup-canvas-1");
+    expect(upscaleLibraryImage).not.toHaveBeenCalled();
+    expect(upscaleImage).not.toHaveBeenCalled();
+  });
+
+  it("retains a remote print's URL and API key for recovery and submission", async () => {
+    const remoteTarget = { baseUrl: "http://plato:7680", apiKey: "plato-secret" };
+    const hosts = useHostsStore();
+    hosts.extras.push({
+      id: "plato-7680",
+      label: "plato",
+      url: remoteTarget.baseUrl,
+      apiKey: remoteTarget.apiKey,
+      status: "ready",
+      error: null,
+      instanceId: "plato-instance",
+    });
+    hosts.capabilities["plato-7680"] = {
+      video_upscale: { available: true, gallery_image: true },
+    } as never;
+    const view = await mountView();
+    finishPrint("remote-motion.mp4", "mp4", {
+      hostId: "plato-7680",
+      hostLabel: "plato",
+    });
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    expect(findRecoverableFramewiseUpscale).toHaveBeenCalledWith(remoteTarget, "remote-motion.mp4");
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscale).toHaveBeenCalledWith(
+      remoteTarget,
+      "remote-motion.mp4",
+      upscaler.name,
+    );
+    expect(upscaleLibraryImage).not.toHaveBeenCalled();
+  });
+
+  it("keeps the opened remote authority frozen across create, poll, and resume", async () => {
+    const originalTarget = { baseUrl: "http://plato:7680", apiKey: "original-secret" };
+    const hosts = useHostsStore();
+    const remote = {
+      id: "plato-7680",
+      label: "plato",
+      url: originalTarget.baseUrl,
+      apiKey: originalTarget.apiKey,
+      status: "ready" as const,
+      error: null,
+      instanceId: "plato-instance",
+    };
+    hosts.extras.push(remote);
+    hosts.capabilities[remote.id] = {
+      video_upscale: { available: true, gallery_image: true },
+    } as never;
+    const pausedAfterPoll = {
+      ...queuedJob,
+      state: "paused",
+      completed_frames: 5,
+    };
+    getFramewiseUpscale.mockResolvedValueOnce(pausedAfterPoll).mockResolvedValueOnce(completedJob);
+    transitionFramewiseUpscale.mockResolvedValueOnce(queuedJob);
+    const view = await mountView();
+    finishPrint("authority-motion.mp4", "mp4", {
+      hostId: remote.id,
+      hostLabel: remote.label,
+    });
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    expect(findRecoverableFramewiseUpscale).toHaveBeenCalledWith(
+      originalTarget,
+      "authority-motion.mp4",
+    );
+
+    remote.url = "http://replacement:7680";
+    remote.apiKey = "replacement-secret";
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscale).toHaveBeenCalledWith(
+      originalTarget,
+      "authority-motion.mp4",
+      upscaler.name,
+    );
+    expect(getFramewiseUpscale).toHaveBeenNthCalledWith(1, originalTarget, "vup-canvas-1");
+    const resume = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Resume",
+    ) as HTMLButtonElement;
+    expect(resume).toBeDefined();
+    resume.click();
+    await flushPromises();
+
+    expect(transitionFramewiseUpscale).toHaveBeenCalledWith(
+      originalTarget,
+      "vup-canvas-1",
+      "resume",
+    );
+    expect(getFramewiseUpscale).toHaveBeenNthCalledWith(2, originalTarget, "vup-canvas-1");
+  });
+
+  it("hides Make bigger when the saved host no longer matches the generation authority", async () => {
+    const hosts = useHostsStore();
+    hosts.extras.push({
+      id: "plato-7680",
+      label: "plato",
+      url: "http://replacement:7680",
+      apiKey: "replacement-secret",
+      status: "ready",
+      error: null,
+      instanceId: "replacement-instance",
+    });
+    hosts.capabilities["plato-7680"] = {
+      video_upscale: { available: true, gallery_image: true },
+    } as never;
+    const generation = useGenerationStore();
+    vi.spyOn(generation, "targetForJob").mockReturnValue({
+      baseUrl: "http://plato:7680",
+      apiKey: "original-secret",
+    });
+    await mountView();
+    finishPrint("mismatched-authority.mp4", "mp4", {
+      hostId: "plato-7680",
+      hostLabel: "plato",
+    });
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='canvas-upscale']")).toBeNull();
+    expect(findRecoverableFramewiseUpscale).not.toHaveBeenCalled();
+  });
+
+  it("hides Make bigger for a video when its source host reports Framewise upscale unavailable", async () => {
+    useHostsStore().capabilities.local = {
+      video_upscale: { available: false, gallery_image: true },
+    } as never;
+    await mountView();
+    finishPrint("unavailable.mp4", "mp4");
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='canvas-upscale']")).toBeNull();
+  });
+
+  it("keeps a PNG on the gallery image upscale endpoint", async () => {
+    const view = await mountView();
+    finishPrint("teapot.png", "png");
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    expect(document.querySelector("[aria-label='Upscale image']")).not.toBeNull();
+    (document.querySelector("[data-test='start-upscale']") as HTMLButtonElement).click();
+    await flushPromises();
+
+    expect(upscaleLibraryImage).toHaveBeenCalledWith(target, "teapot.png", upscaler.name);
+    expect(createFramewiseUpscale).not.toHaveBeenCalled();
+  });
+
+  it("recovers a paused Framewise job and resumes it on the source host", async () => {
+    const pausedJob = {
+      ...queuedJob,
+      id: "vup-paused",
+      state: "paused",
+      completed_frames: 7,
+      model: "real-esrgan-x2plus:fp16",
+    };
+    findRecoverableFramewiseUpscale.mockResolvedValueOnce(pausedJob);
+    transitionFramewiseUpscale.mockResolvedValueOnce({ ...pausedJob, state: "queued" });
+    const view = await mountView();
+    finishPrint("teapot-motion.mp4", "mp4");
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    const resume = [...document.querySelectorAll("button")].find(
+      (button) => button.textContent?.trim() === "Resume",
+    ) as HTMLButtonElement;
+    expect(resume).toBeDefined();
+    resume.click();
+    await flushPromises();
+
+    expect(transitionFramewiseUpscale).toHaveBeenCalledWith(target, "vup-paused", "resume");
+    expect(getFramewiseUpscale).toHaveBeenCalledWith(target, "vup-paused");
+    expect(createFramewiseUpscale).not.toHaveBeenCalled();
+  });
+
+  it("ignores an obsolete recovery after the dialog is closed and reopened", async () => {
+    const staleRecovery = deferred<typeof queuedJob>();
+    findRecoverableFramewiseUpscale
+      .mockReturnValueOnce(staleRecovery.promise)
+      .mockResolvedValueOnce(null);
+    const view = await mountView();
+    finishPrint("teapot-motion.mp4", "mp4");
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    (document.querySelector("[aria-label='Close']") as HTMLButtonElement).click();
+    await flushPromises();
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    expect(document.querySelector("[data-test='start-upscale']")).not.toBeNull();
+
+    staleRecovery.resolve({ ...queuedJob, id: "obsolete", state: "paused" });
+    await flushPromises();
+
+    expect(document.querySelector("[data-test='start-upscale']")).not.toBeNull();
+    expect(
+      [...document.querySelectorAll("button")].some(
+        (button) => button.textContent?.trim() === "Resume",
+      ),
+    ).toBe(false);
+    expect(getFramewiseUpscale).not.toHaveBeenCalledWith(target, "obsolete");
+  });
+
+  it("keeps recovery busy and admits only one create after it settles", async () => {
+    const recovery = deferred<null>();
+    findRecoverableFramewiseUpscale.mockReturnValueOnce(recovery.promise);
+    const view = await mountView();
+    finishPrint("teapot-motion.mp4", "mp4");
+    await flushPromises();
+
+    await view.get("[data-test='canvas-upscale']").trigger("click");
+    await flushPromises();
+    const start = document.querySelector("[data-test='start-upscale']") as HTMLButtonElement;
+    expect(start.disabled).toBe(true);
+    start.click();
+    start.click();
+    expect(createFramewiseUpscale).not.toHaveBeenCalled();
+
+    recovery.resolve(null);
+    await flushPromises();
+    expect(start.disabled).toBe(false);
+    start.click();
+    start.click();
+    await flushPromises();
+
+    expect(createFramewiseUpscale).toHaveBeenCalledTimes(1);
+  });
+});

--- a/desktop/src/views/GenerateView.vue
+++ b/desktop/src/views/GenerateView.vue
@@ -232,6 +232,7 @@ import {
   fullSizeMediaUrl,
   galleryMediaPath,
   localMediaPath,
+  isVideoItem,
   mediaMimeType,
   mediaPath,
   nativeBytes,
@@ -240,8 +241,20 @@ import {
 import { applyGalleryEntryAsSource, canUseGalleryEntryAsSource } from "../lib/gallery/useAsSource";
 import { readGalleryMediaBase64 } from "../lib/gallery/sourceMedia";
 import { useReuseStillPrint } from "../composables/useReuseStillPrint";
-import { upscaleLibraryImage } from "@studio/api/videoUpscale";
-import { defaultUpscaler } from "@studio/lib/upscale";
+import {
+  createFramewiseUpscale,
+  findRecoverableFramewiseUpscale,
+  getFramewiseUpscale,
+  transitionFramewiseUpscale,
+  upscaleLibraryImage,
+  type VideoUpscaleJob,
+} from "@studio/api/videoUpscale";
+import {
+  defaultUpscaler,
+  framewiseProgress,
+  framewiseStatus,
+  shouldPollFramewiseJob,
+} from "@studio/lib/upscale";
 import UpscaleDialog from "@ui/components/UpscaleDialog.vue";
 import { ApiError, apiFetch, apiFetchTo } from "../lib/api/client";
 import { blobToBase64 } from "../lib/image";
@@ -1948,46 +1961,152 @@ async function repeatPrint(candidate: Job, count: number) {
 }
 
 // ── Make bigger (the caption's upscale door) ────────────────────────────────
-// One print, one machine: the canvas result has exactly one origin, so this
-// carries neither the Library's authority picker nor its framewise video
-// recovery. A host that can upscale a gallery file in place does; anything
-// older streams the bytes back and saves the result beside them.
+// The file's media kind selects the workflow, independently of the live form.
+// Durable clips carry a filename, not video_frames (the raw-frame fallback).
 const upscaleEntry = ref<MergedPrint | null>(null);
 const upscaleModel = ref("");
 const upscaleBusy = ref(false);
 const upscaleError = ref("");
+const upscaleJob = ref<VideoUpscaleJob | null>(null);
+const upscaleTarget = ref<ApiTarget | null>(null);
+const upscaleKind = computed(() =>
+  upscaleEntry.value && isVideoItem(upscaleEntry.value.item) ? "video" : "image",
+);
+let upscaleEpoch = 0;
+let upscalePoll: ReturnType<typeof setTimeout> | null = null;
+
+function stopCanvasUpscalePoll() {
+  if (upscalePoll) clearTimeout(upscalePoll);
+  upscalePoll = null;
+}
+
+function canvasUpscaleTarget(j: Job): ApiTarget | null {
+  const current = hostGallery.targetOfOrNull(j.hostId ?? "local");
+  const frozen = generation.targetForJob(j.clientId);
+  // A saved host entry may have been edited since this print was made.
+  // Never apply the replacement host's capabilities to the original file.
+  if (
+    frozen &&
+    (!current || frozen.baseUrl !== current.baseUrl || frozen.apiKey !== current.apiKey)
+  )
+    return null;
+  return frozen ?? current;
+}
 
 function canUpscaleCanvasResult(j: Job): boolean {
+  const entry = canvasPrintEntry(j);
   return (
     j.status === "complete" &&
     !j.result?.video_frames &&
     !isAudioResult(j) &&
     !isMeshResult(j) &&
-    !!canvasPrintEntry(j)
+    !!entry &&
+    !!canvasUpscaleTarget(j) &&
+    (!isVideoItem(entry.item) ||
+      (!!j.result?.filename &&
+        hosts.capabilities[entry.sourceKey]?.video_upscale?.available === true))
   );
 }
 
-function openCanvasUpscale(j: Job) {
-  const entry = canvasPrintEntry(j);
-  if (!entry) return;
+async function openCanvasUpscale(j: Job) {
+  if (!canUpscaleCanvasResult(j)) return;
+  closeCanvasUpscale();
+  const entry = canvasPrintEntry(j)!;
   upscaleEntry.value = entry;
-  upscaleError.value = "";
+  upscaleTarget.value = { ...canvasUpscaleTarget(j)! };
   upscaleModel.value = defaultUpscaler(models.upscalers);
+  if (!isVideoItem(entry.item)) return;
+  const epoch = upscaleEpoch;
+  upscaleBusy.value = true;
+  try {
+    const recovered = await findRecoverableFramewiseUpscale(
+      upscaleTarget.value!,
+      entry.item.filename,
+    );
+    if (epoch !== upscaleEpoch) return;
+    upscaleJob.value = recovered;
+    if (recovered) upscaleModel.value = recovered.model;
+    void pollCanvasUpscale();
+  } catch (error) {
+    if (epoch === upscaleEpoch)
+      upscaleError.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (epoch === upscaleEpoch) upscaleBusy.value = false;
+  }
 }
 
 function closeCanvasUpscale() {
+  upscaleEpoch += 1;
+  stopCanvasUpscalePoll();
   upscaleEntry.value = null;
+  upscaleTarget.value = null;
+  upscaleJob.value = null;
   upscaleBusy.value = false;
   upscaleError.value = "";
+}
+onBeforeUnmount(closeCanvasUpscale);
+
+async function pollCanvasUpscale() {
+  const entry = upscaleEntry.value;
+  const job = upscaleJob.value;
+  const target = upscaleTarget.value;
+  if (!entry || !target || !job || !shouldPollFramewiseJob(job)) return;
+  const epoch = upscaleEpoch;
+  try {
+    const next = await getFramewiseUpscale(target, job.id);
+    if (epoch !== upscaleEpoch) return;
+    upscaleJob.value = next;
+    if (next.state === "completed") {
+      toasts.push(`Framewise upscale complete — ${next.output_filename}`);
+      void hostGallery.refreshHost(entry.sourceKey);
+    }
+    if (shouldPollFramewiseJob(next)) upscalePoll = setTimeout(() => void pollCanvasUpscale(), 750);
+  } catch (error) {
+    if (epoch === upscaleEpoch)
+      upscaleError.value = error instanceof Error ? error.message : String(error);
+  }
+}
+
+async function transitionCanvasUpscale(action: "pause" | "resume" | "cancel") {
+  const entry = upscaleEntry.value;
+  const job = upscaleJob.value;
+  const target = upscaleTarget.value;
+  if (!entry || !target || !job || upscaleBusy.value) return;
+  stopCanvasUpscalePoll();
+  const epoch = ++upscaleEpoch;
+  upscaleBusy.value = true;
+  upscaleError.value = "";
+  try {
+    const next = await transitionFramewiseUpscale(target, job.id, action);
+    if (epoch !== upscaleEpoch) return;
+    upscaleJob.value = next;
+    void pollCanvasUpscale();
+  } catch (error) {
+    if (epoch === upscaleEpoch)
+      upscaleError.value = error instanceof Error ? error.message : String(error);
+  } finally {
+    if (epoch === upscaleEpoch) upscaleBusy.value = false;
+  }
 }
 
 async function startCanvasUpscale() {
   const entry = upscaleEntry.value;
-  const target = entry ? hostGallery.targetOf(entry.sourceKey) : null;
-  if (!entry || !target || upscaleBusy.value) return;
+  const target = upscaleTarget.value;
+  if (!entry || !target || upscaleBusy.value || upscaleJob.value) return;
+  const epoch = ++upscaleEpoch;
   upscaleBusy.value = true;
   upscaleError.value = "";
   try {
+    if (isVideoItem(entry.item)) {
+      if (hosts.capabilities[entry.sourceKey]?.video_upscale?.available !== true) {
+        throw new Error("This print's machine does not support Framewise upscale.");
+      }
+      const created = await createFramewiseUpscale(target, entry.item.filename, upscaleModel.value);
+      if (epoch !== upscaleEpoch) return;
+      upscaleJob.value = created;
+      void pollCanvasUpscale();
+      return;
+    }
     if (hosts.capabilities[entry.sourceKey]?.video_upscale?.gallery_image === true) {
       const result = await upscaleLibraryImage(target, entry.item.filename, upscaleModel.value);
       toasts.push(`Made bigger — ${result.filename}`);
@@ -2002,11 +2121,12 @@ async function startCanvasUpscale() {
       toasts.push(`Made bigger — saved as ${saved}`);
     }
     void hostGallery.refreshHost(entry.sourceKey);
-    closeCanvasUpscale();
+    if (epoch === upscaleEpoch) closeCanvasUpscale();
   } catch (error) {
-    upscaleError.value = error instanceof Error ? error.message : String(error);
+    if (epoch === upscaleEpoch)
+      upscaleError.value = error instanceof Error ? error.message : String(error);
   } finally {
-    upscaleBusy.value = false;
+    if (epoch === upscaleEpoch) upscaleBusy.value = false;
   }
 }
 
@@ -4686,11 +4806,17 @@ onBeforeUnmount(() => {
     <UpscaleDialog
       v-model="upscaleModel"
       :open="!!upscaleEntry"
-      kind="image"
+      :kind="upscaleKind"
       :source-name="upscaleEntry?.item.filename ?? ''"
       :models="models.upscalers"
       :busy="upscaleBusy"
       :error="upscaleError || null"
+      :job-state="upscaleJob?.state ?? null"
+      :status="upscaleJob ? framewiseStatus(upscaleJob) : null"
+      :progress="upscaleJob ? framewiseProgress(upscaleJob) : null"
+      @pause="transitionCanvasUpscale('pause')"
+      @resume="transitionCanvasUpscale('resume')"
+      @cancel="transitionCanvasUpscale('cancel')"
       @confirm="startCanvasUpscale"
       @close="closeCanvasUpscale"
     />

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -52,6 +52,7 @@ const routerReplaceMock = vi.hoisted(() =>
     return Promise.resolve();
   }),
 );
+const routerPushMock = vi.hoisted(() => vi.fn(() => Promise.resolve()));
 vi.mock("vue-router", async (importOriginal) => ({
   ...(await importOriginal<typeof import("vue-router")>()),
   useRoute: () =>
@@ -59,7 +60,7 @@ vi.mock("vue-router", async (importOriginal) => ({
       {},
       { get: (_t, key) => (key === "query" ? routeQuery.value : undefined) },
     ),
-  useRouter: () => ({ replace: routerReplaceMock, push: vi.fn() }),
+  useRouter: () => ({ replace: routerReplaceMock, push: routerPushMock }),
 }));
 
 vi.mock("@microsoft/fetch-event-source", () => ({
@@ -324,6 +325,8 @@ describe("CreatePage layout and behavior", () => {
     generateFormTesting.resetForTest();
     resetNotifications();
     submitMock.mockClear();
+    routerPushMock.mockReset();
+    routerPushMock.mockResolvedValue(undefined);
     promptHistoryApiMock.mockReset();
     promptHistoryApiMock.mockResolvedValue({ entries: [] });
     placementPreviewMock.mockReset();
@@ -841,6 +844,39 @@ describe("CreatePage layout and behavior", () => {
     await nextTick();
     expect((details.element as HTMLDetailsElement).open).toBe(false);
     globalThis.fetch = originalFetch;
+  });
+
+  it("hands a recent video to the Library's durable Framewise upscale flow", async () => {
+    galleryListing.value = [
+      { ...entry, filename: "recent-clip.mp4", format: "mp4" },
+    ];
+    const stubs: Record<string, Component> = pageStubs();
+    stubs.RecentGrid = defineComponent({
+      props: ["entries"],
+      template:
+        '<button data-test="open-recent-video" @click="$emit(\'open\', entries[0])">open</button>',
+    });
+    stubs.Lightbox = defineComponent({
+      props: ["item"],
+      template:
+        '<button v-if="item" data-test="video-upscale" @click="$emit(\'upscale\', item)">upscale</button>',
+    });
+    const wrapper = mount(CreatePage, { global: { stubs } });
+    await flushPromises();
+
+    await wrapper.get('[data-test="open-recent-video"]').trigger("click");
+    await wrapper.get('[data-test="video-upscale"]').trigger("click");
+    await flushPromises();
+
+    expect(routerPushMock).toHaveBeenCalledWith({
+      name: "library",
+      query: {
+        print: "recent-clip.mp4",
+        printHost: ORIGIN_HOST_ID,
+        upscale: "framewise",
+      },
+    });
+    expect(useGenerateForm().state.value.sourceVideo).toBeNull();
   });
 
   it("offers the gallery actions when a Recent tile is right-clicked", async () => {

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -7,6 +7,7 @@ import {
   ref,
   watch,
 } from "vue";
+import { useRouter } from "vue-router";
 import { requestChoice, toast, undoableAction } from "../lib/toasts";
 import ComposerCard from "../components/create/ComposerCard.vue";
 import ResultCanvas from "../components/create/ResultCanvas.vue";
@@ -296,6 +297,7 @@ function loadMuted(): boolean {
 }
 
 const form = useGenerateForm();
+const router = useRouter();
 const { status } = useStatusPoll();
 const routing = useHostRouting();
 const licenseAcceptance = useLicenseAcceptance();
@@ -4313,6 +4315,19 @@ async function onLightboxUseSource(item: GalleryImage) {
 }
 
 async function onLightboxUpscale(item: GalleryImage) {
+  if (mediaKind(item.format, item.filename) === "video") {
+    closeDrawer();
+    await router.push({
+      name: "library",
+      query: {
+        print: item.filename,
+        printHost:
+          (item as GalleryImage & { hostId?: string }).hostId ?? ORIGIN_HOST_ID,
+        upscale: "framewise",
+      },
+    });
+    return;
+  }
   if (!(await attachLightboxSource(item))) return;
   form.state.value.upscaleModel ||= defaultUpscaler(models.value);
   closeDrawer();

--- a/web/src/pages/LibraryPage.test.ts
+++ b/web/src/pages/LibraryPage.test.ts
@@ -404,6 +404,41 @@ describe("LibraryPage", () => {
     );
   });
 
+  it("opens the durable Framewise flow handed off by Create's recent viewer", async () => {
+    listGalleryMock.mockResolvedValue([
+      { ...cat, filename: "recent-clip.mp4", format: "mp4" },
+    ]);
+    hostCapabilitiesMock.mockResolvedValue({
+      gallery: { can_delete: true },
+      video_upscale: { available: true },
+    });
+    routeState.query = {
+      print: "recent-clip.mp4",
+      printHost: "origin",
+      upscale: "framewise",
+    };
+    await mounted();
+
+    await vi.waitFor(() =>
+      expect(
+        document.querySelector("[data-test='upscale-dialog']"),
+      ).not.toBeNull(),
+    );
+    (
+      document.querySelector("[data-test='start-upscale']") as HTMLButtonElement
+    ).click();
+    await flushPromises();
+
+    expect(createFramewiseUpscaleMock).toHaveBeenCalledWith(
+      { baseUrl: window.location.origin, apiKey: null },
+      "recent-clip.mp4",
+      "real-esrgan-x4plus:fp16",
+    );
+    expect(replaceMock).toHaveBeenCalledWith({
+      query: { print: "recent-clip.mp4", printHost: "origin" },
+    });
+  });
+
   it("appends Library source images to Ref2VA's dedicated ordered references", async () => {
     const form = useGenerateForm();
     form.state.value.model = "minimax-h3-ref2va:comfy-pruned-int8";

--- a/web/src/pages/LibraryPage.vue
+++ b/web/src/pages/LibraryPage.vue
@@ -2057,6 +2057,29 @@ async function onUpscale(item: GalleryImage) {
     }
   }
 }
+
+// Create's recent-print viewer hands an existing video to the Library because
+// this page owns the durable Framewise workflow. Wait for the gallery and host
+// capabilities to settle, consume the one-shot intent, then open the same
+// dialog as the Library tile and lightbox actions.
+watch(
+  [loading, selected, () => route.query.upscale],
+  ([isLoading, item, intent]) => {
+    if (isLoading || !item || intent !== "framewise") return;
+    const query = { ...route.query };
+    delete query.upscale;
+    void router.replace({ query });
+    if (!canUpscaleItem(item)) {
+      toast(
+        "error",
+        "Framewise upscale is unavailable on this print's machine.",
+      );
+      return;
+    }
+    void onUpscale(item);
+  },
+  { flush: "post" },
+);
 function upscaleTarget(item: GalleryImage) {
   const host = hostForEntry(item);
   if (!host) throw missingHostError(item);


### PR DESCRIPTION
Completed MP4s on the desktop Create canvas were sent to image upscaling: the action excluded raw `video_frames` but missed encoded video files, then hardcoded the image dialog and endpoint. “Make bigger” now classifies the saved print, checks its source host’s Framewise capability, and uses the durable video workflow with recovery, progress, pause/resume/cancel, and stale-response guards. The target is captured so editing a saved host cannot redirect an open operation.

The cross-surface audit also found that web Create’s recent-video viewer treated “Framewise upscale” as still-image generation settings. It now hands the exact print and host to Library’s existing durable workflow. Desktop Library, mobile, TUI, and CLI already route video correctly; still-image behavior is preserved.

Validation:
- [x] Independent sub-agent peer review; both authority findings addressed and final approval obtained.
- [x] Full frontend checks: 1,818 Studio, 1,941 web, and 6,669 desktop tests plus web/desktop production builds. Used `NODE_OPTIONS=--no-experimental-webstorage` for the local Node 26 environment.
- [x] Final targeted checks: 9 new desktop regressions (remote credentials, host edits, recovery, stale responses, duplicate clicks, MP4/image routing), existing canvas checks, and 160 web Create/Library tests; TypeScript and formatting pass.
- [x] Playwright against rendered desktop GenerateView at 1440×1100 and 390×844 using controlled API fixtures: MP4 opens Framewise dialog and sends GET/POST/GET to `/api/video-upscale-jobs`; paused progress and controls render, with no application exceptions. Chrome blocked Vite’s HMR websocket only.
- [x] No GPU generations launched; this change is UI routing and durable-job control.
