### PR TITLE
ci(docs): install ripgrep so the env-var coverage check actually runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -318,6 +318,8 @@ jobs:
       - name: Install docs dependencies
         working-directory: website
         run: bun install
+      - name: Install ripgrep for the env-var coverage check
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
       - name: Check docs formatting
         working-directory: website
         run: bun run fmt:check

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -32,6 +32,8 @@ jobs:
       - name: Install dependencies
         working-directory: website
         run: bun install
+      - name: Install ripgrep for the env-var coverage check
+        run: sudo apt-get update && sudo apt-get install -y ripgrep
 
       - name: Verify docs
         working-directory: website

--- a/website/scripts/verify-docs.mjs
+++ b/website/scripts/verify-docs.mjs
@@ -235,9 +235,13 @@ for (const fact of requiredH3DownloadFacts) {
 
 let rustEnvVars
 try {
+  // ripgrep runs ALONE: piped through `sed | sort`, a missing `rg` still
+  // exits 0 (the pipeline's status is `sort`'s), the harvest comes back
+  // empty, and the coverage check below passes vacuously with no warning at
+  // all -- which is how CI stayed green with the check dead.
   rustEnvVars = new Set(
     execSync(
-      "rg -o 'MOLD_[A-Z0-9_]+' crates --glob '!**/*test*' -g'*.rs' | sed 's/.*://' | sort -u",
+      "rg -o --no-filename 'MOLD_[A-Z0-9_]+' crates --glob '!**/*test*' -g '*.rs'",
       { cwd: repoRoot, encoding: 'utf8', stdio: ['ignore', 'pipe', 'inherit'] }
     )
       .trim()
@@ -245,9 +249,18 @@ try {
       .filter(Boolean)
   )
 } catch {
-  console.warn(
-    'warning: ripgrep (rg) not found -- skipping env-var coverage check'
-  )
+  // Without ripgrep the harvest is empty and the coverage check below passes
+  // vacuously. A contributor's laptop may skip it, but CI must never: the
+  // docs job ran green on main for weeks with this check dead (#1679).
+  if (process.env.CI) {
+    fail(
+      'ripgrep (rg) not found -- the env-var coverage check cannot run; install ripgrep in the workflow'
+    )
+  } else {
+    console.warn(
+      'warning: ripgrep (rg) not found -- skipping env-var coverage check'
+    )
+  }
   rustEnvVars = new Set()
 }
 


### PR DESCRIPTION
The website verifier harvests `MOLD_*` env-var names with ripgrep and checks each is documented under `website/`. On CI that check has been silently dead: the runner has no ripgrep, and the harvest was a shell pipeline whose exit status was `sort`'s, so a missing `rg` still yielded an empty set and the check passed vacuously with no warning. That is how `main` stayed green with `MOLD_DESTINATION_API_KEY` undocumented until a local run caught it in #1679.

- `docs` job in `ci.yml` and the Pages workflow install ripgrep before `bun run verify`.
- `verify-docs.mjs` runs `rg` alone (filtering in JS) so a missing binary throws.
- Under `CI` a missing ripgrep is a failure; locally it stays a warning.

Verified locally: normal run passes (259 env vars harvested, all documented); with a failing `rg` shim under `CI=1` the verifier fails with the new message; without `CI` it warns and passes. `actionlint` clean.

https://claude.ai/code/session_016L3TinDUYUKsUAWVAFi9kQ