### PR TITLE
feat(mobile): add full-screen image pinch zoom

### DIFF
--- a/apps/mobile/README.md
+++ b/apps/mobile/README.md
@@ -250,8 +250,11 @@ pushed screen opened from the header.
   every kind and only its actions differ, so a 3-D print's export controls
   can no longer push its own model off the screen. A drag that starts on the
   sheet moves the sheet and never pages the gallery; a drag on the media
-  still pages it, and a drag on a mesh still orbits the model. The viewer
-  shows uncropped images, streams videos with native controls, plays
+  still pages it, and a drag on a mesh still orbits the model. A still image
+  owns a two-finger pinch that scales around the fingers up to 5×; while
+  zoomed, one finger pans within the image bounds instead of paging, and
+  returning to 1× restores the gallery swipe. Moving to another print resets
+  the zoom. The viewer shows uncropped images, streams videos with native controls, plays
   audio-only prints (LTX-2 text-to-audio) as a waveform tile above a native
   transport, renders Hunyuan3D meshes in an orbitable WebGL viewer over the
   saved poster (`@studio/components/MeshViewer.vue`, shared with desktop and
@@ -487,7 +490,8 @@ horizontal scrollers, action rows, dialogs, and the full-screen Library viewer
 retain their own gesture authority. Pulling down at the top
 refreshes Images, Styles, Machines, and Machine Detail; Make and Settings
 stay on their existing live polling/streaming paths so an in-progress form is
-never disrupted. The Library viewer keeps its scoped horizontal swipe gesture,
+never disrupted. The Library viewer keeps its scoped horizontal swipe gesture
+at 1× and gives zoomed stills their own bounded pinch/pan gesture,
 and the Library grid keeps a scoped two-finger pinch (`touch-action: pan-y`)
 that resizes thumbnails while one-finger scrolling is unaffected.
 

--- a/changelog.d/mobile-image-pinch-zoom.md
+++ b/changelog.d/mobile-image-pinch-zoom.md
@@ -1,0 +1,1 @@
+- Add smooth focal pinch-to-zoom and panning to the full-screen image viewer on iPhone and Android.

--- a/desktop/src/mobile/MobileGalleryViewer.test.ts
+++ b/desktop/src/mobile/MobileGalleryViewer.test.ts
@@ -837,6 +837,34 @@ describe("MobileGalleryViewer", () => {
     expect(view.emitted("next")).toHaveLength(1);
   });
 
+  it("leaves the complete native touch sequence with viewer controls", async () => {
+    const view = mountViewer(image, { position: 2, total: 4 });
+    await flushPromises();
+    const viewport = view.get("[data-test='gallery-viewer-image-viewport']");
+    const capture = vi.fn();
+    viewport.element.setPointerCapture = capture;
+    const previous = view.get("[data-test='gallery-viewer-previous']");
+
+    await previous.trigger("pointerdown", {
+      pointerId: 31,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 24,
+      clientY: 240,
+    });
+    await previous.trigger("pointerup", {
+      pointerId: 31,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 24,
+      clientY: 240,
+    });
+    await previous.trigger("click");
+
+    expect(capture).not.toHaveBeenCalled();
+    expect(view.emitted("previous")).toHaveLength(1);
+  });
+
   /// Dragging a mesh is how you ROTATE it. The stage arms its swipe on
   /// `pointerdown.capture`, so it fires before the mesh viewer's own handler
   /// and a child cannot stop it — orbiting a model sideways navigated the
@@ -927,6 +955,100 @@ describe("MobileGalleryViewer", () => {
     });
     expect(view.emitted("previous")).toHaveLength(1);
     expect(view.emitted("next")).toHaveLength(1);
+  });
+
+  it("pinch-zooms and pans still images without paging, then resets for the next print", async () => {
+    const view = mountViewer(image, { position: 2, total: 4 });
+    await flushPromises();
+    const viewport = view.get("[data-test='gallery-viewer-image-viewport']");
+    const viewportBounds = {
+      top: 60,
+      bottom: 460,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: 400,
+      x: 0,
+      y: 60,
+      toJSON: () => ({}),
+    };
+    vi.spyOn(viewport.element, "getBoundingClientRect").mockImplementation(() => viewportBounds);
+
+    await viewport.trigger("pointerdown", {
+      pointerId: 41,
+      pointerType: "touch",
+      isPrimary: true,
+      clientX: 150,
+      clientY: 260,
+    });
+    await viewport.trigger("pointerdown", {
+      pointerId: 42,
+      pointerType: "touch",
+      isPrimary: false,
+      clientX: 250,
+      clientY: 260,
+    });
+    window.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 42,
+        pointerType: "touch",
+        isPrimary: false,
+        clientX: 350,
+        clientY: 260,
+      }),
+    );
+    await flushPromises();
+
+    expect(view.get("[data-test='gallery-viewer-image-transform']").attributes("style")).toContain(
+      "scale(2)",
+    );
+    expect(view.get("[data-test='gallery-viewer-stage']").classes()).toContain("is-image-zoomed");
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 42,
+        pointerType: "touch",
+        isPrimary: false,
+        clientX: 350,
+        clientY: 260,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointermove", {
+        pointerId: 41,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 80,
+        clientY: 300,
+      }),
+    );
+    window.dispatchEvent(
+      new PointerEvent("pointerup", {
+        pointerId: 41,
+        pointerType: "touch",
+        isPrimary: true,
+        clientX: 80,
+        clientY: 300,
+      }),
+    );
+    expect(view.emitted("previous")).toBeUndefined();
+    expect(view.emitted("next")).toBeUndefined();
+
+    viewportBounds.width = 800;
+    viewportBounds.right = 800;
+    window.dispatchEvent(new Event("resize"));
+    await flushPromises();
+    expect(view.get("[data-test='gallery-viewer-image-transform']").attributes("style")).toContain(
+      "translate3d(0px,",
+    );
+
+    await view.setProps({ item: { ...image, filename: "print two.png" } });
+    await flushPromises();
+    expect(view.get("[data-test='gallery-viewer-image-transform']").attributes("style")).toContain(
+      "scale(1)",
+    );
+    expect(view.get("[data-test='gallery-viewer-stage']").classes()).not.toContain(
+      "is-image-zoomed",
+    );
   });
 
   it("supports keyboard navigation without stealing keys from video controls", async () => {

--- a/desktop/src/mobile/MobileGalleryViewer.vue
+++ b/desktop/src/mobile/MobileGalleryViewer.vue
@@ -69,6 +69,16 @@ import {
   type MobileCollectionCard,
   type MobileGalleryImage,
 } from "./libraryOrganization";
+import {
+  beginViewerImageZoom,
+  constrainViewerImageZoom,
+  createViewerImageZoom,
+  endViewerImageZoom,
+  moveViewerImageZoom,
+  resetViewerImageZoom,
+  viewerImageIsZoomed,
+  type ViewerImageZoomMetrics,
+} from "./imageViewerZoom";
 
 const props = withDefaults(
   defineProps<{
@@ -635,10 +645,128 @@ let activeMedia: MediaLoad | null = null;
 let gesturePointerId: number | null = null;
 let gestureStartX = 0;
 let gestureStartY = 0;
+const imageViewport = ref<HTMLElement | null>(null);
+const viewerImage = ref<HTMLImageElement | null>(null);
+const imageZoom = createViewerImageZoom();
+const imageZoomScale = ref(imageZoom.scale);
+const imageZoomX = ref(imageZoom.x);
+const imageZoomY = ref(imageZoom.y);
+const imageZoomActive = ref(false);
+const imageZoomed = computed(() => imageZoomScale.value > 1.001);
+const imageZoomStyle = computed(() => ({
+  transform: `translate3d(${imageZoomX.value}px, ${imageZoomY.value}px, 0) scale(${imageZoomScale.value})`,
+}));
 
 const SWIPE_DISTANCE = 48;
 const HORIZONTAL_INTENT_RATIO = 1.25;
 const VIDEO_CONTROL_STRIP_HEIGHT = 64;
+
+function syncImageZoom(): void {
+  imageZoomScale.value = imageZoom.scale;
+  imageZoomX.value = imageZoom.x;
+  imageZoomY.value = imageZoom.y;
+}
+
+function resetImageZoom(): void {
+  resetViewerImageZoom(imageZoom);
+  imageZoomActive.value = false;
+  syncImageZoom();
+}
+
+/** Measure the contained bitmap, not its full-width object-fit element. */
+function imageZoomMetrics(): ViewerImageZoomMetrics {
+  const viewport = imageViewport.value;
+  const bounds = viewport?.getBoundingClientRect();
+  const viewportWidth = bounds?.width || viewport?.clientWidth || 1;
+  const viewportHeight = bounds?.height || viewport?.clientHeight || 1;
+  const naturalWidth =
+    viewerImage.value?.naturalWidth || props.item.metadata.width || viewportWidth;
+  const naturalHeight =
+    viewerImage.value?.naturalHeight || props.item.metadata.height || viewportHeight;
+  const fit = Math.min(viewportWidth / naturalWidth, viewportHeight / naturalHeight);
+  return {
+    left: bounds?.left ?? 0,
+    top: bounds?.top ?? 0,
+    viewportWidth,
+    viewportHeight,
+    mediaWidth: naturalWidth * fit,
+    mediaHeight: naturalHeight * fit,
+  };
+}
+
+function constrainImageZoomToViewport(): void {
+  if (!viewerImageIsZoomed(imageZoom)) return;
+  if (constrainViewerImageZoom(imageZoom, imageZoomMetrics())) syncImageZoom();
+}
+
+function beginImageGesture(event: PointerEvent): boolean {
+  if (
+    video.value ||
+    audio.value ||
+    mesh.value ||
+    event.pointerType === "mouse" ||
+    isSwipeBlockingControl(event.target)
+  ) {
+    return false;
+  }
+  const result = beginViewerImageZoom(imageZoom, event);
+  if (!result.tracked) return result.consumed;
+  try {
+    imageViewport.value?.setPointerCapture?.(event.pointerId);
+  } catch {
+    // Window capture below keeps the gesture alive on older WebViews.
+  }
+  imageZoomActive.value = imageZoom.points.size > 1 || viewerImageIsZoomed(imageZoom);
+  if (result.consumed && event.cancelable) event.preventDefault();
+  return result.consumed;
+}
+
+function trackImageGesture(event: PointerEvent): boolean {
+  const result = moveViewerImageZoom(imageZoom, event, imageZoomMetrics());
+  if (!result.tracked) return false;
+  imageZoomActive.value = result.consumed;
+  if (result.changed) syncImageZoom();
+  if (result.consumed && event.cancelable) event.preventDefault();
+  return result.consumed;
+}
+
+function finishImageGesture(event: PointerEvent): boolean {
+  const result = endViewerImageZoom(imageZoom, event.pointerId);
+  if (!result.tracked) return false;
+  imageZoomActive.value = imageZoom.points.size > 0 && result.consumed;
+  if (result.consumed && event.cancelable) event.preventDefault();
+  return result.consumed;
+}
+
+function beginViewerGesture(event: PointerEvent): void {
+  if (beginImageGesture(event)) {
+    cancelSwipe();
+    return;
+  }
+  beginSwipe(event);
+}
+
+function trackViewerGesture(event: PointerEvent): void {
+  if (trackImageGesture(event)) {
+    cancelSwipe();
+    return;
+  }
+  trackSwipe(event);
+}
+
+function finishViewerGesture(event: PointerEvent): void {
+  if (finishImageGesture(event)) {
+    cancelSwipe();
+    return;
+  }
+  finishSwipe(event);
+}
+
+function cancelViewerGesture(event?: PointerEvent): void {
+  if (event) finishImageGesture(event);
+  else resetImageZoom();
+  cancelSwipe(event);
+}
 
 interface MediaLoad {
   path: string;
@@ -873,6 +1001,7 @@ watch(
   () => {
     collapseSheet();
     resetSheetDrag();
+    resetImageZoom();
     // The next print's details start at the top, not at this one's offset.
     if (sheetBody.value) sheetBody.value.scrollTop = 0;
     actionStatus.value = "";
@@ -1174,9 +1303,11 @@ onMounted(() => {
   // window capture boundary so image -> video -> image navigation cannot be
   // stranded by a media element, while the excluded control strip still gets
   // ordinary taps and scrubbing gestures.
-  window.addEventListener("pointermove", trackSwipe, { capture: true, passive: false });
-  window.addEventListener("pointerup", finishSwipe, true);
-  window.addEventListener("pointercancel", cancelSwipe, true);
+  window.addEventListener("pointermove", trackViewerGesture, { capture: true, passive: false });
+  window.addEventListener("pointerup", finishViewerGesture, true);
+  window.addEventListener("pointercancel", cancelViewerGesture, true);
+  window.addEventListener("resize", constrainImageZoomToViewport);
+  window.visualViewport?.addEventListener("resize", constrainImageZoomToViewport);
   restoreFocusElement = document.activeElement as HTMLElement | null;
   try {
     dialog.value?.showModal();
@@ -1189,10 +1320,12 @@ onMounted(() => {
 
 onBeforeUnmount(() => {
   mounted = false;
-  window.removeEventListener("pointermove", trackSwipe, true);
-  window.removeEventListener("pointerup", finishSwipe, true);
-  window.removeEventListener("pointercancel", cancelSwipe, true);
-  cancelSwipe();
+  window.removeEventListener("pointermove", trackViewerGesture, true);
+  window.removeEventListener("pointerup", finishViewerGesture, true);
+  window.removeEventListener("pointercancel", cancelViewerGesture, true);
+  window.removeEventListener("resize", constrainImageZoomToViewport);
+  window.visualViewport?.removeEventListener("resize", constrainImageZoomToViewport);
+  cancelViewerGesture();
   loadEpoch += 1;
   if (dialog.value?.open && typeof dialog.value.close === "function") dialog.value.close();
   evictLoad(activeMedia);
@@ -1244,14 +1377,46 @@ onBeforeUnmount(() => {
 
     <div
       class="gallery-viewer-stage"
+      :class="{ 'is-image-zoomed': imageZoomed }"
       data-test="gallery-viewer-stage"
-      @pointerdown.capture="beginSwipe"
-      @pointermove="trackSwipe"
-      @pointerup="finishSwipe"
-      @pointercancel="cancelSwipe"
+      @pointerdown.capture="beginViewerGesture"
     >
+      <div
+        v-if="!video && !audio && !mesh"
+        ref="imageViewport"
+        class="gallery-viewer-image-viewport"
+        data-test="gallery-viewer-image-viewport"
+      >
+        <div
+          class="gallery-viewer-image-transform"
+          :class="{ 'is-gesturing': imageZoomActive }"
+          :style="imageZoomStyle"
+          data-test="gallery-viewer-image-transform"
+        >
+          <img
+            v-if="!mediaUrl"
+            class="gallery-viewer-placeholder"
+            :src="thumbnailUrl"
+            alt=""
+            aria-hidden="true"
+            draggable="false"
+          />
+          <img
+            v-else
+            :key="mediaLoadKey"
+            ref="viewerImage"
+            class="gallery-viewer-media"
+            :src="mediaUrl"
+            :alt="item.metadata.prompt || item.filename"
+            data-test="gallery-viewer-image"
+            draggable="false"
+            @load="mediaReady"
+            @error="mediaFailed"
+          />
+        </div>
+      </div>
       <img
-        v-if="!mediaUrl"
+        v-else-if="!mediaUrl"
         class="gallery-viewer-placeholder"
         :src="thumbnailUrl"
         alt=""
@@ -1298,17 +1463,6 @@ onBeforeUnmount(() => {
         preload="metadata"
         data-test="gallery-viewer-video"
         @loadedmetadata="mediaReady"
-        @error="mediaFailed"
-      />
-      <img
-        v-else
-        :key="mediaLoadKey"
-        class="gallery-viewer-media"
-        :src="mediaUrl"
-        :alt="item.metadata.prompt || item.filename"
-        data-test="gallery-viewer-image"
-        draggable="false"
-        @load="mediaReady"
         @error="mediaFailed"
       />
       <span v-if="upscaled" data-test="upscaled-badge" class="gallery-upscaled-badge">

--- a/desktop/src/mobile/imageViewerZoom.test.ts
+++ b/desktop/src/mobile/imageViewerZoom.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it } from "vitest";
+import {
+  VIEWER_IMAGE_ZOOM_MAX,
+  beginViewerImageZoom,
+  constrainViewerImageZoom,
+  createViewerImageZoom,
+  endViewerImageZoom,
+  moveViewerImageZoom,
+  resetViewerImageZoom,
+  viewerImageIsZoomed,
+  type ViewerImageZoomMetrics,
+} from "./imageViewerZoom";
+
+const square: ViewerImageZoomMetrics = {
+  left: 0,
+  top: 0,
+  viewportWidth: 400,
+  viewportHeight: 400,
+  mediaWidth: 400,
+  mediaHeight: 400,
+};
+
+describe("full-screen image pinch zoom", () => {
+  let state: ReturnType<typeof createViewerImageZoom>;
+
+  beforeEach(() => {
+    state = createViewerImageZoom();
+  });
+
+  function down(pointerId: number, x: number, y: number) {
+    return beginViewerImageZoom(state, { pointerId, clientX: x, clientY: y });
+  }
+
+  function move(pointerId: number, x: number, y: number) {
+    return moveViewerImageZoom(state, { pointerId, clientX: x, clientY: y }, square);
+  }
+
+  it("leaves one-finger movement at 1x available to gallery navigation", () => {
+    expect(down(1, 300, 200).consumed).toBe(false);
+    expect(move(1, 180, 205).consumed).toBe(false);
+    expect(endViewerImageZoom(state, 1).consumed).toBe(false);
+    expect(state.scale).toBe(1);
+  });
+
+  it("zooms around the fingers instead of jumping toward the viewport center", () => {
+    down(1, 250, 200);
+    down(2, 350, 200);
+
+    move(2, 450, 200);
+
+    expect(state.scale).toBeCloseTo(2);
+    // The original midpoint was 100px right of center. At 2x that pixel sits
+    // 200px right of center, so keeping it under the new 150px offset requires
+    // a 50px leftward translation.
+    expect(state.x).toBeCloseTo(-50);
+    expect(state.y).toBeCloseTo(0);
+    expect(viewerImageIsZoomed(state)).toBe(true);
+  });
+
+  it("pans a zoomed image and clamps blank space away", () => {
+    down(1, 150, 200);
+    down(2, 250, 200);
+    move(2, 350, 200); // 2x
+    endViewerImageZoom(state, 2);
+
+    move(1, 1000, 900);
+
+    expect(state.x).toBe(200);
+    expect(state.y).toBe(200);
+    expect(endViewerImageZoom(state, 1).consumed).toBe(true);
+  });
+
+  it("locks an axis until a contained portrait image grows past that viewport edge", () => {
+    const portrait = { ...square, mediaWidth: 200, mediaHeight: 400 };
+    down(1, 150, 200);
+    down(2, 250, 200);
+    moveViewerImageZoom(state, { pointerId: 2, clientX: 350, clientY: 200 }, portrait);
+    expect(state.scale).toBeCloseTo(2);
+    expect(state.x).toBe(0);
+
+    endViewerImageZoom(state, 2);
+    moveViewerImageZoom(state, { pointerId: 1, clientX: 250, clientY: 260 }, portrait);
+    expect(state.x).toBe(0);
+    expect(state.y).toBe(60);
+  });
+
+  it("caps magnification and keeps the whole pinch sequence out of paging", () => {
+    down(1, 190, 200);
+    down(2, 210, 200);
+    expect(move(2, 2000, 200).consumed).toBe(true);
+    expect(state.scale).toBe(VIEWER_IMAGE_ZOOM_MAX);
+
+    expect(endViewerImageZoom(state, 2).consumed).toBe(true);
+    expect(endViewerImageZoom(state, 1).consumed).toBe(true);
+  });
+
+  it("returns exactly to home when the pinch closes back to 1x", () => {
+    down(1, 100, 200);
+    down(2, 300, 200);
+    move(2, 380, 240);
+    expect(state.scale).toBeGreaterThan(1);
+
+    move(2, 300, 200);
+
+    expect(state.scale).toBe(1);
+    expect(state.x).toBe(0);
+    expect(state.y).toBe(0);
+    expect(endViewerImageZoom(state, 2).consumed).toBe(true);
+    expect(endViewerImageZoom(state, 1).consumed).toBe(true);
+  });
+
+  it("re-clamps a retained pan when rotation changes the fitted image bounds", () => {
+    down(1, 150, 200);
+    down(2, 250, 200);
+    move(2, 350, 200);
+    endViewerImageZoom(state, 2);
+    move(1, 40, 200);
+    expect(state.x).not.toBe(0);
+
+    const landscape = { ...square, viewportWidth: 800, mediaWidth: 400 };
+    expect(constrainViewerImageZoom(state, landscape)).toBe(true);
+    expect(state.x).toBe(0);
+    expect(state.scale).toBeCloseTo(2);
+  });
+
+  it("resets scale, translation, pointers, and gesture ownership for a new print", () => {
+    down(1, 150, 200);
+    down(2, 250, 200);
+    move(2, 350, 200);
+
+    resetViewerImageZoom(state);
+
+    expect(state).toMatchObject({ scale: 1, x: 0, y: 0, ownsSequence: false });
+    expect(state.points.size).toBe(0);
+    expect(down(3, 300, 200).consumed).toBe(false);
+  });
+});

--- a/desktop/src/mobile/imageViewerZoom.ts
+++ b/desktop/src/mobile/imageViewerZoom.ts
@@ -1,0 +1,210 @@
+/**
+ * Touch geometry for the full-screen still-image viewer.
+ *
+ * The state is deliberately independent of Vue and the DOM. Both native
+ * shells render the same WebView surface, and keeping the gesture math pure
+ * lets iOS and Android exercise the exact same focal zoom and pan contract.
+ */
+export const VIEWER_IMAGE_ZOOM_MIN = 1;
+export const VIEWER_IMAGE_ZOOM_MAX = 5;
+
+export interface ViewerImageZoomPoint {
+  pointerId: number;
+  clientX: number;
+  clientY: number;
+}
+
+export interface ViewerImageZoomMetrics {
+  left: number;
+  top: number;
+  viewportWidth: number;
+  viewportHeight: number;
+  /** The contained image's rendered dimensions at 1x. */
+  mediaWidth: number;
+  mediaHeight: number;
+}
+
+export interface ViewerImageZoomState {
+  points: Map<number, { x: number; y: number }>;
+  scale: number;
+  x: number;
+  y: number;
+  baselineScale: number;
+  baselineX: number;
+  baselineY: number;
+  baselineDistance: number;
+  baselineCenterX: number;
+  baselineCenterY: number;
+  singleStartX: number;
+  singleStartY: number;
+  /** Once two fingers land, no remaining pointer may become a gallery swipe. */
+  ownsSequence: boolean;
+}
+
+export interface ViewerImageZoomResult {
+  tracked: boolean;
+  consumed: boolean;
+  changed: boolean;
+}
+
+export function createViewerImageZoom(): ViewerImageZoomState {
+  return {
+    points: new Map(),
+    scale: VIEWER_IMAGE_ZOOM_MIN,
+    x: 0,
+    y: 0,
+    baselineScale: VIEWER_IMAGE_ZOOM_MIN,
+    baselineX: 0,
+    baselineY: 0,
+    baselineDistance: 0,
+    baselineCenterX: 0,
+    baselineCenterY: 0,
+    singleStartX: 0,
+    singleStartY: 0,
+    ownsSequence: false,
+  };
+}
+
+export function viewerImageIsZoomed(state: ViewerImageZoomState): boolean {
+  return state.scale > VIEWER_IMAGE_ZOOM_MIN + 0.001;
+}
+
+function pair(state: ViewerImageZoomState) {
+  const [first, second] = [...state.points.values()];
+  if (!first || !second) return null;
+  const centerX = (first.x + second.x) / 2;
+  const centerY = (first.y + second.y) / 2;
+  return {
+    centerX,
+    centerY,
+    distance: Math.hypot(second.x - first.x, second.y - first.y),
+  };
+}
+
+function rebaseline(state: ViewerImageZoomState): void {
+  state.baselineScale = state.scale;
+  state.baselineX = state.x;
+  state.baselineY = state.y;
+  const currentPair = pair(state);
+  state.baselineDistance = currentPair?.distance ?? 0;
+  state.baselineCenterX = currentPair?.centerX ?? 0;
+  state.baselineCenterY = currentPair?.centerY ?? 0;
+  const single = state.points.size === 1 ? [...state.points.values()][0] : null;
+  state.singleStartX = single?.x ?? 0;
+  state.singleStartY = single?.y ?? 0;
+}
+
+function clampTranslation(state: ViewerImageZoomState, metrics: ViewerImageZoomMetrics): void {
+  const maxX = Math.max(0, (metrics.mediaWidth * state.scale - metrics.viewportWidth) / 2);
+  const maxY = Math.max(0, (metrics.mediaHeight * state.scale - metrics.viewportHeight) / 2);
+  state.x = maxX === 0 ? 0 : Math.max(-maxX, Math.min(maxX, state.x));
+  state.y = maxY === 0 ? 0 : Math.max(-maxY, Math.min(maxY, state.y));
+}
+
+/** Reconcile a retained zoom after rotation or another viewport resize. */
+export function constrainViewerImageZoom(
+  state: ViewerImageZoomState,
+  metrics: ViewerImageZoomMetrics,
+): boolean {
+  const priorX = state.x;
+  const priorY = state.y;
+  clampTranslation(state, metrics);
+  return priorX !== state.x || priorY !== state.y;
+}
+
+export function beginViewerImageZoom(
+  state: ViewerImageZoomState,
+  point: ViewerImageZoomPoint,
+): ViewerImageZoomResult {
+  if (state.points.size >= 2 || state.points.has(point.pointerId)) {
+    return { tracked: false, consumed: state.ownsSequence, changed: false };
+  }
+  state.points.set(point.pointerId, { x: point.clientX, y: point.clientY });
+  if (state.points.size === 2 || viewerImageIsZoomed(state)) state.ownsSequence = true;
+  rebaseline(state);
+  return {
+    tracked: true,
+    consumed: state.ownsSequence,
+    changed: false,
+  };
+}
+
+export function moveViewerImageZoom(
+  state: ViewerImageZoomState,
+  point: ViewerImageZoomPoint,
+  metrics: ViewerImageZoomMetrics,
+): ViewerImageZoomResult {
+  const tracked = state.points.get(point.pointerId);
+  if (!tracked) return { tracked: false, consumed: false, changed: false };
+  tracked.x = point.clientX;
+  tracked.y = point.clientY;
+
+  if (state.points.size === 2) {
+    state.ownsSequence = true;
+    const current = pair(state);
+    if (!current || current.distance <= 0) {
+      rebaseline(state);
+      return { tracked: true, consumed: true, changed: false };
+    }
+    if (state.baselineDistance <= 0) {
+      rebaseline(state);
+      return { tracked: true, consumed: true, changed: false };
+    }
+
+    const nextScale = Math.max(
+      VIEWER_IMAGE_ZOOM_MIN,
+      Math.min(
+        VIEWER_IMAGE_ZOOM_MAX,
+        state.baselineScale * (current.distance / state.baselineDistance),
+      ),
+    );
+    const viewportCenterX = metrics.left + metrics.viewportWidth / 2;
+    const viewportCenterY = metrics.top + metrics.viewportHeight / 2;
+    // The pixel under the original midpoint stays under the moving midpoint.
+    const contentX =
+      (state.baselineCenterX - viewportCenterX - state.baselineX) / state.baselineScale;
+    const contentY =
+      (state.baselineCenterY - viewportCenterY - state.baselineY) / state.baselineScale;
+    state.scale = nextScale;
+    state.x = current.centerX - viewportCenterX - contentX * nextScale;
+    state.y = current.centerY - viewportCenterY - contentY * nextScale;
+    clampTranslation(state, metrics);
+    if (!viewerImageIsZoomed(state)) {
+      state.scale = VIEWER_IMAGE_ZOOM_MIN;
+      state.x = 0;
+      state.y = 0;
+    }
+    return { tracked: true, consumed: true, changed: true };
+  }
+
+  if (viewerImageIsZoomed(state)) {
+    state.ownsSequence = true;
+    state.x = state.baselineX + point.clientX - state.singleStartX;
+    state.y = state.baselineY + point.clientY - state.singleStartY;
+    clampTranslation(state, metrics);
+    return { tracked: true, consumed: true, changed: true };
+  }
+  return { tracked: true, consumed: state.ownsSequence, changed: false };
+}
+
+export function endViewerImageZoom(
+  state: ViewerImageZoomState,
+  pointerId: number,
+): ViewerImageZoomResult {
+  if (!state.points.delete(pointerId)) {
+    return { tracked: false, consumed: false, changed: false };
+  }
+  const consumed = state.ownsSequence || viewerImageIsZoomed(state);
+  rebaseline(state);
+  if (state.points.size === 0) state.ownsSequence = false;
+  return { tracked: true, consumed, changed: false };
+}
+
+export function resetViewerImageZoom(state: ViewerImageZoomState): void {
+  state.points.clear();
+  state.scale = VIEWER_IMAGE_ZOOM_MIN;
+  state.x = 0;
+  state.y = 0;
+  state.ownsSequence = false;
+  rebaseline(state);
+}

--- a/desktop/src/mobile/mobile.css
+++ b/desktop/src/mobile/mobile.css
@@ -3055,6 +3055,31 @@ button:disabled {
   object-fit: contain;
 }
 
+/* Still images own two-finger gestures in both native WebViews. The outer
+   viewport never moves; the inner plane tracks the fingers and is clipped to
+   the same stage that already contains the unzoomed print. */
+.gallery-viewer-image-viewport,
+.gallery-viewer-image-transform {
+  width: 100%;
+  min-width: 0;
+  height: 100%;
+}
+
+.gallery-viewer-image-viewport {
+  overflow: hidden;
+  touch-action: none;
+}
+
+.gallery-viewer-image-transform {
+  transform-origin: center;
+  will-change: transform;
+}
+
+.gallery-viewer-stage.is-image-zoomed .gallery-viewer-nav {
+  pointer-events: none;
+  opacity: 0;
+}
+
 .gallery-viewer-placeholder {
   filter: brightness(0.55);
 }

--- a/desktop/src/mobile/mobile.css.test.ts
+++ b/desktop/src/mobile/mobile.css.test.ts
@@ -550,6 +550,21 @@ describe("mobile gallery viewer", () => {
     expect(media?.[1]).toMatch(/max-width:\s*100%\s*;/);
   });
 
+  it("keeps still-image pinch zoom inside a dedicated clipped touch surface", () => {
+    const viewport = css.match(/\.gallery-viewer-image-viewport\s*\{([^}]*)\}/s);
+    const transforms = [
+      ...css.matchAll(/(?:^|\n)\.gallery-viewer-image-transform\s*\{([^}]*)\}/gs),
+    ];
+    const transform = transforms.at(-1);
+    const zoomedNav = css.match(
+      /\.gallery-viewer-stage\.is-image-zoomed \.gallery-viewer-nav\s*\{([^}]*)\}/s,
+    );
+    expect(viewport?.[1]).toMatch(/overflow:\s*hidden\s*;/);
+    expect(viewport?.[1]).toMatch(/touch-action:\s*none\s*;/);
+    expect(transform?.[1]).toMatch(/transform-origin:\s*center\s*;/);
+    expect(zoomedNav?.[1]).toMatch(/pointer-events:\s*none\s*;/);
+  });
+
   /**
    * The media is the page: the stage is the whole dialog, the header floats
    * over its top edge, and the details sheet is parked below the bottom one

--- a/website/guide/iphone.md
+++ b/website/guide/iphone.md
@@ -267,6 +267,9 @@ partial cleanup.
 Tap a tile to open the full-screen viewer:
 
 - images are shown uncropped;
+- pinch an image with two fingers to zoom around the point between them, then
+  drag with one finger to inspect it; pinching back to the original size
+  restores the left/right gallery swipe;
 - generated images open this same viewer when tapped;
 - videos stream from their owning host with native playback and seeking;
 - **Upscale…** enlarges an image, while **Framewise upscale…** queues a durable


### PR DESCRIPTION
## Summary
- add focal two-finger pinch zoom up to 5× for full-screen still images on the shared iOS/Android mobile surface
- pan zoomed images within their rendered bounds while preserving 1× gallery swipes and existing video/audio/mesh gestures
- reset/re-clamp zoom across print changes and viewport rotation, with mobile docs and release notes

## Validation
- `nix develop -c bash -lc 'cd desktop && bun run test'` (506 files, 6,812 tests)\n- `bun run build:mobile`\n- `bun run check:architecture`\n- `./scripts/ci-local.sh docs`\n- iOS release assets, TestFlight distribution, and simulator-pick contract scripts\n- rendered 390×844 mobile UAT with clean console\n- independent GPT-5.6 Sol medium peer review approved the corrected diff\n\n## Residual risk\n- physical-device two-finger UAT remains for iOS WKWebView and Android WebView; CI exercises both native packaging paths.