### PR TITLE
fix(scheduler): preserve chains across shutdown

### DIFF
--- a/changelog.d/scheduler-shutdown-chain-recovery.md
+++ b/changelog.d/scheduler-shutdown-chain-recovery.md
@@ -1,0 +1,4 @@
+- **Long Wan clips now survive a machine restart.** The multi-GPU scheduler
+  keeps ownership of active clip leases while GPU workers stop, so an
+  interrupted auto-chained video is parked for Resume instead of being marked
+  failed and swept as temporary work.

--- a/crates/mold-server/src/chain_job_runner.rs
+++ b/crates/mold-server/src/chain_job_runner.rs
@@ -220,6 +220,44 @@ pub struct StageExecution {
     pub device_ordinal: Option<usize>,
 }
 
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum StageExecutionError {
+    Failed(String),
+    SchedulerStopped,
+}
+
+impl StageExecutionError {
+    #[cfg(test)]
+    pub(crate) fn contains(&self, needle: &str) -> bool {
+        match self {
+            Self::Failed(error) => error.contains(needle),
+            Self::SchedulerStopped => {
+                "scheduler coordinator stopped before settling the chain-stage lease"
+                    .contains(needle)
+            }
+        }
+    }
+}
+
+impl std::fmt::Display for StageExecutionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Failed(error) => f.write_str(error),
+            Self::SchedulerStopped => {
+                f.write_str("scheduler coordinator stopped before settling the chain-stage lease")
+            }
+        }
+    }
+}
+
+impl std::error::Error for StageExecutionError {}
+
+impl From<String> for StageExecutionError {
+    fn from(error: String) -> Self {
+        Self::Failed(error)
+    }
+}
+
 /// Fully-owned chain stage payload transported only by a scheduler lease.
 /// The optional plan is chosen from the exact per-device candidates during
 /// grant construction and validated again on the owner thread before CUDA.
@@ -240,7 +278,8 @@ pub struct ScheduledChainStageWork {
     pub on_leased: Option<ChainLeaseCallback>,
     pub execution_plan: Option<crate::execution_plan::ResolvedExecutionPlan>,
     pub expected_model_fingerprint: Option<String>,
-    pub result_tx: Option<tokio::sync::oneshot::Sender<Result<StageExecution, String>>>,
+    pub result_tx:
+        Option<tokio::sync::oneshot::Sender<Result<StageExecution, StageExecutionError>>>,
     #[cfg(test)]
     pub before_second_fence: Option<Box<dyn FnOnce() + Send>>,
 }
@@ -527,6 +566,105 @@ impl ChainJobRunnerHandle {
         self.events
             .publish_then_remove(job_id, ChainJobEvent::StateChanged { state, error });
         self.cancel.unregister(job_id);
+    }
+
+    /// Resolve chain attempts whose scheduler leases outlived the bounded
+    /// owner drain. This runs before the coordinator releases the deferred
+    /// result senders, so durable state never remains `Running` between the
+    /// coordinator exit and the actor observing its closed lease.
+    pub async fn settle_scheduler_drain_deadline(
+        &self,
+        db: &MetadataDb,
+        job_ids: impl IntoIterator<Item = String>,
+        fatal_cuda: bool,
+    ) {
+        let lock_deadline = tokio::time::Instant::now() + Duration::from_secs(3);
+        for job_id in job_ids {
+            let Ok(_guard) = tokio::time::timeout_at(lock_deadline, self.lock_job(&job_id)).await
+            else {
+                tracing::error!(%job_id, "chain mutation lock exceeded scheduler drain settlement budget");
+                continue;
+            };
+            let result = (|| -> anyhow::Result<()> {
+                let Some(row) = chain_jobs::get_job(db, &job_id)? else {
+                    return Ok(());
+                };
+                if row.state != ChainJobState::Running {
+                    return Ok(());
+                }
+                let mut manifest = ChainJobManifest::read_from_dir(&row.job_dir)?;
+                let now = now_ms_i64();
+                if fatal_cuda {
+                    let error = "CUDA context is fatally poisoned; server restart required";
+                    if let Some(stage_idx) = manifest
+                        .stage_status
+                        .iter()
+                        .find(|stage| stage.state == StageState::Running)
+                        .map(|stage| stage.idx)
+                    {
+                        mark_manifest_stage_failed(
+                            &mut manifest,
+                            &JobDirLayout::new(row.job_dir.clone()),
+                            stage_idx,
+                            error,
+                        )?;
+                        let seed = manifest.stage_status[stage_idx as usize].seed;
+                        chain_jobs::upsert_stage(
+                            db,
+                            &ChainJobStageRow {
+                                job_id: job_id.clone(),
+                                stage_idx,
+                                state: StageState::Failed,
+                                seed,
+                                frames_emitted: None,
+                                generation_time_ms: None,
+                                segment_rel_path: None,
+                                error: Some(error.to_string()),
+                                updated_at_ms: now,
+                            },
+                        )?;
+                    }
+                    if chain_jobs::try_transition(
+                        db,
+                        &job_id,
+                        &[ChainJobState::Running],
+                        ChainJobState::Failed,
+                        Some(error),
+                        now,
+                    )? {
+                        self.publish_settled_state(
+                            &job_id,
+                            ChainJobState::Failed,
+                            Some(error.to_string()),
+                        );
+                    }
+                } else {
+                    reset_running_stages_for_retry(db, &job_id, &row.job_dir, &mut manifest, now)?;
+                    let user_requested = self.cancel.was_user_requested(&job_id);
+                    let target = if user_requested {
+                        ChainJobState::Cancelled
+                    } else {
+                        ChainJobState::Paused
+                    };
+                    let error =
+                        (!user_requested).then_some("server shutdown interrupted chain job");
+                    if chain_jobs::try_transition(
+                        db,
+                        &job_id,
+                        &[ChainJobState::Running],
+                        target,
+                        error,
+                        now,
+                    )? {
+                        self.publish_settled_state(&job_id, target, error.map(str::to_string));
+                    }
+                }
+                Ok(())
+            })();
+            if let Err(error) = result {
+                tracing::error!(%error, %job_id, "failed to settle chain at scheduler drain deadline");
+            }
+        }
     }
 
     /// SSE attach: MUST be called BEFORE snapshot synthesis (buffered
@@ -992,54 +1130,74 @@ async fn run_v2_loop(
     let mut active = HashSet::new();
     let mut tasks = tokio::task::JoinSet::new();
     let mut task_jobs = HashMap::new();
+    let mut shutting_down = false;
 
     loop {
         while let Ok(cmd) = kick_rx.try_recv() {
-            if !handle_runner_cmd(deps.clone(), cmd).await {
-                return;
+            match cmd {
+                RunnerCmd::Shutdown => shutting_down = true,
+                cmd if !shutting_down => {
+                    if !handle_runner_cmd(deps.clone(), cmd).await {
+                        shutting_down = true;
+                    }
+                }
+                RunnerCmd::Gc { reply } => {
+                    let _ = reply.send(Err("chain job runner is shutting down".to_string()));
+                }
+                RunnerCmd::Kick => {}
             }
         }
 
-        if let Some(db) = deps.db.as_ref() {
-            match chain_jobs::jobs_in_state(db, ChainJobState::Queued) {
-                Ok(jobs) => {
-                    for job in jobs {
-                        if active.contains(&job.id) {
-                            continue;
-                        }
-                        match claim_for_execution_async(&deps, &job).await {
-                            Ok(true) => {
-                                let job_id = job.id.clone();
-                                let start_stage = job.current_stage;
-                                active.insert(job_id.clone());
-                                let deps_for_job = deps.clone();
-                                let tracked_job_id = job_id.clone();
-                                let abort = tasks.spawn(async move {
-                                    let result =
-                                        run_chain_actor(deps_for_job, job, start_stage).await;
-                                    (job_id, result)
-                                });
-                                task_jobs.insert(abort.id(), tracked_job_id);
+        if !shutting_down {
+            if let Some(db) = deps.db.as_ref() {
+                match chain_jobs::jobs_in_state(db, ChainJobState::Queued) {
+                    Ok(jobs) => {
+                        for job in jobs {
+                            if active.contains(&job.id) {
+                                continue;
                             }
-                            Ok(false) => {}
-                            Err(error) => {
-                                tracing::warn!(
-                                    job_id = %job.id,
-                                    "chain job V2 claim failed: {error:#}"
-                                );
+                            match claim_for_execution_async(&deps, &job).await {
+                                Ok(true) => {
+                                    let job_id = job.id.clone();
+                                    let start_stage = job.current_stage;
+                                    active.insert(job_id.clone());
+                                    let deps_for_job = deps.clone();
+                                    let tracked_job_id = job_id.clone();
+                                    let abort = tasks.spawn(async move {
+                                        let result =
+                                            run_chain_actor(deps_for_job, job, start_stage).await;
+                                        (job_id, result)
+                                    });
+                                    task_jobs.insert(abort.id(), tracked_job_id);
+                                }
+                                Ok(false) => {}
+                                Err(error) => {
+                                    tracing::warn!(
+                                        job_id = %job.id,
+                                        "chain job V2 claim failed: {error:#}"
+                                    );
+                                }
                             }
                         }
                     }
+                    Err(error) => tracing::warn!("chain-job V2 queued lookup failed: {error:#}"),
                 }
-                Err(error) => tracing::warn!("chain-job V2 queued lookup failed: {error:#}"),
             }
         }
 
+        if shutting_down && tasks.is_empty() {
+            break;
+        }
+
         tokio::select! {
-            maybe_cmd = kick_rx.recv() => {
-                let Some(cmd) = maybe_cmd else { break };
-                if !handle_runner_cmd(deps.clone(), cmd).await {
-                    break;
+            maybe_cmd = kick_rx.recv(), if !shutting_down => {
+                match maybe_cmd {
+                    Some(RunnerCmd::Shutdown) | None => shutting_down = true,
+                    Some(cmd) => {
+                        if !handle_runner_cmd(deps.clone(), cmd).await {
+                            shutting_down = true;
+                        }
+                    }
                 }
             }
             joined = tasks.join_next_with_id(), if !tasks.is_empty() => {
@@ -1062,7 +1220,7 @@ async fn run_v2_loop(
                 // parent ready without a route kick.
                 tokio::task::yield_now().await;
             }
-            _ = daily.tick() => {
+            _ = daily.tick(), if !shutting_down => {
                 if let Err(error) = run_gc_for_runner(deps.clone(), false).await {
                     tracing::warn!("daily chain job GC failed: {error}");
                 }
@@ -1479,6 +1637,18 @@ fn execute_job_inner(
             ) {
                 Ok(execution) => execution,
                 Err(err) => {
+                    // The scheduler remains the deferred-result authority
+                    // while its leases drain. If that bounded drain expires,
+                    // dropping the authority wakes this actor with an error;
+                    // a shutdown cancellation still makes the attempt a
+                    // resumable interruption, never a failed render.
+                    if err.downcast_ref::<StageExecutionError>()
+                        == Some(&StageExecutionError::SchedulerStopped)
+                    {
+                        set_cancelled(db, deps, &job.id)?;
+                        terminal = true;
+                        return Ok(());
+                    }
                     let error = format!("{err:#}");
                     {
                         let _guard = deps.job_locks.blocking_lock(&job.id);
@@ -2929,6 +3099,8 @@ pub struct ProductionStageExecutor {
     config: Arc<tokio::sync::RwLock<mold_core::Config>>,
     scheduled_work: crate::scheduler::ScheduledWorkHandle,
     dispatch_mode: crate::dispatch_mode::DispatchMode,
+    #[cfg(test)]
+    before_scheduled_submit: Mutex<Option<Box<dyn FnOnce() + Send>>>,
 }
 
 impl ProductionStageExecutor {
@@ -2943,6 +3115,8 @@ impl ProductionStageExecutor {
             config,
             scheduled_work,
             dispatch_mode,
+            #[cfg(test)]
+            before_scheduled_submit: Mutex::new(None),
         }
     }
 
@@ -3206,7 +3380,7 @@ impl StageExecutor for ProductionStageExecutor {
                 carry: carry.cloned(),
                 motion_tail_frames,
                 progress,
-                cancelled,
+                cancelled: cancelled.clone(),
                 cancellation,
                 on_leased,
                 execution_plan: None,
@@ -3219,14 +3393,40 @@ impl StageExecutor for ProductionStageExecutor {
         .with_preferred_ordinal(preferred_ordinal);
         let handle = tokio::runtime::Handle::try_current()
             .map_err(|_| anyhow!("V2 chain stage submission requires a Tokio runtime"))?;
-        handle
-            .block_on(self.scheduled_work.submit(work))
-            .map_err(anyhow::Error::msg)?;
-        result_rx
-            .blocking_recv()
-            .map_err(|_| anyhow!("scheduled chain stage owner dropped its result"))?
-            .map_err(anyhow::Error::msg)
+        #[cfg(test)]
+        if let Some(before_submit) = self
+            .before_scheduled_submit
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner())
+            .take()
+        {
+            before_submit();
+        }
+        if let Err(error) = handle.block_on(self.scheduled_work.submit(work)) {
+            let fatal_cuda = self
+                .gpu_pool
+                .workers
+                .iter()
+                .any(|worker| worker.fatal_cuda_error.load(Ordering::SeqCst));
+            if cancelled() && !fatal_cuda {
+                return Err(anyhow::Error::new(StageExecutionError::SchedulerStopped));
+            }
+            return Err(anyhow!(error));
+        }
+        receive_scheduled_stage_result(result_rx)
     }
+}
+
+fn receive_scheduled_stage_result(
+    result_rx: tokio::sync::oneshot::Receiver<Result<StageExecution, StageExecutionError>>,
+) -> anyhow::Result<StageExecution> {
+    result_rx
+        .blocking_recv()
+        // A vanished sender means scheduler authority was released without a
+        // stage verdict. Treat that as the same resumable interruption as the
+        // deferred coordinator completion's Drop path.
+        .map_err(|_| anyhow::Error::new(StageExecutionError::SchedulerStopped))?
+        .map_err(anyhow::Error::new)
 }
 
 pub struct ProductionQueueProbe {
@@ -4440,6 +4640,29 @@ mod tests {
         cancel_on_progress: AtomicBool,
     }
 
+    struct FailingExecutor;
+
+    impl StageExecutor for FailingExecutor {
+        fn freeze_model(
+            &self,
+            model: &str,
+        ) -> anyhow::Result<mold_core::chain_job::FrozenChainModel> {
+            Ok(test_frozen_model(model))
+        }
+
+        fn render_stage(
+            &self,
+            _model: &str,
+            _stage_req: &GenerateRequest,
+            _carry: Option<&ChainTail>,
+            _motion_tail_frames: u32,
+            _progress: &(dyn Fn(u32, u32) -> ControlFlow<()> + Send + Sync),
+            _cancelled: &(dyn Fn() -> bool + Send + Sync),
+        ) -> anyhow::Result<StageRenderOutcome> {
+            Err(anyhow::Error::new(StageExecutionError::SchedulerStopped))
+        }
+    }
+
     impl StageExecutor for FakeExecutor {
         fn freeze_model(
             &self,
@@ -5520,6 +5743,157 @@ mod tests {
             Some("server shutdown interrupted chain job")
         );
         assert!(job_dir.exists());
+    }
+
+    #[test]
+    fn shutdown_error_from_dropped_scheduler_authority_parks_ephemeral_job() {
+        let dir = tempfile::tempdir().unwrap();
+        let db = db();
+        let req = request(vec![TransitionMode::Smooth]);
+        let job_dir = dir.path().join("job");
+        let row = persist_job(
+            &db,
+            &job_dir,
+            "01JBR55DRAINERROR",
+            &req,
+            ChainJobState::Queued,
+        );
+        let mut manifest = ChainJobManifest::read_from_dir(&job_dir).unwrap();
+        manifest.ephemeral = true;
+        manifest.write_atomic(&job_dir).unwrap();
+        let deps = deps(
+            db,
+            dir.path().join("jobs"),
+            Arc::new(FailingExecutor),
+            Arc::new(FakeProbe(AtomicUsize::new(0))),
+        );
+        deps.cancel.request_all();
+
+        execute_job(&deps, &row, 0).unwrap();
+
+        let db = deps.db.as_ref().as_ref().unwrap();
+        let parked = chain_jobs::get_job(db, &row.id).unwrap().unwrap();
+        assert_eq!(parked.state, ChainJobState::Paused);
+        assert_eq!(
+            parked.error.as_deref(),
+            Some("server shutdown interrupted chain job")
+        );
+        startup_reconcile(db, dir.path().join("jobs").as_path()).unwrap();
+        assert_eq!(
+            chain_jobs::get_job(db, &row.id).unwrap().unwrap().state,
+            ChainJobState::Paused,
+            "startup reconciliation must preserve the resumable parent"
+        );
+        assert_eq!(
+            startup_gc_sweep(db, dir.path().join("jobs").as_path())
+                .unwrap()
+                .swept_ephemeral_jobs,
+            0,
+            "a shutdown-interrupted one-shot is resumable work, not GC debris"
+        );
+        assert!(job_dir.exists());
+    }
+
+    #[test]
+    fn dropped_scheduled_stage_sender_is_a_typed_shutdown_interruption() {
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        drop(result_tx);
+
+        let error = match receive_scheduled_stage_result(result_rx) {
+            Ok(_) => panic!("a dropped sender must interrupt the stage"),
+            Err(error) => error,
+        };
+
+        assert_eq!(
+            error.downcast_ref::<StageExecutionError>(),
+            Some(&StageExecutionError::SchedulerStopped)
+        );
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn shutdown_between_chain_cancel_check_and_scheduler_submit_is_typed() {
+        let pool = Arc::new(crate::gpu_pool::GpuPool {
+            workers: vec![].into(),
+        });
+        let (scheduled_tx, scheduled_rx) = tokio::sync::mpsc::channel(1);
+        drop(scheduled_rx);
+        let executor = Arc::new(ProductionStageExecutor::new(
+            pool,
+            Arc::new(tokio::sync::RwLock::new(mold_core::Config::default())),
+            crate::scheduler::ScheduledWorkHandle::new(scheduled_tx),
+            crate::dispatch_mode::DispatchMode::V2,
+        ));
+        let cancelled = Arc::new(AtomicBool::new(false));
+        let cancel_at_submit = cancelled.clone();
+        *executor.before_scheduled_submit.lock().unwrap() = Some(Box::new(move || {
+            cancel_at_submit.store(true, Ordering::SeqCst);
+        }));
+        let req = request(vec![TransitionMode::Smooth]);
+        let stage_req = build_stage_generate_request(&req.stages[0], &req, 42, 0);
+        let cancelled_probe = cancelled.clone();
+
+        let error = tokio::task::spawn_blocking(move || {
+            executor.render_stage_with_context(
+                "shutdown-submit-race",
+                0,
+                &req.model,
+                &stage_req,
+                None,
+                req.motion_tail_frames,
+                None,
+                None,
+                Some("chain:shutdown-submit-race:stage:0"),
+                None,
+                mold_inference::InferenceCancellationToken::default(),
+                Arc::new(|_, _| ControlFlow::Continue(())),
+                Arc::new(move || cancelled_probe.load(Ordering::SeqCst)),
+            )
+        })
+        .await
+        .unwrap()
+        .err()
+        .expect("closed shutdown ingress must interrupt the stage");
+
+        assert_eq!(
+            error.downcast_ref::<StageExecutionError>(),
+            Some(&StageExecutionError::SchedulerStopped)
+        );
+    }
+
+    #[tokio::test]
+    async fn scheduler_drain_deadline_settles_running_chain_before_returning() {
+        for fatal_cuda in [false, true] {
+            let dir = tempfile::tempdir().unwrap();
+            let db = db();
+            let req = request(vec![TransitionMode::Smooth]);
+            let job_id = if fatal_cuda {
+                "01JBR55FATALDEADLINE"
+            } else {
+                "01JBR55SHUTDOWNDEADLINE"
+            };
+            let job_dir = dir.path().join("job");
+            persist_job(&db, &job_dir, job_id, &req, ChainJobState::Running);
+            mark_stage_running(&db, &job_dir, job_id, 0, 42).unwrap();
+            let handle = ChainJobRunnerHandle::inert_for_tests();
+
+            handle
+                .settle_scheduler_drain_deadline(&db, [job_id.to_string()], fatal_cuda)
+                .await;
+
+            let row = chain_jobs::get_job(&db, job_id).unwrap().unwrap();
+            let manifest = ChainJobManifest::read_from_dir(&job_dir).unwrap();
+            if fatal_cuda {
+                assert_eq!(row.state, ChainJobState::Failed);
+                assert_eq!(manifest.stage_status[0].state, StageState::Failed);
+            } else {
+                assert_eq!(row.state, ChainJobState::Paused);
+                assert_eq!(manifest.stage_status[0].state, StageState::Pending);
+                assert_eq!(
+                    row.error.as_deref(),
+                    Some("server shutdown interrupted chain job")
+                );
+            }
+        }
     }
 
     #[test]

--- a/crates/mold-server/src/gpu_pool.rs
+++ b/crates/mold-server/src/gpu_pool.rs
@@ -739,7 +739,9 @@ impl OwnerWork {
             }
             Self::ChainStage(job) => {
                 if let Some(tx) = job.result_tx {
-                    let _ = tx.send(Err(error));
+                    let _ = tx.send(Err(crate::chain_job_runner::StageExecutionError::Failed(
+                        error,
+                    )));
                 }
             }
             Self::PromptExpansion(job) => {

--- a/crates/mold-server/src/gpu_worker.rs
+++ b/crates/mold-server/src/gpu_worker.rs
@@ -794,7 +794,9 @@ fn run_gpu_owner_loop(
                         .map(|tx| DeferredOwnerCompletion::ChainStage {
                             tx: Some(tx),
                             result: Some(chain_result.unwrap_or_else(|| {
-                                Err("chain stage ended without an actor result".to_string())
+                                Err(crate::chain_job_runner::StageExecutionError::Failed(
+                                    "chain stage ended without an actor result".to_string(),
+                                ))
                             })),
                         });
                 let _ = scheduler_tx.send(crate::scheduler::WorkerEvent::Completed {
@@ -837,7 +839,10 @@ fn run_gpu_owner_loop(
                         .map(|tx| DeferredOwnerCompletion::ChainStage {
                             tx: Some(tx),
                             result: Some(Err(
-                                "GPU owner panicked while executing the chain stage".to_string()
+                                crate::chain_job_runner::StageExecutionError::Failed(
+                                    "GPU owner panicked while executing the chain stage"
+                                        .to_string(),
+                                ),
                             )),
                         });
                 let _ = scheduler_tx.send(crate::scheduler::WorkerEvent::Completed {
@@ -1082,9 +1087,19 @@ fn validate_grant_before_acceptance(
 pub enum DeferredOwnerCompletion {
     ChainStage {
         tx: Option<
-            tokio::sync::oneshot::Sender<Result<crate::chain_job_runner::StageExecution, String>>,
+            tokio::sync::oneshot::Sender<
+                Result<
+                    crate::chain_job_runner::StageExecution,
+                    crate::chain_job_runner::StageExecutionError,
+                >,
+            >,
         >,
-        result: Option<Result<crate::chain_job_runner::StageExecution, String>>,
+        result: Option<
+            Result<
+                crate::chain_job_runner::StageExecution,
+                crate::chain_job_runner::StageExecutionError,
+            >,
+        >,
     },
 }
 
@@ -1113,7 +1128,9 @@ impl DeferredOwnerCompletion {
                 let _ = tx
                     .take()
                     .expect("deferred actor completion owns its sender")
-                    .send(Err(error));
+                    .send(Err(crate::chain_job_runner::StageExecutionError::Failed(
+                        error,
+                    )));
             }
         }
     }
@@ -1125,8 +1142,7 @@ impl Drop for DeferredOwnerCompletion {
             Self::ChainStage { tx, .. } => {
                 if let Some(tx) = tx.take() {
                     let _ = tx.send(Err(
-                        "scheduler coordinator stopped before settling the chain-stage lease"
-                            .to_string(),
+                        crate::chain_job_runner::StageExecutionError::SchedulerStopped,
                     ));
                 }
             }
@@ -1141,7 +1157,12 @@ enum OwnerProcessOutcome {
         /// Kept separate from `successful` so the scheduler can record it as
         /// `EstimateOutcome::Invalidated` rather than memory evidence.
         cancelled: bool,
-        chain_result: Option<Result<crate::chain_job_runner::StageExecution, String>>,
+        chain_result: Option<
+            Result<
+                crate::chain_job_runner::StageExecution,
+                crate::chain_job_runner::StageExecutionError,
+            >,
+        >,
     },
     PlanInvalidated {
         grant: Box<LeaseGrant>,
@@ -1193,8 +1214,11 @@ fn process_owner_work(
 ) -> OwnerProcessOutcome {
     if let Err(error) = ensure_owner_thread(worker) {
         let error = error.to_string();
-        let chain_result =
-            matches!(&grant.work, OwnerWork::ChainStage(_)).then(|| Err(error.clone()));
+        let chain_result = matches!(&grant.work, OwnerWork::ChainStage(_)).then(|| {
+            Err(crate::chain_job_runner::StageExecutionError::Failed(
+                error.clone(),
+            ))
+        });
         if chain_result.is_none() {
             grant.work.reject(error);
         }
@@ -1306,7 +1330,9 @@ fn process_owner_work(
             .take()
             .and_then(|on_leased| on_leased(worker.gpu.ordinal).err())
         {
-            let chain_result = Some(Err(error));
+            let chain_result = Some(Err(crate::chain_job_runner::StageExecutionError::Failed(
+                error,
+            )));
             return OwnerProcessOutcome::Completed {
                 successful: false,
                 cancelled: false,
@@ -1716,7 +1742,7 @@ fn chain_stage_failure_message(
 fn process_scheduled_chain_stage(
     worker: &GpuWorker,
     mut job: crate::chain_job_runner::ScheduledChainStageWork,
-) -> Result<crate::chain_job_runner::StageExecution, String> {
+) -> Result<crate::chain_job_runner::StageExecution, crate::chain_job_runner::StageExecutionError> {
     if (job.cancelled)() {
         return Ok(crate::chain_job_runner::StageExecution {
             outcome: crate::chain_job_runner::StageRenderOutcome::Cancelled,

--- a/crates/mold-server/src/scheduler/mod.rs
+++ b/crates/mold-server/src/scheduler/mod.rs
@@ -1675,6 +1675,9 @@ struct Coordinator {
     plan_invalidations: BTreeMap<String, u8>,
     dispatch_retry_round: u8,
     dispatch_retry_not_before_ms: Option<u64>,
+    /// Once set, the coordinator is a settlement drain: it may answer an
+    /// already-issued lease, but it must never create another one.
+    drain_cause: Option<CoordinatorDrainCause>,
     /// Grace before an idle, unschedulable generation is settled. A field so a
     /// test can collapse it — the monotonic clock is near zero early in a
     /// process, so "pretend the observation is old" cannot be expressed by
@@ -1694,6 +1697,21 @@ struct Coordinator {
 enum PlanningPass {
     Admission,
     Optimize,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum CoordinatorDrainCause {
+    Shutdown,
+    FatalCuda,
+}
+
+impl CoordinatorDrainCause {
+    fn message(self) -> &'static str {
+        match self {
+            Self::Shutdown => "generation scheduler is shutting down",
+            Self::FatalCuda => "CUDA context is fatally poisoned; server restart required",
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1784,6 +1802,7 @@ impl Coordinator {
             plan_invalidations: BTreeMap::new(),
             dispatch_retry_round: 0,
             dispatch_retry_not_before_ms: None,
+            drain_cause: None,
             unschedulable_idle_grace_ms: UNSCHEDULABLE_IDLE_GRACE_MS,
             estimates,
             cpu_utility_tx: None,
@@ -2335,6 +2354,14 @@ impl Coordinator {
                 owner_epoch,
                 worker_generation,
             } => {
+                if self.drain_cause.is_some() {
+                    tracing::debug!(
+                        device_id,
+                        ordinal,
+                        "ignoring GPU readiness during shutdown drain"
+                    );
+                    return;
+                }
                 let is_cpu_utility = device_id == CPU_UTILITY_DEVICE_ID;
                 let was_starting =
                     !is_cpu_utility && self.state.gpu_pool.workers.is_starting(&device_id);
@@ -2523,7 +2550,11 @@ impl Coordinator {
                 self.replan_and_publish_with(PlanningPass::Admission);
             }
             WorkerEvent::FollowupReady { work } => {
-                self.enqueue_owner_work(*work, immediate);
+                if let Some(cause) = self.drain_cause {
+                    self.settle_owner_work_for_drain(work.work, cause);
+                } else {
+                    self.enqueue_owner_work(*work, immediate);
+                }
             }
             WorkerEvent::Rejected {
                 device_id,
@@ -2631,6 +2662,13 @@ impl Coordinator {
                     );
                 }
                 let LeaseGrant { work, retry, .. } = *grant;
+                if let Some(cause) = self.drain_cause {
+                    self.plan_invalidations.remove(&work_id);
+                    self.settle_owner_work_for_drain(work, cause);
+                    self.mutate(immediate);
+                    self.replan_and_publish_with(PlanningPass::Admission);
+                    return;
+                }
                 match work {
                     OwnerWork::Generation(job) => {
                         let (generation_job, prepared_inputs) =
@@ -2888,6 +2926,8 @@ impl Coordinator {
                             "GPU owner completion did not match an authoritative scheduler lease"
                                 .to_string(),
                         );
+                    } else if self.drain_cause == Some(CoordinatorDrainCause::Shutdown) {
+                        completion.finish();
                     } else if let Err(error) = publication.as_ref() {
                         completion.fail(format!(
                             "internal scheduler error: could not publish the authoritative \
@@ -2948,7 +2988,7 @@ impl Coordinator {
                     .gpu_pool
                     .workers
                     .wait_and_reap(&device_id, owner_epoch);
-                if removed {
+                if removed && self.drain_cause.is_none() {
                     if self.state.device_registry.desired_enabled(&device_id) {
                         if let Ok(new_epoch) = self.state.gpu_pool.workers.start(&device_id) {
                             self.state
@@ -6767,6 +6807,36 @@ impl Coordinator {
         self.retain_all_unstarted("CUDA context is fatally poisoned; server restart required");
     }
 
+    fn settle_owner_work_for_drain(&self, work: OwnerWork, cause: CoordinatorDrainCause) {
+        match work {
+            OwnerWork::Generation(job) => {
+                let (job, _) = generation_and_prepared_from_gpu_job(*job);
+                retain_generation(&self.state, job, cause.message().to_string());
+            }
+            work @ OwnerWork::ChainStage(_) if cause == CoordinatorDrainCause::Shutdown => {
+                // Shutdown is an interruption, not a failed render. The typed
+                // cancellation lets the chain actor reset the partial stage
+                // and park the durable parent for explicit resume.
+                work.cancel_queued();
+            }
+            work => {
+                reject_owner_work_preserving_completed_generation(work, cause.message().to_string())
+            }
+        }
+    }
+
+    fn settle_all_unstarted_for_drain(&mut self, cause: CoordinatorDrainCause) {
+        let pending = std::mem::take(&mut self.pending);
+        self.plan_invalidations.clear();
+        for (_, pending) in pending {
+            retain_generation(&self.state, pending.job, cause.message().to_string());
+        }
+        let pending_owner_work = std::mem::take(&mut self.pending_owner_work);
+        for (_, pending) in pending_owner_work {
+            self.settle_owner_work_for_drain(pending.work, cause);
+        }
+    }
+
     fn retain_all_unstarted(&mut self, message: &str) {
         let pending = std::mem::take(&mut self.pending);
         self.plan_invalidations.clear();
@@ -6813,6 +6883,8 @@ pub async fn run_scheduler_coordinator(
     let mut generation_ingress_open = true;
     let mut owner_ingress_open = true;
     let mut resource_stream_open = true;
+    let mut worker_stream_open = true;
+    let mut drain_deadline: Option<tokio::time::Instant> = None;
     // The job id rides beside the task so a reclaim whose job was cancelled
     // or dispatched is aborted rather than left flushing the cache.
     let mut host_reclaim: Option<(
@@ -6835,9 +6907,17 @@ pub async fn run_scheduler_coordinator(
                     }
                 }
             }
-            _ = shutdown.cancelled() => {
+            _ = shutdown.cancelled(), if coordinator.drain_cause.is_none() => {
+                let cause = if fatal_cuda_latched(&coordinator) {
+                    fatal = true;
+                    CoordinatorDrainCause::FatalCuda
+                } else {
+                    CoordinatorDrainCause::Shutdown
+                };
+                coordinator.drain_cause = Some(cause);
                 job_rx.close();
                 owner_work_rx.close();
+                preview_rx.close();
                 while let Ok(job) = job_rx.try_recv() {
                     retain_generation(
                         &coordinator.state,
@@ -6846,25 +6926,56 @@ pub async fn run_scheduler_coordinator(
                     );
                 }
                 while let Ok(work) = owner_work_rx.try_recv() {
-                    work.work
-                        .reject("generation scheduler is shutting down".to_string());
+                    coordinator.settle_owner_work_for_drain(
+                        work.work,
+                        cause,
+                    );
                 }
-                coordinator.retain_all_unstarted("generation scheduler is shutting down");
+                coordinator.settle_all_unstarted_for_drain(cause);
+                if let Some((_, task)) = host_reclaim.take() {
+                    task.abort();
+                }
+                coordinator.stop_preparations().await;
+                for worker in &coordinator.state.gpu_pool.workers {
+                    worker.request_shutdown();
+                }
+                let _ = cpu_utility_tx.try_send(crate::gpu_pool::GpuWorkerCommand::Shutdown);
+                drain_deadline = Some(tokio::time::Instant::now() + scheduler_drain_budget());
+                tracing::info!(
+                    active_leases = coordinator.leases.len(),
+                    ?cause,
+                    "multi-GPU scheduler entered shutdown drain"
+                );
+            }
+            _ = async {
+                tokio::time::sleep_until(drain_deadline.expect("guarded drain deadline")).await;
+            }, if drain_deadline.is_some() => {
+                let cause = effective_drain_cause(&coordinator);
+                fatal |= cause == CoordinatorDrainCause::FatalCuda;
+                tracing::warn!(
+                    active_leases = coordinator.leases.len(),
+                    "scheduler shutdown drain deadline elapsed; releasing remaining lease authority"
+                );
+                let settlement = chain_deadline_settlement_parts(&coordinator);
+                settle_chain_leases_at_deadline(
+                    settlement,
+                    cause,
+                ).await;
                 break;
             }
-            job = job_rx.recv(), if generation_ingress_open => {
+            job = job_rx.recv(), if generation_ingress_open && coordinator.drain_cause.is_none() => {
                 match job {
                     Some(job) => coordinator.enqueue(job, &mut immediate),
                     None => generation_ingress_open = false,
                 }
             }
-            work = owner_work_rx.recv(), if owner_ingress_open => {
+            work = owner_work_rx.recv(), if owner_ingress_open && coordinator.drain_cause.is_none() => {
                 match work {
                     Some(work) => coordinator.enqueue_owner_work(work, &mut immediate),
                     None => owner_ingress_open = false,
                 }
             }
-            preview = preview_rx.recv() => {
+            preview = preview_rx.recv(), if coordinator.drain_cause.is_none() => {
                 if let Some(preview) = preview {
                     match preview {
                         PlacementPreviewQuery::Generation {
@@ -6914,20 +7025,40 @@ pub async fn run_scheduler_coordinator(
                     }
                 }
             }
-            event = worker_rx.recv() => {
-                if let Some(event) = event {
-                    coordinator.handle_worker_event_serialized(event, &mut immediate).await;
+            event = worker_rx.recv(), if worker_stream_open => {
+                match event {
+                    Some(event) => coordinator.handle_worker_event_serialized(event, &mut immediate).await,
+                    None => {
+                        worker_stream_open = false;
+                        if !coordinator.leases.is_empty() {
+                            if let Some(cause) = coordinator.drain_cause {
+                                let cause = if fatal_cuda_latched(&coordinator) {
+                                    fatal = true;
+                                    CoordinatorDrainCause::FatalCuda
+                                } else {
+                                    cause
+                                };
+                                tracing::warn!(
+                                    active_leases = coordinator.leases.len(),
+                                    "scheduler worker event stream closed during drain"
+                                );
+                                let settlement = chain_deadline_settlement_parts(&coordinator);
+                                settle_chain_leases_at_deadline(settlement, cause).await;
+                                break;
+                            }
+                        }
+                    }
                 }
             }
-            event = coordinator.preparation_rx.recv() => {
+            event = coordinator.preparation_rx.recv(), if coordinator.drain_cause.is_none() => {
                 if let Some(event) = event {
                     coordinator.handle_preparation_event(event, &mut immediate);
                 }
             }
-            _ = registry_notify.notified() => {
+            _ = registry_notify.notified(), if coordinator.drain_cause.is_none() => {
                 coordinator.reconcile_external_mutations(&mut immediate);
             }
-            resource = resource_rx.recv(), if resource_stream_open => {
+            resource = resource_rx.recv(), if resource_stream_open && coordinator.drain_cause.is_none() => {
                 match resource {
                     Ok(_) | Err(tokio::sync::broadcast::error::RecvError::Lagged(_)) => {
                         coordinator.reconcile_resource_capacity(&mut immediate);
@@ -6937,14 +7068,32 @@ pub async fn run_scheduler_coordinator(
                     }
                 }
             }
-            _ = ticker.tick() => {
+            _ = ticker.tick(), if coordinator.drain_cause.is_none() => {
                 coordinator.reconcile_external_mutations(&mut immediate);
             }
-            _ = memory_ticker.tick() => {
+            _ = memory_ticker.tick(), if coordinator.drain_cause.is_none() => {
                 coordinator.collect_host_memory();
                 coordinator.sample_active_lease_high_waters();
                 coordinator.mutate(&mut immediate);
             }
+        }
+        if coordinator.drain_cause == Some(CoordinatorDrainCause::Shutdown)
+            && fatal_cuda_latched(&coordinator)
+        {
+            fatal = true;
+            coordinator.drain_cause = Some(CoordinatorDrainCause::FatalCuda);
+            coordinator.reject_all_unstarted_for_fatal_cuda();
+            coordinator.publish_device_state_if_changed();
+            tracing::error!("scheduler shutdown drain promoted to fatal CUDA drain");
+        }
+        if let Some(cause) = coordinator.drain_cause {
+            // A rejected not-yet-accepted grant can return to a pending set
+            // while draining. Settle it immediately and never run planning.
+            coordinator.settle_all_unstarted_for_drain(cause);
+            if coordinator.leases.is_empty() {
+                break;
+            }
+            continue;
         }
         if !generation_ingress_open
             && !owner_ingress_open
@@ -7033,7 +7182,23 @@ pub async fn run_scheduler_coordinator(
             // a reconnect or shutdown.
             coordinator.publish_device_state_if_changed();
             fatal = true;
-            break;
+            coordinator.drain_cause = Some(CoordinatorDrainCause::FatalCuda);
+            preview_rx.close();
+            if let Some((_, task)) = host_reclaim.take() {
+                task.abort();
+            }
+            coordinator.stop_preparations().await;
+            for worker in &coordinator.state.gpu_pool.workers {
+                worker.request_shutdown();
+            }
+            let _ = cpu_utility_tx.try_send(crate::gpu_pool::GpuWorkerCommand::Shutdown);
+            drain_deadline = Some(tokio::time::Instant::now() + scheduler_drain_budget());
+        }
+        if coordinator.drain_cause.is_some() {
+            if coordinator.leases.is_empty() {
+                break;
+            }
+            continue;
         }
         if immediate {
             let _ = coordinator
@@ -7049,9 +7214,17 @@ pub async fn run_scheduler_coordinator(
         }
     }
     coordinator.stop_preparations().await;
-    let _ = cpu_utility_tx.send(crate::gpu_pool::GpuWorkerCommand::Shutdown);
-    if cpu_utility_handle.join().is_err() {
-        tracing::error!("CPU utility owner panicked during shutdown");
+    let _ = cpu_utility_tx.try_send(crate::gpu_pool::GpuWorkerCommand::Shutdown);
+    match tokio::time::timeout(
+        Duration::from_secs(4),
+        tokio::task::spawn_blocking(move || cpu_utility_handle.join()),
+    )
+    .await
+    {
+        Ok(Ok(Ok(()))) => {}
+        Ok(Ok(Err(_))) => tracing::error!("CPU utility owner panicked during shutdown"),
+        Ok(Err(error)) => tracing::error!(%error, "CPU utility owner join task failed"),
+        Err(_) => tracing::warn!("CPU utility owner exceeded the bounded shutdown join"),
     }
     for worker in &coordinator.state.gpu_pool.workers {
         worker.request_shutdown();
@@ -7060,6 +7233,71 @@ pub async fn run_scheduler_coordinator(
         coordinator.reject_all_unstarted_for_fatal_cuda();
     }
     tracing::info!("multi-GPU scheduler coordinator stopped");
+}
+
+fn scheduler_drain_budget() -> Duration {
+    // Leave a small margin for the owner joins and process-level fallback.
+    Duration::from_secs(
+        crate::resolve_shutdown_abort_secs()
+            .saturating_sub(5)
+            .max(1),
+    )
+}
+
+fn fatal_cuda_latched(coordinator: &Coordinator) -> bool {
+    coordinator
+        .state
+        .gpu_pool
+        .workers
+        .iter()
+        .any(|worker| worker.fatal_cuda_error.load(Ordering::SeqCst))
+}
+
+fn effective_drain_cause(coordinator: &Coordinator) -> CoordinatorDrainCause {
+    if fatal_cuda_latched(coordinator) {
+        CoordinatorDrainCause::FatalCuda
+    } else {
+        coordinator
+            .drain_cause
+            .unwrap_or(CoordinatorDrainCause::Shutdown)
+    }
+}
+
+type ChainDeadlineSettlement = (
+    Arc<crate::chain_job_runner::ChainJobRunnerHandle>,
+    Arc<Option<mold_db::MetadataDb>>,
+    BTreeSet<String>,
+);
+
+fn chain_deadline_settlement_parts(coordinator: &Coordinator) -> Option<ChainDeadlineSettlement> {
+    let chain_jobs = coordinator.state.chain_jobs.clone()?;
+    if coordinator.state.metadata_db.as_ref().is_none() {
+        return None;
+    }
+    let db = coordinator.state.metadata_db.clone();
+    let job_ids = coordinator
+        .leases
+        .values()
+        .filter_map(|lease| {
+            chain_work_identity(&lease.work_id).map(|(job_id, _)| job_id.to_string())
+        })
+        .collect::<BTreeSet<_>>();
+    Some((chain_jobs, db, job_ids))
+}
+
+async fn settle_chain_leases_at_deadline(
+    settlement: Option<ChainDeadlineSettlement>,
+    cause: CoordinatorDrainCause,
+) {
+    let Some((chain_jobs, db, job_ids)) = settlement else {
+        return;
+    };
+    let Some(db) = db.as_ref().as_ref() else {
+        return;
+    };
+    chain_jobs
+        .settle_scheduler_drain_deadline(db, job_ids, cause == CoordinatorDrainCause::FatalCuda)
+        .await;
 }
 
 fn gpu_job_from_generation(
@@ -13888,6 +14126,148 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn shutdown_drain_cancels_unaccepted_chain_stage_with_typed_outcome() {
+        let (worker, worker_rx) = test_worker(0);
+        let device_id = worker_device_id(&worker);
+        let pool = Arc::new(GpuPool {
+            workers: vec![worker.clone()].into(),
+        });
+        let (ingress_tx, _ingress_rx) = tokio::sync::mpsc::channel(1);
+        let state = AppState::empty(
+            mold_core::Config::default(),
+            QueueHandle::new(ingress_tx),
+            pool,
+            1,
+        );
+        let mut coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+        let (generation, _) = fake_generation("shutdown-chain-template");
+        let (result_tx, result_rx) = tokio::sync::oneshot::channel();
+        let work_id = "chain:shutdown-parent:attempt:1:stage:0";
+        let work =
+            OwnerWork::ChainStage(Box::new(crate::chain_job_runner::ScheduledChainStageWork {
+                id: work_id.to_string(),
+                model: "ltx2".to_string(),
+                cache_key: "ltx2".to_string(),
+                config: mold_core::Config::default(),
+                stage_req: generation.request,
+                carry: None,
+                motion_tail_frames: 1,
+                progress: Arc::new(|_, _| std::ops::ControlFlow::Continue(())),
+                cancelled: Arc::new(|| true),
+                cancellation: mold_inference::InferenceCancellationToken::default(),
+                on_leased: None,
+                execution_plan: None,
+                expected_model_fingerprint: None,
+                result_tx: Some(result_tx),
+                before_second_fence: None,
+            }));
+        let fence = LeaseFence {
+            work_id: work_id.to_string(),
+            device_id: device_id.clone(),
+            owner_epoch: 1,
+            state_version: 1,
+            plan_version: 1,
+            worker_generation: 1,
+            memory_sample_generation: 1,
+            memory_ledger_sequence: 1,
+        };
+        coordinator.leases.insert(
+            device_id.clone(),
+            ActiveLease {
+                work_id: work_id.to_string(),
+                owner_epoch: 1,
+                plan_version: 1,
+                worker_generation: 1,
+                accepted: false,
+                previous_target: None,
+                estimated_finish_ms: 1,
+                ready_at_ms: 0,
+                bypass_count: 0,
+                warm_wait_started_ms: None,
+                started_at: Instant::now(),
+                estimate_key: EstimateKey::default(),
+                vram_high_water_bytes: None,
+                host_incremental_high_water_bytes: None,
+                fallback_reason: None,
+                projection: WorkSnapshot::new(work_id, 0, Vec::new()),
+                assignment_reason: AssignmentReason::Priority,
+            },
+        );
+        worker.in_flight.store(1, Ordering::SeqCst);
+        coordinator.drain_cause = Some(CoordinatorDrainCause::Shutdown);
+
+        let mut immediate = false;
+        coordinator.handle_worker_event(
+            WorkerEvent::Rejected {
+                device_id: device_id.clone(),
+                ordinal: 0,
+                owner_epoch: 1,
+                worker_generation: 1,
+                grant: Box::new(LeaseGrant {
+                    fence,
+                    work,
+                    retry: None,
+                }),
+                reason: LeaseRejection::StaleWorkerGeneration,
+            },
+            &mut immediate,
+        );
+
+        let execution = result_rx.await.unwrap().unwrap();
+        assert!(matches!(
+            execution.outcome,
+            crate::chain_job_runner::StageRenderOutcome::Cancelled
+        ));
+        assert!(coordinator.leases.is_empty());
+        assert_eq!(worker.in_flight.load(Ordering::SeqCst), 0);
+        coordinator.handle_worker_event(
+            WorkerEvent::Ready {
+                device_id,
+                ordinal: 0,
+                owner_epoch: 1,
+                worker_generation: 1,
+            },
+            &mut immediate,
+        );
+        assert!(coordinator.ready.is_empty());
+        assert!(matches!(
+            worker_rx.try_recv(),
+            Err(std::sync::mpsc::TryRecvError::Empty)
+        ));
+    }
+
+    #[tokio::test]
+    async fn shutdown_observes_a_fatal_cuda_latch_before_draining() {
+        let (worker, _worker_rx) = test_worker(0);
+        let pool = Arc::new(GpuPool {
+            workers: vec![worker.clone()].into(),
+        });
+        let (ingress_tx, _ingress_rx) = tokio::sync::mpsc::channel(1);
+        let state = AppState::empty(
+            mold_core::Config::default(),
+            QueueHandle::new(ingress_tx),
+            pool,
+            1,
+        );
+        let coordinator = Coordinator::with_preparer_and_memory(
+            state,
+            Arc::new(ImmediatePreparer),
+            ample_memory(),
+        );
+
+        // The worker latches fatal before supervision cancels the scheduler.
+        // This is the ordering that previously entered the resumable branch
+        // when shutdown won select! ahead of the Completed event.
+        worker.fatal_cuda_error.store(true, Ordering::SeqCst);
+
+        assert!(fatal_cuda_latched(&coordinator));
+    }
+
+    #[tokio::test]
     async fn chain_plan_invalidation_requeues_same_stage_id_with_backoff_and_open_result() {
         let root = tempfile::tempdir().unwrap();
         let transformer = root.path().join("transformer.safetensors");
@@ -14493,7 +14873,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn chain_success_and_error_results_settle_only_after_authoritative_completion() {
+    async fn chain_success_and_error_results_settle_during_shutdown_drain() {
         for successful in [true, false] {
             let (worker, _worker_rx) = test_worker(0);
             let device_id = worker_device_id(&worker);
@@ -14512,6 +14892,7 @@ mod tests {
                 Arc::new(ImmediatePreparer),
                 ample_memory(),
             );
+            coordinator.drain_cause = Some(CoordinatorDrainCause::Shutdown);
             let stage_id = format!("chain:result:{successful}:attempt:1:stage:0");
             coordinator.leases.insert(
                 device_id.clone(),
@@ -14565,7 +14946,9 @@ mod tests {
                     device_ordinal: Some(0),
                 })
             } else {
-                Err("typed stage render failure".to_string())
+                Err(crate::chain_job_runner::StageExecutionError::Failed(
+                    "typed stage render failure".to_string(),
+                ))
             };
             let completion = crate::gpu_worker::DeferredOwnerCompletion::ChainStage {
                 tx: Some(result_tx),
@@ -14602,7 +14985,7 @@ mod tests {
             } else {
                 match settled {
                     Ok(_) => panic!("failed stage must retain its typed error"),
-                    Err(error) => assert_eq!(error, "typed stage render failure"),
+                    Err(error) => assert_eq!(error.to_string(), "typed stage render failure"),
                 }
             }
             assert!(!coordinator.leases.contains_key(&device_id));


### PR DESCRIPTION
## Summary

- keep the scheduler coordinator alive as a bounded settlement drain after shutdown begins instead of dropping active lease authority immediately
- park interrupted ephemeral Wan chain parents for explicit resume, including pre-submit, unaccepted-grant, accepted-completion, closed-channel, and drain-deadline races
- preserve fatal CUDA and ordinary execution failures as failures, retain ordinary durable generations, suppress new dispatch/restarts during drain, and bound CPU-owner plus chain-lock teardown
- keep active chain actors alive until their scheduler results settle and prevent startup reconciliation/GC from deleting resumable one-shot work

## Root cause

Plato received an external SIGTERM while four Wan auto-chains were active. The coordinator exited as soon as shutdown cancellation fired and dropped `DeferredOwnerCompletion` before the GPU owners returned their cancellation results. Each chain actor received `scheduler coordinator stopped before settling the chain-stage lease`, treated it as a render failure, and the startup ephemeral GC later swept the failed parents. The H3 job started after the restart and completed successfully; it exposed the shutdown/lease race but did not cause an OOM, CUDA XID, or scheduler capacity failure.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `nix develop -c cargo check -p mold-ai-server --features mdns`
- `nix develop -c cargo test -p mold-ai-server --features mdns shutdown --lib` (29 passed)
- `nix develop -c cargo test -p mold-ai-server --features mdns scheduler_drain_deadline_settles_running_chain_before_returning --lib`
- `nix develop -c cargo test -p mold-ai-server --features mdns scheduler::tests --lib` (144 passed)
- `nix develop -c cargo clippy -p mold-ai-server --features mdns --lib --tests -- -D warnings`

## Review

The implementation and its plan were independently peer-reviewed. The review specifically covered graceful-vs-fatal shutdown classification, accepted and unaccepted leases, pre-submit and closed-result races, deadline persistence, worker-stream closure, bounded CPU/lock waits, and startup reconciliation/GC. No actionable findings remain.
