### PR TITLE
fix(web): read the meter prop as a number so the cold typecheck passes

### DIFF
--- a/web/src/components/create/MachineCard.test.ts
+++ b/web/src/components/create/MachineCard.test.ts
@@ -82,7 +82,9 @@ describe("MachineCard", () => {
     );
     const bar = wrapper.findComponent(ProgressBar);
     expect(bar.props("height")).toBe(5);
-    expect(Math.round(bar.props("value"))).toBe(62);
+    // `props()` is typed `unknown` on a cold typecheck (the Nix sandbox has no
+    // tsbuildinfo), so read it as a number before rounding.
+    expect(Math.round(Number(bar.props("value")))).toBe(62);
   });
 
   it("shows no meter for a machine that reports no memory", () => {


### PR DESCRIPTION
`nix build` of `mold-web` (and therefore plato's system) fails on main since #1703:

```
src/components/create/MachineCard.test.ts:85:23 - error TS2345: Argument of type 'unknown' is not assignable to parameter of type 'number'.
```

Inside the sandbox (isolated linker, no tsbuildinfo) `wrapper.findComponent(ProgressBar).props("value")` is typed `unknown`; the warm local `vue-tsc -b` accepted it. The test now coerces with `Number()` before rounding. Test-only change.

https://claude.ai/code/session_01GeRRjMgQf3MsowVeLEubDx