### PR TITLE
fix(studio): the Start-from-a-photo advisory names what the style does with the picture

### DIFF
--- a/changelog.d/source-image-advisory.md
+++ b/changelog.d/source-image-advisory.md
@@ -1,0 +1,7 @@
+- **The Start-from-a-photo advisory names what the style does with the
+  picture.** A 3-D style that needs a picture used to be told it was
+  "image-to-video only" — a clip's sentence. It now says the style builds
+  from a picture and asks for a source image to give it a shape; a still
+  style says it needs a picture to work from; a clip style keeps its
+  first-frame sentence. Every one of these sentences says style, never
+  checkpoint, and the lexicon check now reads them.

--- a/desktop/src/lib/generateValidation.ts
+++ b/desktop/src/lib/generateValidation.ts
@@ -348,6 +348,7 @@ export function sourceConditioningValidationError(
     hasEndFrame: caps.supportsEndFrame && Boolean(form.endFrame),
     frames: caps.supportsVideo ? form.frames : null,
     model: form.model,
+    outputKind: canvasless ? "mesh" : caps.supportsVideo ? "video" : "image",
   });
 }
 

--- a/desktop/src/lib/lexicon.test.ts
+++ b/desktop/src/lib/lexicon.test.ts
@@ -525,3 +525,39 @@ describe("lexicon — view copy and assistive labels", () => {
     }
   });
 });
+
+/**
+ * `studio/lib/sourceImageCapability.ts` is not a Vue template, so the
+ * template-text scans above never reach its returned sentences — that gap is
+ * how "This checkpoint is image-to-video only…" escaped the lexicon. Scan the
+ * module's own string and template literals against the generic never-say
+ * words (host, model, checkpoint); the Styles-page-specific ones name UI this
+ * module has none of.
+ */
+describe("lexicon — source-image advisory copy", () => {
+  // Vitest runs from `desktop/`, like the native-menu read above.
+  const source = readFileSync("../studio/lib/sourceImageCapability.ts", "utf8");
+
+  it("never says host, model, or checkpoint in a returned sentence", () => {
+    // Doc comments quote identifiers in backticks (`/api/models[].source_image`);
+    // strip every comment first so only code-level literals are read.
+    const code = source.replace(/\/\*[\s\S]*?\*\//g, "").replace(/^\s*\/\/.*$/gm, "");
+    const literals = [
+      ...code.matchAll(/"((?:[^"\\]|\\.)*)"/g),
+      ...code.matchAll(/`((?:[^`\\]|\\.)*)`/g),
+    ].map((m) => m[1]!);
+    const sentences = literals.filter((s) => s.length > 20);
+    expect(sentences.length).toBeGreaterThan(0);
+    const genericBanned = NEVER_SAID_ON_STYLES_AND_MACHINES.filter((re) =>
+      [/\bhost\b/i, /\bmodels?\b/i, /\bcheckpoints?\b/i].some(
+        (allowed) => allowed.source === re.source,
+      ),
+    );
+    expect(genericBanned.length).toBeGreaterThan(0);
+    for (const sentence of sentences) {
+      for (const banned of genericBanned) {
+        expect(sentence, String(banned)).not.toMatch(banned);
+      }
+    }
+  });
+});

--- a/studio/lib/sourceImageCapability.test.ts
+++ b/studio/lib/sourceImageCapability.test.ts
@@ -170,11 +170,53 @@ describe("sourceImageValidationError", () => {
         capability: "required",
         hasSourceImage: false,
       }),
-    ).toMatch(/image-to-video only/);
+    ).toBe(
+      "This style is image-to-video only. Attach a source image to use as the first frame.",
+    );
     expect(
       sourceImageValidationError({
         capability: "required",
         hasSourceImage: true,
+      }),
+    ).toBeNull();
+  });
+
+  // A 3-D style reconstructs a shape from a picture — it is not an
+  // image-to-VIDEO checkpoint, and the advisory must not say it is.
+  it("names the picture a required 3-D style builds a shape from", () => {
+    expect(
+      sourceImageValidationError({
+        capability: "required",
+        hasSourceImage: false,
+        outputKind: "mesh",
+      }),
+    ).toBe(
+      "This style builds from a picture. Attach a source image to give it a shape.",
+    );
+    expect(
+      sourceImageValidationError({
+        capability: "required",
+        hasSourceImage: true,
+        outputKind: "mesh",
+      }),
+    ).toBeNull();
+  });
+
+  // A still-image style that requires a source (e.g. an edit checkpoint)
+  // reads a picture, not a video's first frame.
+  it("names the picture a required still-image style works from", () => {
+    expect(
+      sourceImageValidationError({
+        capability: "required",
+        hasSourceImage: false,
+        outputKind: "image",
+      }),
+    ).toBe("This style needs a picture to work from. Attach a source image.");
+    expect(
+      sourceImageValidationError({
+        capability: "required",
+        hasSourceImage: true,
+        outputKind: "image",
       }),
     ).toBeNull();
   });
@@ -185,7 +227,9 @@ describe("sourceImageValidationError", () => {
         capability: "unsupported",
         hasSourceImage: true,
       }),
-    ).toMatch(/text-to-video only/);
+    ).toBe(
+      "This style is text-to-video only and does not accept a source image. Remove the image, or pick an image-to-video style.",
+    );
   });
 
   it("refuses an end frame without a first frame", () => {

--- a/studio/lib/sourceImageCapability.ts
+++ b/studio/lib/sourceImageCapability.ts
@@ -190,6 +190,13 @@ export interface SourceImageValidationInput {
    * floor, exactly like the server's manifest-name resolution.
    */
   model?: string | null;
+  /**
+   * What a render produces, so a Required advisory can name what the
+   * picture is FOR instead of assuming a video's first frame. Absent reads
+   * as `"video"`, the historical (and still by far the most common) meaning
+   * — a caller that does not know the output kind gets today's wording.
+   */
+  outputKind?: "image" | "video" | "mesh";
 }
 
 /**
@@ -219,10 +226,10 @@ export function sourceImageValidationError(
   // that has none.
   if (input.capability === "unsupported") {
     if (input.hasSourceImage) {
-      return "This checkpoint is text-to-video only and does not accept a source image. Remove the image, or pick an image-to-video checkpoint.";
+      return "This style is text-to-video only and does not accept a source image. Remove the image, or pick an image-to-video style.";
     }
     if (input.isExtend) {
-      return "This checkpoint is text-to-video only and cannot continue an existing clip — a continuation is seeded with the source clip's final frame. Pick an image-to-video checkpoint.";
+      return "This style is text-to-video only and cannot continue an existing clip — a continuation is seeded with the source clip's final frame. Pick an image-to-video style.";
     }
   }
   if (
@@ -230,7 +237,13 @@ export function sourceImageValidationError(
     !input.hasSourceImage &&
     !input.isExtend
   ) {
-    return "This checkpoint is image-to-video only. Attach a source image to use as the first frame.";
+    if (input.outputKind === "mesh") {
+      return "This style builds from a picture. Attach a source image to give it a shape.";
+    }
+    if (input.outputKind === "image") {
+      return "This style needs a picture to work from. Attach a source image.";
+    }
+    return "This style is image-to-video only. Attach a source image to use as the first frame.";
   }
   if (!input.hasEndFrame) return null;
   if (!input.hasSourceImage) {
@@ -243,7 +256,7 @@ export function sourceImageValidationError(
     isWanTi2vModel(input.model) &&
     (input.frames as number) < WAN_TI2V_FLF_MIN_FRAMES
   ) {
-    return `This checkpoint pins both endpoints in latent space, so a first/last-frame render needs at least ${WAN_TI2V_FLF_MIN_FRAMES} frames.`;
+    return `This style pins both endpoints in latent space, so a first/last-frame render needs at least ${WAN_TI2V_FLF_MIN_FRAMES} frames.`;
   }
   return null;
 }

--- a/web/src/components/create/SourceMediaPanel.test.ts
+++ b/web/src/components/create/SourceMediaPanel.test.ts
@@ -128,7 +128,7 @@ describe("SourceMediaPanel — per-model source-image contract (#772)", () => {
       true,
     );
     expect(wrapper.get("[data-test='source-conditioning-error']").text()).toBe(
-      "This checkpoint is image-to-video only. Attach a source image to use as the first frame.",
+      "This style is image-to-video only. Attach a source image to use as the first frame.",
     );
   });
 

--- a/web/src/components/create/SourceMediaPanel.vue
+++ b/web/src/components/create/SourceMediaPanel.vue
@@ -205,6 +205,11 @@ const sourceConditioningError = computed(() =>
         hasEndFrame: hasEndFrame.value,
         frames: caps.value.supportsVideo ? props.modelValue.frames : null,
         model: props.modelValue.model,
+        outputKind: caps.value.canvasless
+          ? "mesh"
+          : caps.value.supportsVideo
+            ? "video"
+            : "image",
       })
     : null,
 );

--- a/web/src/lib/lexicon.test.ts
+++ b/web/src/lib/lexicon.test.ts
@@ -27,6 +27,7 @@ import loraPicker from "../components/LoraPicker.vue?raw";
 import lightbox from "../components/gallery/Lightbox.vue?raw";
 import appNav from "../components/shell/AppNav.vue?raw";
 import commands from "./commands.ts?raw";
+import sourceImageCapabilitySource from "@studio/lib/sourceImageCapability.ts?raw";
 
 /*
  * The binding lexicon (docs/design/README.md §2) on the web surface. Desktop's
@@ -169,5 +170,36 @@ describe("lexicon — the shell", () => {
     // The wordmark is lowercase mono; the product name in a sentence stays Mold.
     expect(appNav).not.toMatch(/brand__word[^>]*>\s*Mold\b/);
     expect(appNav).toMatch(/brand__word[^>]*>\s*mold\b/);
+  });
+});
+
+/**
+ * `studio/lib/sourceImageCapability.ts` is not a Vue template, so the
+ * Styles/Machines template-text scan above never reaches its returned
+ * sentences — that gap is exactly how "This checkpoint is image-to-video
+ * only…" escaped the lexicon. This scans the module's own string and
+ * template literals directly (comments are not quoted, so they cannot
+ * trip it), against the generic never-say words rather than the two
+ * Styles/Machines-page-specific ones (`/\bmodel page\b/i`, `/\bPull\b/`,
+ * `/\binstalled\b/i`, `/\bInstall\b/`) that name UI this module has none of.
+ */
+describe("lexicon — source-image advisory copy", () => {
+  it("never says host, model, or checkpoint in a returned sentence", () => {
+    const literals = [
+      ...sourceImageCapabilitySource.matchAll(/"((?:[^"\\]|\\.)*)"/g),
+      ...sourceImageCapabilitySource.matchAll(/`((?:[^`\\]|\\.)*)`/g),
+    ].map((m) => m[1]!);
+    const sentences = literals.filter((s) => s.length > 20);
+    expect(sentences.length).toBeGreaterThan(0);
+    const genericBanned = NEVER_SAID_ON_STYLES_AND_MACHINES.filter((re) =>
+      [/\bhost\b/i, /\bmodels?\b/i, /\bcheckpoints?\b/i].some(
+        (allowed) => allowed.source === re.source,
+      ),
+    );
+    for (const sentence of sentences) {
+      for (const banned of genericBanned) {
+        expect(sentence, String(banned)).not.toMatch(banned);
+      }
+    }
   });
 });

--- a/web/src/lib/lexicon.test.ts
+++ b/web/src/lib/lexicon.test.ts
@@ -185,9 +185,14 @@ describe("lexicon — the shell", () => {
  */
 describe("lexicon — source-image advisory copy", () => {
   it("never says host, model, or checkpoint in a returned sentence", () => {
+    // Doc comments quote identifiers in backticks (`/api/models[].source_image`);
+    // strip every comment first so only code-level literals are read.
+    const code = sourceImageCapabilitySource
+      .replace(/\/\*[\s\S]*?\*\//g, "")
+      .replace(/^\s*\/\/.*$/gm, "");
     const literals = [
-      ...sourceImageCapabilitySource.matchAll(/"((?:[^"\\]|\\.)*)"/g),
-      ...sourceImageCapabilitySource.matchAll(/`((?:[^`\\]|\\.)*)`/g),
+      ...code.matchAll(/"((?:[^"\\]|\\.)*)"/g),
+      ...code.matchAll(/`((?:[^`\\]|\\.)*)`/g),
     ].map((m) => m[1]!);
     const sentences = literals.filter((s) => s.length > 20);
     expect(sentences.length).toBeGreaterThan(0);

--- a/web/src/pages/CreatePage.test.ts
+++ b/web/src/pages/CreatePage.test.ts
@@ -2517,11 +2517,43 @@ describe("CreatePage layout and behavior", () => {
 
     expect(submitMock).not.toHaveBeenCalled();
     expect(wrapper.text()).toContain(
-      "This checkpoint is image-to-video only. Attach a source image to use as the first frame.",
+      "This style is image-to-video only. Attach a source image to use as the first frame.",
     );
 
     form.state.value.imageAttachments = [
       { kind: "upload", filename: "open.png", base64: "FIRST" },
+    ];
+    await nextTick();
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+    expect(submitMock).toHaveBeenCalled();
+  });
+
+  // A 3-D style reconstructs a shape from a picture — it is not an
+  // image-to-VIDEO checkpoint, and the advisory must say so.
+  it("holds Generate for a required 3-D style with the mesh-specific advisory", async () => {
+    hostModelsMock.mockResolvedValue([
+      installedModelRow("hunyuan3d-mini-turbo:fp16", "hunyuan3d"),
+    ]);
+    const wrapper = mount(CreatePage, { global: { stubs: pageStubs() } });
+    await flushPromises();
+    const form = useGenerateForm();
+    form.state.value.model = "hunyuan3d-mini-turbo:fp16";
+    form.state.value.modelFamily = "hunyuan3d";
+    form.state.value.sourceImageCapability = "required";
+    await nextTick();
+
+    await wrapper.get("[data-test='composer-submit']").trigger("click");
+    await flushPromises();
+
+    expect(submitMock).not.toHaveBeenCalled();
+    expect(wrapper.text()).toContain(
+      "This style builds from a picture. Attach a source image to give it a shape.",
+    );
+    expect(wrapper.text()).not.toContain("image-to-video");
+
+    form.state.value.imageAttachments = [
+      { kind: "upload", filename: "reference.png", base64: "REFERENCE" },
     ];
     await nextTick();
     await wrapper.get("[data-test='composer-submit']").trigger("click");
@@ -2556,7 +2588,7 @@ describe("CreatePage layout and behavior", () => {
     await wrapper.get("[data-test='composer-submit']").trigger("click");
     await flushPromises();
 
-    expect(wrapper.text()).not.toContain("This checkpoint is image-to-video");
+    expect(wrapper.text()).not.toContain("This style is image-to-video");
     expect(submitMock).toHaveBeenCalled();
   });
 

--- a/web/src/pages/CreatePage.vue
+++ b/web/src/pages/CreatePage.vue
@@ -1334,6 +1334,11 @@ const sourceConditioningError = computed<string | null>(() =>
           ? form.state.value.frames
           : null,
         model: form.state.value.model,
+        outputKind: capabilities.value.canvasless
+          ? "mesh"
+          : capabilities.value.supportsVideo
+            ? "video"
+            : "image",
       }),
 );
 


### PR DESCRIPTION
Part of #1706. The Start-from-a-photo advisory told a Hunyuan3D style it was "image-to-video only", in a sentence that also used the retired word "checkpoint".

## What changed

`sourceImageValidationError` (`studio/lib/sourceImageCapability.ts`, the one validator every surface calls) takes an `outputKind` and names what the style does with the picture — James's wording for 3-D:

- 3-D: "This style builds from a picture. Attach a source image to give it a shape."
- still: "This style needs a picture to work from. Attach a source image."
- clip: "This style is image-to-video only. Attach a source image to use as the first frame."

An absent kind means clip, the historical meaning, so no caller changes behaviour silently. The two text-to-video refusals and the TI2V first/last-frame floor say "style" instead of "checkpoint". Web's `SourceMediaPanel` and `CreatePage`, desktop's `generateValidation` and the phone through it pass the kind they already know (canvasless → 3-D, video → clip, else still).

Why it escaped: the lexicon tests scan only Styles and Machines `.vue` templates. Both `web/src/lib/lexicon.test.ts` and `desktop/src/lib/lexicon.test.ts` now read this module's own code-level string literals (comments stripped) against the generic never-say words, so the next sentence written here cannot say host, model or checkpoint.

## Gates

`vue-tsc -b` web + desktop; studio validator suite (26), web CreatePage + SourceMediaPanel (195), desktop generateValidation + MobileApp (423), both lexicon suites; `fmt:check` in all three scopes; `check:architecture`; `check:dead-code`.

https://claude.ai/code/session_0161V41MdQsiVqsHFnbfgRde
